### PR TITLE
Adding support for passing ${file} as cwd.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -88,6 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             catch (Exception ex)
             {
                 Logger.Write(LogLevel.Error, "cwd path is bad: " + ex.Message);
+                workingDir = Environment.CurrentDirectory;
             }
 
             var setWorkingDirCommand = new PSCommand();


### PR DESCRIPTION
If cwd is a file path we check for that and if so, we grab its folder.  If any error occurs during this test for dir/grab parent dir operation we log it and continue.  I don't think we should crash the debugger.  Unfortunately the call to set-location with a bad path doens't get echoed to the debug console (just the debugAdapter.log) so the user won't know they typo'd a path - if they change the default.  :-(