### PR TITLE
Add support for more variable scopes in debugger

### DIFF
--- a/src/PowerShellEditorServices.Host/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Host/DebugAdapter.cs
@@ -276,7 +276,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 newStackFrames.Add(
                     StackFrame.Create(
                         stackFrames[i], 
-                        i + 1));
+                        i));
             }
 
             await requestContext.SendResult(
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             EditorSession editorSession,
             RequestContext<VariablesResponseBody, object> requestContext)
         {
-            VariableDetails[] variables =
+            VariableDetailsBase[] variables =
                 editorSession.DebugService.GetVariables(
                     variablesParams.VariablesReference);
 

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/ScopesRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/ScopesRequest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Diagnostics;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
@@ -14,6 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             RequestType<ScopesRequestArguments, ScopesResponseBody, object>.Create("scopes");
     }
 
+    [DebuggerDisplay("FrameId = {FrameId}")]
     public class ScopesRequestArguments
     {
         public int FrameId { get; set; }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StackTraceRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StackTraceRequest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Diagnostics;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
@@ -14,6 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             RequestType<StackTraceRequestArguments, StackTraceResponseBody, object>.Create("stackTrace");
     }
 
+    [DebuggerDisplay("ThreadId = {ThreadId}, Levels = {Levels}")]
     public class StackTraceRequestArguments
     {
         public int ThreadId { get; private set; }
@@ -27,4 +29,3 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public StackFrame[] StackFrames { get; set; }
     }
 }
-

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Variable.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Variable.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 		// /** If variablesReference is > 0, the variable is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. */
         public int VariablesReference { get; set; }
 
-        public static Variable Create(VariableDetails variable)
+        public static Variable Create(VariableDetailsBase variable)
         {
             return new Variable
             {

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/VariablesRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/VariablesRequest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Diagnostics;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
@@ -14,6 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             RequestType<VariablesRequestArguments, VariablesResponseBody, object>.Create("variables");
     }
 
+    [DebuggerDisplay("VariablesReference = {VariablesReference}")]
     public class VariablesRequestArguments
     {
         public int VariablesReference { get; set; }

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading.Tasks;
-using Microsoft.PowerShell.EditorServices.Debugging;
 
 namespace Microsoft.PowerShell.EditorServices
 {

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -306,8 +306,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         private async Task FetchStackFramesAndVariables()
         {
-            // Avoid using 0 as it indicates a variable node with no children.
-            this.nextVariableId = 1;
+            this.nextVariableId = VariableDetailsBase.FirstVariableId;
             this.variables = new List<VariableDetailsBase>();
 
             // Create a dummy variable for index 0, should never see this.

--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
 using System.Management.Automation;
-using Microsoft.PowerShell.EditorServices.Debugging;
 
 namespace Microsoft.PowerShell.EditorServices
 {

--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Management.Automation;
+using Microsoft.PowerShell.EditorServices.Debugging;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -35,25 +36,31 @@ namespace Microsoft.PowerShell.EditorServices
         public int ColumnNumber { get; private set; }
 
         /// <summary>
+        /// Gets or sets the VariableContainerDetails that contains the local variables.
+        /// </summary>
+        public VariableContainerDetails LocalVariables { get; private set; }
+
+        /// <summary>
         /// Creates an instance of the StackFrameDetails class from a
         /// CallStackFrame instance provided by the PowerShell engine.
         /// </summary>
         /// <param name="callStackFrame">
         /// The original CallStackFrame instance from which details will be obtained.
         /// </param>
+        /// <param name="localVariables">
+        /// A variable container with all the local variables for this stack frame.
         /// <returns>A new instance of the StackFrameDetails class.</returns>
         static internal StackFrameDetails Create(
-            CallStackFrame callStackFrame)
+            CallStackFrame callStackFrame,
+            VariableContainerDetails localVariables)
         {
-            Dictionary<string, PSVariable> localVariables =
-                callStackFrame.GetFrameVariables();
-
             return new StackFrameDetails
             {
                 ScriptPath = callStackFrame.ScriptName,
                 FunctionName = callStackFrame.FunctionName,
                 LineNumber = callStackFrame.Position.StartLineNumber,
-                ColumnNumber = callStackFrame.Position.StartColumnNumber
+                ColumnNumber = callStackFrame.Position.StartColumnNumber,
+                LocalVariables = localVariables
             };
         }
     }

--- a/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.PowerShell.EditorServices.Utility;
 
-namespace Microsoft.PowerShell.EditorServices.Debugging
+namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
     /// Container for variables that is not itself a variable per se.  However given how

--- a/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.Debugging
+{
+    /// <summary>
+    /// Container for variables that is not itself a variable per se.  However given how
+    /// VSCode uses an integer variable reference id for every node under the "Variables" tool
+    /// window, it is useful to treat containers, typically scope containers, as a variable.
+    /// Note that these containers are not necessarily always a scope container. Consider a
+    /// container such as "Auto" or "My".  These aren't scope related but serve as just another
+    /// way to organize variables into a useful UI structure.
+    /// </summary>
+    [DebuggerDisplay("Name = {Name}, Id = {Id}, Count = {Children.Count}")]
+    public class VariableContainerDetails : VariableDetailsBase
+    {
+        private readonly List<VariableDetailsBase> children;
+
+        /// <summary>
+        /// Instantiates an instance of VariableScopeDetails.
+        /// </summary>
+        /// <param name="id">The variable reference id for this scope.</param>
+        /// <param name="name">The name of the variable scope.</param>
+        public VariableContainerDetails(int id, string name)
+        {
+            Validate.IsNotNull(name, "name");
+
+            this.Id = id;
+            this.Name = name;
+            this.IsExpandable = true;
+            this.ValueString = " "; // An empty string isn't enough due to a temporary bug in VS Code.
+
+            this.children = new List<VariableDetailsBase>();
+        }
+
+        /// <summary>
+        /// Gets the collection of child variables.
+        /// </summary>
+        public List<VariableDetailsBase> Children
+        {
+            get { return this.children; }
+        }
+
+        /// <summary>
+        /// Returns the details of the variable container's children.  If empty, returns an empty array.
+        /// </summary>
+        /// <returns></returns>
+        public override VariableDetailsBase[] GetChildren()
+        {
+            return this.children.ToArray();
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetails.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
@@ -16,7 +17,8 @@ namespace Microsoft.PowerShell.EditorServices
     /// Contains details pertaining to a variable in the current 
     /// debugging session.
     /// </summary>
-    public class VariableDetails
+    [DebuggerDisplay("Name = {Name}, Id = {Id}, Value = {ValueString}")]
+    public class VariableDetails : VariableDetailsBase
     {
         #region Fields
 
@@ -25,52 +27,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public const string DollarPrefix = "$";
 
-        /// <summary>
-        /// Provides a constant for the variable ID of the local variable scope.
-        /// </summary>
-        public const int LocalScopeVariableId = 1;
-
-        /// <summary>
-        /// Provides a constant for the variable ID of the global variable scope.
-        /// </summary>
-        public const int GlobalScopeVariableId = 2;
-
-        /// <summary>
-        /// Provides a constant that is used as the starting variable ID for all
-        /// variables in a given scope.
-        /// </summary>
-        public const int FirstVariableId = 10;
-
         private object valueObject;
         private VariableDetails[] cachedChildren;
-
-        #endregion
-
-        #region Properties
-
-        /// <summary>
-        /// Gets the numeric ID of the variable which can be used to refer
-        /// to it in future requests.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets the variable's name.
-        /// </summary>
-        public string Name { get; private set; }
-
-        /// <summary>
-        /// Gets the string representation of the variable's value.
-        /// If the variable is an expandable object, this string
-        /// will be empty.
-        /// </summary>
-        public string ValueString { get; private set; }
-
-        /// <summary>
-        /// Returns true if the variable's value is expandable, meaning
-        /// that it has child properties or its contents can be enumerated.
-        /// </summary>
-        public bool IsExpandable { get; private set; }
 
         #endregion
 
@@ -110,6 +68,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             this.valueObject = value;
 
+            this.Id = -1; // Not been assigned a variable reference id yet
             this.Name = name;
             this.IsExpandable = GetIsExpandable(value);
             this.ValueString =
@@ -127,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// details of its children.  Otherwise it returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public VariableDetails[] GetChildren()
+        public override VariableDetailsBase[] GetChildren()
         {
             VariableDetails[] childVariables = null;
 

--- a/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
@@ -12,7 +12,8 @@ namespace Microsoft.PowerShell.EditorServices
     public abstract class VariableDetailsBase
     {
         /// <summary>
-        /// Provides a constant that is used as the starting variable ID for all
+        /// Provides a constant that is used as the starting variable ID for all.
+        /// Avoid 0 as it indicates a variable node with no children.
         /// variables.
         /// </summary>
         public const int FirstVariableId = 1;

--- a/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
@@ -1,0 +1,51 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Defines the common details between a variable and a variable container such as a scope 
+    /// in the current debugging session.
+    /// </summary>
+    public abstract class VariableDetailsBase
+    {
+        /// <summary>
+        /// Provides a constant that is used as the starting variable ID for all
+        /// variables.
+        /// </summary>
+        public const int FirstVariableId = 1;
+
+        /// <summary>
+        /// Gets the numeric ID of the variable which can be used to refer
+        /// to it in future requests.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets the variable's name.
+        /// </summary>
+        public string Name { get; protected set; }
+
+        /// <summary>
+        /// Gets the string representation of the variable's value.
+        /// If the variable is an expandable object, this string
+        /// will be empty.
+        /// </summary>
+        public string ValueString { get; protected set; }
+
+        /// <summary>
+        /// Returns true if the variable's value is expandable, meaning
+        /// that it has child properties or its contents can be enumerated.
+        /// </summary>
+        public bool IsExpandable { get; protected set; }
+
+        /// <summary>
+        /// If this variable instance is expandable, this method returns the
+        /// details of its children.  Otherwise it returns an empty array.
+        /// </summary>
+        /// <returns></returns>
+        public abstract VariableDetailsBase[] GetChildren();
+    }
+}

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -63,7 +63,9 @@
     <Compile Include="Debugging\DebugService.cs" />
     <Compile Include="Debugging\StackFrameDetails.cs" />
     <Compile Include="Debugging\VariableDetails.cs" />
+    <Compile Include="Debugging\VariableDetailsBase.cs" />
     <Compile Include="Debugging\VariableScope.cs" />
+    <Compile Include="Debugging\VariableContainerDetails.cs" />
     <Compile Include="IHost.cs" />
     <Compile Include="Language\AstOperations.cs" />
     <Compile Include="Language\CommandHelpers.cs" />

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -171,9 +171,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.powerShellContext.ExecuteScriptString(variablesFile.FilePath);
             await this.AssertDebuggerStopped(variablesFile.FilePath);
 
-            VariableDetails[] variables = 
-                debugService.GetVariables(
-                    VariableDetails.LocalScopeVariableId);
+            StackFrameDetails[] stackFrames = debugService.GetStackFrames();
+
+            VariableDetailsBase[] variables = 
+                debugService.GetVariables(stackFrames[0].LocalVariables.Id);
 
             // TODO: Add checks for correct value strings as well
 


### PR DESCRIPTION
This PR adds support for displaying Global and Script scope variables.  It also supports showing local variables for stack frames other than the topmost frame (frame 0).