### PR TITLE
Implementation for issue #98 - shorting file path completion list.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -994,10 +994,10 @@ function __Expand-Alias {
                 // Look for type encoded in the tooltip for parameters and variables.
                 // Display PowerShell type names in [] to be consistent with PowerShell syntax
                 // and now the debugger displays type names.
-                var matches = Regex.Matches(completionDetails.ToolTipText, @"^\[(.+)\]");
+                var matches = Regex.Matches(completionDetails.ToolTipText, @"^(\[.+\])");
                 if ((matches.Count > 0) && (matches[0].Groups.Count > 1))
                 {
-                    detailString = "[" + matches[0].Groups[1].Value + "]";
+                    detailString = matches[0].Groups[1].Value;
                 }
 
                 // PowerShell returns ListItemText for parameters & variables that is not prefixed

--- a/src/PowerShellEditorServices/Language/CompletionResults.cs
+++ b/src/PowerShellEditorServices/Language/CompletionResults.cs
@@ -108,6 +108,11 @@ namespace Microsoft.PowerShell.EditorServices
         ParameterValue,
 
         /// <summary>
+        /// Identifies a completion for a .NET property.
+        /// </summary>
+        Property,
+
+        /// <summary>
         /// Identifies a completion for a variable name.
         /// </summary>
         Variable,
@@ -148,6 +153,11 @@ namespace Microsoft.PowerShell.EditorServices
         public string CompletionText { get; private set; }
 
         /// <summary>
+        /// Gets the text that should be dispayed in a drop-down completion list.
+        /// </summary>
+        public string ListItemText { get; private set; }
+
+        /// <summary>
         /// Gets the text that can be used to display a tooltip for
         /// the statement at the requested file offset.
         /// </summary>
@@ -183,6 +193,7 @@ namespace Microsoft.PowerShell.EditorServices
             return new CompletionDetails
             {
                 CompletionText = completionResult.CompletionText,
+                ListItemText = completionResult.ListItemText,
                 ToolTipText = toolTipText,
                 SymbolTypeName = ExtractSymbolTypeNameFromToolTip(completionResult.ToolTip),
                 CompletionType = 
@@ -195,12 +206,14 @@ namespace Microsoft.PowerShell.EditorServices
             string completionText,
             CompletionType completionType,
             string toolTipText = null,
-            string symbolTypeName = null)
+            string symbolTypeName = null,
+            string listItemText = null)
         {
             return new CompletionDetails
             {
                 CompletionText = completionText,
                 CompletionType = completionType,
+                ListItemText = listItemText,
                 ToolTipText = toolTipText,
                 SymbolTypeName = symbolTypeName
             };
@@ -238,9 +251,10 @@ namespace Microsoft.PowerShell.EditorServices
         {
             return
                 string.Format(
-                    "{0}{1}{2}{3}",
+                    "{0}{1}{2}{3}{4}",
                     this.CompletionText,
                     this.CompletionType,
+                    this.ListItemText,
                     this.ToolTipText,
                     this.SymbolTypeName).GetHashCode();
         }
@@ -265,6 +279,9 @@ namespace Microsoft.PowerShell.EditorServices
 
                 case CompletionResultType.ParameterValue:
                     return CompletionType.ParameterValue;
+
+                case CompletionResultType.Property:
+                    return CompletionType.Property;
 
                 case CompletionResultType.Variable:
                     return CompletionType.Variable;

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                         c => c.Label == "$ConsoleFileName");
 
             Assert.NotNull(consoleFileNameItem);
-            Assert.Equal("string", consoleFileNameItem.Detail);
+            Assert.Equal("[string]", consoleFileNameItem.Detail);
         }
 
         [Fact(Skip = "Skipped until variable documentation gathering is added back.")]


### PR DESCRIPTION
This commit not only addresses issue #98 but also improves completion list support overall for commands (shows resolved command or path to exe), parameters (shows parameter type) as well as .NET properties and methods (shows signature).