### PR TITLE
Improvements to REPL execution

### DIFF
--- a/src/PowerShellEditorServices.Channel.WebSocket/Properties/AssemblyInfo.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/Properties/AssemblyInfo.cs
@@ -1,4 +1,9 @@
-﻿using System.Reflection;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PowerShellEditorServices.Channel.WebSocket")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright �  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,3 +39,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/src/PowerShellEditorServices.Channel.WebSocket/WebsocketClientChannel.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/WebsocketClientChannel.cs
@@ -1,4 +1,9 @@
-﻿using System;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
@@ -150,3 +155,4 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
         }
     }
 }
+

--- a/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
@@ -1,4 +1,9 @@
-﻿using System;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
@@ -170,3 +175,4 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
         }
     }
 }
+

--- a/src/PowerShellEditorServices.Host/Program.cs
+++ b/src/PowerShellEditorServices.Host/Program.cs
@@ -94,7 +94,15 @@ namespace Microsoft.PowerShell.EditorServices.Host
             }
 #endif
 
-            Logger.Write(LogLevel.Normal, "PowerShell Editor Services Host starting...");
+            FileVersionInfo fileVersionInfo =
+                FileVersionInfo.GetVersionInfo(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+            Logger.Write(
+                LogLevel.Normal,
+                string.Format(
+                    "PowerShell Editor Services Host v{0} starting...",
+                    fileVersionInfo.FileVersion));
 
             // Start the server
             server.Start();

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/EvaluateRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/EvaluateRequest.cs
@@ -16,17 +16,37 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
     public class EvaluateRequestArguments
     {
+        /// <summary>
+        /// The expression to evaluate.
+        /// </summary>
         public string Expression { get; set; }
 
-    //        /** Evaluate the expression in the context of this stack frame. If not specified, the top most frame is used. */
+        /// <summary>
+        /// The context in which the evaluate request is run. Possible
+        /// values are 'watch' if evaluate is run in a watch or 'repl'
+        /// if run from the REPL console.
+        /// </summary>
+        public string Context { get; set; }
+
+        /// <summary>
+        /// Evaluate the expression in the context of this stack frame.
+        /// If not specified, the top most frame is used.
+        /// </summary>
         public int FrameId { get; set; }
     }
 
     public class EvaluateResponseBody
     {
+        /// <summary>
+        /// The evaluation result.
+        /// </summary>
         public string Result { get; set; }
 
-//            /** If variablesReference is > 0, the evaluate result is structured and its children can be retrieved by passing variablesReference to the VariablesRequest */
+        /// <summary>
+        /// If variablesReference is > 0, the evaluate result is
+        /// structured and its children can be retrieved by passing
+        /// variablesReference to the VariablesRequest
+        /// </summary>
         public int VariablesReference { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -312,10 +312,17 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             EvaluateRequestArguments evaluateParams,
             RequestContext<EvaluateResponseBody> requestContext)
         {
+            bool isFromRepl =
+                string.Equals(
+                    evaluateParams.Context,
+                    "repl",
+                    StringComparison.InvariantCultureIgnoreCase);
+
             VariableDetails result =
                 await editorSession.DebugService.EvaluateExpression(
                     evaluateParams.Expression,
-                    evaluateParams.FrameId);
+                    evaluateParams.FrameId,
+                    isFromRepl);
 
             string valueString = null;
             int variableId = 0;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -679,6 +679,7 @@ function __Expand-Alias {
             var results = 
                 await this.editorSession.PowerShellContext.ExecuteScriptString(
                     evaluateParams.Expression,
+                    true,
                     true);
 
             // Return an empty result since the result value is irrelevant

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -676,27 +676,17 @@ function __Expand-Alias {
             DebugAdapterMessages.EvaluateRequestArguments evaluateParams,
             RequestContext<DebugAdapterMessages.EvaluateResponseBody> requestContext)
         {
-            VariableDetails result =
-                await editorSession.DebugService.EvaluateExpression(
-                    evaluateParams.Expression,
-                    evaluateParams.FrameId);
+            var results = 
+                await this.editorSession.PowerShellContext.ExecuteScriptString(
+                    evaluateParams.Expression);
 
-            string valueString = null;
-            int variableId = 0;
-
-            if (result != null)
-            {
-                valueString = result.ValueString;
-                variableId =
-                    result.IsExpandable ?
-                        result.Id : 0;
-            }
-
+            // Return an empty result since the result value is irrelevant
+            // for this request in the LanguageServer
             await requestContext.SendResult(
                 new DebugAdapterMessages.EvaluateResponseBody
                 {
-                    Result = valueString,
-                    VariablesReference = variableId
+                    Result = "",
+                    VariablesReference = 0
                 });
         }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -678,7 +678,8 @@ function __Expand-Alias {
         {
             var results = 
                 await this.editorSession.PowerShellContext.ExecuteScriptString(
-                    evaluateParams.Expression);
+                    evaluateParams.Expression,
+                    true);
 
             // Return an empty result since the result value is irrelevant
             // for this request in the LanguageServer

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -238,15 +238,21 @@ namespace Microsoft.PowerShell.EditorServices
         {
             var results = 
                 await this.powerShellContext.ExecuteScriptString(
-                    expressionString);
+                    expressionString,
+                    false);
 
             // Since this method should only be getting invoked in the debugger,
             // we can assume that Out-String will be getting used to format results
-            // of command executions into string output.
+            // of command executions into string output.  However, if null is returned
+            // then pass null through so that no output gets displayed.
+            string outputString =
+                results != null ?
+                    string.Join(Environment.NewLine, results) :
+                    null;
 
             return new VariableDetails(
-                expressionString, 
-                string.Join(Environment.NewLine, results));
+                expressionString,
+                outputString);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -233,26 +233,38 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="expressionString">The expression string to execute.</param>
         /// <param name="stackFrameId">The ID of the stack frame in which the expression should be executed.</param>
+        /// <param name="writeResultAsOutput">
+        /// If true, writes the expression result as host output rather than returning the results.
+        /// In this case, the return value of this function will be null.</param>
         /// <returns>A VariableDetails object containing the result.</returns>
-        public async Task<VariableDetails> EvaluateExpression(string expressionString, int stackFrameId)
+        public async Task<VariableDetails> EvaluateExpression(
+            string expressionString,
+            int stackFrameId,
+            bool writeResultAsOutput)
         {
             var results = 
                 await this.powerShellContext.ExecuteScriptString(
                     expressionString,
-                    false);
+                    false,
+                    writeResultAsOutput);
 
             // Since this method should only be getting invoked in the debugger,
             // we can assume that Out-String will be getting used to format results
             // of command executions into string output.  However, if null is returned
-            // then pass null through so that no output gets displayed.
+            // then return null so that no output gets displayed.
             string outputString =
                 results != null ?
                     string.Join(Environment.NewLine, results) :
                     null;
 
-            return new VariableDetails(
-                expressionString,
-                outputString);
+            // If we've written the result as output, don't return a
+            // VariableDetails instance.
+            return
+                writeResultAsOutput ?
+                    null :
+                    new VariableDetails(
+                        expressionString,
+                        outputString);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -180,18 +180,24 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A collection of SymbolReference objects</returns>
         static public IEnumerable<SymbolReference> FindSymbolsInDocument(Ast scriptAst, Version powerShellVersion)
         {
+            IEnumerable<SymbolReference> symbolReferences = null;
+
             if (powerShellVersion >= new Version(5,0))
             {
+#if PowerShellv5
                 FindSymbolsVisitor2 findSymbolsVisitor = new FindSymbolsVisitor2();
                 scriptAst.Visit(findSymbolsVisitor);
-                return findSymbolsVisitor.SymbolReferences;
+                symbolReferences = findSymbolsVisitor.SymbolReferences;
+#endif
             }
             else
             {
                 FindSymbolsVisitor findSymbolsVisitor = new FindSymbolsVisitor();
                 scriptAst.Visit(findSymbolsVisitor);
-                return findSymbolsVisitor.SymbolReferences;
+                symbolReferences = findSymbolsVisitor.SymbolReferences;
             }
+
+            return symbolReferences;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
+++ b/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
@@ -3,6 +3,7 @@ using System.Management.Automation.Language;
 
 namespace Microsoft.PowerShell.EditorServices
 {
+#if PowerShellv5
     /// <summary>
     /// The visitor used to find all the symbols (function and class defs) in the AST. 
     /// </summary>
@@ -67,4 +68,5 @@ namespace Microsoft.PowerShell.EditorServices
             return AstVisitAction.Continue;
         }
     }
+#endif
 }

--- a/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
+++ b/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
 using System.Management.Automation.Language;
 
 namespace Microsoft.PowerShell.EditorServices
@@ -70,3 +75,4 @@ namespace Microsoft.PowerShell.EditorServices
     }
 #endif
 }
+

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -130,7 +130,15 @@ namespace Microsoft.PowerShell.EditorServices
             // TODO: Should this be configurable?
             this.SetExecutionPolicy(ExecutionPolicy.RemoteSigned);
 
-            PowerShellVersion = GetPowerShellVersion();
+            // Get the PowerShell runtime version
+            this.PowerShellVersion = GetPowerShellVersion();
+
+            // Write out the PowerShell version for tracking purposes
+            Logger.Write(
+                LogLevel.Normal,
+                string.Format(
+                    "PowerShell runtime version: {0}",
+                    this.PowerShellVersion));
 
 #if !PowerShellv3
             if (PowerShellVersion > new Version(3,0))

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -380,7 +380,7 @@ namespace Microsoft.PowerShell.EditorServices
         public Task<IEnumerable<object>> ExecuteScriptString(
             string scriptString)
         {
-            return this.ExecuteScriptString(scriptString, false);
+            return this.ExecuteScriptString(scriptString, false, true);
         }
 
         /// <summary>
@@ -388,10 +388,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="scriptString">The script string to execute.</param>
         /// <param name="writeInputToHost">If true, causes the script string to be written to the host.</param>
+        /// <param name="writeOutputToHost">If true, causes the script output to be written to the host.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
         public async Task<IEnumerable<object>> ExecuteScriptString(
             string scriptString,
-            bool writeInputToHost)
+            bool writeInputToHost,
+            bool writeOutputToHost)
         {
             if (writeInputToHost)
             {
@@ -404,7 +406,7 @@ namespace Microsoft.PowerShell.EditorServices
             PSCommand psCommand = new PSCommand();
             psCommand.AddScript(scriptString);
 
-            return await this.ExecuteCommand<object>(psCommand, true);
+            return await this.ExecuteCommand<object>(psCommand, writeOutputToHost);
         }
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test.Channel.WebSocket/Properties/AssemblyInfo.cs
+++ b/test/PowerShellEditorServices.Test.Channel.WebSocket/Properties/AssemblyInfo.cs
@@ -1,4 +1,9 @@
-﻿using System.Reflection;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,7 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PowerShellEditorServices.Channel.WebSocket.Test")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright �  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,3 +39,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/test/PowerShellEditorServices.Test.Channel.WebSocket/WebSocketChannelTest.cs
+++ b/test/PowerShellEditorServices.Test.Channel.WebSocket/WebSocketChannelTest.cs
@@ -1,4 +1,9 @@
-﻿using System;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
 using Microsoft.PowerShell.EditorServices.Protocol.Client;
@@ -63,3 +68,4 @@ namespace Microsoft.PowerShell.EditorServices.Test.Channel.WebSocket
         }
     }
 }
+

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -39,6 +39,18 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/test/PowerShellEditorServices.Test.Host/packages.config
+++ b/test/PowerShellEditorServices.Test.Host/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/PowerShellEditorServices.Test/Console/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/PowerShellContextTests.cs
@@ -107,9 +107,19 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     "\"{0}\"",
                     TestOutputString));
 
+            // Prompt strings are returned as normal output, ignore the prompt
+            string[] normalOutputLines =
+                this.GetOutputForType(OutputType.Normal)
+                    .Split(
+                        new string[] { Environment.NewLine },
+                        StringSplitOptions.None);
+
+            // The output should be 3 lines: the expected string,
+            // an empty line, and the prompt string.
+            Assert.Equal(3, normalOutputLines.Length);
             Assert.Equal(
-                TestOutputString + Environment.NewLine, 
-                this.GetOutputForType(OutputType.Normal));
+                TestOutputString,
+                normalOutputLines[0]);
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
@@ -1,4 +1,9 @@
-﻿using Microsoft.Win32;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -76,3 +81,4 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         }
     }
 }
+

--- a/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
@@ -16,7 +16,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [InlineData("5")]
         public void CompilesWithPowerShellVersion(string version)
         {
-            var assemblyPath = string.Format(@"..\..\..\..\packages\Microsoft.PowerShell.{0}.ReferenceAssemblies.1.0.0\lib\net4\System.Management.Automation.dll", version);
+            var assemblyPath = 
+                Path.GetFullPath(
+                    string.Format(
+                        @"..\..\..\..\packages\Microsoft.PowerShell.{0}.ReferenceAssemblies.1.0.0\lib\net4\System.Management.Automation.dll", 
+                        version));
+
             var projectPath = @"..\..\..\..\src\PowerShellEditorServices\PowerShellEditorServices.csproj";
             FileInfo fi = new FileInfo(projectPath);
             var projectVersion = Path.Combine(fi.DirectoryName, version + ".PowerShellEditorServices.csproj");


### PR DESCRIPTION
These changes vastly improve the current state of execution of commands in the REPL both while running inside and outside of the debugger.  The biggest change is that we now show the PowerShell prompt in the REPL output.  We also can now stream the results of commands run in the debugger console so that the user doesn't have to wait to see output until the command finishes.  Lastly, we now handle RuntimeExceptions correctly sending the error output to the host.