### PR TITLE
Fixes #196 - reorder messages to prevent dbgr fail to start

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -54,19 +54,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             object shutdownParams,
             RequestContext<InitializeResponseBody> requestContext)
         {
-            // Send the Initialized event first so that we get breakpoints
-            await requestContext.SendEvent(
-                InitializedEvent.Type,
-                null);
-
             // Now send the Initialize response to continue setup
             await requestContext.SendResult(
-                new InitializeResponseBody
-                {
+                new InitializeResponseBody {
                     SupportsConfigurationDoneRequest = true,
                     SupportsConditionalBreakpoints = true,
                     SupportsFunctionBreakpoints = true
                 });
+
+            // Send the Initialized event first so that we get breakpoints
+            await requestContext.SendEvent(
+                InitializedEvent.Type,
+                null);
         }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -62,11 +62,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     SupportsFunctionBreakpoints = true
                 });
 
-            // Send the Initialized event first so that we get breakpoints
+            // Send the Initialized event so that we get breakpoints
             await requestContext.SendEvent(
                 InitializedEvent.Type,
                 null);
         }
     }
 }
-


### PR DESCRIPTION
This commit sends the initialized event *after* the initializeRequest response (that sends capabilities info).  This was recommended by @isidorn in issue http://github.com/Microsoft/vscode/issues/4567.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/204)
<!-- Reviewable:end -->
