### PR TITLE
Fix #181: Fix crash for unsupported field types

### DIFF
--- a/src/PowerShellEditorServices/Console/FieldDetails.cs
+++ b/src/PowerShellEditorServices/Console/FieldDetails.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Host;
+using System.Security;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -89,7 +90,17 @@ namespace Microsoft.PowerShell.EditorServices.Console
             this.IsMandatory = isMandatory;
             this.DefaultValue = defaultValue;
 
-            if (typeof(IList).IsAssignableFrom(fieldType))
+            if (typeof(SecureString) == fieldType)
+            {
+                throw new NotSupportedException(
+                    "Input fields of type 'SecureString' are currently not supported.");
+            }
+            else if (typeof(PSCredential) == fieldType)
+            {
+                throw new NotSupportedException(
+                    "Input fields of type 'PSCredential' are currently not supported.");
+            }
+            else if (typeof(IList).IsAssignableFrom(fieldType))
             {
                 this.IsCollection = true;
                 this.ElementType = typeof(object);

--- a/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
@@ -154,7 +154,8 @@ namespace Microsoft.PowerShell.EditorServices
             PSCredentialTypes allowedCredentialTypes, 
             PSCredentialUIOptions options)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException(
+                "'Get-Credential' is not yet supported.");
         }
 
         public override PSCredential PromptForCredential(
@@ -163,7 +164,13 @@ namespace Microsoft.PowerShell.EditorServices
             string userName, 
             string targetName)
         {
-            throw new NotImplementedException();
+            return this.PromptForCredential(
+                caption,
+                message,
+                userName,
+                targetName,
+                PSCredentialTypes.Default,
+                PSCredentialUIOptions.Default);
         }
 
         public override PSHostRawUserInterface RawUI
@@ -198,7 +205,8 @@ namespace Microsoft.PowerShell.EditorServices
 
         public override SecureString ReadLineAsSecureString()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException(
+                "'Read-Host -AsSecureString' is not yet supported.");
         }
 
         public override void Write(


### PR DESCRIPTION
This change adds proper error handling for input prompt requests for field
types that we don't yet support like SecureString and PSCredential.
Previously any Read-Host or Get-Credential call which prompts for either
of these types would crash the language and debugging services.  The fix
causes errors to be written to the host stating that these commands and
field types are not yet supported.