### PR TITLE
Fixes #195 - set breakpoint in non-existing file doesn't crash

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Breakpoint.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Utility;
+
 namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {
     public class Breakpoint
@@ -32,6 +34,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public static Breakpoint Create(
             BreakpointDetails breakpointDetails)
         {
+            Validate.IsNotNull(nameof(breakpointDetails), breakpointDetails);
+
             return new Breakpoint
             {
                 Verified = breakpointDetails.Verified,
@@ -45,9 +49,30 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public static Breakpoint Create(
             CommandBreakpointDetails breakpointDetails)
         {
+            Validate.IsNotNull(nameof(breakpointDetails), breakpointDetails);
+
             return new Breakpoint {
                 Verified = breakpointDetails.Verified,
                 Message = breakpointDetails.Message
+            };
+        }
+
+        public static Breakpoint Create(
+            SourceBreakpoint sourceBreakpoint,
+            string source,
+            string message,
+            bool verified = false)
+        {
+            Validate.IsNotNull(nameof(sourceBreakpoint), sourceBreakpoint);
+            Validate.IsNotNull(nameof(source), source);
+            Validate.IsNotNull(nameof(message), message);
+
+            return new Breakpoint {
+                Verified = verified,
+                Message = message,
+                Source = source,
+                Line = sourceBreakpoint.Line,
+                Column = sourceBreakpoint.Column
             };
         }
     }


### PR DESCRIPTION
This fixes the crash at the protocol layer for VSCode.  This does not cause the debug host to spit anything out to the debug console.  I was finding a good way to get a ScriptFile down to the SetLineBreakpoint() method for a source path that does not exist.  I figured at the least, we could eliminate the debug host crash for now.  

I also believe the VSCode folks should fix this by displaying our message in the breakpoints list UI.  See https://github.com/microsoft/vscode/issues/4935

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/205)
<!-- Reviewable:end -->
