### PR TITLE
Fix casing of event messages from debug adapter

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/ProtocolServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/ProtocolServer.cs
@@ -110,20 +110,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 this.serverChannel.MessageDispatcher.SynchronizationContext.Post(
                     async (obj) =>
                     {
-                        await this.serverChannel.MessageWriter.WriteMessage(
-                            Message.Event(
-                                eventType.MethodName,
-                                JToken.FromObject(eventParams)));
+                        await this.serverChannel.MessageWriter.WriteEvent(
+                            eventType,
+                            eventParams);
                     }, null);
 
                 return Task.FromResult(true);
             }
             else
             {
-                return this.serverChannel.MessageWriter.WriteMessage(
-                    Message.Event(
-                        eventType.MethodName,
-                        JToken.FromObject(eventParams)));
+                return this.serverChannel.MessageWriter.WriteEvent(
+                    eventType,
+                    eventParams);
             }
         }
 


### PR DESCRIPTION
This change fixes the casing of event messages raised from the debug
adapter.  This issue caused the VS Code debugger UI to not display details
correctly when stopped at a breakpoint.