### PR TITLE
Fix #147: Enable native console app output in REPL

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerShell.EditorServices
 {
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
+    using System.Reflection;
 
     /// <summary>
     /// Manages the lifetime and usage of a PowerShell session.
@@ -114,6 +115,23 @@ namespace Microsoft.PowerShell.EditorServices
 
             this.Initialize(runspace);
 
+            // Use reflection to execute ConsoleVisibility.AlwaysCaptureApplicationIO = true;
+            Type consoleVisibilityType =
+                Type.GetType(
+                    "System.Management.Automation.ConsoleVisibility, System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35");
+
+            if (consoleVisibilityType != null)
+            {
+                PropertyInfo propertyInfo =
+                    consoleVisibilityType.GetProperty(
+                        "AlwaysCaptureApplicationIO",
+                        BindingFlags.Static | BindingFlags.Public);
+
+                if (propertyInfo != null)
+                {
+                    propertyInfo.SetValue(null, true);
+                }
+            }
         }
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -565,6 +565,30 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             await evaluateTask;
         }
 
+        [Fact]
+        public async Task ServiceExecutesNativeCommandAndReceivesCommand()
+        {
+            OutputReader outputReader = new OutputReader(this.protocolClient);
+
+            // Execute the script but don't await the task yet because
+            // the choice prompt will block execution from completing
+            Task<EvaluateResponseBody> evaluateTask =
+                this.SendRequest(
+                    EvaluateRequest.Type,
+                    new EvaluateRequestArguments
+                    {
+                        Expression = "cmd.exe /c 'echo Test Output'",
+                        Context = "repl"
+                    });
+
+            // Skip the command line and the following newline
+            await outputReader.ReadLines(2);
+
+            // Wait for the selection to appear as output
+            await evaluateTask;
+            Assert.Equal("Test Output", await outputReader.ReadLine());
+        }
+
         private async Task SendOpenFileEvent(string filePath, bool waitForDiagnostics = true)
         {
             string fileContents = string.Join(Environment.NewLine, File.ReadAllLines(filePath));


### PR DESCRIPTION
This change enables native console app output to be written in the host
process without it breaking the standard I/O channel between the client
and host.  It accomplishes this by setting an internal property in the
PowerShell runtime called ConsoleVisibility.AlwaysCaptureApplicationIO.
This is a short term solution until we find a better way to deal with
native application output.