### PR TITLE
Renamed FunctionBreakpointDetails to CommandBreakpointDetails

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         }
 
         public static Breakpoint Create(
-            FunctionBreakpointDetails breakpointDetails)
+            CommandBreakpointDetails breakpointDetails)
         {
             return new Breakpoint {
                 Verified = breakpointDetails.Verified,

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -242,16 +242,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             SetFunctionBreakpointsRequestArguments setBreakpointsParams,
             RequestContext<SetBreakpointsResponseBody> requestContext)
         {
-            var breakpointDetails = new FunctionBreakpointDetails[setBreakpointsParams.Breakpoints.Length];
+            var breakpointDetails = new CommandBreakpointDetails[setBreakpointsParams.Breakpoints.Length];
             for (int i = 0; i < breakpointDetails.Length; i++)
             {
                 FunctionBreakpoint funcBreakpoint = setBreakpointsParams.Breakpoints[i];
-                breakpointDetails[i] = FunctionBreakpointDetails.Create(
+                breakpointDetails[i] = CommandBreakpointDetails.Create(
                     funcBreakpoint.Name,
                     funcBreakpoint.Condition);
             }
 
-            FunctionBreakpointDetails[] breakpoints =
+            CommandBreakpointDetails[] breakpoints =
                 await editorSession.DebugService.SetCommandBreakpoints(
                     breakpointDetails);
 

--- a/src/PowerShellEditorServices/Debugging/CommandBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/CommandBreakpointDetails.cs
@@ -10,46 +10,46 @@ using Microsoft.PowerShell.EditorServices.Utility;
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
-    /// Provides details about a function breakpoint that is set in the
+    /// Provides details about a command breakpoint that is set in the
     /// PowerShell debugger.
     /// </summary>
-    public class FunctionBreakpointDetails : BreakpointDetailsBase
+    public class CommandBreakpointDetails : BreakpointDetailsBase
     {
         /// <summary>
-        /// Gets the name of the function or command name for a function breakpoint.
+        /// Gets the name of the command on which the command breakpoint has been set.
         /// </summary>
         public string Name { get; private set; }
 
-        private FunctionBreakpointDetails()
+        private CommandBreakpointDetails()
         {
         }
 
         /// <summary>
-        /// Creates an instance of the BreakpointDetails class from the individual
+        /// Creates an instance of the <see cref="CommandBreakpointDetails"/> class from the individual
         /// pieces of breakpoint information provided by the client.
         /// </summary>
-        /// <param name="name">The name of the function or command to break on.</param>
+        /// <param name="name">The name of the command to break on.</param>
         /// <param name="condition">Condition string that would be applied to the breakpoint Action parameter.</param>
         /// <returns></returns>
-        public static FunctionBreakpointDetails Create(
+        public static CommandBreakpointDetails Create(
             string name,
             string condition = null)
         {
             Validate.IsNotNull(nameof(name), name);
 
-            return new FunctionBreakpointDetails {
+            return new CommandBreakpointDetails {
                 Name = name,
                 Condition = condition
             };
         }
 
         /// <summary>
-        /// Creates an instance of the BreakpointDetails class from a
-        /// PowerShell Breakpoint object.
+        /// Creates an instance of the <see cref="CommandBreakpointDetails"/> class from a
+        /// PowerShell CommandBreakpoint object.
         /// </summary>
         /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
         /// <returns>A new instance of the BreakpointDetails class.</returns>
-        public static FunctionBreakpointDetails Create(Breakpoint breakpoint)
+        public static CommandBreakpointDetails Create(Breakpoint breakpoint)
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices
                     "Unexpected breakpoint type: " + breakpoint.GetType().Name);
             }
 
-            var breakpointDetails = new FunctionBreakpointDetails {
+            var breakpointDetails = new CommandBreakpointDetails {
                 Verified = true,
                 Name = commandBreakpoint.Command,
                 Condition = commandBreakpoint.Action?.ToString()

--- a/src/PowerShellEditorServices/Debugging/CommandBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/CommandBreakpointDetails.cs
@@ -10,8 +10,7 @@ using Microsoft.PowerShell.EditorServices.Utility;
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
-    /// Provides details about a command breakpoint that is set in the
-    /// PowerShell debugger.
+    /// Provides details about a command breakpoint that is set in the PowerShell debugger.
     /// </summary>
     public class CommandBreakpointDetails : BreakpointDetailsBase
     {

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -132,14 +132,14 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Sets the list of command breakpoints for the current debugging session. 
         /// </summary>
-        /// <param name="breakpoints">BreakpointDetails for each command breakpoint that will be set.</param>
+        /// <param name="breakpoints">CommandBreakpointDetails for each command breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing function breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<FunctionBreakpointDetails[]> SetCommandBreakpoints(
-            FunctionBreakpointDetails[] breakpoints,
+        public async Task<CommandBreakpointDetails[]> SetCommandBreakpoints(
+            CommandBreakpointDetails[] breakpoints,
             bool clearExisting = true)
         {
-            var resultBreakpointDetails = new List<FunctionBreakpointDetails>();
+            var resultBreakpointDetails = new List<CommandBreakpointDetails>();
 
             if (clearExisting)
             {
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (breakpoints.Length > 0)
             {
-                foreach (FunctionBreakpointDetails breakpoint in breakpoints)
+                foreach (CommandBreakpointDetails breakpoint in breakpoints)
                 {
                     PSCommand psCommand = new PSCommand();
                     psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.EditorServices
                     // The order in which the breakpoints are returned is significant to the 
                     // VSCode client and should match the order in which they are passed in.
                     resultBreakpointDetails.AddRange(
-                        configuredBreakpoints.Select(FunctionBreakpointDetails.Create));
+                        configuredBreakpoints.Select(CommandBreakpointDetails.Create));
                 }
             }
 

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -62,7 +62,7 @@
     <Compile Include="Debugging\BreakpointDetails.cs" />
     <Compile Include="Debugging\BreakpointDetailsBase.cs" />
     <Compile Include="Debugging\DebugService.cs" />
-    <Compile Include="Debugging\FunctionBreakpointDetails.cs" />
+    <Compile Include="Debugging\CommandBreakpointDetails.cs" />
     <Compile Include="Debugging\StackFrameDetails.cs" />
     <Compile Include="Debugging\VariableDetails.cs" />
     <Compile Include="Debugging\VariableDetailsBase.cs" />

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -150,11 +150,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsAndClearsFunctionBreakpoints()
         {
-            FunctionBreakpointDetails[] breakpoints =
+            CommandBreakpointDetails[] breakpoints =
                 await this.debugService.SetCommandBreakpoints(
                     new[] {
-                        FunctionBreakpointDetails.Create("Write-Host"),
-                        FunctionBreakpointDetails.Create("Get-Date")
+                        CommandBreakpointDetails.Create("Write-Host"),
+                        CommandBreakpointDetails.Create("Get-Date")
                     });
 
             Assert.Equal(2, breakpoints.Length);
@@ -163,14 +163,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             breakpoints =
                 await this.debugService.SetCommandBreakpoints(
-                    new[] { FunctionBreakpointDetails.Create("Get-Host") });
+                    new[] { CommandBreakpointDetails.Create("Get-Host") });
 
             Assert.Equal(1, breakpoints.Length);
             Assert.Equal("Get-Host", breakpoints[0].Name);
 
             breakpoints =
                 await this.debugService.SetCommandBreakpoints(
-                    new FunctionBreakpointDetails[] {});
+                    new CommandBreakpointDetails[] {});
 
             Assert.Equal(0, breakpoints.Length);
         }
@@ -178,10 +178,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerStopsOnFunctionBreakpoints()
         {
-            FunctionBreakpointDetails[] breakpoints =
+            CommandBreakpointDetails[] breakpoints =
                 await this.debugService.SetCommandBreakpoints(
                     new[] {
-                        FunctionBreakpointDetails.Create("Write-Host")
+                        CommandBreakpointDetails.Create("Write-Host")
                     });
 
             await this.AssertStateChange(PowerShellContextState.Ready);


### PR DESCRIPTION
The services API should be oriented more towards PowerShell (and not VSCode) terminology.