### PR TITLE
For for issue #75, variables display isn't displaying anything for ge…

### DIFF
--- a/src/PowerShellEditorServices/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetails.cs
@@ -130,6 +130,7 @@ namespace Microsoft.PowerShell.EditorServices
             return
                 valueObject != null &&
                 !valueType.IsPrimitive &&
+                !(valueObject is decimal) &&
                 !(valueObject is UnableToRetrievePropertyMessage) &&
                 !(valueObject is string); // Strings get treated as IEnumerables
         }

--- a/src/PowerShellEditorServices/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetails.cs
@@ -129,7 +129,8 @@ namespace Microsoft.PowerShell.EditorServices
 
             return
                 valueObject != null &&
-                !valueType.IsValueType &&
+                !valueType.IsPrimitive &&
+                !(valueObject is UnableToRetrievePropertyMessage) &&
                 !(valueObject is string); // Strings get treated as IEnumerables
         }
 
@@ -143,13 +144,23 @@ namespace Microsoft.PowerShell.EditorServices
             }
             else if (isExpandable)
             {
-                Type objType = value.GetType(); 
+                Type objType = value.GetType();
 
-                // Get the "value" for an expandable object.  This will either
-                // be the short type name or the ToString() response if ToString()
-                // responds with something other than the type name.
-                if (value.ToString().Equals(objType.FullName))
+                // Get the "value" for an expandable object.  
+                if (value is DictionaryEntry)
                 {
+                    // For DictionaryEntry - display the key/value as the value.
+                    var entry = (DictionaryEntry)value;
+                    valueString =
+                        string.Format(
+                            "[{0}, {1}]",
+                            entry.Key,
+                            GetValueString(entry.Value, GetIsExpandable(entry.Value)));
+                }
+                else if (value.ToString().Equals(objType.ToString()))
+                {
+                    // If the ToString() matches the type name, then display the type 
+                    // name in PowerShell format.
                     string shortTypeName = objType.Name;
 
                     // For arrays and ICollection, display the number of contained items.
@@ -176,7 +187,8 @@ namespace Microsoft.PowerShell.EditorServices
             }
             else
             {
-                if (value.GetType() == typeof(string))
+                // ToString() output is not the typename, so display that as this object's value
+                if (value is string)
                 {
                     valueString = "\"" + value + "\"";
                 }
@@ -215,6 +227,11 @@ namespace Microsoft.PowerShell.EditorServices
         {
             List<VariableDetails> childVariables = new List<VariableDetails>();
 
+            if (obj == null)
+            {
+                return childVariables.ToArray();
+            }
+
             PSObject psObject = obj as PSObject;
             IDictionary dictionary = obj as IDictionary;
             IEnumerable enumerable = obj as IEnumerable;
@@ -223,59 +240,55 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 if (psObject != null)
                 {
+                    // PowerShell wrapped objects can have extra ETS properties so let's use
+                    // PowerShell's infrastructure to get those properties.
                     childVariables.AddRange(
                         psObject
                             .Properties
                             .Select(p => new VariableDetails(p)));
                 }
-                else if (dictionary != null)
+                else 
                 {
-                    childVariables.AddRange(
-                        dictionary
-                            .OfType<DictionaryEntry>()
-                            .Select(e => new VariableDetails(e.Key.ToString(), e.Value)));
-                }
-                else if (enumerable != null && !(obj is string))
-                {
-                    int i = 0;
-                    foreach (var item in enumerable)
-                    {
-                        childVariables.Add(
-                            new VariableDetails(
-                                string.Format("[{0}]", i),
-                                item));
-
-                        i++;
-                    }
-                }
-                else if (obj != null)
-                {
-                    // Object must be a normal .NET type, pull all of its
-                    // properties and their values
-                    Type objectType = obj.GetType();
-                    var properties = 
-                        objectType.GetProperties(
-                            BindingFlags.Public | BindingFlags.Instance);
-
-                    foreach (var property in properties)
-                    {
-                        try
+                    // We're in the realm of regular, unwrapped .NET objects
+                    if (dictionary != null)
+                    { 
+                        // Buckle up kids, this is a bit weird.  We could not use the LINQ
+                        // operator OfType<DictionaryEntry>.  Even though R# will squiggle the
+                        // "foreach" keyword below and offer to convert to a LINQ-expression - DON'T DO IT!
+                        // The reason is that LINQ extension methods work with objects of type
+                        // IEnumerable.  Objects of type Dictionary<,>, respond to iteration via
+                        // IEnumerable by returning KeyValuePair<,> objects.  Unfortunately non-generic 
+                        // dictionaries like HashTable return DictionaryEntry objects.
+                        // It turns out that iteration via C#'s foreach loop, operates on the variable's
+                        // type which in this case is IDictionary.  IDictionary was designed to always
+                        // return DictionaryEntry objects upon iteration and the Dictionary<,> implementation
+                        // honors that when the object is reintepreted as an IDictionary object.
+                        // FYI, a test case for this is to open $PSBoundParameters when debugging a
+                        // function that defines parameters and has been passed parameters.  
+                        // If you open the $PSBoundParameters variable node in this scenario and see nothing, 
+                        // this code is broken.
+                        int i = 0;
+                        foreach (DictionaryEntry entry in dictionary)
                         {
                             childVariables.Add(
                                 new VariableDetails(
-                                    property.Name,
-                                    property.GetValue(obj)));
-                        }
-                        catch (Exception)
-                        {
-                            // Some properties can throw exceptions, add the property
-                            // name and empty string
-                            childVariables.Add(
-                                new VariableDetails(
-                                    property.Name,
-                                    string.Empty));
+                                    "[" + i++ + "]",
+                                    entry));
                         }
                     }
+                    else if (enumerable != null && !(obj is string))
+                    {
+                        int i = 0;
+                        foreach (var item in enumerable)
+                        {
+                            childVariables.Add(
+                                new VariableDetails(
+                                    "[" + i++ + "]",
+                                    item));
+                        }
+                    }
+
+                    AddDotNetProperties(obj, childVariables);
                 }
             }
             catch (GetValueInvocationException)
@@ -290,6 +303,61 @@ namespace Microsoft.PowerShell.EditorServices
             return childVariables.ToArray();
         }
 
+        private static void AddDotNetProperties(object obj, List<VariableDetails> childVariables)
+        {
+            Type objectType = obj.GetType();
+            var properties =
+                objectType.GetProperties(
+                    BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var property in properties)
+            {
+                // Don't display indexer properties, it causes an exception anyway.
+                if (property.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    childVariables.Add(
+                        new VariableDetails(
+                            property.Name,
+                            property.GetValue(obj)));
+                }
+                catch (Exception ex)
+                {
+                    // Some properties can throw exceptions, add the property
+                    // name and info about the error.
+                    if (ex.GetType() == typeof (TargetInvocationException))
+                    {
+                        ex = ex.InnerException;
+                    }
+
+                    childVariables.Add(
+                        new VariableDetails(
+                            property.Name,
+                            new UnableToRetrievePropertyMessage(
+                                "Error retrieving property - " + ex.GetType().Name)));
+                }
+            }
+        }
+
         #endregion
+
+        private struct UnableToRetrievePropertyMessage
+        {
+            public UnableToRetrievePropertyMessage(string message)
+            {
+                this.Message = message;
+            }
+
+            public string Message { get; }
+
+            public override string ToString()
+            {
+                return "<" + Message + ">";
+            }
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -201,14 +201,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.True(objVar.IsExpandable);
 
             var objChildren = debugService.GetVariables(objVar.Id);
-            Assert.Equal(2, objChildren.Length);
+            Assert.Equal(9, objChildren.Length);
 
             var arrVar = variables.FirstOrDefault(v => v.Name == "$arrVar");
             Assert.NotNull(arrVar);
             Assert.True(arrVar.IsExpandable);
 
             var arrChildren = debugService.GetVariables(arrVar.Id);
-            Assert.Equal(4, arrChildren.Length);
+            Assert.Equal(11, arrChildren.Length);
 
             var classVar = variables.FirstOrDefault(v => v.Name == "$classVar");
             Assert.NotNull(classVar);


### PR DESCRIPTION
…neric dictionaries like PSBoundParametersDictionary.  Also enhanced the determination of what is expandable.  We were not allowing structs like DateTime, TimeSpan and DictionaryEntry to expand.  Changed test from !IsValueType to !IsPrimitive.  Also enhanced the display of property values where we encounter an exception when trying to retrieve the property.  Following VS debugger's lead on this on.   You can see the display by looking at $Host.Runspace.  And we also weren't displaying .NET properties for colletions and dictionaries.  We now do that - in addition to the elements in the collection or dictionary.  Also, don't try to add properties that are indexers.

@daviwil - this one is a bit more change in VariablesDetails.cs than I was anticipating.  Please give it a good look over.