### PR TITLE
Fix missing OutputEvents in DebugAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PowerShell Editor Services Release History
 
+## 0.3.1
+### Thursday, December 17, 2015
+
+- Fixed issue PowerShell/vscode-powershell#49, Debug Console does not receive script output
+
 ## 0.3.0
 ### Tuesday, December 15, 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ configuration: Release
 clone_depth: 10
 
 environment:
-  core_version: '0.3.0'
+  core_version: '0.3.1'
   prerelease_name: '-beta'
 
 branches:

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.editorSession = new EditorSession();
             this.editorSession.StartSession();
             this.editorSession.DebugService.DebuggerStopped += this.DebugService_DebuggerStopped;
+            this.editorSession.PowerShellContext.OutputWritten += this.powerShellContext_OutputWritten;
         }
 
         protected override void Initialize()
@@ -353,6 +354,17 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     Column = e.InvocationInfo.OffsetInLine,
                     ThreadId = 1, // TODO: Change this based on context
                     Reason = "breakpoint" // TODO: Change this based on context
+                });
+        }
+
+        async void powerShellContext_OutputWritten(object sender, OutputWrittenEventArgs e)
+        {
+            await this.SendEvent(
+                OutputEvent.Type,
+                new OutputEventBody
+                {
+                    Output = e.OutputText + (e.IncludeNewLine ? "\r\n" : string.Empty),
+                    Category = (e.OutputType == OutputType.Error) ? "stderr" : "stdout"
                 });
         }
 

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/DebugTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/DebugTest.ps1
@@ -1,6 +1,4 @@
-﻿Get-Process -bla
-
-$i = 1
+﻿$i = 1
 
 while ($i -le 500000)
 {

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             BreakpointDetails[] breakpoints =
                 await this.debugService.SetBreakpoints(
                     this.debugScriptFile, 
-                    new int[] { 5, 9 });
+                    new int[] { 5, 7 });
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 5);
             this.debugService.Continue();
 
-            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 9);
+            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 7);
 
             // Abort script execution early and wait for completion
             this.debugService.Abort();


### PR DESCRIPTION
This change fixes an issue from the latest refactoring which causes
the DebugAdapter to not send OutputEvents when output is written while
script is running.  This was reported in PowerShell/vscode-powershell#49.

This change also introduces a new test to ensure that the DebugAdapter is
writing output.