### PR TITLE
Partial fix for issue 95 - set all scopes but Local as expensive.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             return new Scope {
                 Name = scope.Name,
                 VariablesReference = scope.Id,
+                // Temporary fix for #95 to get debug hover tips to work well at least for the local scope.
                 Expensive = (scope.Name != VariableContainerDetails.LocalScopeName)
             };
         }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
@@ -3,34 +3,33 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {
     public class Scope
     {
-//        /** name of the scope (as such 'Arguments', 'Locals') */
-//        name: string;
+        /// <summary>
+        /// Gets or sets the name of the scope (as such 'Arguments', 'Locals')
+        /// </summary>
         public string Name { get; set; }
 
-//        /** The variables of this scope can be retrieved by passing the value of variablesReference to the VariablesRequest. */
-//        variablesReference: number;
+        /// <summary>
+        /// Gets or sets the variables of this scope can be retrieved by passing the 
+        /// value of variablesReference to the VariablesRequest.
+        /// </summary>
         public int VariablesReference { get; set; }
 
-//        /** If true, the number of variables in this scope is large or expensive to retrieve. */
-//        expensive: boolean;
+        /// <summary>
+        /// Gets or sets a boolean value indicating if number of variables in 
+        /// this scope is large or expensive to retrieve. 
+        /// </summary>
         public bool Expensive { get; set; }
 
         public static Scope Create(VariableScope scope)
         {
-            return new Scope
-            {
+            return new Scope {
                 Name = scope.Name,
-                VariablesReference = scope.Id
+                VariablesReference = scope.Id,
+                Expensive = (scope.Name != VariableContainerDetails.LocalScopeName)
             };
         }
     }


### PR DESCRIPTION
This makes the debug hover tips work better.  But if you want to look at a variable in a higher scope, you have to select that scope in the callstack so the variable is a "local" variable in that scope.