### PR TITLE
Finish PowerShell v3 and v4 support

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -295,7 +295,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             object pauseParams,
             RequestContext<object> requestContext)
         {
-            editorSession.DebugService.Break();
+            try
+            {
+                editorSession.DebugService.Break();
+            }
+            catch (NotSupportedException e)
+            {
+                return requestContext.SendError(e.Message);
+            }
 
             // This request is responded to by sending the "stopped" event
             return Task.FromResult(true);

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -98,8 +98,12 @@
     <Compile Include="Console\ChoiceDetails.cs" />
     <Compile Include="Session\EditorSession.cs" />
     <Compile Include="Console\IConsoleHost.cs" />
+    <Compile Include="Session\IVersionSpecificOperations.cs" />
     <Compile Include="Session\OutputType.cs" />
     <Compile Include="Session\OutputWrittenEventArgs.cs" />
+    <Compile Include="Session\PowerShell3Operations.cs" />
+    <Compile Include="Session\PowerShell4Operations.cs" />
+    <Compile Include="Session\PowerShell5Operations.cs" />
     <Compile Include="Session\PowerShellExecutionResult.cs" />
     <Compile Include="Session\PowerShellContext.cs" />
     <Compile Include="Session\PowerShellContextState.cs" />

--- a/src/PowerShellEditorServices/Session/IVersionSpecificOperations.cs
+++ b/src/PowerShellEditorServices/Session/IVersionSpecificOperations.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    internal interface IVersionSpecificOperations
+    {
+        void ConfigureDebugger(Runspace runspace);
+
+        void PauseDebugger(Runspace runspace);
+
+        IEnumerable<TResult> ExecuteCommandInDebugger<TResult>(
+            PowerShellContext powerShellContext,
+            Runspace currentRunspace,
+            PSCommand psCommand,
+            bool sendOutputToHost);
+    }
+}
+

--- a/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    internal class PowerShell3Operations : IVersionSpecificOperations
+    {
+        public void ConfigureDebugger(Runspace runspace)
+        {
+            // The debugger has no SetDebugMode in PowerShell v3.
+        }
+
+        public void PauseDebugger(Runspace runspace)
+        {
+            // The debugger cannot be paused in PowerShell v3.
+            throw new NotSupportedException("Debugger cannot be paused in PowerShell v3");
+        }
+
+        public IEnumerable<TResult> ExecuteCommandInDebugger<TResult>(
+            PowerShellContext powerShellContext,
+            Runspace currentRunspace,
+            PSCommand psCommand,
+            bool sendOutputToHost)
+        {
+            IEnumerable<TResult> executionResult = null;
+
+            using (var nestedPipeline = currentRunspace.CreateNestedPipeline())
+            {
+                foreach (var command in psCommand.Commands)
+                {
+                    nestedPipeline.Commands.Add(command);
+                }
+
+                executionResult =
+                    nestedPipeline
+                        .Invoke()
+                        .Select(pso => pso.BaseObject)
+                        .Cast<TResult>();
+            }
+
+            // Write the output to the host if necessary
+            if (sendOutputToHost)
+            {
+                foreach (var line in executionResult)
+                {
+                    powerShellContext.WriteOutput(line.ToString(), true);
+                }
+            }
+
+            return executionResult;
+        }
+    }
+}
+

--- a/src/PowerShellEditorServices/Session/PowerShell4Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell4Operations.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    internal class PowerShell4Operations : IVersionSpecificOperations
+    {
+        public void ConfigureDebugger(Runspace runspace)
+        {
+#if !PowerShellv3
+            runspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
+#endif
+        }
+
+        public virtual void PauseDebugger(Runspace runspace)
+        {
+            // The debugger cannot be paused in PowerShell v4.
+            throw new NotSupportedException("Debugger cannot be paused in PowerShell v4");
+        }
+
+        public IEnumerable<TResult> ExecuteCommandInDebugger<TResult>(
+            PowerShellContext powerShellContext,
+            Runspace currentRunspace,
+            PSCommand psCommand,
+            bool sendOutputToHost)
+        {
+            PSDataCollection<PSObject> outputCollection = new PSDataCollection<PSObject>();
+
+#if !PowerShellv3
+            if (sendOutputToHost)
+            {
+                outputCollection.DataAdded +=
+                    (obj, e) =>
+                    {
+                        for (int i = e.Index; i < outputCollection.Count; i++)
+                        {
+                            powerShellContext.WriteOutput(
+                                outputCollection[i].ToString(),
+                                true);
+                        }
+                    };
+            }
+
+            DebuggerCommandResults commandResults =
+                currentRunspace.Debugger.ProcessCommand(
+                    psCommand,
+                    outputCollection);
+#endif
+
+            return
+                outputCollection
+                    .Select(pso => pso.BaseObject)
+                    .Cast<TResult>();
+        }
+    }
+}
+

--- a/src/PowerShellEditorServices/Session/PowerShell5Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell5Operations.cs
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Management.Automation.Runspaces;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    internal class PowerShell5Operations : PowerShell4Operations
+    {
+        public override void PauseDebugger(Runspace runspace)
+        {
+#if !PowerShellv3 && !PowerShellv4
+            runspace.Debugger.SetDebuggerStepMode(true);
+#endif
+        }
+    }
+}
+

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -1021,7 +1021,8 @@ namespace Microsoft.PowerShell.EditorServices
                 if (taskIndex == 0)
                 {
                     // Write a new output line before continuing
-                    this.WriteOutput("", true);
+                    // TODO: Re-enable this with fix for #133
+                    //this.WriteOutput("", true);
 
                     e.ResumeAction = this.debuggerStoppedTask.Task.Result;
                     Logger.Write(LogLevel.Verbose, "Received debugger resume action " + e.ResumeAction.ToString());

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices
 {
+    using Session;
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
     using System.Reflection;
@@ -38,6 +39,7 @@ namespace Microsoft.PowerShell.EditorServices
         private Runspace currentRunspace;
         private ConsoleServicePSHost psHost;
         private InitialSessionState initialSessionState;
+        private IVersionSpecificOperations versionSpecificOperations;
         private int pipelineThreadId;
 
         private TaskCompletionSource<DebuggerResumeAction> debuggerStoppedTask;
@@ -174,12 +176,28 @@ namespace Microsoft.PowerShell.EditorServices
                     "PowerShell runtime version: {0}",
                     this.PowerShellVersion));
 
-#if !PowerShellv3
-            if (PowerShellVersion > new Version(3,0))
+            if (PowerShellVersion >= new Version(5,0))
             {
-                this.currentRunspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
+                this.versionSpecificOperations = new PowerShell5Operations();
             }
-#endif
+            else if (PowerShellVersion.Major == 4)
+            {
+                this.versionSpecificOperations = new PowerShell4Operations();
+            }
+            else if (PowerShellVersion.Major == 3)
+            {
+                this.versionSpecificOperations = new PowerShell3Operations();
+            }
+            else
+            {
+                throw new NotSupportedException(
+                    "This computer has an unsupported version of PowerShell installed: " +
+                    PowerShellVersion.ToString());
+            }
+
+            // Configure the runspace's debugger
+            this.versionSpecificOperations.ConfigureDebugger(
+                this.currentRunspace);
 
             this.SessionState = PowerShellContextState.Ready;
 
@@ -510,12 +528,9 @@ namespace Microsoft.PowerShell.EditorServices
         {
             Logger.Write(LogLevel.Verbose, "Debugger break requested...");
 
-#if PowerShellv5
-            if (PowerShellVersion >= new Version(5, 0))
-            {
-                this.currentRunspace.Debugger.SetDebuggerStepMode(true);
-            }
-#endif
+            // Pause the debugger
+            this.versionSpecificOperations.PauseDebugger(
+                this.currentRunspace);
         }
 
         internal void ResumeDebugger(DebuggerResumeAction resumeAction)
@@ -659,72 +674,14 @@ namespace Microsoft.PowerShell.EditorServices
 
         private IEnumerable<TResult> ExecuteCommandInDebugger<TResult>(PSCommand psCommand, bool sendOutputToHost)
         {
-            IEnumerable<TResult> executionResult = null;
-
-            if (PowerShellVersion >= new Version(4, 0))
-            {
-#if PowerShellv4 || PowerShellv5
-                PSDataCollection<PSObject> outputCollection = new PSDataCollection<PSObject>();
-
-                if (sendOutputToHost)
-                {
-                    outputCollection.DataAdded +=
-                        (obj, e) =>
-                        {
-                            for (int i = e.Index; i < outputCollection.Count; i++)
-                            {
-                                this.WriteOutput(outputCollection[i].ToString(), true);
-                            }
-                        };
-                }
-
-                DebuggerCommandResults commandResults =
-                    this.currentRunspace.Debugger.ProcessCommand(
-                        psCommand,
-                        outputCollection);
-
-                // If the command was a debugger action, run it
-                if (commandResults.ResumeAction.HasValue)
-                {
-                    this.ResumeDebugger(commandResults.ResumeAction.Value);
-                }
-
-                executionResult =
-                    outputCollection
-                        .Select(pso => pso.BaseObject)
-                        .Cast<TResult>();
-#endif
-            }
-            else
-            {
-                using (var nestedPipeline = this.currentRunspace.CreateNestedPipeline())
-                {
-                    foreach (var command in psCommand.Commands)
-                    {
-                        nestedPipeline.Commands.Add(command);
-                    }
-
-                    executionResult =
-                        nestedPipeline
-                            .Invoke()
-                            .Select(pso => pso.BaseObject)
-                            .Cast<TResult>();
-                }
-
-                // Write the output to the host if necessary
-                if (sendOutputToHost)
-                {
-                    foreach (var line in executionResult)
-                    {
-                        this.WriteOutput(line.ToString(), true);
-                    }
-                }
-            }
-
-            return executionResult;
+            return this.versionSpecificOperations.ExecuteCommandInDebugger<TResult>(
+                this,
+                this.currentRunspace,
+                psCommand,
+                sendOutputToHost);
         }
 
-        private void WriteOutput(string outputString, bool includeNewLine)
+        internal void WriteOutput(string outputString, bool includeNewLine)
         {
             if (this.ConsoleHost != null)
             {


### PR DESCRIPTION
This change finishes our PowerShell v3 and v4 support by conditionally
changing behavior for those versions.  This works by using an interface
facade in front of any version-specific behavior so that the CLR doesn't
try to resolve method names that aren't available in a particular version.