### PR TITLE
Add intervallic buffering of OutputEvent messages

### DIFF
--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LanguageServer\References.cs" />
     <Compile Include="Server\LanguageServerSettings.cs" />
+    <Compile Include="Server\OutputDebouncer.cs" />
     <Compile Include="Server\PromptHandlers.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/PowerShellEditorServices.Protocol/Properties/AssemblyInfo.cs
+++ b/src/PowerShellEditorServices.Protocol/Properties/AssemblyInfo.cs
@@ -41,3 +41,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.0.0.0")]
 [assembly: AssemblyInformationalVersion("0.0.0.0")]
 
+[assembly: InternalsVisibleTo("Microsoft.PowerShell.EditorServices.Test.Protocol")]

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -6,7 +6,6 @@
 using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
-using Microsoft.PowerShell.EditorServices.Protocol.Server;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
@@ -19,6 +18,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     public class DebugAdapter : DebugAdapterBase
     {
         private EditorSession editorSession;
+        private OutputDebouncer outputDebouncer;
 
         public DebugAdapter() : this(new StdioServerChannel())
         {
@@ -30,6 +30,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.editorSession.StartSession();
             this.editorSession.DebugService.DebuggerStopped += this.DebugService_DebuggerStopped;
             this.editorSession.ConsoleService.OutputWritten += this.powerShellContext_OutputWritten;
+
+            // Set up the output debouncer to throttle output event writes
+            this.outputDebouncer = new OutputDebouncer(this);
         }
 
         protected override void Initialize()
@@ -59,6 +62,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         protected override void Shutdown()
         {
+            // Make sure remaining output is flushed before exiting
+            this.outputDebouncer.Flush().Wait();
+
             Logger.Write(LogLevel.Normal, "Debug adapter is shutting down...");
 
             if (this.editorSession != null)
@@ -359,6 +365,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         async void DebugService_DebuggerStopped(object sender, DebuggerStopEventArgs e)
         {
+            // Flush pending output before sending the event
+            await this.outputDebouncer.Flush();
+
             await this.SendEvent(
                 StoppedEvent.Type,
                 new StoppedEventBody
@@ -376,13 +385,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         async void powerShellContext_OutputWritten(object sender, OutputWrittenEventArgs e)
         {
-            await this.SendEvent(
-                OutputEvent.Type,
-                new OutputEventBody
-                {
-                    Output = e.OutputText + (e.IncludeNewLine ? "\r\n" : string.Empty),
-                    Category = (e.OutputType == OutputType.Error) ? "stderr" : "stdout"
-                });
+            // Queue the output for writing
+            await this.outputDebouncer.Invoke(e);
         }
 
         #endregion

--- a/src/PowerShellEditorServices.Protocol/Server/OutputDebouncer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/OutputDebouncer.cs
@@ -1,0 +1,102 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.Server
+{
+    /// <summary>
+    /// Throttles output written via OutputEvents by batching all output
+    /// written within a short time window and writing it all out at once.
+    /// </summary>
+    internal class OutputDebouncer : AsyncDebouncer<OutputWrittenEventArgs>
+    {
+        #region Private Fields
+
+        private IMessageSender messageSender;
+        private bool currentOutputIsError = false;
+        private string currentOutputString = null;
+
+        #endregion
+
+        #region Constants
+
+        // Set a really short window for output flushes.  This
+        // gives the appearance of fast output without the crushing
+        // overhead of sending an OutputEvent for every single line
+        // written.  At this point it seems that around 10-20 lines get
+        // batched for each flush when Get-Process is called.
+        public const int OutputFlushInterval = 200;
+
+        #endregion
+
+        #region Constructors
+
+        public OutputDebouncer(IMessageSender messageSender)
+            : base(OutputFlushInterval, false)
+        {
+            this.messageSender = messageSender;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        protected override async Task OnInvoke(OutputWrittenEventArgs output)
+        {
+            bool outputIsError = output.OutputType == OutputType.Error;
+
+            if (this.currentOutputIsError != outputIsError)
+            {
+                if (this.currentOutputString != null)
+                {
+                    // Flush the output
+                    await this.OnFlush();
+                }
+
+                this.currentOutputString = string.Empty;
+                this.currentOutputIsError = outputIsError;
+            }
+
+            // Output string could be null if the last output was already flushed
+            if (this.currentOutputString == null)
+            {
+                this.currentOutputString = string.Empty;
+            }
+
+            // Add to string (and include newline)
+            this.currentOutputString +=
+                output.OutputText +
+                (output.IncludeNewLine ? 
+                    System.Environment.NewLine :
+                    string.Empty);
+        }
+
+        protected override async Task OnFlush()
+        {
+            // Only flush output if there is some to flush
+            if (this.currentOutputString != null)
+            {
+                // Send an event for the current output
+                await this.messageSender.SendEvent(
+                    OutputEvent.Type,
+                    new OutputEventBody
+                    {
+                        Output = this.currentOutputString,
+                        Category = (this.currentOutputIsError) ? "stderr" : "stdout"
+                    });
+
+                // Clear the output string for the next batch
+                this.currentOutputString = null;
+            }
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Session\SessionPSHostUserInterface.cs" />
     <Compile Include="Session\SessionStateChangedEventArgs.cs" />
     <Compile Include="Utility\AsyncContextThread.cs" />
+    <Compile Include="Utility\AsyncDebouncer.cs" />
     <Compile Include="Utility\AsyncLock.cs" />
     <Compile Include="Utility\AsyncQueue.cs" />
     <Compile Include="Utility\AsyncContext.cs" />

--- a/src/PowerShellEditorServices/Utility/AsyncDebouncer.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncDebouncer.cs
@@ -1,0 +1,169 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Restricts the invocation of an operation to a specified time
+    /// interval.  Can also cause previous requests to be cancelled
+    /// by new requests within that time window.  Typically used for
+    /// buffering information for an operation or ensuring that an
+    /// operation only runs after some interval.
+    /// </summary>
+    /// <typeparam name="TInvokeArgs">The argument type for the Invoke method.</typeparam>
+    public abstract class AsyncDebouncer<TInvokeArgs>
+    {
+        #region Private Fields
+
+        private int flushInterval;
+        private bool restartOnInvoke;
+
+        private Task currentTimerTask;
+        private CancellationTokenSource timerCancellationSource;
+
+        private AsyncLock asyncLock = new AsyncLock();
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Creates a new instance of the AsyncDebouncer class with the
+        /// specified flush interval.  If restartOnInvoke is true, any
+        /// calls to Invoke will cancel previous calls which have not yet
+        /// passed the flush interval.
+        /// </summary>
+        /// <param name="flushInterval">
+        /// A millisecond interval to use for flushing prior Invoke calls.
+        /// </param>
+        /// <param name="restartOnInvoke">
+        /// If true, Invoke calls will reset prior calls which haven't passed the flush interval.
+        /// </param>
+        public AsyncDebouncer(int flushInterval, bool restartOnInvoke)
+        {
+            this.flushInterval = flushInterval;
+            this.restartOnInvoke = restartOnInvoke;
+        }
+
+        /// <summary>
+        /// Invokes the debouncer with the given input.  The debouncer will
+        /// wait for the specified interval before calling the Flush method
+        /// to complete the operation.
+        /// </summary>
+        /// <param name="invokeArgument">
+        /// The argument for this implementation's Invoke method.
+        /// </param>
+        /// <returns>A Task to be awaited until the Invoke is queued.</returns>
+        public async Task Invoke(TInvokeArgs invokeArgument)
+        {
+            using (await this.asyncLock.LockAsync())
+            {
+                // Invoke the implementor
+                await this.OnInvoke(invokeArgument);
+
+                // If there's no timer, start one
+                if (this.currentTimerTask == null)
+                {
+                    this.StartTimer();
+                }
+                else if (this.currentTimerTask != null && this.restartOnInvoke)
+                {
+                    // Restart the existing timer
+                    if (this.CancelTimer())
+                    {
+                        this.StartTimer();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Flushes the latest state regardless of the current interval.
+        /// An AsyncDebouncer MUST NOT invoke its own Flush method otherwise
+        /// deadlocks could occur.
+        /// </summary>
+        /// <returns>A Task to be awaited until Flush completes.</returns>
+        public async Task Flush()
+        {
+            using (await this.asyncLock.LockAsync())
+            {
+                // Cancel the current timer
+                this.CancelTimer();
+
+                // Flush the current output
+                await this.OnFlush();
+            }
+        }
+
+        #endregion
+
+        #region Abstract Methods
+
+        /// <summary>
+        /// Implemented by the subclass to take the argument for the
+        /// future operation that will be performed by OnFlush.
+        /// </summary>
+        /// <param name="invokeArgument">
+        /// The argument for this implementation's OnInvoke method.
+        /// </param>
+        /// <returns>A Task to be awaited for the invoke to complete.</returns>
+        protected abstract Task OnInvoke(TInvokeArgs invokeArgument);
+
+        /// <summary>
+        /// Implemented by the subclass to complete the current operation.
+        /// </summary>
+        /// <returns>A Task to be awaited for the operation to complete.</returns>
+        protected abstract Task OnFlush();
+
+        #endregion
+
+        #region Private Methods
+
+        private void StartTimer()
+        {
+            this.timerCancellationSource = new CancellationTokenSource();
+
+            this.currentTimerTask =
+                Task.Delay(this.flushInterval, this.timerCancellationSource.Token)
+                    .ContinueWith(
+                        t =>
+                        {
+                            if (!t.IsCanceled)
+                            {
+                                return this.Flush();
+                            }
+                            else
+                            {
+                                return Task.FromResult(true);
+                            }
+                        });
+        }
+
+        private bool CancelTimer()
+        {
+            if (this.timerCancellationSource != null)
+            {
+                // Attempt to cancel the timer task
+                this.timerCancellationSource.Cancel();
+            }
+
+            // Was the task cancelled?
+            bool wasCancelled = 
+                this.currentTimerTask == null || 
+                this.currentTimerTask.IsCanceled;
+
+            // Clear the current task so that another may be created
+            this.currentTimerTask = null;
+
+            return wasCancelled;
+        }
+
+        #endregion
+    }
+}
+

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -36,7 +36,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     new StdioClientChannel(
                         "Microsoft.PowerShell.EditorServices.Host.exe",
                         "/debugAdapter",
-                        "/logPath:\"" + testLogPath + "\""));
+                        "/logPath:\"" + testLogPath + "\"",
+                        "/logLevel:Verbose"));
 
             return this.debugAdapterClient.Start();
         }
@@ -85,13 +86,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         [Fact]
         public async Task DebugAdapterReceivesOutputEvents()
         {
-            Task<OutputEventBody> outputEventTask = this.WaitForEvent(OutputEvent.Type);
+            OutputReader outputReader = new OutputReader(this.debugAdapterClient);
+
             await this.LaunchScript(DebugScriptPath);
 
-            // Wait for an output event
-            OutputEventBody outputDetails = await outputEventTask;
-            Assert.Equal("Output 1", outputDetails.Output);
-            Assert.Equal("stdout", outputDetails.Category);
+            // Make sure we're getting output from the script
+            Assert.Equal("Output 1", await outputReader.ReadLine());
 
             // Abort script execution
             Task terminatedEvent = this.WaitForEvent(TerminatedEvent.Type);

--- a/test/PowerShellEditorServices.Test.Host/OutputReader.cs
+++ b/test/PowerShellEditorServices.Test.Host/OutputReader.cs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Host
+{
+    internal class OutputReader
+    {
+        private AsyncQueue<OutputEventBody> outputQueue = new AsyncQueue<OutputEventBody>();
+
+        private string currentOutputCategory;
+        private Queue<string> bufferedOutput = new Queue<string>();
+
+        public OutputReader(ProtocolEndpoint protocolClient)
+        {
+            protocolClient.SetEventHandler(
+                OutputEvent.Type,
+                this.OnOutputEvent);
+        }
+
+        public async Task<string> ReadLine(string expectedOutputCategory = "stdout")
+        {
+            if (this.bufferedOutput.Count > 0)
+            {
+                Assert.Equal(expectedOutputCategory, this.currentOutputCategory);
+
+                return this.bufferedOutput.Dequeue();
+            }
+
+            // Execution reaches this point if a buffered line wasn't available
+            OutputEventBody nextOutputEvent = await this.outputQueue.DequeueAsync();
+
+            Assert.Equal(expectedOutputCategory, nextOutputEvent.Category);
+            this.currentOutputCategory = nextOutputEvent.Category;
+
+            string[] outputLines = 
+                nextOutputEvent.Output.Split(
+                    new string[] { "\n", "\r\n" },
+                    StringSplitOptions.None);
+
+            // Buffer remaining lines
+            if (outputLines.Length > 1)
+            {
+                for (int i = 1; i < outputLines.Length; i++)
+                {
+                    this.bufferedOutput.Enqueue(outputLines[i]);
+                }
+            }
+
+            return outputLines[0];
+        }
+
+        public async Task<string[]> ReadLines(int lineCount, string expectedOutputCategory = "stdout")
+        {
+            List<string> outputLines = new List<string>();
+
+            for (int i = 0; i < lineCount; i++)
+            {
+                outputLines.Add(
+                    await this.ReadLine(
+                        expectedOutputCategory));
+            }
+
+            return outputLines.ToArray();
+        }
+
+        private async Task OnOutputEvent(OutputEventBody outputEvent, EventContext context)
+        {
+            await this.outputQueue.EnqueueAsync(outputEvent);
+        }
+    }
+}
+

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="AttachHelper.cs" />
     <Compile Include="DebugAdapterTests.cs" />
+    <Compile Include="OutputReader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LanguageServerTests.cs" />
     <Compile Include="ServerTestsBase.cs" />

--- a/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
+++ b/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Message\MessageReaderWriterTests.cs" />
     <Compile Include="Message\TestMessageTypes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Server\OutputDebouncerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
+++ b/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
@@ -1,0 +1,125 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Protocol.Server;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
+{
+    public class OutputDebouncerTests
+    {
+        [Fact]
+        public async Task OutputDebouncerAggregatesOutputEvents()
+        {
+            TestMessageSender messageSender = new TestMessageSender();
+            OutputDebouncer debouncer = new OutputDebouncer(messageSender);
+
+            await SendOutput(debouncer, "This ");
+            await SendOutput(debouncer, "is a ");
+            await SendOutput(debouncer, "test", true);
+            await SendOutput(debouncer, "Another line");
+
+            // Make sure no output events have been written yet
+            Assert.Empty(messageSender.OutputEvents);
+
+            // Wait for the output to be flushed
+            await Task.Delay(OutputDebouncer.OutputFlushInterval + 100);
+
+            // Write some more output after the first flush
+            await SendOutput(debouncer, "Another test line", true);
+            await SendOutput(debouncer, "for great justice");
+
+            // Assert that there's only one event with the expected string
+            Assert.Equal(1, messageSender.OutputEvents.Count);
+            Assert.Equal(
+                "This is a test\r\nAnother line",
+                messageSender.OutputEvents[0].Output);
+
+            // Wait for the next output to be flushed
+            await Task.Delay(OutputDebouncer.OutputFlushInterval + 100);
+
+            // Assert that there's only one event with the expected string
+            Assert.Equal(2, messageSender.OutputEvents.Count);
+            Assert.Equal(
+                "Another test line\r\nfor great justice",
+                messageSender.OutputEvents[1].Output);
+        }
+
+        [Fact]
+        public async Task OutputDebouncerDoesNotDuplicateOutput()
+        {
+            TestMessageSender messageSender = new TestMessageSender();
+            OutputDebouncer debouncer = new OutputDebouncer(messageSender);
+
+            // Send many messages in quick succession to ensure that
+            // output is not being duplicated in subsequent events.
+            for (int i = 1; i <= 50; i++)
+            {
+                await SendOutput(debouncer, "Output " + i, true);
+
+                if (i == 25)
+                {
+                    // Artificially insert a delay to force another event
+                    await Task.Delay(OutputDebouncer.OutputFlushInterval + 100);
+                }
+            }
+
+            // Wait for the final event to be written
+            await Task.Delay(OutputDebouncer.OutputFlushInterval + 100);
+
+            // Ensure that the two events start with the correct lines
+            Assert.Equal(2, messageSender.OutputEvents.Count);
+            Assert.Equal("Output 1", messageSender.OutputEvents[0].Output.Split('\r')[0]);
+            Assert.Equal("Output 26", messageSender.OutputEvents[1].Output.Split('\r')[0]);
+        }
+
+        private static Task SendOutput(
+            OutputDebouncer debouncer,
+            string outputText,
+            bool includeNewLine = false)
+        {
+            return debouncer.Invoke(
+                new OutputWrittenEventArgs(
+                    outputText,
+                    includeNewLine,
+                    OutputType.Normal,
+                    ConsoleColor.White,
+                    ConsoleColor.Black));
+        }
+    }
+
+    internal class TestMessageSender : IMessageSender
+    {
+        public List<OutputEventBody> OutputEvents { get; } = new List<OutputEventBody>();
+
+        public Task SendEvent<TParams>(
+            EventType<TParams> eventType,
+            TParams eventParams)
+        {
+            OutputEventBody outputEvent = eventParams as OutputEventBody;
+
+            if (outputEvent != null)
+            {
+                this.OutputEvents.Add(outputEvent);
+            }
+
+            return Task.FromResult(true);
+        }
+
+        public Task<TResult> SendRequest<TParams, TResult>(
+            RequestType<TParams, TResult> requestType,
+            TParams requestParams, bool waitForResponse)
+        {
+            // Legitimately not implemented for these tests.
+            throw new NotImplementedException();
+        }
+    }
+}
+

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Console\ConsoleServiceTests.cs" />
     <Compile Include="Console\ChoicePromptHandlerTests.cs" />
     <Compile Include="Session\ScriptFileTests.cs" />
+    <Compile Include="Utility\AsyncDebouncerTests.cs" />
     <Compile Include="Utility\AsyncLockTests.cs" />
     <Compile Include="Utility\AsyncQueueTests.cs" />
     <Compile Include="Utility\LoggerTests.cs" />

--- a/test/PowerShellEditorServices.Test/Utility/AsyncDebouncerTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncDebouncerTests.cs
@@ -1,0 +1,138 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Utility
+{
+    public class AsyncDebouncerTests
+    {
+        [Fact]
+        public async Task AsyncDebouncerFlushesAfterInterval()
+        {
+            TestAsyncDebouncer debouncer = new TestAsyncDebouncer();
+
+            await debouncer.Invoke(1);
+            await debouncer.Invoke(2);
+            await debouncer.Invoke(3);
+            await Task.Delay(TestAsyncDebouncer.Interval + 100);
+
+            // Add a few more items to ensure they are added after the initial interval
+            await debouncer.Invoke(4);
+            await debouncer.Invoke(5);
+            await debouncer.Invoke(6);
+
+            Assert.Equal(new List<int> { 1, 2, 3 }, debouncer.FlushedBuffer);
+            Assert.True(
+                debouncer.TimeToFlush > 
+                TimeSpan.FromMilliseconds(TestAsyncDebouncer.Interval),
+                "Debouncer flushed before interval lapsed.");
+
+            // Check for the later items to see if they've been flushed
+            await Task.Delay(TestAsyncDebouncer.Interval + 100);
+            Assert.Equal(new List<int> { 4, 5, 6 }, debouncer.FlushedBuffer);
+        }
+
+        [Fact]
+        public async Task AsyncDebouncerRestartsAfterInvoke()
+        {
+            TestAsyncRestartDebouncer debouncer = new TestAsyncRestartDebouncer();
+
+            // Invoke the debouncer and wait a bit between each
+            // invoke to make sure the debouncer isn't flushed
+            // until after the last invoke.
+            await debouncer.Invoke(1);
+            await Task.Delay(TestAsyncRestartDebouncer.Interval - 100);
+            await debouncer.Invoke(2);
+            await Task.Delay(TestAsyncRestartDebouncer.Interval - 100);
+            await debouncer.Invoke(3);
+            await Task.Delay(TestAsyncRestartDebouncer.Interval + 100);
+
+            // The only item flushed should be 3 since its interval has lapsed
+            Assert.Equal(new List<int> { 3 }, debouncer.FlushedBuffer);
+        }
+    }
+
+    #region TestAsyncDebouncer
+
+    internal class TestAsyncDebouncer : AsyncDebouncer<int>
+    {
+        public const int Interval = 1500;
+
+        DateTime? firstInvoke;
+        private List<int> invokeBuffer = new List<int>();
+
+        public List<int> FlushedBuffer { get; private set; }
+
+        public TimeSpan TimeToFlush { get; private set; }
+
+        public TestAsyncDebouncer() : base(Interval, false)
+        {
+        }
+
+        protected override Task OnInvoke(int args)
+        {
+            if (!this.firstInvoke.HasValue)
+            {
+                this.firstInvoke = DateTime.Now;
+            }
+
+            this.invokeBuffer.Add(args);
+
+            return Task.FromResult(true);
+        }
+
+        protected override Task OnFlush()
+        {
+            // Mark the flush time
+            this.TimeToFlush = DateTime.Now - this.firstInvoke.Value;
+
+            // Copy the buffer contents
+            this.FlushedBuffer = this.invokeBuffer.ToList();
+            this.invokeBuffer.Clear();
+
+            return Task.FromResult(true);
+        }
+    }
+
+    #endregion
+
+    #region TestAsyncRestartDebouncer
+
+    internal class TestAsyncRestartDebouncer : AsyncDebouncer<int>
+    {
+        public const int Interval = 300;
+
+        private int lastInvokeInt = -1;
+
+        public List<int> FlushedBuffer { get; } = new List<int>();
+
+        public TestAsyncRestartDebouncer() : base(Interval, true)
+        {
+        }
+
+        protected override Task OnInvoke(int args)
+        {
+            this.lastInvokeInt = args;
+            return Task.FromResult(true);
+        }
+
+        protected override Task OnFlush()
+        {
+            this.FlushedBuffer.Add(this.lastInvokeInt);
+
+            return Task.FromResult(true);
+        }
+    }
+
+    #endregion
+
+}
+


### PR DESCRIPTION
This change introduces a new AsyncDebouncer class which is able to gate
invocation requests to only occur after a specified interval.  This class
is used to implement an OutputDebouncer which takes all output messages
written from the PowerShell host and buffers them.  This causes many lines
of output written in a short time window to be sent as one OutputEvent
rather than writing individual events for each line.

Resolves #113.