### PR TITLE
Remove Nito.AsyncEx dependency, add replacements

### DIFF
--- a/src/PowerShellEditorServices.Host.x86/PowerShellEditorServices.Host.x86.csproj
+++ b/src/PowerShellEditorServices.Host.x86/PowerShellEditorServices.Host.x86.csproj
@@ -37,18 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -71,7 +59,6 @@
     <None Include="..\PowerShellEditorServices.Host\App.config">
       <Link>App.config</Link>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\submodules\PSScriptAnalyzer\Engine\ScriptAnalyzerEngine.csproj">

--- a/src/PowerShellEditorServices.Host.x86/packages.config
+++ b/src/PowerShellEditorServices.Host.x86/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
-</packages>

--- a/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
+++ b/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
@@ -39,18 +39,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -69,7 +57,6 @@
     <Content Include="Microsoft.PowerShell.EditorServices.Host.DebugAdapter.cmd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\submodules\PSScriptAnalyzer\Engine\ScriptAnalyzerEngine.csproj">

--- a/src/PowerShellEditorServices.Host/packages.config
+++ b/src/PowerShellEditorServices.Host/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
-</packages>

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/NextRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/NextRequest.cs
@@ -4,8 +4,6 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
-using Nito.AsyncEx;
-using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/SetExceptionBreakpointsRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/SetExceptionBreakpointsRequest.cs
@@ -4,8 +4,6 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
-using Nito.AsyncEx;
-using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
@@ -6,7 +6,6 @@
 using Microsoft.PowerShell.EditorServices.Utility;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Nito.AsyncEx;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -38,18 +38,6 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
 using Microsoft.PowerShell.EditorServices.Protocol.Messages;
 using Microsoft.PowerShell.EditorServices.Utility;
-using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -780,7 +779,7 @@ function __Expand-Alias {
             if (!this.currentSettings.ScriptAnalysis.Enable.Value)
             {
                 // If the user has disabled script analysis, skip it entirely
-                return TaskConstants.Completed;
+                return Task.FromResult(true);
             }
 
             // If there's an existing task, attempt to cancel it
@@ -806,7 +805,9 @@ function __Expand-Alias {
                         "Exception while cancelling analysis task:\n\n{0}",
                         e.ToString()));
 
-                return TaskConstants.Canceled;
+                TaskCompletionSource<bool> cancelTask = new TaskCompletionSource<bool>();
+                cancelTask.SetCanceled();
+                return cancelTask.Task;
             }
 
             // Create a fresh cancellation token and then start the task.
@@ -826,7 +827,7 @@ function __Expand-Alias {
                 TaskCreationOptions.None,
                 TaskScheduler.Default);
 
-            return TaskConstants.Completed;
+            return Task.FromResult(true);
         }
 
         private static async Task DelayThenInvokeDiagnostics(

--- a/src/PowerShellEditorServices.Protocol/packages.config
+++ b/src/PowerShellEditorServices.Protocol/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -38,18 +38,6 @@
     <DocumentationFile>bin\Release\Microsoft.PowerShell.EditorServices.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation" />
@@ -109,7 +97,12 @@
     <Compile Include="Session\SessionPSHostRawUserInterface.cs" />
     <Compile Include="Session\SessionPSHostUserInterface.cs" />
     <Compile Include="Session\SessionStateChangedEventArgs.cs" />
+    <Compile Include="Utility\AsyncContextThread.cs" />
+    <Compile Include="Utility\AsyncLock.cs" />
+    <Compile Include="Utility\AsyncQueue.cs" />
+    <Compile Include="Utility\AsyncContext.cs" />
     <Compile Include="Utility\Logger.cs" />
+    <Compile Include="Utility\ThreadSynchronizationContext.cs" />
     <Compile Include="Utility\Validate.cs" />
     <Compile Include="Workspace\BufferRange.cs" />
     <Compile Include="Workspace\FileChange.cs" />
@@ -118,9 +111,6 @@
     <Compile Include="Workspace\ScriptFileMarker.cs" />
     <Compile Include="Workspace\ScriptRegion.cs" />
     <Compile Include="Workspace\Workspace.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\submodules\PSScriptAnalyzer\Engine\ScriptAnalyzerEngine.csproj">

--- a/src/PowerShellEditorServices/Utility/AsyncContext.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncContext.cs
@@ -1,0 +1,52 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Simplifies the setup of a SynchronizationContext for the use
+    /// of async calls in the current thread.
+    /// </summary>
+    public static class AsyncContext
+    {
+        /// <summary>
+        /// Starts a new ThreadSynchronizationContext, attaches it to
+        /// the thread, and then runs the given async main function.
+        /// </summary>
+        /// <param name="asyncMainFunc">
+        /// The Task-returning Func which represents the "main" function
+        /// for the thread.
+        /// </param>
+        public static void Start(Func<Task> asyncMainFunc)
+        {
+            // Is there already a synchronization context?
+            if (SynchronizationContext.Current != null)
+            {
+                throw new InvalidOperationException(
+                    "A SynchronizationContext is already assigned on this thread.");
+            }
+
+            // Create and register a synchronization context for this thread
+            var threadSyncContext = new ThreadSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(threadSyncContext);
+
+            // Get the main task and act on its completion
+            Task asyncMainTask = asyncMainFunc();
+            asyncMainTask.ContinueWith(
+                t => threadSyncContext.EndLoop(),
+                TaskScheduler.Default);
+
+            // Start the synchronization context's request loop and
+            // wait for the main task to complete
+            threadSyncContext.RunLoopOnCurrentThread();
+            asyncMainTask.GetAwaiter().GetResult();
+        }
+    }
+}
+

--- a/src/PowerShellEditorServices/Utility/AsyncContextThread.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncContextThread.cs
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides a simplified interface for creating a new thread
+    /// and establishing an AsyncContext in it.
+    /// </summary>
+    public class AsyncContextThread
+    {
+        #region Private Fields
+
+        private Task threadTask;
+        private string threadName;
+        private CancellationTokenSource threadCancellationToken =
+            new CancellationTokenSource();
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the AsyncContextThread class.
+        /// </summary>
+        /// <param name="threadName">
+        /// The name of the thread for debugging purposes.
+        /// </param>
+        public AsyncContextThread(string threadName)
+        {
+            this.threadName = threadName;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Runs a task on the AsyncContextThread.
+        /// </summary>
+        /// <param name="taskReturningFunc">
+        /// A Func which returns the task to be run on the thread.
+        /// </param>
+        /// <returns>
+        /// A Task which can be used to monitor the thread for completion.
+        /// </returns>
+        public Task Run(Func<Task> taskReturningFunc)
+        {
+            // Start up a long-running task with the action as the
+            // main entry point for the thread
+            this.threadTask =
+                Task.Factory.StartNew(
+                    () =>
+                    {
+                        // Set the thread's name to help with debugging
+                        Thread.CurrentThread.Name = "AsyncContextThread: " + this.threadName;
+
+                        // Set up an AsyncContext to run the task
+                        AsyncContext.Start(taskReturningFunc);
+                    },
+                    this.threadCancellationToken.Token,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+
+            return this.threadTask;
+        }
+
+        /// <summary>
+        /// Stops the thread task.
+        /// </summary>
+        public void Stop()
+        {
+            this.threadCancellationToken.Cancel();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Utility/AsyncLock.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncLock.cs
@@ -1,0 +1,103 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides a simple wrapper over a SemaphoreSlim to allow
+    /// synchronization locking inside of async calls.  Cannot be
+    /// used recursively.
+    /// </summary>
+    public class AsyncLock
+    {
+        #region Fields
+
+        private Task<IDisposable> lockReleaseTask;
+        private SemaphoreSlim lockSemaphore = new SemaphoreSlim(1, 1);
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the AsyncLock class.
+        /// </summary>
+        public AsyncLock()
+        {
+            this.lockReleaseTask =
+                Task.FromResult(
+                    (IDisposable)new LockReleaser(this));
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Locks
+        /// </summary>
+        /// <returns>A task which has an IDisposable</returns>
+        public Task<IDisposable> LockAsync()
+        {
+            return this.LockAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Obtains or waits for a lock which can be used to synchronize
+        /// access to a resource.  The wait may be cancelled with the
+        /// given CancellationToken.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A CancellationToken which can be used to cancel the lock.
+        /// </param>
+        /// <returns></returns>
+        public Task<IDisposable> LockAsync(CancellationToken cancellationToken)
+        {
+            Task waitTask = lockSemaphore.WaitAsync(cancellationToken);
+
+            return waitTask.IsCompleted ?
+                this.lockReleaseTask :
+                waitTask.ContinueWith(
+                    (t, releaser) =>
+                    {
+                        return (IDisposable)releaser;
+                    },
+                    this.lockReleaseTask.Result,
+                    cancellationToken,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+        }
+
+        #endregion
+
+        #region Private Classes
+
+        /// <summary>
+        /// Provides an IDisposable wrapper around an AsyncLock so
+        /// that it can easily be used inside of a 'using' block.
+        /// </summary>
+        private class LockReleaser : IDisposable
+        {
+            private AsyncLock lockToRelease;
+
+            internal LockReleaser(AsyncLock lockToRelease)
+            {
+                this.lockToRelease = lockToRelease;
+            }
+
+            public void Dispose()
+            {
+                this.lockToRelease.lockSemaphore.Release();
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Utility/AsyncQueue.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncQueue.cs
@@ -1,0 +1,149 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides a synchronized queue which can be used from within async
+    /// operations.  This is primarily used for producer/consumer scenarios.
+    /// </summary>
+    /// <typeparam name="T">The type of item contained in the queue.</typeparam>
+    public class AsyncQueue<T>
+    {
+        #region Private Fields
+
+        private AsyncLock queueLock = new AsyncLock();
+        private Queue<T> itemQueue;
+        private Queue<TaskCompletionSource<T>> requestQueue;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Returns true if the queue is currently empty.
+        /// </summary>
+        public bool IsEmpty { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes an empty instance of the AsyncQueue class.
+        /// </summary>
+        public AsyncQueue() : this(Enumerable.Empty<T>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the AsyncQueue class, pre-populated
+        /// with the given collection of items.
+        /// </summary>
+        /// <param name="initialItems">
+        /// An IEnumerable containing the initial items with which the queue will
+        /// be populated.
+        /// </param>
+        public AsyncQueue(IEnumerable<T> initialItems)
+        {
+            this.itemQueue = new Queue<T>(initialItems);
+            this.requestQueue = new Queue<TaskCompletionSource<T>>();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Enqueues an item onto the end of the queue.
+        /// </summary>
+        /// <param name="item">The item to be added to the queue.</param>
+        /// <returns>
+        /// A Task which can be awaited until the synchronized enqueue
+        /// operation completes.
+        /// </returns>
+        public async Task EnqueueAsync(T item)
+        {
+            using (await queueLock.LockAsync())
+            {
+                if (this.requestQueue.Count > 0)
+                {
+                    // There are requests waiting, immediately dispatch the item
+                    TaskCompletionSource<T> requestTaskSource = this.requestQueue.Dequeue();
+                    requestTaskSource.SetResult(item);
+                }
+                else
+                {
+                    // No requests waiting, queue the item for a later request
+                    this.itemQueue.Enqueue(item);
+                    this.IsEmpty = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Dequeues an item from the queue or waits asynchronously
+        /// until an item is available.
+        /// </summary>
+        /// <returns>
+        /// A Task which can be awaited until a value can be dequeued.
+        /// </returns>
+        public Task<T> DequeueAsync()
+        {
+            return this.DequeueAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Dequeues an item from the queue or waits asynchronously
+        /// until an item is available.  The wait can be cancelled
+        /// using the given CancellationToken.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A CancellationToken with which a dequeue wait can be cancelled.
+        /// </param>
+        /// <returns>
+        /// A Task which can be awaited until a value can be dequeued.
+        /// </returns>
+        public async Task<T> DequeueAsync(CancellationToken cancellationToken)
+        {
+            Task<T> requestTask;
+
+            using (await queueLock.LockAsync(cancellationToken))
+            {
+                if (this.itemQueue.Count > 0)
+                {
+                    // Items are waiting to be taken so take one immediately
+                    T item = this.itemQueue.Dequeue();
+                    this.IsEmpty = this.itemQueue.Count == 0;
+
+                    return item;
+                }
+                else
+                {
+                    // Queue the request for the next item
+                    var requestTaskSource = new TaskCompletionSource<T>();
+                    this.requestQueue.Enqueue(requestTaskSource);
+
+                    // Register the wait task for cancel notifications
+                    cancellationToken.Register(
+                        () => requestTaskSource.TrySetCanceled());
+
+                    requestTask = requestTaskSource.Task;
+                }
+            }
+
+            // Wait for the request task to complete outside of the lock
+            return await requestTask;
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Utility/ThreadSynchronizationContext.cs
+++ b/src/PowerShellEditorServices/Utility/ThreadSynchronizationContext.cs
@@ -1,0 +1,77 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides a SynchronizationContext implementation that can be used
+    /// in console applications or any thread which doesn't have its
+    /// own SynchronizationContext.
+    /// </summary>
+    public class ThreadSynchronizationContext : SynchronizationContext
+    {
+        #region Private Fields
+
+        private BlockingCollection<Tuple<SendOrPostCallback, object>> requestQueue =
+            new BlockingCollection<Tuple<SendOrPostCallback, object>>();
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Posts a request for execution to the SynchronizationContext.
+        /// This will be executed on the SynchronizationContext's thread.
+        /// </summary>
+        /// <param name="callback">
+        /// The callback to be invoked on the SynchronizationContext's thread.
+        /// </param>
+        /// <param name="state">
+        /// A state object to pass along to the callback when executed through
+        /// the SynchronizationContext.
+        /// </param>
+        public override void Post(SendOrPostCallback callback, object state)
+        {
+            // Add the request to the queue
+            this.requestQueue.Add(
+                new Tuple<SendOrPostCallback, object>(
+                    callback, state));
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Starts the SynchronizationContext message loop on the current thread.
+        /// </summary>
+        public void RunLoopOnCurrentThread()
+        {
+            Tuple<SendOrPostCallback, object> request;
+
+            while (this.requestQueue.TryTake(out request, Timeout.Infinite))
+            {
+                // Invoke the request's callback
+                request.Item1(request.Item2);
+            }
+        }
+
+        /// <summary>
+        /// Ends the SynchronizationContext message loop.
+        /// </summary>
+        public void EndLoop()
+        {
+            // Tell the blocking queue that we're done
+            this.requestQueue.CompleteAdding();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/packages.config
+++ b/src/PowerShellEditorServices/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
-</packages>

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -39,18 +39,6 @@
       <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
+++ b/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
@@ -1,6 +1,11 @@
-﻿using Microsoft.PowerShell.EditorServices.Protocol.Client;
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.Client;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
-using Nito.AsyncEx;
+using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
@@ -11,8 +16,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
     {
         protected ProtocolClient protocolClient;
 
-        private ConcurrentDictionary<string, AsyncProducerConsumerQueue<object>> eventQueuePerType =
-            new ConcurrentDictionary<string, AsyncProducerConsumerQueue<object>>();
+        private ConcurrentDictionary<string, AsyncQueue<object>> eventQueuePerType =
+            new ConcurrentDictionary<string, AsyncQueue<object>>();
 
         protected Task<TResult> SendRequest<TParams, TResult>(
             RequestType<TParams, TResult> requestType, 
@@ -37,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             var eventQueue =
                 this.eventQueuePerType.AddOrUpdate(
                     eventType.MethodName,
-                    new AsyncProducerConsumerQueue<object>(),
+                    new AsyncQueue<object>(),
                     (key, queue) => queue);
 
             this.protocolClient.SetEventHandler(
@@ -55,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Task<TParams> eventTask = null;
 
             // Use the event queue if one has been registered
-            AsyncProducerConsumerQueue<object> eventQueue = null;
+            AsyncQueue<object> eventQueue = null;
             if (this.eventQueuePerType.TryGetValue(eventType.MethodName, out eventQueue))
             {
                 eventTask =
@@ -101,3 +106,4 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         }
     }
 }
+

--- a/test/PowerShellEditorServices.Test.Host/packages.config
+++ b/test/PowerShellEditorServices.Test.Host/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Nito.AsyncEx;
+using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Linq;
 using System.Management.Automation;
@@ -22,10 +22,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         private PowerShellContext powerShellContext;
         private SynchronizationContext runnerContext;
 
-        private AsyncProducerConsumerQueue<DebuggerStopEventArgs> debuggerStoppedQueue =
-            new AsyncProducerConsumerQueue<DebuggerStopEventArgs>();
-        private AsyncProducerConsumerQueue<SessionStateChangedEventArgs> sessionStateQueue =
-            new AsyncProducerConsumerQueue<SessionStateChangedEventArgs>();
+        private AsyncQueue<DebuggerStopEventArgs> debuggerStoppedQueue =
+            new AsyncQueue<DebuggerStopEventArgs>();
+        private AsyncQueue<SessionStateChangedEventArgs> sessionStateQueue =
+            new AsyncQueue<SessionStateChangedEventArgs>();
 
         public DebugServiceTests()
         {
@@ -45,12 +45,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.runnerContext = SynchronizationContext.Current;
         }
 
-        void powerShellContext_SessionStateChanged(object sender, SessionStateChangedEventArgs e)
+        async void powerShellContext_SessionStateChanged(object sender, SessionStateChangedEventArgs e)
         {
             // Skip all transitions except those back to 'Ready'
             if (e.NewSessionState == PowerShellContextState.Ready)
             {
-                this.sessionStateQueue.Enqueue(e);
+                await this.sessionStateQueue.EnqueueAsync(e);
             }
         }
 
@@ -59,9 +59,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             // TODO: Needed?
         }
 
-        void debugService_DebuggerStopped(object sender, DebuggerStopEventArgs e)
+        async void debugService_DebuggerStopped(object sender, DebuggerStopEventArgs e)
         {
-            this.debuggerStoppedQueue.Enqueue(e);
+            await this.debuggerStoppedQueue.EnqueueAsync(e);
         }
 
         public void Dispose()

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -37,18 +37,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nito.AsyncEx, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Concurrent, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Concurrent.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nito.AsyncEx.Enlightenment, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Nito.AsyncEx.3.0.1\lib\net45\Nito.AsyncEx.Enlightenment.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation" />
@@ -83,6 +71,8 @@
     <Compile Include="Console\ConsoleServiceTests.cs" />
     <Compile Include="Console\ChoicePromptHandlerTests.cs" />
     <Compile Include="Session\ScriptFileTests.cs" />
+    <Compile Include="Utility\AsyncLockTests.cs" />
+    <Compile Include="Utility\AsyncQueueTests.cs" />
     <Compile Include="Utility\LoggerTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Nito.AsyncEx;
+using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
     public class PowerShellContextTests : IDisposable
     {
         private PowerShellContext powerShellContext;
-        private AsyncProducerConsumerQueue<SessionStateChangedEventArgs> stateChangeQueue;
+        private AsyncQueue<SessionStateChangedEventArgs> stateChangeQueue;
 
         private const string DebugTestFilePath =
             @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1";
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             this.powerShellContext = new PowerShellContext();
             this.powerShellContext.SessionStateChanged += OnSessionStateChanged;
-            this.stateChangeQueue = new AsyncProducerConsumerQueue<SessionStateChangedEventArgs>();
+            this.stateChangeQueue = new AsyncQueue<SessionStateChangedEventArgs>();
         }
 
         public void Dispose()
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         private void OnSessionStateChanged(object sender, SessionStateChangedEventArgs e)
         {
-            this.stateChangeQueue.Enqueue(e);
+            this.stateChangeQueue.EnqueueAsync(e).Wait();
         }
 
         #endregion

--- a/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Utility
+{
+    public class AsyncLockTests
+    {
+        [Fact]
+        public async Task AsyncLockSynchronizesAccess()
+        {
+            AsyncLock asyncLock = new AsyncLock();
+
+            Task<IDisposable> lockOne = asyncLock.LockAsync();
+            Task<IDisposable> lockTwo = asyncLock.LockAsync();
+
+            Assert.Equal(TaskStatus.RanToCompletion, lockOne.Status);
+            Assert.Equal(TaskStatus.WaitingForActivation, lockTwo.Status);
+            lockOne.Result.Dispose();
+
+            await lockTwo;
+            Assert.Equal(TaskStatus.RanToCompletion, lockTwo.Status);
+        }
+
+        [Fact]
+        public void AsyncLockCancelsWhenRequested()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            AsyncLock asyncLock = new AsyncLock();
+
+            Task<IDisposable> lockOne = asyncLock.LockAsync();
+            Task<IDisposable> lockTwo = asyncLock.LockAsync(cts.Token);
+
+            // Cancel the second lock before the first is released
+            cts.Cancel();
+            lockOne.Result.Dispose();
+
+            Assert.Equal(TaskStatus.RanToCompletion, lockOne.Status);
+            Assert.Equal(TaskStatus.Canceled, lockTwo.Status);
+        }
+    }
+}
+

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Utility
+{
+    public class AsyncQueueTests
+    {
+        [Fact]
+        public async Task AsyncQueueSynchronizesAccess()
+        {
+            ConcurrentBag<int> outputItems = new ConcurrentBag<int>();
+            AsyncQueue<int> inputQueue = new AsyncQueue<int>(Enumerable.Range(0, 100));
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+            try
+            {
+                // Start 5 consumers
+                await Task.WhenAll(
+                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(
+                        async () =>
+                        {
+                            // Wait for a bit and then add more items to the queue
+                            await Task.Delay(250);
+
+                            foreach (var i in Enumerable.Range(100, 200))
+                            {
+                                await inputQueue.EnqueueAsync(i);
+                            }
+
+                            // Cancel the waiters
+                            cancellationTokenSource.Cancel();
+                        }));
+            }
+            catch (TaskCanceledException)
+            {
+                // Do nothing, this is expected.
+            }
+
+            // At this point, numbers 0 through 299 should be in the outputItems
+            IEnumerable<int> expectedItems = Enumerable.Range(0, 300);
+            Assert.Equal(0, expectedItems.Except(outputItems).Count());
+        }
+
+        private async Task ConsumeItems(
+            AsyncQueue<int> inputQueue,
+            ConcurrentBag<int> outputItems,
+            CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                int consumedItem = await inputQueue.DequeueAsync(cancellationToken);
+                outputItems.Add(consumedItem);
+            }
+        }
+    }
+}
+

--- a/test/PowerShellEditorServices.Test/packages.config
+++ b/test/PowerShellEditorServices.Test/packages.config
@@ -3,7 +3,6 @@
   <package id="Microsoft.PowerShell.3.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.PowerShell.4.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.0.0" targetFramework="net45" />
-  <package id="Nito.AsyncEx" version="3.0.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
This change removes all uses of the Nito.AsyncEx NuGet package from the
solution.  This change was made to remove the use of this third-party
dependency so that consumers don't need to get extra open-source approval
when using PowerShell Editor Services.

Removing this dependency required the creation of our own custom
implementations of the classes we were using from Nito.AsyncEx.  These new
classes were written from scratch.

Resolves #115