### PR TITLE
Fix hang when debug adapter finishes executing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ lock
 /target
 .corext/gen
 registered_data.ini
-
+.vs/
 
 # quickbuild.exe
 /VersionGeneratingLogs/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,5 +36,5 @@ build:
 test:
   assemblies:
   - Microsoft.PowerShell.EditorServices.Test.dll
+  - Microsoft.PowerShell.EditorServices.Test.Protocol.dll
   - Microsoft.PowerShell.EditorServices.Test.Host.dll
-  - Microsoft.PowerShell.EditorServices.Test.Transport.Stdio.dll

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -56,6 +56,17 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.SetRequestHandler(EvaluateRequest.Type, this.HandleEvaluateRequest);
         }
 
+        protected override void Shutdown()
+        {
+            Logger.Write(LogLevel.Normal, "Debug adapter is shutting down...");
+
+            if (this.editorSession != null)
+            {
+                this.editorSession.Dispose();
+                this.editorSession = null;
+            }
+        }
+
         #region Built-in Message Handlers
 
         protected async Task HandleLaunchRequest(

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -70,7 +70,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             Logger.Write(LogLevel.Normal, "Language service is shutting down...");
 
-            this.editorSession.Dispose();
+            if (this.editorSession != null)
+            {
+                this.editorSession.Dispose();
+                this.editorSession = null;
+            }
         }
 
         #region Built-in Message Handlers

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -84,6 +84,9 @@
     <None Include="TestFiles\SimpleSyntaxError.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/test/PowerShellEditorServices.Test.Host/xunit.runner.json
+++ b/test/PowerShellEditorServices.Test.Host/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "parallelizeTestCollections": false,
+  "methodDisplay": "method"
+}

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -61,11 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         void debugService_DebuggerStopped(object sender, DebuggerStopEventArgs e)
         {
-            this.runnerContext.Post(
-                (o) =>
-                {
-                    this.debuggerStoppedQueue.Enqueue(e);
-                }, null);
+            this.debuggerStoppedQueue.Enqueue(e);
         }
 
         public void Dispose()
@@ -119,7 +115,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.debugService.Continue();
 
             await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 9);
-            this.debugService.Continue();
 
             // Abort script execution early and wait for completion
             this.debugService.Abort();

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -87,6 +87,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\PowerShellEditorServices\PowerShellEditorServices.csproj">

--- a/test/PowerShellEditorServices.Test/xunit.runner.json
+++ b/test/PowerShellEditorServices.Test/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "parallelizeTestCollections": false,
+  "methodDisplay": "method"
+}


### PR DESCRIPTION
This change fixes a hang that was caused by the recent refactoring of host
process server implementations.  In the debug adapter implementation, the
PowerShellContext was not being disposed at shutdown which was causing the
process to stay open because the associated threads were still alive.
This change adds the necessary ProtocolServer.Shutdown implementation.