### PR TITLE
This is a *proposed* change to address the issue that the launch requ…

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             RequestContext<object> requestContext)
         {
             // Ensure that only the second message between launch and
-            // configurationDone - actually launches the script.
+            // configurationDone requests, actually launches the script.
             lock (syncLock)
             {
                 if (!this.isLaunchRequestComplete)
@@ -116,8 +116,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
 
             // The order of debug protocol messages apparently isn't as guaranteed as we might like.
-            // Need to be able to handle the case where we get configurationDone after launch request
-            // and vice-versa.
+            // Need to be able to handle the case where we get the configurationDone request after the 
+            // launch request.
             if (this.isLaunchRequestComplete)
             {
                 this.LaunchScript(requestContext);
@@ -162,13 +162,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // We may not actually launch the script in response to this
             // request unless it comes after the configurationDone request. 
             // If the launch request comes first, then stash the launch
-            // params so that the subsequent configurationDone request can
-            // launch the script. 
+            // params so that the subsequent configurationDone request handler 
+            // can launch the script. 
             this.scriptPathToLaunch = launchParams.Program;
             this.arguments = arguments;
 
             // Ensure that only the second message between launch and
-            // configurationDone - actually launches the script.
+            // configurationDone requests, actually launches the script.
             lock (syncLock)
             {
                 if (!this.isConfigurationDoneRequestComplete)
@@ -178,8 +178,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
 
             // The order of debug protocol messages apparently isn't as guaranteed as we might like.
-            // Need to be able to handle the case where we get configurationDone after launch request
-            // and vice-versa.
+            // Need to be able to handle the case where we get the launch request after the 
+            // configurationDone request.
             if (this.isConfigurationDoneRequestComplete)
             {
                 this.LaunchScript(requestContext);


### PR DESCRIPTION
…est could come after the configurationDone request (https://github.com/Microsoft/vscode/issues/3548).

This commit "should" allow the messages to come in either order and still work.  **However, it needs a good review. ** BTW it appears all the messages are processed on the same thread (or maybe that was coincidence).  If that is the case then perhaps the lock is not needed.  Still it is a fairly lightweight lock - one bool check and an assignment.