### PR TITLE
Fixes issue with notepad.exe running correctly.

### DIFF
--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Management.Automation.Host;
 
@@ -65,8 +66,10 @@ namespace Microsoft.PowerShell.EditorServices
 
         public override Version Version
         {
-            // TODO: Pull this from the host application
-            get { return new Version("0.1.0"); }
+            get
+            {
+                return this.GetType().Assembly.GetName().Version;
+            }
         }
 
         // TODO: Pull these from IConsoleHost
@@ -88,22 +91,22 @@ namespace Microsoft.PowerShell.EditorServices
 
         public override void EnterNestedPrompt()
         {
-            throw new NotImplementedException();
+            Logger.Write(LogLevel.Verbose, "EnterNestedPrompt() called.");
         }
 
         public override void ExitNestedPrompt()
         {
-            throw new NotImplementedException();
+            Logger.Write(LogLevel.Verbose, "ExitNestedPrompt() called.");
         }
 
         public override void NotifyBeginApplication()
         {
-            throw new NotImplementedException();
+            Logger.Write(LogLevel.Verbose, "NotifyBeginApplication() called.");
         }
 
         public override void NotifyEndApplication()
         {
-            throw new NotImplementedException();
+            Logger.Write(LogLevel.Verbose, "NotifyEndApplication() called.");
         }
 
         public override void SetShouldExit(int exitCode)


### PR DESCRIPTION
For some reason, the PowerShell engine thinks notepad.exe is a command-line app and calls the SessionPSHost BeginNotifyApplication() which used to throw NotImplementedException.  It now just logs the call.  

Also updated the PSHost version to pull the version from the services dll.  I tried several ways to pull from the host app (reflection Process.GetCurrentProcess().MainModule) but both caused the unit tests to hang.