### PR TITLE
Fix #99: 'using module' relative path resolution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '$(core_version).{build}'
-os: Unstable
+os: WMF 5
 configuration: Release
 clone_depth: 10
 

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -13,9 +13,16 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <DefineConstants Condition=" '$(PowerShellVersion)' == 'v3'">PowerShellv3</DefineConstants>
-    <DefineConstants Condition=" '$(PowerShellVersion)' == 'v4'">PowerShellv4</DefineConstants>
-    <DefineConstants Condition=" '$(PowerShellVersion)' == '' Or '$(PowerShellVersion)' == 'v5'">PowerShellv5</DefineConstants>
+    <DefineConstants Condition="'$(PowerShellVersion)' == 'v3'">$(DefineConstants);PowerShellv3</DefineConstants>
+    <DefineConstants Condition="'$(PowerShellVersion)' == 'v4'">$(DefineConstants);PowerShellv4</DefineConstants>
+    <!-- NOTE: -->
+    <!-- For PowerShell v5 there are some differences between the APIs released with -->
+    <!-- Windows 10 RTM and Windows 10 Update 1, thus we need to distinguish between -->
+    <!-- the two in our code.  v5r1 indicates Win 10 RTM (10240) and v5r2 indicates  -->
+    <!-- Win10 Update 1 (10586).  The PowerShellv5 constant will be defined for both -->
+    <!-- of these versions for anything that should work against both APIs.          -->
+    <DefineConstants Condition="'$(PowerShellVersion)' == 'v5r1'">$(DefineConstants);PowerShellv5r1;PowerShellv5</DefineConstants>
+    <DefineConstants Condition="'$(PowerShellVersion)' == 'v5r2' Or '$(PowerShellVersion)' == ''">$(DefineConstants);PowerShellv5r2;PowerShellv5</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -60,9 +60,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public void StartSession()
         {
-            // Create a workspace to contain open files
-            this.Workspace = new Workspace();
-
             // Initialize all services
             this.PowerShellContext = new PowerShellContext();
             this.LanguageService = new LanguageService(this.PowerShellContext);
@@ -81,6 +78,9 @@ namespace Microsoft.PowerShell.EditorServices
                     LogLevel.Warning,
                     "Script Analyzer binaries not found, AnalysisService will be disabled.");
             }
+
+            // Create a workspace to contain open files
+            this.Workspace = new Workspace(this.PowerShellContext.PowerShellVersion);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
+        private Version powerShellVersion;
         private Dictionary<string, ScriptFile> workspaceFiles = new Dictionary<string, ScriptFile>();
 
         #endregion
@@ -30,6 +31,19 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets or sets the root path of the workspace.
         /// </summary>
         public string WorkspacePath { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the Workspace class.
+        /// </summary>
+        /// <param name="powerShellVersion">The version of PowerShell for which scripts will be parsed.</param>
+        public Workspace(Version powerShellVersion)
+        {
+            this.powerShellVersion = powerShellVersion;
+        }
 
         #endregion
 
@@ -63,7 +77,13 @@ namespace Microsoft.PowerShell.EditorServices
 
                 using (StreamReader streamReader = new StreamReader(resolvedFilePath, Encoding.UTF8))
                 {
-                    scriptFile = new ScriptFile(resolvedFilePath, filePath, streamReader);
+                    scriptFile = 
+                        new ScriptFile(
+                            resolvedFilePath,
+                            filePath,
+                            streamReader,
+                            this.powerShellVersion);
+
                     this.workspaceFiles.Add(keyName, scriptFile);
                 }
 
@@ -92,7 +112,13 @@ namespace Microsoft.PowerShell.EditorServices
             ScriptFile scriptFile = null;
             if (!this.workspaceFiles.TryGetValue(keyName, out scriptFile))
             {
-                scriptFile = new ScriptFile(resolvedFilePath, filePath, initialBuffer);
+                scriptFile = 
+                    new ScriptFile(
+                        resolvedFilePath,
+                        filePath,
+                        initialBuffer,
+                        this.powerShellVersion);
+
                 this.workspaceFiles.Add(keyName, scriptFile);
 
                 Logger.Write(LogLevel.Verbose, "Opened file as in-memory buffer: " + resolvedFilePath);

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -82,6 +82,21 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         }
 
         [Fact]
+        public async Task ServiceReturnsNoErrorsForUsingRelativeModulePaths()
+        {
+            // Send the 'didOpen' event
+            await this.SendOpenFileEvent("TestFiles\\Module.psm1", false);
+
+            // Wait for the diagnostic event
+            PublishDiagnosticsNotification diagnostics = 
+                await this.WaitForEvent(
+                    PublishDiagnosticsNotification.Type);
+
+            // Was there a syntax error?
+            Assert.Equal(0, diagnostics.Diagnostics.Length);
+        }
+
+        [Fact]
         public async Task ServiceCompletesFunctionName()
         {
             await this.SendOpenFileEvent("TestFiles\\CompleteFunctionName.ps1");

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -74,10 +74,16 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+    <None Include="TestFiles\ChildModule\ChildModule.psm1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\CompleteFunctionName.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="TestFiles\FindReferences.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="TestFiles\Module.psm1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="TestFiles\MultiLineReplace.ps1">

--- a/test/PowerShellEditorServices.Test.Host/TestFiles/ChildModule/ChildModule.psm1
+++ b/test/PowerShellEditorServices.Test.Host/TestFiles/ChildModule/ChildModule.psm1
@@ -1,0 +1,2 @@
+﻿function Get-Stuff {
+}

--- a/test/PowerShellEditorServices.Test.Host/TestFiles/Module.psm1
+++ b/test/PowerShellEditorServices.Test.Host/TestFiles/Module.psm1
@@ -1,0 +1,1 @@
+﻿using module ".\ChildModule"

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -30,7 +30,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         public DebugServiceTests()
         {
-            this.workspace = new Workspace();
+            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext.SessionStateChanged += powerShellContext_SessionStateChanged;
+
+            this.workspace = new Workspace(this.powerShellContext.PowerShellVersion);
 
             // Load the test debug file
             this.debugScriptFile =
@@ -41,13 +44,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 this.workspace.GetFile(
                     @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
 
-            this.powerShellContext = new PowerShellContext();
-            this.powerShellContext.SessionStateChanged += powerShellContext_SessionStateChanged;
-
             this.debugService = new DebugService(this.powerShellContext);
             this.debugService.DebuggerStopped += debugService_DebuggerStopped;
             this.debugService.BreakpointUpdated += debugService_BreakpointUpdated;
             this.runnerContext = SynchronizationContext.Current;
+
+            // Load the test debug file
+            this.debugScriptFile =
+                this.workspace.GetFile(
+                    @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1");
         }
 
         async void powerShellContext_SessionStateChanged(object sender, SessionStateChangedEventArgs e)

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -32,9 +32,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
         public LanguageServiceTests()
         {
-            this.workspace = new Workspace();
-
             this.powerShellContext = new PowerShellContext();
+            this.workspace = new Workspace(this.powerShellContext.PowerShellVersion);
             this.languageService = new LanguageService(this.powerShellContext);
         }
 

--- a/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/PowerShellVersionTests.cs
@@ -16,10 +16,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
     public class PowerShellVersionTests 
     {
         [Theory]
-        [InlineData("3")]
-        [InlineData("4")]
-        [InlineData("5")]
-        public void CompilesWithPowerShellVersion(string version)
+        [InlineData("3", "4")]
+        [InlineData("4", "4")]
+        [InlineData("5", "5r1")]
+        public void CompilesWithPowerShellVersion(string version, string versionSuffix)
         {
             var assemblyPath = 
                 Path.GetFullPath(
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             try
             {
-                Compile(projectVersion, version);
+                Compile(projectVersion, version, versionSuffix);
             }
             finally
             {
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             }
         }
 
-        private void Compile(string project, string version)
+        private void Compile(string project, string version, string versionSuffix)
         {
             string msbuild;
             using (var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0"))

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.PowerShell.EditorServices;
+using System;
 using System.IO;
 using Xunit;
 
@@ -11,6 +12,8 @@ namespace PSLanguageService.Test
 {
     public class FileChangeTests
     {
+        private static readonly Version PowerShellVersion = new Version("5.0"); 
+
         [Fact]
         public void CanApplySingleLineInsert()
         {
@@ -135,7 +138,13 @@ namespace PSLanguageService.Test
 
             using (StringReader stringReader = new StringReader(exampleScriptContents))
             {
-                ScriptFile scriptFile = new ScriptFile("DotSourceTestFile.ps1", "DotSourceTestFile.ps1", stringReader);
+                ScriptFile scriptFile = 
+                    new ScriptFile(
+                        "DotSourceTestFile.ps1",
+                        "DotSourceTestFile.ps1",
+                        stringReader,
+                        PowerShellVersion);
+
                 Assert.Equal(3, scriptFile.ReferencedFiles.Length);
                 System.Console.Write("a" + scriptFile.ReferencedFiles[0]);
                 Assert.Equal(@".\athing.ps1", scriptFile.ReferencedFiles[0]);
@@ -150,7 +159,12 @@ namespace PSLanguageService.Test
             using (StringReader stringReader = new StringReader(initialString))
             {
                 // Create an in-memory file from the StringReader
-                ScriptFile fileToChange = new ScriptFile("TestFile.ps1", "TestFile.ps1", stringReader);
+                ScriptFile fileToChange = 
+                    new ScriptFile(
+                        "TestFile.ps1",
+                        "TestFile.ps1",
+                        stringReader,
+                        PowerShellVersion);
 
                 // Apply the FileChange and assert the resulting contents
                 fileToChange.ApplyChange(fileChange);


### PR DESCRIPTION
This change fixes an issue with relative module path resolution with the
'using module' statement in more recent versions of PowerShell v5.  A new
method overload was added to the PowerShell API's Parser.ParseInput method
which allows the script's path to be specified.  By using this parameter,
the PowerShell parser resolves relative module paths correctly.

This change also required a change to how PowerShell API usage is verified
for different PowerShell versions.  Since the PowerShell v5 reference
assemblies don't (yet) contain Parser.ParseInput overload, we now have to
make a distinction between the PowerShell v5 which is specified by the
reference assemblies and the one that is currently shipped in the latest
official Windows 10 release (10586).  Once updated reference assemblies
have been shipped for PowerShell v5 we may revisit this approach.