### PR TITLE
Easier launching of the debugging when /waitForDebugger passed in.

### DIFF
--- a/src/PowerShellEditorServices.Host/Program.cs
+++ b/src/PowerShellEditorServices.Host/Program.cs
@@ -27,15 +27,15 @@ namespace Microsoft.PowerShell.EditorServices.Host
                             "/waitForDebugger",
                             StringComparison.InvariantCultureIgnoreCase));
 
-            // Should we wait for the debugger before starting?
             if (waitForDebugger)
             {
-                // Wait for 25 seconds and then continue
-                int waitCountdown = 25;
-                while (!Debugger.IsAttached && waitCountdown > 0)
+                if (Debugger.IsAttached)
                 {
-                    Thread.Sleep(1000);
-                    waitCountdown--;
+                    Debugger.Break();
+                }
+                else
+                {
+                    Debugger.Launch();
                 }
             }
 #endif


### PR DESCRIPTION
OK been doing a lot of debugging of the debug adapater and this has been driving me crazy.   Launch VSCode, open PS1 file so I can find the PID of the editor host.  Then debug the script, hop over to VS attach to process, find the PID of the second host process (the debug instance) and attach.  This new approach will just pop up a dialog box asking which instance of VS to use to debug.  You can press NO to skip attaching the debugger and the script will continue to execute.