### PR TITLE
Add support for loading host profile scripts

### DIFF
--- a/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
     {
         public LanguageServerWebSocketConnection()
         {
-            Server = new LanguageServer(Channel);
+            Server = new LanguageServer(null, Channel);
         }
     }
 
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
     {
         public DebugAdapterWebSocketConnection()
         {
-            Server = new DebugAdapter(Channel);
+            Server = new DebugAdapter(null, Channel);
         }
     }
 

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -6,6 +6,7 @@
 using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
+using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
@@ -25,14 +26,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         private string scriptPathToLaunch;
         private string arguments;
 
-        public DebugAdapter() : this(new StdioServerChannel())
+        public DebugAdapter(HostDetails hostDetails)
+            : this(hostDetails, new StdioServerChannel())
         {
         }
 
-        public DebugAdapter(ChannelBase serverChannel) : base(serverChannel)
+        public DebugAdapter(HostDetails hostDetails, ChannelBase serverChannel)
+            : base(serverChannel)
         {
             this.editorSession = new EditorSession();
-            this.editorSession.StartSession();
+            this.editorSession.StartSession(hostDetails);
             this.editorSession.DebugService.DebuggerStopped += this.DebugService_DebuggerStopped;
             this.editorSession.ConsoleService.OutputWritten += this.powerShellContext_OutputWritten;
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -6,7 +6,7 @@
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
-using Microsoft.PowerShell.EditorServices.Protocol.Messages;
+using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
@@ -24,18 +24,27 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     {
         private static CancellationTokenSource existingRequestCancellation;
 
+        private bool profilesLoaded;
         private EditorSession editorSession;
         private OutputDebouncer outputDebouncer;
         private LanguageServerSettings currentSettings = new LanguageServerSettings();
 
-        public LanguageServer() : this(new StdioServerChannel())
+        /// <param name="hostDetails">
+        /// Provides details about the host application.
+        /// </param>
+        public LanguageServer(HostDetails hostDetails)
+            : this(hostDetails, new StdioServerChannel())
         {
         }
 
-        public LanguageServer(ChannelBase serverChannel) : base(serverChannel)
+        /// <param name="hostDetails">
+        /// Provides details about the host application.
+        /// </param>
+        public LanguageServer(HostDetails hostDetails, ChannelBase serverChannel)
+            : base(serverChannel)
         {
             this.editorSession = new EditorSession();
-            this.editorSession.StartSession();
+            this.editorSession.StartSession(hostDetails);
             this.editorSession.ConsoleService.OutputWritten += this.powerShellContext_OutputWritten;
 
             // Always send console prompts through the UI in the language service
@@ -59,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.SetEventHandler(DidOpenTextDocumentNotification.Type, this.HandleDidOpenTextDocumentNotification);
             this.SetEventHandler(DidCloseTextDocumentNotification.Type, this.HandleDidCloseTextDocumentNotification);
             this.SetEventHandler(DidChangeTextDocumentNotification.Type, this.HandleDidChangeTextDocumentNotification);
-            this.SetEventHandler(DidChangeConfigurationNotification<SettingsWrapper>.Type, this.HandleDidChangeConfigurationNotification);
+            this.SetEventHandler(DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type, this.HandleDidChangeConfigurationNotification);
 
             this.SetRequestHandler(DefinitionRequest.Type, this.HandleDefinitionRequest);
             this.SetRequestHandler(ReferencesRequest.Type, this.HandleReferencesRequest);
@@ -287,14 +296,23 @@ function __Expand-Alias {
         }
 
         protected async Task HandleDidChangeConfigurationNotification(
-            DidChangeConfigurationParams<SettingsWrapper> configChangeParams,
+            DidChangeConfigurationParams<LanguageServerSettingsWrapper> configChangeParams,
             EventContext eventContext)
         {
+            bool oldLoadProfiles = this.currentSettings.EnableProfileLoading;
             bool oldScriptAnalysisEnabled =
                 this.currentSettings.ScriptAnalysis.Enable.HasValue;
 
             this.currentSettings.Update(
                 configChangeParams.Settings.Powershell);
+
+            if (!this.profilesLoaded &&
+                this.currentSettings.EnableProfileLoading &&
+                oldLoadProfiles != this.currentSettings.EnableProfileLoading)
+            {
+                await this.editorSession.PowerShellContext.LoadHostProfiles();
+                this.profilesLoaded = true;
+            }
 
             if (oldScriptAnalysisEnabled != this.currentSettings.ScriptAnalysis.Enable)
             {

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -7,6 +7,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     public class LanguageServerSettings
     {
+        public bool EnableProfileLoading { get; set; }
+
         public ScriptAnalysisSettings ScriptAnalysis { get; set; }
 
         public LanguageServerSettings()
@@ -18,6 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             if (settings != null)
             {
+                this.EnableProfileLoading = settings.EnableProfileLoading;
                 this.ScriptAnalysis.Update(settings.ScriptAnalysis);
             }
         }
@@ -41,7 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         }
     }
 
-    public class SettingsWrapper
+    public class LanguageServerSettingsWrapper
     {
         // NOTE: This property is capitalized as 'Powershell' because the
         // mode name sent from the client is written as 'powershell' and

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Console\ChoiceDetails.cs" />
     <Compile Include="Session\EditorSession.cs" />
     <Compile Include="Console\IConsoleHost.cs" />
+    <Compile Include="Session\HostDetails.cs" />
     <Compile Include="Session\IVersionSpecificOperations.cs" />
     <Compile Include="Session\OutputType.cs" />
     <Compile Include="Session\OutputWrittenEventArgs.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="Session\PowerShellExecutionResult.cs" />
     <Compile Include="Session\PowerShellContext.cs" />
     <Compile Include="Session\PowerShellContextState.cs" />
+    <Compile Include="Session\ProfilePaths.cs" />
     <Compile Include="Session\ProgressDetails.cs" />
     <Compile Include="Session\RunspaceHandle.cs" />
     <Compile Include="Session\SessionPSHost.cs" />

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -4,13 +4,9 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
-using System;
 using System.IO;
-using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using System.Reflection;
-using System.Threading;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -62,8 +58,20 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public void StartSession()
         {
+            this.StartSession(null);
+        }
+
+        /// <summary>
+        /// Starts the session using the provided IConsoleHost implementation
+        /// for the ConsoleService.
+        /// </summary>
+        /// <param name="hostDetails">
+        /// Provides details about the host application.
+        /// </param>
+        public void StartSession(HostDetails hostDetails)
+        {
             // Initialize all services
-            this.PowerShellContext = new PowerShellContext();
+            this.PowerShellContext = new PowerShellContext(hostDetails);
             this.LanguageService = new LanguageService(this.PowerShellContext);
             this.DebugService = new DebugService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);

--- a/src/PowerShellEditorServices/Session/HostDetails.cs
+++ b/src/PowerShellEditorServices/Session/HostDetails.cs
@@ -1,0 +1,92 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    /// <summary>
+    /// Contains details about the current host application (most
+    /// likely the editor which is using the host process).
+    /// </summary>
+    public class HostDetails
+    {
+        #region Constants
+
+        /// <summary>
+        /// The default host name for PowerShell Editor Services.  Used
+        /// if no host name is specified by the host application.
+        /// </summary>
+        public const string DefaultHostName = "PowerShell Editor Services Host";
+
+        /// <summary>
+        /// The default host ID for PowerShell Editor Services.  Used
+        /// for the host-specific profile path if no host ID is specified.
+        /// </summary>
+        public const string DefaultHostProfileId = "Microsoft.PowerShellEditorServices";
+
+        /// <summary>
+        /// The default host version for PowerShell Editor Services.  If
+        /// no version is specified by the host application, we use 0.0.0
+        /// to indicate a lack of version.
+        /// </summary>
+        public static readonly Version DefaultHostVersion = new Version("0.0.0");
+
+        /// <summary>
+        /// The default host details in a HostDetails object.
+        /// </summary>
+        public static readonly HostDetails Default = new HostDetails(null, null, null);
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the name of the host.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the profile ID of the host, used to determine the
+        /// host-specific profile path.
+        /// </summary>
+        public string ProfileId { get; private set; }
+
+        /// <summary>
+        /// Gets the version of the host.
+        /// </summary>
+        public Version Version { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates an instance of the HostDetails class.
+        /// </summary>
+        /// <param name="name">
+        /// The display name for the host, typically in the form of
+        /// "[Application Name] Host".
+        /// </param>
+        /// <param name="profileId">
+        /// The identifier of the PowerShell host to use for its profile path.
+        /// loaded. Used to resolve a profile path of the form 'X_profile.ps1'
+        /// where 'X' represents the value of hostProfileId.  If null, a default
+        /// will be used.
+        /// </param>
+        /// <param name="version">The host application's version.</param>
+        public HostDetails(
+            string name,
+            string profileId,
+            Version version)
+        {
+            this.Name = name ?? DefaultHostName;
+            this.ProfileId = profileId ?? DefaultHostProfileId;
+            this.Version = version ?? DefaultHostVersion;
+        }
+
+        #endregion
+    }
+}

--- a/src/PowerShellEditorServices/Session/ProfilePaths.cs
+++ b/src/PowerShellEditorServices/Session/ProfilePaths.cs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Runspaces;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    /// <summary>
+    /// Provides profile path resolution behavior relative to the name
+    /// of a particular PowerShell host.
+    /// </summary>
+    public class ProfilePaths
+    {
+        #region Constants
+
+        /// <summary>
+        /// The file name for the "all hosts" profile.  Also used as the
+        /// suffix for the host-specific profile filenames.
+        /// </summary>
+        public const string AllHostsProfileName = "profile.ps1";
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the profile path for all users, all hosts.
+        /// </summary>
+        public string AllUsersAllHosts { get; private set; }
+
+        /// <summary>
+        /// Gets the profile path for all users, current host.
+        /// </summary>
+        public string AllUsersCurrentHost { get; private set; }
+
+        /// <summary>
+        /// Gets the profile path for the current user, all hosts.
+        /// </summary>
+        public string CurrentUserAllHosts { get; private set; }
+
+        /// <summary>
+        /// Gets the profile path for the current user and host.
+        /// </summary>
+        public string CurrentUserCurrentHost { get; private set; }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Creates a new instance of the ProfilePaths class.
+        /// </summary>
+        /// <param name="hostProfileId">
+        /// The identifier of the host used in the host-specific X_profile.ps1 filename.</param>
+        /// <param name="runspace">A runspace used to gather profile path locations.</param>
+        public ProfilePaths(
+            string hostProfileId,
+            Runspace runspace)
+        {
+            string allUsersPath =
+                (string)runspace
+                    .SessionStateProxy
+                    .PSVariable
+                    .Get("PsHome")
+                    .Value;
+
+            string currentUserPath =
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "WindowsPowerShell");
+
+            string currentHostProfileName =
+                string.Format(
+                    "{0}_{1}",
+                    hostProfileId,
+                    AllHostsProfileName);
+
+            this.AllUsersCurrentHost = Path.Combine(allUsersPath, currentHostProfileName);
+            this.CurrentUserCurrentHost = Path.Combine(currentUserPath, currentHostProfileName);
+            this.AllUsersAllHosts = Path.Combine(allUsersPath, AllHostsProfileName);
+            this.CurrentUserAllHosts = Path.Combine(currentUserPath, AllHostsProfileName);
+        }
+
+        /// <summary>
+        /// Gets the list of profile paths that exist on the filesystem.
+        /// </summary>
+        /// <returns>An IEnumerable of profile path strings to be loaded.</returns>
+        public IEnumerable<string> GetLoadableProfilePaths()
+        {
+            var profilePaths =
+                new string[]
+                {
+                    this.AllUsersAllHosts,
+                    this.AllUsersCurrentHost,
+                    this.CurrentUserAllHosts,
+                    this.CurrentUserCurrentHost
+                };
+
+            return profilePaths.Where(p => File.Exists(p));
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Management.Automation.Host;
@@ -19,6 +20,7 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
+        private HostDetails hostDetails;
         private IConsoleHost consoleHost;
         private Guid instanceId = Guid.NewGuid();
         private ConsoleServicePSHostUserInterface hostUserInterface;
@@ -40,12 +42,17 @@ namespace Microsoft.PowerShell.EditorServices
         #endregion
 
         #region Constructors
+
         /// <summary>
         /// Creates a new instance of the ConsoleServicePSHost class
         /// with the given IConsoleHost implementation.
         /// </summary>
-        public ConsoleServicePSHost()
+        /// <param name="hostDetails">
+        /// Provides details about the host application.
+        /// </param>
+        public ConsoleServicePSHost(HostDetails hostDetails)
         {
+            this.hostDetails = hostDetails;
             this.hostUserInterface = new ConsoleServicePSHostUserInterface();
         }
 
@@ -60,16 +67,12 @@ namespace Microsoft.PowerShell.EditorServices
 
         public override string Name
         {
-            // TODO: Change this based on proper naming!
-            get { return "PowerShell Editor Services"; }
+            get { return this.hostDetails.Name; }
         }
 
         public override Version Version
         {
-            get
-            {
-                return this.GetType().Assembly.GetName().Version;
-            }
+            get { return this.hostDetails.Version; }
         }
 
         // TODO: Pull these from IConsoleHost

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -9,6 +9,8 @@ using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
 using Microsoft.PowerShell.EditorServices.Protocol.Messages;
+using Microsoft.PowerShell.EditorServices.Protocol.Server;
+using Microsoft.PowerShell.EditorServices.Session;
 using System;
 using System.IO;
 using System.Linq;
@@ -37,6 +39,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                 new LanguageServiceClient(
                     new StdioClientChannel(
                         "Microsoft.PowerShell.EditorServices.Host.exe",
+                        //"/waitForDebugger",
+                        "/hostName:\"PowerShell Editor Services Test Host\"",
+                        "/hostProfileId:Test.PowerShellEditorServices",
+                        "/hostVersion:1.0.0",
                         "/logPath:\"" + testLogPath + "\"",
                         "/logLevel:Verbose"));
 
@@ -608,6 +614,76 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             // Wait for the selection to appear as output
             await evaluateTask;
             Assert.Equal("Test Output", await outputReader.ReadLine());
+        }
+
+        [Fact]
+        public async Task ServiceLoadsProfilesOnDemand()
+        {
+            // Send the configuration change to cause profiles to be loaded
+            await this.languageServiceClient.SendEvent(
+                DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type,
+                new DidChangeConfigurationParams<LanguageServerSettingsWrapper>
+                {
+                    Settings = new LanguageServerSettingsWrapper
+                    {
+                        Powershell = new LanguageServerSettings
+                        {
+                            EnableProfileLoading = true,
+                            ScriptAnalysis = null
+                        }
+                    }
+                });
+
+            string testProfilePath =
+                Path.GetFullPath(
+                    @"..\..\..\PowerShellEditorServices.Test.Shared\Profile\Profile.ps1");
+
+            string testHostName = "Test.PowerShellEditorServices";
+            string profileName =
+                string.Format(
+                    "{0}_{1}",
+                    testHostName,
+                    ProfilePaths.AllHostsProfileName);
+
+            string currentUserCurrentHostPath =
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "WindowsPowerShell",
+                    profileName);
+
+            // Copy the test profile to the current user's host profile path
+            File.Copy(testProfilePath, currentUserCurrentHostPath, true);
+
+            OutputReader outputReader = new OutputReader(this.protocolClient);
+
+            Task<EvaluateResponseBody> evaluateTask =
+                this.SendRequest(
+                    EvaluateRequest.Type,
+                    new EvaluateRequestArguments
+                    {
+                        Expression = "\"PROFILE: $(Assert-ProfileLoaded)\"",
+                        Context = "repl"
+                    });
+
+            // Try reading up to 10 lines to find the
+            string outputString = null;
+            for (int i = 0; i < 10; i++)
+            {
+                outputString = await outputReader.ReadLine();
+
+                if (outputString.StartsWith("PROFILE"))
+                {
+                    break;
+                }
+            }
+
+            // Delete the test profile before any assert failures
+            // cause the function to exit
+            File.Delete(currentUserCurrentHostPath);
+
+            // Wait for the selection to appear as output
+            await evaluateTask;
+            Assert.Equal("PROFILE: True", outputString);
         }
 
         private async Task SendOpenFileEvent(string filePath, bool waitForDiagnostics = true)

--- a/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
+++ b/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
@@ -66,6 +66,8 @@
     </None>
     <None Include="Debugging\Debug With Params [Test].ps1" />
     <None Include="Debugging\VariableTest.ps1" />
+    <None Include="Profile\Profile.ps1" />
+    <None Include="Profile\ProfileTest.ps1" />
     <None Include="SymbolDetails\SymbolDetails.ps1" />
     <None Include="Symbols\MultipleSymbols.ps1" />
     <None Include="Symbols\NoSymbols.ps1" />

--- a/test/PowerShellEditorServices.Test.Shared/Profile/Profile.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Profile/Profile.ps1
@@ -1,0 +1,3 @@
+﻿function Assert-ProfileLoaded {
+	return $true
+}

--- a/test/PowerShellEditorServices.Test.Shared/Profile/ProfileTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Profile/ProfileTest.ps1
@@ -1,0 +1,1 @@
+﻿Assert-ProfileLoaded

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -3,9 +3,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading.Tasks;
@@ -21,9 +23,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         private const string DebugTestFilePath =
             @"..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1";
 
+        private static readonly HostDetails TestHostDetails =
+            new HostDetails(
+                "PowerShell Editor Services Test Host",
+                "Test.PowerShellEditorServices",
+                new Version("1.0.0"));
+
         public PowerShellContextTests()
         {
-            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext = new PowerShellContext(TestHostDetails);
             this.powerShellContext.SessionStateChanged += OnSessionStateChanged;
             this.stateChangeQueue = new AsyncQueue<SessionStateChangedEventArgs>();
         }
@@ -92,6 +100,79 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             await executeTask;
+        }
+
+        [Fact]
+        public async Task CanResolveAndLoadProfilesForHostId()
+        {
+            string testProfilePath =
+                Path.GetFullPath(
+                    @"..\..\..\PowerShellEditorServices.Test.Shared\Profile\Profile.ps1");
+
+            string profileName =
+                string.Format(
+                    "{0}_{1}",
+                    TestHostDetails.ProfileId,
+                    ProfilePaths.AllHostsProfileName);
+
+            string currentUserPath =
+                Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                    "WindowsPowerShell");
+            string allUsersPath = null; // To be set later
+
+            using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandle())
+            {
+                allUsersPath =
+                    (string)runspaceHandle
+                        .Runspace
+                        .SessionStateProxy
+                        .PSVariable
+                        .Get("PsHome")
+                        .Value;
+            }
+
+            string[] expectedProfilePaths =
+                new string[]
+                {
+                    Path.Combine(allUsersPath, ProfilePaths.AllHostsProfileName),
+                    Path.Combine(allUsersPath, profileName),
+                    Path.Combine(currentUserPath, ProfilePaths.AllHostsProfileName),
+                    Path.Combine(currentUserPath, profileName)
+                };
+
+            // Copy the test profile to the current user's host profile path
+            File.Copy(testProfilePath, expectedProfilePaths[3], true);
+
+            // Load the profiles for the test host name
+            await this.powerShellContext.LoadHostProfiles();
+
+            // Delete the test profile before any assert failures
+            // cause the function to exit
+            File.Delete(expectedProfilePaths[3]);
+
+            // Ensure that all the paths are set in the correct variables
+            // and that the current user's host profile got loaded
+            PSCommand psCommand = new PSCommand();
+            psCommand.AddScript(
+                "\"$($profile.AllUsersAllHosts) " +
+                "$($profile.AllUsersCurrentHost) " +
+                "$($profile.CurrentUserAllHosts) " +
+                "$($profile.CurrentUserCurrentHost) " +
+                "$(Assert-ProfileLoaded)\"");
+
+            var result =
+                await this.powerShellContext.ExecuteCommand<string>(
+                    psCommand);
+
+            string expectedString =
+                string.Format(
+                    "{0} True",
+                    string.Join(
+                        " ",
+                        expectedProfilePaths));
+
+            Assert.Equal(expectedString, result.FirstOrDefault(), true);
         }
 
         #region Helper Methods


### PR DESCRIPTION
This change adds support for loading both host-agnostic and host-specific
profile scripts for the current user and all users depending on which of
those scripts are available on the system.  Profile loading behavior is
opt-in and not enabled by default.  Regardless of whether profiles get
loaded, a $profile variable is inserted into the PowerShellContext's
runspace upon initialization.

Resolves #111.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/199)
<!-- Reviewable:end -->
