### PR TITLE
Fix #153: Script Analyzer is not returning markers

### DIFF
--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -66,6 +66,22 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         }
 
         [Fact]
+        public async Task ServiceReturnsSemanticMarkers()
+        {
+            // Send the 'didOpen' event
+            await this.SendOpenFileEvent("TestFiles\\SimpleSemanticError.ps1", false);
+
+            // Wait for the diagnostic event
+            PublishDiagnosticsNotification diagnostics = 
+                await this.WaitForEvent(
+                    PublishDiagnosticsNotification.Type);
+
+            // Was there a semantic error?
+            Assert.NotEqual(0, diagnostics.Diagnostics.Length);
+            Assert.Contains("unapproved", diagnostics.Diagnostics[0].Message);
+        }
+
+        [Fact]
         public async Task ServiceCompletesFunctionName()
         {
             await this.SendOpenFileEvent("TestFiles\\CompleteFunctionName.ps1");

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -83,6 +83,9 @@
     <None Include="TestFiles\MultiLineReplace.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\SimpleSemanticError.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\SimpleSyntaxError.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/PowerShellEditorServices.Test.Host/TestFiles/SimpleSemanticError.ps1
+++ b/test/PowerShellEditorServices.Test.Host/TestFiles/SimpleSemanticError.ps1
@@ -1,0 +1,3 @@
+﻿function Do-Work {
+	# This should trigger the PSUseApprovedVerbs rule
+}


### PR DESCRIPTION
This change fixes an issue in 0.4.1 where Script Analyzer analysis markers
are not being returned by the AnalysisService.  This issue was caused by a
new optional parameter to the ScriptAnalyzer.Initialize method called
'includeDefaultRules' which was introduced in 1.3.0.  Since this parameter
has a default value of 'false', the default Script Analyzer rules were not
being loaded or applied in analysis runs.