### PR TITLE
Fixes #155 - selecting outermost scope crashes debug host.

### DIFF
--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             return new StackFrameDetails
             {
-                ScriptPath = callStackFrame.ScriptName,
+                ScriptPath = callStackFrame.ScriptName ?? "<No File>",
                 FunctionName = callStackFrame.FunctionName,
                 LineNumber = callStackFrame.Position.StartLineNumber,
                 ColumnNumber = callStackFrame.Position.StartColumnNumber,

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -455,18 +455,22 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A Task that can be awaited for completion.</returns>
         public async Task ExecuteScriptAtPath(string scriptPath, string arguments = null)
         {
-            // If we don't escape wildcard characters in the script path, the script can
-            // fail to execute if say the script name was foo][.ps1.
-            // Related to issue #123.
-            string escapedScriptPath = EscapePath(scriptPath, escapeSpaces: true);
+            PSCommand command = new PSCommand();
 
             if (arguments != null)
             {
-                escapedScriptPath += " " + arguments;
-            }
+                // If we don't escape wildcard characters in the script path, the script can
+                // fail to execute if say the script name was foo][.ps1.
+                // Related to issue #123.
+                string escapedScriptPath = EscapePath(scriptPath, escapeSpaces: true);
+                string scriptWithArgs = escapedScriptPath + " " + arguments;
 
-            PSCommand command = new PSCommand();
-            command.AddScript(escapedScriptPath);
+                command.AddScript(scriptWithArgs);
+            }
+            else
+            {
+                command.AddCommand(scriptPath);
+            }
 
             await this.ExecuteCommand<object>(command, true);
         }


### PR DESCRIPTION
Because we use AddScript, that adds another scope not associated with any filename.  That resulted in a StackFrame ScriptPath with a null value.  Later, VSCode sent us a request for soruce with a sourceReference value of null.  That caused the JSON deserialization of that message to throw and that crashed the debug host.  I made two changes.  First, when we construct the StackFrameDetails, if the PowerShell CallStackFrame.ScriptName is null, we use the string "<No File>" instead for ScriptPath.  The second change was to ExecuteScriptAtPath.  Essentially, if you do not pass args we now use AddCommand(scriptPath) which does not add the extra stack frame.  If you do use args then we still use AddScript.  You will see the extra outermost stack frame of "<ScriptBlock>, <NoFile>".  What is somewhat useful about this is that you can open Script variables to look at $MyInvocation.Line to see how the script was invoked with the args.