### PR TITLE
Fix #166: Handle lack of Script Analyzer binaries

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -891,11 +891,23 @@ function __Expand-Alias {
             // Get the requested files
             foreach (ScriptFile scriptFile in filesToAnalyze)
             {
-                Logger.Write(LogLevel.Verbose, "Analyzing script file: " + scriptFile.FilePath);
+                ScriptFileMarker[] semanticMarkers = null;
+                if (editorSession.AnalysisService != null)
+                {
+                    Logger.Write(LogLevel.Verbose, "Analyzing script file: " + scriptFile.FilePath);
 
-                var semanticMarkers =
-                    editorSession.AnalysisService.GetSemanticMarkers(
-                        scriptFile);
+                    semanticMarkers =
+                        editorSession.AnalysisService.GetSemanticMarkers(
+                            scriptFile);
+
+                    Logger.Write(LogLevel.Verbose, "Analysis complete.");
+                }
+                else
+                {
+                    // Semantic markers aren't available if the AnalysisService
+                    // isn't available
+                    semanticMarkers = new ScriptFileMarker[0];
+                }
 
                 var allMarkers = scriptFile.SyntaxMarkers.Concat(semanticMarkers);
 
@@ -904,8 +916,6 @@ function __Expand-Alias {
                     semanticMarkers,
                     eventContext);
             }
-
-            Logger.Write(LogLevel.Verbose, "Analysis complete.");
         }
 
         private static async Task PublishScriptDiagnostics(

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -4,6 +4,8 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.PowerShell.EditorServices.Utility;
+using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading;
@@ -64,9 +66,21 @@ namespace Microsoft.PowerShell.EditorServices
             // Initialize all services
             this.PowerShellContext = new PowerShellContext();
             this.LanguageService = new LanguageService(this.PowerShellContext);
-            this.AnalysisService = new AnalysisService();
             this.DebugService = new DebugService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
+
+            // AnalysisService will throw FileNotFoundException if
+            // Script Analyzer binaries are not included.
+            try
+            {
+                this.AnalysisService = new AnalysisService();
+            }
+            catch (FileNotFoundException)
+            {
+                Logger.Write(
+                    LogLevel.Warning,
+                    "Script Analyzer binaries not found, AnalysisService will be disabled.");
+            }
         }
 
         #endregion


### PR DESCRIPTION
This change enables PowerShell Editor Services to operate correctly in the
scenario where no Script Analyzer binaries are available.  This is a first
step in the direction of removing the direct dependency on Script Analyzer
and moving analysis behavior to the new extensibility model.