### PR TITLE
Fixes #137 - working dir should be set to something reasonable.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
@@ -33,10 +33,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public string RuntimeExecutable { get; set; }
 
     //        /** Optional arguments passed to the runtime executable. */
-        public string[] RuntimeArguments { get; set; }
+        public string[] RuntimeArgs { get; set; }
 
     //        /** Optional environment variables to pass to the debuggee. The string valued properties of the 'environmentVariables' are used as key/value pairs. */
-        public Dictionary<string, string> EnvironmentVariables { get; set; }
+        public Dictionary<string, string> Env { get; set; }
     }
 }
 

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
@@ -24,10 +24,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public bool StopOnEntry { get; set; }
 
     //        /** Optional arguments passed to the debuggee. */
-        public string[] Arguments { get; set; }
+        public string[] Args { get; set; }
 
     //        /** Launch the debuggee in this working directory (specified as an absolute path). If omitted the debuggee is lauched in its own directory. */
-        public string WorkingDirectory { get; set; }
+        public string Cwd { get; set; }
 
     //        /** Absolute path to the runtime executable to be used. Default is the runtime executable on the PATH. */
         public string RuntimeExecutable { get; set; }


### PR DESCRIPTION
Turns out vscode passes us the cwd.  Just needed to rename the property in the LaunchRequest class to match. Same for args (renamed Arguments).  I have not hooked up script args yet though.

@daviwil - please look over the ExecuteCommand for Set-Location to make sure I'm doing the ContinueWith() correctly.