### PR TITLE
Fixex #141 - passes args to script.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -97,14 +97,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             await editorSession.PowerShellContext.ExecuteCommand(setWorkingDirCommand);
 
-            Logger.Write(LogLevel.Verbose, "Working dir set to '" + workingDir + "'");
+            Logger.Write(LogLevel.Verbose, "Working dir set to: " + workingDir);
+
+            // Prepare arguments to the script - if specified
+            string arguments = null;
+            if ((launchParams.Args != null) && (launchParams.Args.Length > 0))
+            {
+                arguments = string.Join(" ", launchParams.Args);
+                Logger.Write(LogLevel.Verbose, "Script arguments are: " + arguments);
+            }
 
             // Execute the given PowerShell script and send the response.
             // Note that we aren't waiting for execution to complete here
             // because the debugger could stop while the script executes.
             Task executeTask =
                 editorSession.PowerShellContext
-                    .ExecuteScriptAtPath(launchParams.Program)
+                    .ExecuteScriptAtPath(launchParams.Program, arguments)
                     .ContinueWith(
                         async (t) => {
                             Logger.Write(LogLevel.Verbose, "Execution completed, terminating...");

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -432,16 +432,22 @@ namespace Microsoft.PowerShell.EditorServices
         /// Executes a script file at the specified path.
         /// </summary>
         /// <param name="scriptPath">The path to the script file to execute.</param>
+        /// <param name="arguments">Arguments to pass to the script.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task ExecuteScriptAtPath(string scriptPath)
+        public async Task ExecuteScriptAtPath(string scriptPath, string arguments = null)
         {
             // If we don't escape wildcard characters in the script path, the script can
             // fail to execute if say the script name was foo][.ps1.
             // Related to issue #123.
             string escapedScriptPath = EscapeWildcardsInPath(scriptPath);
 
+            if (arguments != null)
+            {
+                escapedScriptPath += " " + arguments;
+            }
+
             PSCommand command = new PSCommand();
-            command.AddCommand(escapedScriptPath);
+            command.AddScript(escapedScriptPath);
 
             await this.ExecuteCommand<object>(command, true);
         }

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/DebugWithParamsTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/DebugWithParamsTest.ps1
@@ -1,0 +1,3 @@
+﻿param($Param1, $Param2, [switch]$Force)
+
+"args are $args"

--- a/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
+++ b/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
@@ -64,6 +64,7 @@
     <None Include="Completion\CompletionExamples.psm1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Debugging\DebugWithParamsTest.ps1" />
     <None Include="Debugging\VariableTest.ps1" />
     <None Include="SymbolDetails\SymbolDetails.ps1" />
     <None Include="Symbols\MultipleSymbols.ps1" />

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -5,12 +5,12 @@
 
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 {
@@ -67,6 +67,76 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public void Dispose()
         {
             this.powerShellContext.Dispose();
+        }
+
+        public static IEnumerable<object[]> DebuggerAcceptsScriptArgsTestData
+        {
+            get
+            {
+                var data = new[]
+                {
+                    new[] { new []{ "Foo -Param2 @('Bar','Baz') -Force Extra1" }},
+                    new[] { new []{ "Foo", "-Param2", "@('Bar','Baz')", "-Force", "Extra1" }},
+                };
+
+                return data;
+            }
+        }
+
+        [Theory]
+        [MemberData("DebuggerAcceptsScriptArgsTestData")]
+        public async Task DebuggerAcceptsScriptArgs(string[] args)
+        {
+            ScriptFile debugWithParamsFile =
+                this.workspace.GetFile(
+                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugWithParamsTest.ps1");
+
+            await this.debugService.SetBreakpoints(
+                debugWithParamsFile,
+                new int[] { 3 });
+
+            string arguments = string.Join(" ", args);
+
+            // Execute the script and wait for the breakpoint to be hit
+            this.powerShellContext.ExecuteScriptAtPath(
+                debugWithParamsFile.FilePath, arguments);
+
+            await this.AssertDebuggerStopped(debugWithParamsFile.FilePath);
+
+            StackFrameDetails[] stackFrames = debugService.GetStackFrames();
+
+            VariableDetailsBase[] variables =
+                debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            var var = variables.FirstOrDefault(v => v.Name == "$Param1");
+            Assert.NotNull(var);
+            Assert.Equal("\"Foo\"", var.ValueString);
+            Assert.False(var.IsExpandable);
+
+            var = variables.FirstOrDefault(v => v.Name == "$Param2");
+            Assert.NotNull(var);
+            Assert.True(var.IsExpandable);
+            
+            var childVars = debugService.GetVariables(var.Id);
+            Assert.Equal(9, childVars.Length);
+            Assert.Equal("\"Bar\"", childVars[0].ValueString);
+            Assert.Equal("\"Baz\"", childVars[1].ValueString);
+
+            var = variables.FirstOrDefault(v => v.Name == "$Force");
+            Assert.NotNull(var);
+            Assert.Equal("True", var.ValueString);
+            Assert.True(var.IsExpandable);
+
+            var = variables.FirstOrDefault(v => v.Name == "$args");
+            Assert.NotNull(var);
+            Assert.True(var.IsExpandable);
+
+            childVars = debugService.GetVariables(var.Id);
+            Assert.Equal(8, childVars.Length);
+            Assert.Equal("\"Extra1\"", childVars[0].ValueString);
+
+            // Abort execution of the script
+            this.powerShellContext.AbortExecution();
         }
 
         [Fact]


### PR DESCRIPTION
This approach concats args (if any passed) with a space delimiter and then appends that to the scriptpath (space separed) and used AddScript() which takes this combination of script and args.