### PR TITLE
Fix #157: Tests using OutputReader sometimes hang

### DIFF
--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -490,8 +490,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     ChosenItem = "a"
                 });
 
-            // Skip the initial script lines (6 script lines plus 3 blank lines)
-            await outputReader.ReadLines(9);
+            // Skip the initial script lines (6 script lines plus 2 blank lines)
+            string[] outputLines = await outputReader.ReadLines(8);
 
             // Wait for the selection to appear as output
             await evaluateTask;
@@ -541,18 +541,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             // Skip the initial script lines (4 script lines plus 2 blank lines)
             string[] scriptLines = await outputReader.ReadLines(6);
 
-            // In some cases an extra newline appears after the script lines.
-            // I have no idea why this happens, but it normally seems to occur
-            // on my local machine and not the CI server.  For now, adjust for
-            // it here.
-            string outputLine = await outputReader.ReadLine();
-            if (string.IsNullOrEmpty(outputLine))
-            {
-                outputLine = await outputReader.ReadLine();
-            }
-
             // Verify the first line
-            Assert.Equal("Name: John", outputLine);
+            Assert.Equal("Name: John", await outputReader.ReadLine());
 
             // Verify the rest of the output
             string[] outputLines = await outputReader.ReadLines(4);

--- a/test/PowerShellEditorServices.Test.Host/OutputReader.cs
+++ b/test/PowerShellEditorServices.Test.Host/OutputReader.cs
@@ -89,9 +89,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                                     outputLines[i],
 
                                     // The line has a newline if it's not the last segment or
-                                    // if the current output string ends with a newline
+                                    // if the last segment is not an empty string and the
+                                    // complete output string ends with a newline
                                     i < outputLines.Length - 1 ||
-                                    nextOutputEvent.Output.EndsWith("\n")));
+                                    (outputLines[outputLines.Length - 1].Length > 0 &&
+                                     nextOutputEvent.Output.EndsWith("\n"))));
                         }
                     }
 


### PR DESCRIPTION
This fix handles an edge case when buffered output that ends with a
newline is treated incorrectly causing an extra empty line to be returend
by the OutputReader.