### PR TITLE
Fix for #87, enums display as expandable when they have no properties…

### DIFF
--- a/src/PowerShellEditorServices/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetails.cs
@@ -130,9 +130,10 @@ namespace Microsoft.PowerShell.EditorServices
             return
                 valueObject != null &&
                 !valueType.IsPrimitive &&
+                !valueType.IsEnum && // Enums don't have any properties
+                !(valueObject is string) && // Strings get treated as IEnumerables
                 !(valueObject is decimal) &&
-                !(valueObject is UnableToRetrievePropertyMessage) &&
-                !(valueObject is string); // Strings get treated as IEnumerables
+                !(valueObject is UnableToRetrievePropertyMessage);
         }
 
         private static string GetValueString(object value, bool isExpandable)


### PR DESCRIPTION
….  VS also doesn't show enum values as expandable.  Note that this is a specific fix for enums but I think we need a more general fix where we don't show any variable as expandable *if* it has no properties to show.