### PR TITLE
Fixes #94 - adds support for conditional breakpoints

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
@@ -7,9 +7,23 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {
     public class Breakpoint
     {
+        /// <summary>
+        /// Gets an boolean indicator that if true, breakpoint could be set 
+        /// (but not necessarily at the desired location).  
+        /// </summary>
         public bool Verified { get; set; }
 
+        /// <summary>
+        /// Gets an optional message about the state of the breakpoint. This is shown to the user 
+        /// and can be used to explain why a breakpoint could not be verified.
+        /// </summary>
+        public string Message { get; set; }
+
+        public string Source { get; set; }
+
         public int Line { get; set; }
+
+        public int? Column { get; set; }
 
         private Breakpoint()
         {
@@ -20,8 +34,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         {
             return new Breakpoint
             {
+                Verified = breakpointDetails.Verified,
+                Message = breakpointDetails.Message,
+                Source = breakpointDetails.Source,
                 Line = breakpointDetails.LineNumber,
-                Verified = true
+                Column = breakpointDetails.ColumnNumber
             };
         }
     }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/SetBreakpointsRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/SetBreakpointsRequest.cs
@@ -7,11 +7,12 @@ using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {
-    //    /** SetBreakpoints request; value of command field is "setBreakpoints".
-    //        Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
-    //        To clear all breakpoint for a source, specify an empty array.
-    //        When a breakpoint is hit, a StoppedEvent (event type 'breakpoint') is generated.
-    //    */
+    /// <summary>
+    /// SetBreakpoints request; value of command field is "setBreakpoints".
+    /// Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
+    /// To clear all breakpoint for a source, specify an empty array.
+    /// When a breakpoint is hit, a StoppedEvent (event type 'breakpoint') is generated.
+    /// </summary>
     public class SetBreakpointsRequest
     {
         public static readonly
@@ -23,7 +24,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
     {
         public Source Source { get; set; }
 
-        public int[] Lines { get; set; }
+        public SourceBreakpoint[] Breakpoints { get; set; }
+    }
+
+    public class SourceBreakpoint
+    {
+        public int Line { get; set; }
+
+        public int? Column { get; set; }
+
+        public string Condition { get; set; }
     }
 
     public class SetBreakpointsResponseBody
@@ -31,4 +41,3 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public Breakpoint[] Breakpoints { get; set; }
     }
 }
-

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -172,10 +172,21 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 editorSession.Workspace.GetFile(
                     setBreakpointsParams.Source.Path);
 
+            var breakpointDetails = new BreakpointDetails[setBreakpointsParams.Breakpoints.Length];
+            for (int i = 0; i < breakpointDetails.Length; i++)
+            {
+                SourceBreakpoint srcBreakpoint = setBreakpointsParams.Breakpoints[i];
+                breakpointDetails[i] = BreakpointDetails.Create(
+                    scriptFile.FilePath, 
+                    srcBreakpoint.Line, 
+                    srcBreakpoint.Column, 
+                    srcBreakpoint.Condition);
+            }
+
             BreakpointDetails[] breakpoints =
-                await editorSession.DebugService.SetBreakpoints(
+                await editorSession.DebugService.SetLineBreakpoints(
                     scriptFile,
-                    setBreakpointsParams.Lines);
+                    breakpointDetails);
 
             await requestContext.SendResult(
                 new SetBreakpointsResponseBody

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -60,7 +60,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 null);
 
             // Now send the Initialize response to continue setup
-            await requestContext.SendResult(new InitializeResponseBody());
+            await requestContext.SendResult(
+                new InitializeResponseBody
+                {
+                    SupportsConditionalBreakpoints = true,
+                });
         }
     }
 }

--- a/src/PowerShellEditorServices/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/BreakpointDetails.cs
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Management.Automation;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -16,9 +16,66 @@ namespace Microsoft.PowerShell.EditorServices
     public class BreakpointDetails
     {
         /// <summary>
+        /// Gets or sets a boolean indicator that if true, breakpoint could be set 
+        /// (but not necessarily at the desired location).  
+        /// </summary>
+        public bool Verified { get; set; }
+
+        /// <summary>
+        /// Gets or set an optional message about the state of the breakpoint. This is shown to the user 
+        /// and can be used to explain why a breakpoint could not be verified.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets the source where the breakpoint is located.  Used only for debug purposes.
+        /// </summary>
+        public string Source { get; private set; }
+
+        /// <summary>
         /// Gets the line number at which the breakpoint is set.
         /// </summary>
         public int LineNumber { get; private set; }
+
+        /// <summary>
+        /// Gets the column number at which the breakpoint is set. If null, the default of 1 is used.
+        /// </summary>
+        public int? ColumnNumber { get; private set; }
+
+        /// <summary>
+        /// Gets the breakpoint condition string.
+        /// </summary>
+        public string Condition { get; private set; }
+
+        private BreakpointDetails()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the BreakpointDetails class from the individual
+        /// pieces of breakpoint information provided by the client.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="line"></param>
+        /// <param name="column"></param>
+        /// <param name="condition"></param>
+        /// <returns></returns>
+        public static BreakpointDetails Create(
+            string source, 
+            int line, 
+            int? column = null, 
+            string condition = null)
+        {
+            Validate.IsNotNull("source", source);
+
+            return new BreakpointDetails
+            {
+                Source = source,
+                LineNumber = line,
+                ColumnNumber = column,
+                Condition = condition
+            };
+        }
 
         /// <summary>
         /// Creates an instance of the BreakpointDetails class from a
@@ -31,18 +88,26 @@ namespace Microsoft.PowerShell.EditorServices
             Validate.IsNotNull("breakpoint", breakpoint);
 
             LineBreakpoint lineBreakpoint = breakpoint as LineBreakpoint;
-            if (lineBreakpoint != null)
-            {
-                return new BreakpointDetails
-                {
-                    LineNumber = lineBreakpoint.Line
-                };
-            }
-            else
+            if (lineBreakpoint == null)
             {
                 throw new ArgumentException(
                     "Expected breakpoint type:" + breakpoint.GetType().Name);
             }
+
+            var breakpointDetails = new BreakpointDetails
+            {
+                Verified = true,
+                Source = lineBreakpoint.Script,
+                LineNumber = lineBreakpoint.Line,
+                Condition = lineBreakpoint.Action?.ToString()
+            };
+
+            if (lineBreakpoint.Column > 0)
+            {
+                breakpointDetails.ColumnNumber = lineBreakpoint.Column;
+            }
+
+            return breakpointDetails;
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         }
 
         [Fact]
-        public async Task DebugAdapterStopsOnBreakpoints()
+        public async Task DebugAdapterStopsOnLineBreakpoints()
         {
             await this.SendRequest(
                 SetBreakpointsRequest.Type,
@@ -58,7 +58,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     {
                         Path = DebugScriptPath
                     },
-                    Lines = new int[] { 5, 7 }
+                    Breakpoints = new []
+                    {
+                        new SourceBreakpoint { Line = 5 },
+                        new SourceBreakpoint { Line = 7 }
+                    }
                 });
 
             Task<StoppedEventBody> breakEventTask = this.WaitForEvent(StoppedEvent.Type);

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         private Workspace workspace;
         private DebugService debugService;
         private ScriptFile debugScriptFile;
+        private ScriptFile variableScriptFile;
         private PowerShellContext powerShellContext;
         private SynchronizationContext runnerContext;
 
@@ -35,6 +36,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.debugScriptFile =
                 this.workspace.GetFile(
                     @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1");
+
+            this.variableScriptFile =
+                this.workspace.GetFile(
+                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
 
             this.powerShellContext = new PowerShellContext();
             this.powerShellContext.SessionStateChanged += powerShellContext_SessionStateChanged;
@@ -94,9 +99,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 this.workspace.GetFile(
                     @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\Debug` With Params `[Test].ps1");
 
-            await this.debugService.SetBreakpoints(
+            await this.debugService.SetLineBreakpoints(
                 debugWithParamsFile,
-                new int[] { 3 });
+                new[] { BreakpointDetails.Create("", 3) });
 
             string arguments = string.Join(" ", args);
 
@@ -146,37 +151,44 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerSetsAndClearsBreakpoints()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetBreakpoints(
-                    this.debugScriptFile, 
-                    new int[] { 5, 9 });
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] {
+                        BreakpointDetails.Create("", 5),
+                        BreakpointDetails.Create("", 10)
+                    });
 
             Assert.Equal(2, breakpoints.Length);
             Assert.Equal(5, breakpoints[0].LineNumber);
-            Assert.Equal(9, breakpoints[1].LineNumber);
+            Assert.Equal(10, breakpoints[1].LineNumber);
 
             breakpoints =
-                await this.debugService.SetBreakpoints(
-                    this.debugScriptFile, 
-                    new int[] { 2 });
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] { BreakpointDetails.Create("", 2) });
 
             Assert.Equal(1, breakpoints.Length);
             Assert.Equal(2, breakpoints[0].LineNumber);
 
             breakpoints =
-                await this.debugService.SetBreakpoints(
-                    this.debugScriptFile, 
-                    new int[0]);
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] { BreakpointDetails.Create("", 0) });
 
             Assert.Equal(0, breakpoints.Length);
         }
 
         [Fact]
-        public async Task DebuggerStopsOnBreakpoints()
+        public async Task DebuggerStopsOnLineBreakpoints()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetBreakpoints(
-                    this.debugScriptFile, 
-                    new int[] { 5, 7 });
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] {
+                        BreakpointDetails.Create("", 5),
+                        BreakpointDetails.Create("", 7)
+                    });
+
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
@@ -192,6 +204,79 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             // Abort script execution early and wait for completion
             this.debugService.Abort();
             await executeTask;
+        }
+
+        [Fact]
+        public async Task DebuggerStopsOnConditionalBreakpoints()
+        {
+            const int breakpointValue1 = 10;
+            const int breakpointValue2 = 20;
+
+            BreakpointDetails[] breakpoints =
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] {
+                        BreakpointDetails.Create("", 7, null, $"$i -eq {breakpointValue1} -or $i -eq {breakpointValue2}"),
+                    });
+
+            await this.AssertStateChange(PowerShellContextState.Ready);
+
+            Task executeTask =
+                this.powerShellContext.ExecuteScriptAtPath(
+                    this.debugScriptFile.FilePath);
+
+            // Wait for conditional breakpoint to hit
+            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 7);
+
+            StackFrameDetails[] stackFrames = debugService.GetStackFrames();
+            VariableDetailsBase[] variables =
+                debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            // Verify the breakpoint only broke at the condition ie. $i -eq breakpointValue1
+            var i = variables.FirstOrDefault(v => v.Name == "$i");
+            Assert.NotNull(i);
+            Assert.False(i.IsExpandable);
+            Assert.Equal($"{breakpointValue1}", i.ValueString);
+
+            // The conditional breakpoint should not fire again, until the value of
+            // i reaches breakpointValue2.
+            this.debugService.Continue();
+            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 7);
+
+            stackFrames = debugService.GetStackFrames();
+            variables = debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            // Verify the breakpoint only broke at the condition ie. $i -eq breakpointValue1
+            i = variables.FirstOrDefault(v => v.Name == "$i");
+            Assert.NotNull(i);
+            Assert.False(i.IsExpandable);
+            Assert.Equal($"{breakpointValue2}", i.ValueString);
+
+            // Abort script execution early and wait for completion
+            this.debugService.Abort();
+            await executeTask;
+        }
+
+        [Fact]
+        public async Task DebuggerProvidesMessageForInvalidConditionalBreakpoint()
+        {
+            BreakpointDetails[] breakpoints =
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] {
+                        BreakpointDetails.Create("", 5),
+                        BreakpointDetails.Create("", 10, column: null, condition: "$i -ez 100")
+                    });
+
+            Assert.Equal(2, breakpoints.Length);
+            Assert.Equal(5, breakpoints[0].LineNumber);
+            Assert.True(breakpoints[0].Verified);
+            Assert.Null(breakpoints[0].Message);
+
+            Assert.Equal(10, breakpoints[1].LineNumber);
+            Assert.False(breakpoints[1].Verified);
+            Assert.NotNull(breakpoints[1].Message);
+            Assert.Contains("Unexpected token '-ez'", breakpoints[1].Message);
         }
 
         [Fact]
@@ -243,20 +328,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableStringDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -275,20 +356,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerGetsVariables()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile, 
-                new int[] { 14 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 14) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -329,20 +406,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableEnumDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -361,20 +434,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableHashtableDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -400,20 +469,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariablePSObjectDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -439,20 +504,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariablePSCustomObjectDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
@@ -480,20 +541,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableProcessObjDisplaysCorrectly()
         {
-            ScriptFile variablesFile =
-                this.workspace.GetFile(
-                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
-
-            await this.debugService.SetBreakpoints(
-                variablesFile,
-                new int[] { 18 });
+            await this.debugService.SetLineBreakpoints(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
                 this.powerShellContext.ExecuteScriptString(
-                    variablesFile.FilePath);
+                    this.variableScriptFile.FilePath);
 
-            await this.AssertDebuggerStopped(variablesFile.FilePath);
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -280,6 +280,28 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         }
 
         [Fact]
+        public async Task DebuggerFindsParseableButInvalidSimpleBreakpointConditions()
+        {
+            BreakpointDetails[] breakpoints =
+                await this.debugService.SetLineBreakpoints(
+                    this.debugScriptFile,
+                    new[] {
+                        BreakpointDetails.Create("", 5, column: null, condition: "$i == 100"),
+                        BreakpointDetails.Create("", 7, column: null, condition: "$i > 100")
+                    });
+
+            Assert.Equal(2, breakpoints.Length);
+            Assert.Equal(5, breakpoints[0].LineNumber);
+            Assert.False(breakpoints[0].Verified);
+            Assert.Contains("Use '-eq' instead of '=='", breakpoints[0].Message);
+
+            Assert.Equal(7, breakpoints[1].LineNumber);
+            Assert.False(breakpoints[1].Verified);
+            Assert.NotNull(breakpoints[1].Message);
+            Assert.Contains("Use '-gt' instead of '>'", breakpoints[1].Message);
+        }
+
+        [Fact]
         public async Task DebuggerBreaksWhenRequested()
         {
             Task executeTask =


### PR DESCRIPTION
This adds some unit tests for conditional breakpoints and refactors some existing unit tests I wrote to be a bit more DRY.  Also, VSCode supports column breakpoints in its protocol.  And PowerShell supports breakpoints on columns other than 1.  So why don't I see any UI in VSCode to create a breakpoint at a specific column?  Is there something we have to do to declare support for column breakpoints?