### PR TITLE
Fix for issue #123, wildcard chars in script path prevent breakpoints…

### DIFF
--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -57,6 +57,16 @@ namespace Microsoft.PowerShell.EditorServices
         #region Public Methods
 
         /// <summary>
+        /// Returns the passed in path with the [ and ] wildcard characters escaped.
+        /// </summary>
+        /// <param name="path">The path to process.</param>
+        /// <returns>The path with [ and ] escaped.</returns>
+        public static string EscapeWilcardsInPath(string path)
+        {
+            return path.Replace("[", "`[").Replace("]", "`]");
+        }
+
+        /// <summary>
         /// Sets the list of breakpoints for the current debugging session.
         /// </summary>
         /// <param name="scriptFile">The ScriptFile in which breakpoints will be set.</param>
@@ -77,9 +87,13 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (lineNumbers.Length > 0)
             {
+                // Fix for issue #123 - file paths that contain wildcard chars [ and ] need to
+                // quoted and have those wildcard chars escaped.
+                string escapedScriptPath = EscapeWilcardsInPath(scriptFile.FilePath);
+
                 PSCommand psCommand = new PSCommand();
                 psCommand.AddCommand("Set-PSBreakpoint");
-                psCommand.AddParameter("Script", scriptFile.FilePath);
+                psCommand.AddParameter("Script", escapedScriptPath);
                 psCommand.AddParameter("Line", lineNumbers.Length > 0 ? lineNumbers : null);
 
                 resultBreakpoints =

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -57,16 +57,6 @@ namespace Microsoft.PowerShell.EditorServices
         #region Public Methods
 
         /// <summary>
-        /// Returns the passed in path with the [ and ] wildcard characters escaped.
-        /// </summary>
-        /// <param name="path">The path to process.</param>
-        /// <returns>The path with [ and ] escaped.</returns>
-        public static string EscapeWilcardsInPath(string path)
-        {
-            return path.Replace("[", "`[").Replace("]", "`]");
-        }
-
-        /// <summary>
         /// Sets the list of breakpoints for the current debugging session.
         /// </summary>
         /// <param name="scriptFile">The ScriptFile in which breakpoints will be set.</param>
@@ -89,7 +79,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 // Fix for issue #123 - file paths that contain wildcard chars [ and ] need to
                 // quoted and have those wildcard chars escaped.
-                string escapedScriptPath = EscapeWilcardsInPath(scriptFile.FilePath);
+                string escapedScriptPath = PowerShellContext.EscapeWildcardsInPath(scriptFile.FilePath);
 
                 PSCommand psCommand = new PSCommand();
                 psCommand.AddCommand("Set-PSBreakpoint");

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -435,8 +435,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A Task that can be awaited for completion.</returns>
         public async Task ExecuteScriptAtPath(string scriptPath)
         {
+            // If we don't escape wildcard characters in the script path, the script can
+            // fail to execute if say the script name was foo][.ps1.
+            // Related to issue #123.
+            string escapedScriptPath = DebugService.EscapeWilcardsInPath(scriptPath);
+
             PSCommand command = new PSCommand();
-            command.AddCommand(scriptPath);
+            command.AddCommand(escapedScriptPath);
 
             await this.ExecuteCommand<object>(command, true);
         }

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PowerShell.EditorServices
             // If we don't escape wildcard characters in the script path, the script can
             // fail to execute if say the script name was foo][.ps1.
             // Related to issue #123.
-            string escapedScriptPath = DebugService.EscapeWilcardsInPath(scriptPath);
+            string escapedScriptPath = EscapeWildcardsInPath(scriptPath);
 
             PSCommand command = new PSCommand();
             command.AddCommand(escapedScriptPath);
@@ -550,6 +550,16 @@ namespace Microsoft.PowerShell.EditorServices
                     LogLevel.Error,
                     "The PowerShellContext.runspaceWaitQueue has more than one item");
             }
+        }
+
+        /// <summary>
+        /// Returns the passed in path with the [ and ] wildcard characters escaped.
+        /// </summary>
+        /// <param name="path">The path to process.</param>
+        /// <returns>The path with [ and ] escaped.</returns>
+        internal static string EscapeWildcardsInPath(string path)
+        {
+            return path.Replace("[", "`[").Replace("]", "`]");
         }
 
         #endregion


### PR DESCRIPTION
… from working.

Once I got breakpoints to be able to set for files like foo[1].ps1 and foo][.ps1 I noticed that the script named foo][.ps1 would not execute at all!! You get an error saying something like the specified wildcard character pattern is not valid.  FWIW ISE fails with this same message.  So PSES has one up on ISE.  :-)