### PR TITLE
Rkeithhill/fix getvariables failed

### DIFF
--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -360,16 +360,19 @@ namespace Microsoft.PowerShell.EditorServices
                 new VariableContainerDetails(this.nextVariableId++, "Scope: " + scope);
             this.variables.Add(scopeVariableContainer);
 
-            var results = await this.powerShellContext.ExecuteCommand<PSVariable>(psCommand);
-            foreach (PSVariable psvariable in results)
+            var results = await this.powerShellContext.ExecuteCommand<PSVariable>(psCommand, sendErrorToHost: false);
+            if (results != null)
             {
-                var variableDetails = new VariableDetails(psvariable) { Id = this.nextVariableId++ };
-                this.variables.Add(variableDetails);
-                scopeVariableContainer.Children.Add(variableDetails.Name, variableDetails);
-
-                if ((autoVariables != null) && AddToAutoVariables(psvariable, scope))
+                foreach (PSVariable psvariable in results)
                 {
-                    autoVariables.Children.Add(variableDetails.Name, variableDetails);
+                    var variableDetails = new VariableDetails(psvariable) {Id = this.nextVariableId++};
+                    this.variables.Add(variableDetails);
+                    scopeVariableContainer.Children.Add(variableDetails.Name, variableDetails);
+
+                    if ((autoVariables != null) && AddToAutoVariables(psvariable, scope))
+                    {
+                        autoVariables.Children.Add(variableDetails.Name, variableDetails);
+                    }
                 }
             }
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -208,13 +208,17 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="sendOutputToHost">
         /// If true, causes any output written during command execution to be written to the host.
         /// </param>
+        /// <param name="sendErrorToHost">
+        /// If true, causes any errors encountered during command execution to be written to the host.
+        /// </param>
         /// <returns>
         /// An awaitable Task which will provide results once the command
         /// execution completes.
         /// </returns>
         public async Task<IEnumerable<TResult>> ExecuteCommand<TResult>(
             PSCommand psCommand,
-            bool sendOutputToHost = false)
+            bool sendOutputToHost = false,
+            bool sendErrorToHost = true)
         {
             RunspaceHandle runspaceHandle = null;
             IEnumerable<TResult> executionResult = null;
@@ -324,8 +328,11 @@ namespace Microsoft.PowerShell.EditorServices
                         LogLevel.Error,
                         "Runtime exception occurred while executing command:\r\n\r\n" + e.ToString());
 
-                    // Write the error to the host
-                    this.WriteExceptionToHost(e);
+                    if (sendErrorToHost)
+                    {
+                        // Write the error to the host
+                        this.WriteExceptionToHost(e);
+                    }
                 }
                 finally
                 {


### PR DESCRIPTION
Fix for Get-Variable -Scope doesn't always work. 

Ideally we should be using CallStackFrame.GetFrameVariables() but it currently seems to be broken.  We've been informed that using Get-Variable -Scope <num> isn't great because scope numbers and frames don't always line up.  For instance, dot source introducing a new stack frame but not a new scope.  But until GetFrameVariables is fixed in a future drop, we have no option but to use Get-Variable -Scope <num>.  This will result in stack frames that have no Auto or Local variables.  But the good news is that the debug host will no longer crash.  :-)

BTW this commit introduces a new optional parameter on PowerShellContext.ExecuteCommand().  While there is a parameter to suppress "output" there was no parameter to suppress "errors" from being written to the debug console.  I see no benefit in littering the user's debug console with a bunch of "get-variable : The scope number '#' exceeds the number of active scopes".  So there is now a "sendErrorToHost" parameter that defaults to true.  However, even when that parameter is set to false, the error info shows up in the DebugAdapter.log file.
