### PR TITLE
Fixes #173 - implementation for function breakpoints 

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
@@ -17,14 +17,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
         {
         }
 
-        public Task LaunchScript(string scriptFilePath)
+        public async Task LaunchScript(string scriptFilePath)
         {
-            return this.SendRequest(
+            await this.SendRequest(
                 LaunchRequest.Type,
-                new LaunchRequestArguments
-                {
+                new LaunchRequestArguments {
                     Program = scriptFilePath
                 });
+
+            await this.SendRequest(ConfigurationDoneRequest.Type, null);
         }
 
         protected override async Task OnStart()

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public string Source { get; set; }
 
-        public int Line { get; set; }
+        public int? Line { get; set; }
 
         public int? Column { get; set; }
 
@@ -39,6 +39,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
                 Source = breakpointDetails.Source,
                 Line = breakpointDetails.LineNumber,
                 Column = breakpointDetails.ColumnNumber
+            };
+        }
+
+        public static Breakpoint Create(
+            FunctionBreakpointDetails breakpointDetails)
+        {
+            return new Breakpoint {
+                Verified = breakpointDetails.Verified,
+                Message = breakpointDetails.Message
             };
         }
     }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/ConfigurationDoneRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/ConfigurationDoneRequest.cs
@@ -1,0 +1,16 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
+{
+    public class ConfigurationDoneRequest
+    {
+        public static readonly
+            RequestType<object, object> Type =
+            RequestType<object, object>.Create("configurationDone");
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/SetFunctionBreakpointsRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/SetFunctionBreakpointsRequest.cs
@@ -1,0 +1,31 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
+{
+    public class SetFunctionBreakpointsRequest
+    {
+        public static readonly
+            RequestType<SetFunctionBreakpointsRequestArguments, SetBreakpointsResponseBody> Type =
+            RequestType<SetFunctionBreakpointsRequestArguments, SetBreakpointsResponseBody>.Create("setFunctionBreakpoints");
+    }
+
+    public class SetFunctionBreakpointsRequestArguments
+    {
+        public FunctionBreakpoint[] Breakpoints { get; set; }
+    }
+
+    public class FunctionBreakpoint
+    {
+        /// <summary>
+        /// Gets or sets the name of the function to break on when it is invoked.
+        /// </summary>
+        public string Name { get; set; }
+
+        public string Condition { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -50,7 +50,9 @@
   <ItemGroup>
     <Compile Include="DebugAdapter\AttachRequest.cs" />
     <Compile Include="DebugAdapter\Breakpoint.cs" />
+    <Compile Include="DebugAdapter\ConfigurationDoneRequest.cs" />
     <Compile Include="DebugAdapter\ContinueRequest.cs" />
+    <Compile Include="DebugAdapter\SetFunctionBreakpointsRequest.cs" />
     <Compile Include="LanguageServer\FindModuleRequest.cs" />
     <Compile Include="LanguageServer\InstallModuleRequest.cs" />
     <Compile Include="MessageProtocol\IMessageSender.cs" />

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -20,6 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     {
         private EditorSession editorSession;
         private OutputDebouncer outputDebouncer;
+        private string scriptPathToLaunch;
+        private string arguments;
 
         public DebugAdapter() : this(new StdioServerChannel())
         {
@@ -42,10 +44,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             this.SetRequestHandler(LaunchRequest.Type, this.HandleLaunchRequest);
             this.SetRequestHandler(AttachRequest.Type, this.HandleAttachRequest);
+            this.SetRequestHandler(ConfigurationDoneRequest.Type, this.HandleConfigurationDoneRequest);
             this.SetRequestHandler(DisconnectRequest.Type, this.HandleDisconnectRequest);
 
             this.SetRequestHandler(SetBreakpointsRequest.Type, this.HandleSetBreakpointsRequest);
             this.SetRequestHandler(SetExceptionBreakpointsRequest.Type, this.HandleSetExceptionBreakpointsRequest);
+            this.SetRequestHandler(SetFunctionBreakpointsRequest.Type, this.HandleSetFunctionBreakpointsRequest);
 
             this.SetRequestHandler(ContinueRequest.Type, this.HandleContinueRequest);
             this.SetRequestHandler(NextRequest.Type, this.HandleNextRequest);
@@ -110,12 +114,35 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 Logger.Write(LogLevel.Verbose, "Script arguments are: " + arguments);
             }
 
+            // NOTE: We don't actually launch the script in response to this
+            // request.  We wait until we receive the configurationDone request
+            // to actually launch the script under the debugger.  This gives
+            // us and VSCode a chance to finish configuring all the types of
+            // breakpoints.
+            this.scriptPathToLaunch = launchParams.Program;
+            this.arguments = arguments;
+
+            await requestContext.SendResult(null);
+        }
+
+        protected Task HandleAttachRequest(
+            AttachRequestArguments attachParams,
+            RequestContext<object> requestContext)
+        {
+            // TODO: Implement this once we support attaching to processes
+            throw new NotImplementedException();
+        }
+
+        protected async Task HandleConfigurationDoneRequest(
+            object args,
+            RequestContext<object> requestContext)
+        {
             // Execute the given PowerShell script and send the response.
             // Note that we aren't waiting for execution to complete here
             // because the debugger could stop while the script executes.
             Task executeTask =
                 editorSession.PowerShellContext
-                    .ExecuteScriptAtPath(launchParams.Program, arguments)
+                    .ExecuteScriptAtPath(this.scriptPathToLaunch, this.arguments)
                     .ContinueWith(
                         async (t) => {
                             Logger.Write(LogLevel.Verbose, "Execution completed, terminating...");
@@ -129,14 +156,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         });
 
             await requestContext.SendResult(null);
-        }
-
-        protected Task HandleAttachRequest(
-            AttachRequestArguments attachParams,
-            RequestContext<object> requestContext)
-        {
-            // TODO: Implement this once we support attaching to processes
-            throw new NotImplementedException();
         }
 
         protected Task HandleDisconnectRequest(
@@ -191,6 +210,32 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             await requestContext.SendResult(
                 new SetBreakpointsResponseBody
                 {
+                    Breakpoints =
+                        breakpoints
+                            .Select(Protocol.DebugAdapter.Breakpoint.Create)
+                            .ToArray()
+                });
+        }
+
+        protected async Task HandleSetFunctionBreakpointsRequest(
+            SetFunctionBreakpointsRequestArguments setBreakpointsParams,
+            RequestContext<SetBreakpointsResponseBody> requestContext)
+        {
+            var breakpointDetails = new FunctionBreakpointDetails[setBreakpointsParams.Breakpoints.Length];
+            for (int i = 0; i < breakpointDetails.Length; i++)
+            {
+                FunctionBreakpoint funcBreakpoint = setBreakpointsParams.Breakpoints[i];
+                breakpointDetails[i] = FunctionBreakpointDetails.Create(
+                    funcBreakpoint.Name,
+                    funcBreakpoint.Condition);
+            }
+
+            FunctionBreakpointDetails[] breakpoints =
+                await editorSession.DebugService.SetFunctionBreakpoints(
+                    breakpointDetails);
+
+            await requestContext.SendResult(
+                new SetBreakpointsResponseBody {
                     Breakpoints =
                         breakpoints
                             .Select(Protocol.DebugAdapter.Breakpoint.Create)

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -231,7 +231,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
 
             FunctionBreakpointDetails[] breakpoints =
-                await editorSession.DebugService.SetFunctionBreakpoints(
+                await editorSession.DebugService.SetCommandBreakpoints(
                     breakpointDetails);
 
             await requestContext.SendResult(

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -63,7 +63,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             await requestContext.SendResult(
                 new InitializeResponseBody
                 {
+                    SupportsConfigurationDoneRequest = true,
                     SupportsConditionalBreakpoints = true,
+                    SupportsFunctionBreakpoints = true
                 });
         }
     }

--- a/src/PowerShellEditorServices/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/BreakpointDetails.cs
@@ -13,20 +13,8 @@ namespace Microsoft.PowerShell.EditorServices
     /// Provides details about a breakpoint that is set in the
     /// PowerShell debugger.
     /// </summary>
-    public class BreakpointDetails
+    public class BreakpointDetails : BreakpointDetailsBase
     {
-        /// <summary>
-        /// Gets or sets a boolean indicator that if true, breakpoint could be set 
-        /// (but not necessarily at the desired location).  
-        /// </summary>
-        public bool Verified { get; set; }
-
-        /// <summary>
-        /// Gets or set an optional message about the state of the breakpoint. This is shown to the user 
-        /// and can be used to explain why a breakpoint could not be verified.
-        /// </summary>
-        public string Message { get; set; }
-
         /// <summary>
         /// Gets the source where the breakpoint is located.  Used only for debug purposes.
         /// </summary>
@@ -41,11 +29,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the column number at which the breakpoint is set. If null, the default of 1 is used.
         /// </summary>
         public int? ColumnNumber { get; private set; }
-
-        /// <summary>
-        /// Gets the breakpoint condition string.
-        /// </summary>
-        public string Condition { get; private set; }
 
         private BreakpointDetails()
         {
@@ -91,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (lineBreakpoint == null)
             {
                 throw new ArgumentException(
-                    "Expected breakpoint type:" + breakpoint.GetType().Name);
+                    "Unexpected breakpoint type: " + breakpoint.GetType().Name);
             }
 
             var breakpointDetails = new BreakpointDetails

--- a/src/PowerShellEditorServices/Debugging/BreakpointDetailsBase.cs
+++ b/src/PowerShellEditorServices/Debugging/BreakpointDetailsBase.cs
@@ -1,0 +1,31 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Provides details about a breakpoint that is set in the
+    /// PowerShell debugger.
+    /// </summary>
+    public abstract class BreakpointDetailsBase
+    {
+        /// <summary>
+        /// Gets or sets a boolean indicator that if true, breakpoint could be set 
+        /// (but not necessarily at the desired location).  
+        /// </summary>
+        public bool Verified { get; set; }
+
+        /// <summary>
+        /// Gets or set an optional message about the state of the breakpoint. This is shown to the user 
+        /// and can be used to explain why a breakpoint could not be verified.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets the breakpoint condition string.
+        /// </summary>
+        public string Condition { get; protected set; }
+    }
+}

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.EditorServices
                     psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
                     psCommand.AddParameter("Command", breakpoint.Name);
 
-                    // Check if this is a "conditional" line breakpoint.
+                    // Check if this is a "conditional" command breakpoint.
                     if (breakpoint.Condition != null)
                     {
                         ScriptBlock actionScriptBlock = GetBreakpointActionScriptBlock(breakpoint);

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -122,55 +122,25 @@ namespace Microsoft.PowerShell.EditorServices
                     {
                         // It bums me out that PowerShell will silently ignore a breakpoint
                         // where either the line or the column is invalid.  I'd rather have an
-                        // error message I could rely back to the client.
+                        // error or warning message I could relay back to the client.
                         psCommand.AddParameter("Column", breakpoint.ColumnNumber.Value);
                     }
 
                     // Check if this is a "conditional" line breakpoint.
                     if (breakpoint.Condition != null)
                     {
-                        try
+                        ScriptBlock actionScriptBlock =
+                            GetBreakpointActionScriptBlock(breakpoint);
+
+                        // If there was a problem with the condition string, 
+                        // move onto the next breakpoint.
+                        if (actionScriptBlock == null)
                         {
-                            ScriptBlock actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
-
-                            // Check for simple, common errors that ScriptBlock parsing will not catch 
-                            // e.g. $i == 3 and $i > 3
-                            string message;
-                            if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out message))
-                            {
-                                breakpoint.Verified = false;
-                                breakpoint.Message = message;
-                                resultBreakpointDetails.Add(breakpoint);
-                                continue;
-                            }
-
-                            // Check for "advanced" condition syntax i.e. if the user has specified
-                            // a "break" or  "continue" statement anywhere in their scriptblock,
-                            // pass their scriptblock through to the Action parameter as-is.
-                            Ast breakOrContinueStatementAst =
-                                actionScriptBlock.Ast.Find(
-                                    ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
-
-                            // If this isn't advanced syntax then the conditions string should be a simple
-                            // expression that needs to be wrapped in a "if" test that conditionally executes
-                            // a break statement.
-                            if (breakOrContinueStatementAst == null)
-                            {
-                                string wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
-                                actionScriptBlock = ScriptBlock.Create(wrappedCondition);
-                            }
-
-                            psCommand.AddParameter("Action", actionScriptBlock);
-                        }
-                        catch (ParseException ex)
-                        {
-                            // Failed to create conditional breakpoint likely because the user provided an 
-                            // invalid PowerShell expression. Let the user know why.
-                            breakpoint.Verified = false;
-                            breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
                             resultBreakpointDetails.Add(breakpoint);
                             continue;
                         }
+
+                        psCommand.AddParameter("Action", actionScriptBlock);
                     }
 
                     IEnumerable<Breakpoint> configuredBreakpoints =
@@ -178,6 +148,85 @@ namespace Microsoft.PowerShell.EditorServices
 
                     resultBreakpointDetails.AddRange(
                         configuredBreakpoints.Select(BreakpointDetails.Create));
+                }
+            }
+
+            return resultBreakpointDetails.ToArray();
+        }
+
+        /// <summary>
+        /// Sets the list of line breakpoints for the current debugging session.
+        /// </summary>
+        /// <param name="scriptFile">The ScriptFile in which breakpoints will be set.</param>
+        /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
+        /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
+        /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
+        public async Task<FunctionBreakpointDetails[]> SetFunctionBreakpoints(
+            FunctionBreakpointDetails[] breakpoints,
+            bool clearExisting = true)
+        {
+            var resultBreakpointDetails = new List<FunctionBreakpointDetails>();
+
+            if (clearExisting)
+            {
+                await this.ClearCommandBreakpoints();
+            }
+
+            if (breakpoints.Length > 0)
+            {
+                // Line function breakpoints with no condition are the most common, 
+                // so let's optimize for that case by making a single call to Set-PSBreakpoint 
+                // with all the command names to set a breakpoint on.
+                string[] commandOnlyBreakpoints =
+                    breakpoints.Where(b => (b.Condition == null))
+                        .Select(b => b.Name)
+                        .ToArray();
+
+                if (commandOnlyBreakpoints.Length > 0)
+                {
+                    PSCommand psCommand = new PSCommand();
+                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
+                    psCommand.AddParameter("Command", commandOnlyBreakpoints);
+
+                    var configuredBreakpoints =
+                        await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
+
+                    resultBreakpointDetails.AddRange(
+                        configuredBreakpoints.Select(FunctionBreakpointDetails.Create));
+                }
+
+                // Process the rest of the breakpoints
+                var advancedCommandBreakpoints =
+                    breakpoints.Where(b => (b.Condition != null))
+                        .ToArray();
+
+                foreach (FunctionBreakpointDetails breakpoint in advancedCommandBreakpoints)
+                {
+                    PSCommand psCommand = new PSCommand();
+                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
+                    psCommand.AddParameter("Command", breakpoint.Name);
+
+                    // Check if this is a "conditional" line breakpoint.
+                    if (breakpoint.Condition != null)
+                    {
+                        ScriptBlock actionScriptBlock = GetBreakpointActionScriptBlock(breakpoint);
+
+                        // If there was a problem with the condition string, 
+                        // move onto the next breakpoint.
+                        if (actionScriptBlock == null)
+                        {
+                            resultBreakpointDetails.Add(breakpoint);
+                            continue;
+                        }
+
+                        psCommand.AddParameter("Action", actionScriptBlock);
+                    }
+
+                    IEnumerable<Breakpoint> configuredBreakpoints =
+                        await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
+
+                    resultBreakpointDetails.AddRange(
+                        configuredBreakpoints.Select(FunctionBreakpointDetails.Create));
                 }
             }
 
@@ -402,7 +451,7 @@ namespace Microsoft.PowerShell.EditorServices
                 if (breakpoints.Count > 0)
                 {
                     PSCommand psCommand = new PSCommand();
-                    psCommand.AddCommand("Remove-PSBreakpoint");
+                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
                     psCommand.AddParameter("Breakpoint", breakpoints.ToArray());
 
                     await this.powerShellContext.ExecuteCommand<object>(psCommand);
@@ -411,6 +460,16 @@ namespace Microsoft.PowerShell.EditorServices
                     breakpoints.Clear();
                 }
             }
+        }
+
+        private async Task ClearCommandBreakpoints()
+        {
+            PSCommand psCommand = new PSCommand();
+            psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
+            psCommand.AddParameter("Type", "Command");
+            psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
+
+            await this.powerShellContext.ExecuteCommand<object>(psCommand);
         }
 
         private async Task FetchStackFramesAndVariables()
@@ -547,6 +606,59 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        /// <summary>
+        /// Inspects the condition, putting in the appropriate scriptblock template 
+        /// "if (expression) { break }".  If errors are found in the condition, the 
+        /// breakpoint passed in is updated to set Verified to false and an error
+        /// message is put into the breakpoint.Message property.
+        /// </summary>
+        /// <param name="breakpoint"></param>
+        /// <returns></returns>
+        private ScriptBlock GetBreakpointActionScriptBlock(
+            BreakpointDetailsBase breakpoint)
+        {
+            try
+            {
+                ScriptBlock actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
+
+                // Check for simple, common errors that ScriptBlock parsing will not catch 
+                // e.g. $i == 3 and $i > 3
+                string message;
+                if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out message))
+                {
+                    breakpoint.Verified = false;
+                    breakpoint.Message = message;
+                    return null;
+                }
+
+                // Check for "advanced" condition syntax i.e. if the user has specified
+                // a "break" or  "continue" statement anywhere in their scriptblock,
+                // pass their scriptblock through to the Action parameter as-is.
+                Ast breakOrContinueStatementAst =
+                    actionScriptBlock.Ast.Find(
+                        ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
+
+                // If this isn't advanced syntax then the conditions string should be a simple
+                // expression that needs to be wrapped in a "if" test that conditionally executes
+                // a break statement.
+                if (breakOrContinueStatementAst == null)
+                {
+                    string wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
+                    actionScriptBlock = ScriptBlock.Create(wrappedCondition);
+                }
+
+                return actionScriptBlock;
+            }
+            catch (ParseException ex)
+            {
+                // Failed to create conditional breakpoint likely because the user provided an 
+                // invalid PowerShell expression. Let the user know why.
+                breakpoint.Verified = false;
+                breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
+                return null;
+            }
+        }
+
         private bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
         {
             message = string.Empty;
@@ -654,38 +766,44 @@ namespace Microsoft.PowerShell.EditorServices
 
         private void OnBreakpointUpdated(object sender, BreakpointUpdatedEventArgs e)
         {
-            List<Breakpoint> breakpoints = null;
+            // This event callback also gets called when a CommandBreakpoint is modified.
+            // Only execute the following code for LineBreakpoint so we can keep track
+            // of which line breakpoints exist per script file.  We use this later when
+            // we need to clear all breakpoints in a script file.  We do not need to do
+            // this for CommandBreakpoint, as those span all script files.
+            LineBreakpoint lineBreakpoint = e.Breakpoint as LineBreakpoint;
+            if (lineBreakpoint != null)
+            {
+                List<Breakpoint> breakpoints;
 
-            // Normalize the script filename for proper indexing
-            string normalizedScriptName = e.Breakpoint.Script.ToLower();
+                // Normalize the script filename for proper indexing
+                string normalizedScriptName = lineBreakpoint.Script.ToLower();
 
-            // Get the list of breakpoints for this file
-            if (!this.breakpointsPerFile.TryGetValue(normalizedScriptName, out breakpoints))
-            {
-                breakpoints = new List<Breakpoint>();
-                this.breakpointsPerFile.Add(
-                    normalizedScriptName,
-                    breakpoints);
+                // Get the list of breakpoints for this file
+                if (!this.breakpointsPerFile.TryGetValue(normalizedScriptName, out breakpoints))
+                {
+                    breakpoints = new List<Breakpoint>();
+                    this.breakpointsPerFile.Add(
+                        normalizedScriptName,
+                        breakpoints);
+                }
+
+                // Add or remove the breakpoint based on the update type
+                if (e.UpdateType == BreakpointUpdateType.Set)
+                {
+                    breakpoints.Add(e.Breakpoint);
+                }
+                else if (e.UpdateType == BreakpointUpdateType.Removed)
+                {
+                    breakpoints.Remove(e.Breakpoint);
+                }
+                else
+                {
+                    // TODO: Do I need to switch out instances for updated breakpoints?
+                }
             }
 
-            // Add or remove the breakpoint based on the update type
-            if (e.UpdateType == BreakpointUpdateType.Set)
-            {
-                breakpoints.Add(e.Breakpoint);
-            }
-            else if(e.UpdateType == BreakpointUpdateType.Removed)
-            {
-                breakpoints.Remove(e.Breakpoint);
-            }
-            else
-            {
-                // TODO: Do I need to switch out instances for updated breakpoints?
-            }
-
-            if (this.BreakpointUpdated != null)
-            {
-                this.BreakpointUpdated(sender, e);
-            }
+            this.BreakpointUpdated?.Invoke(sender, e);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -130,7 +130,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Sets the list of line breakpoints for the current debugging session.
         /// </summary>
-        /// <param name="scriptFile">The ScriptFile in which breakpoints will be set.</param>
         /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -119,6 +119,8 @@ namespace Microsoft.PowerShell.EditorServices
                     IEnumerable<Breakpoint> configuredBreakpoints =
                         await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
 
+                    // The order in which the breakpoints are returned is significant to the 
+                    // VSCode client and should match the order in which they are passed in.
                     resultBreakpointDetails.AddRange(
                         configuredBreakpoints.Select(BreakpointDetails.Create));
                 }
@@ -128,12 +130,12 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
-        /// Sets the list of line breakpoints for the current debugging session.
+        /// Sets the list of command breakpoints for the current debugging session. 
         /// </summary>
-        /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
-        /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
+        /// <param name="breakpoints">BreakpointDetails for each command breakpoint that will be set.</param>
+        /// <param name="clearExisting">If true, causes all existing function breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<FunctionBreakpointDetails[]> SetFunctionBreakpoints(
+        public async Task<FunctionBreakpointDetails[]> SetCommandBreakpoints(
             FunctionBreakpointDetails[] breakpoints,
             bool clearExisting = true)
         {
@@ -171,6 +173,8 @@ namespace Microsoft.PowerShell.EditorServices
                     IEnumerable<Breakpoint> configuredBreakpoints =
                         await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
 
+                    // The order in which the breakpoints are returned is significant to the 
+                    // VSCode client and should match the order in which they are passed in.
                     resultBreakpointDetails.AddRange(
                         configuredBreakpoints.Select(FunctionBreakpointDetails.Create));
                 }

--- a/src/PowerShellEditorServices/Debugging/FunctionBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/FunctionBreakpointDetails.cs
@@ -1,0 +1,74 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Management.Automation;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Provides details about a function breakpoint that is set in the
+    /// PowerShell debugger.
+    /// </summary>
+    public class FunctionBreakpointDetails : BreakpointDetailsBase
+    {
+        /// <summary>
+        /// Gets the name of the function or command name for a function breakpoint.
+        /// </summary>
+        public string Name { get; private set; }
+
+        private FunctionBreakpointDetails()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the BreakpointDetails class from the individual
+        /// pieces of breakpoint information provided by the client.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="line"></param>
+        /// <param name="column"></param>
+        /// <param name="condition"></param>
+        /// <returns></returns>
+        public static FunctionBreakpointDetails Create(
+            string name,
+            string condition = null)
+        {
+            Validate.IsNotNull(nameof(name), name);
+
+            return new FunctionBreakpointDetails {
+                Name = name,
+                Condition = condition
+            };
+        }
+
+        /// <summary>
+        /// Creates an instance of the BreakpointDetails class from a
+        /// PowerShell Breakpoint object.
+        /// </summary>
+        /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
+        /// <returns>A new instance of the BreakpointDetails class.</returns>
+        public static FunctionBreakpointDetails Create(Breakpoint breakpoint)
+        {
+            Validate.IsNotNull("breakpoint", breakpoint);
+
+            CommandBreakpoint commandBreakpoint = breakpoint as CommandBreakpoint;
+            if (commandBreakpoint == null)
+            {
+                throw new ArgumentException(
+                    "Unexpected breakpoint type: " + breakpoint.GetType().Name);
+            }
+
+            var breakpointDetails = new FunctionBreakpointDetails {
+                Verified = true,
+                Name = commandBreakpoint.Command,
+                Condition = commandBreakpoint.Action?.ToString()
+            };
+
+            return breakpointDetails;
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Debugging/FunctionBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/FunctionBreakpointDetails.cs
@@ -28,10 +28,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// Creates an instance of the BreakpointDetails class from the individual
         /// pieces of breakpoint information provided by the client.
         /// </summary>
-        /// <param name="name"></param>
-        /// <param name="line"></param>
-        /// <param name="column"></param>
-        /// <param name="condition"></param>
+        /// <param name="name">The name of the function or command to break on.</param>
+        /// <param name="condition">Condition string that would be applied to the breakpoint Action parameter.</param>
         /// <returns></returns>
         public static FunctionBreakpointDetails Create(
             string name,

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -60,7 +60,9 @@
     <Compile Include="Console\IPromptHandlerContext.cs" />
     <Compile Include="Console\PromptHandler.cs" />
     <Compile Include="Debugging\BreakpointDetails.cs" />
+    <Compile Include="Debugging\BreakpointDetailsBase.cs" />
     <Compile Include="Debugging\DebugService.cs" />
+    <Compile Include="Debugging\FunctionBreakpointDetails.cs" />
     <Compile Include="Debugging\StackFrameDetails.cs" />
     <Compile Include="Debugging\VariableDetails.cs" />
     <Compile Include="Debugging\VariableDetailsBase.cs" />

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -105,9 +105,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     terminatedEvent);
         }
 
-        private Task LaunchScript(string scriptPath)
+        private async Task LaunchScript(string scriptPath)
         {
-            return this.debugAdapterClient.LaunchScript(scriptPath);
+            await this.debugAdapterClient.LaunchScript(scriptPath);
+            await this.SendRequest(ConfigurationDoneRequest.Type, null);
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/DebugTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/DebugTest.ps1
@@ -8,3 +8,5 @@ while ($i -le 500000)
 }
 
 Write-Host "Done!"
+Get-Date
+Get-Host

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerSetsAndClearsFunctionBreakpoints()
         {
             FunctionBreakpointDetails[] breakpoints =
-                await this.debugService.SetFunctionBreakpoints(
+                await this.debugService.SetCommandBreakpoints(
                     new[] {
                         FunctionBreakpointDetails.Create("Write-Host"),
                         FunctionBreakpointDetails.Create("Get-Date")
@@ -162,14 +162,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal("Get-Date", breakpoints[1].Name);
 
             breakpoints =
-                await this.debugService.SetFunctionBreakpoints(
+                await this.debugService.SetCommandBreakpoints(
                     new[] { FunctionBreakpointDetails.Create("Get-Host") });
 
             Assert.Equal(1, breakpoints.Length);
             Assert.Equal("Get-Host", breakpoints[0].Name);
 
             breakpoints =
-                await this.debugService.SetFunctionBreakpoints(
+                await this.debugService.SetCommandBreakpoints(
                     new FunctionBreakpointDetails[] {});
 
             Assert.Equal(0, breakpoints.Length);
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerStopsOnFunctionBreakpoints()
         {
             FunctionBreakpointDetails[] breakpoints =
-                await this.debugService.SetFunctionBreakpoints(
+                await this.debugService.SetCommandBreakpoints(
                     new[] {
                         FunctionBreakpointDetails.Create("Write-Host")
                     });

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -148,7 +148,81 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         }
 
         [Fact]
-        public async Task DebuggerSetsAndClearsBreakpoints()
+        public async Task DebuggerSetsAndClearsFunctionBreakpoints()
+        {
+            FunctionBreakpointDetails[] breakpoints =
+                await this.debugService.SetFunctionBreakpoints(
+                    new[] {
+                        FunctionBreakpointDetails.Create("Write-Host"),
+                        FunctionBreakpointDetails.Create("Get-Date")
+                    });
+
+            Assert.Equal(2, breakpoints.Length);
+            Assert.Equal("Write-Host", breakpoints[0].Name);
+            Assert.Equal("Get-Date", breakpoints[1].Name);
+
+            breakpoints =
+                await this.debugService.SetFunctionBreakpoints(
+                    new[] { FunctionBreakpointDetails.Create("Get-Host") });
+
+            Assert.Equal(1, breakpoints.Length);
+            Assert.Equal("Get-Host", breakpoints[0].Name);
+
+            breakpoints =
+                await this.debugService.SetFunctionBreakpoints(
+                    new FunctionBreakpointDetails[] {});
+
+            Assert.Equal(0, breakpoints.Length);
+        }
+
+        [Fact]
+        public async Task DebuggerStopsOnFunctionBreakpoints()
+        {
+            FunctionBreakpointDetails[] breakpoints =
+                await this.debugService.SetFunctionBreakpoints(
+                    new[] {
+                        FunctionBreakpointDetails.Create("Write-Host")
+                    });
+
+            await this.AssertStateChange(PowerShellContextState.Ready);
+
+            Task executeTask =
+                this.powerShellContext.ExecuteScriptAtPath(
+                    this.debugScriptFile.FilePath);
+
+            // Wait for function breakpoint to hit
+            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 6);
+
+            StackFrameDetails[] stackFrames = debugService.GetStackFrames();
+            VariableDetailsBase[] variables =
+                debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            // Verify the function breakpoint broke at Write-Host and $i is 1
+            var i = variables.FirstOrDefault(v => v.Name == "$i");
+            Assert.NotNull(i);
+            Assert.False(i.IsExpandable);
+            Assert.Equal("1", i.ValueString);
+
+            // The function breakpoint should fire the next time through the loop.
+            this.debugService.Continue();
+            await this.AssertDebuggerStopped(this.debugScriptFile.FilePath, 6);
+
+            stackFrames = debugService.GetStackFrames();
+            variables = debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            // Verify the function breakpoint broke at Write-Host and $i is 1
+            i = variables.FirstOrDefault(v => v.Name == "$i");
+            Assert.NotNull(i);
+            Assert.False(i.IsExpandable);
+            Assert.Equal("2", i.ValueString);
+
+            // Abort script execution early and wait for completion
+            this.debugService.Abort();
+            await executeTask;
+        }
+
+        [Fact]
+        public async Task DebuggerSetsAndClearsLineBreakpoints()
         {
             BreakpointDetails[] breakpoints =
                 await this.debugService.SetLineBreakpoints(


### PR DESCRIPTION
This PR introduces support for the configurationDone request.  In fact, due to the order in which set*Breakpoints requests and the launch request come in, we now defer the execution of the script until we receive the configurationDone request.  When we executed from the launch request, the debug host would appear to hang.  It did not like executing Set/Remove-PSBreakpoint commands when the host debugger was running (not in a stopped state) AFAICT.

The first commit has a known issue with VSCode mixing up which breakpoint has a condition associated with it when you add/remove a breakpoint (see Microsoft/vscode#3558).  The second commit fixes this issue.