### PR TITLE
Rkeithhill/script analysis profile path

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -6,7 +6,6 @@
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
-using Microsoft.PowerShell.EditorServices.Protocol.Messages;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
@@ -292,9 +291,19 @@ function __Expand-Alias {
         {
             bool oldScriptAnalysisEnabled =
                 this.currentSettings.ScriptAnalysis.Enable.HasValue;
+            string oldScriptAnalysisSettingsPath =
+                this.currentSettings.ScriptAnalysis.SettingsPath;
 
             this.currentSettings.Update(
                 configChangeParams.Settings.Powershell);
+
+            string newSettingsPath = this.currentSettings.ScriptAnalysis.SettingsPath;
+            
+            // If there is a new settings file path, restart the analyzer with the new settigs.
+            if (!(oldScriptAnalysisSettingsPath?.Equals(newSettingsPath, StringComparison.OrdinalIgnoreCase) ?? false))
+            {
+                this.editorSession.RestartAnalysisService(newSettingsPath);
+            }
 
             if (oldScriptAnalysisEnabled != this.currentSettings.ScriptAnalysis.Enable)
             {

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -3,10 +3,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.IO;
+using Microsoft.PowerShell.EditorServices.Utility;
+
 namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     public class LanguageServerSettings
     {
+        public bool EnableProfileLoading { get; set; }
+
         public ScriptAnalysisSettings ScriptAnalysis { get; set; }
 
         public LanguageServerSettings()
@@ -14,11 +19,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.ScriptAnalysis = new ScriptAnalysisSettings();
         }
 
-        public void Update(LanguageServerSettings settings)
+        public void Update(LanguageServerSettings settings, string workspaceRootPath)
         {
             if (settings != null)
             {
-                this.ScriptAnalysis.Update(settings.ScriptAnalysis);
+                this.EnableProfileLoading = settings.EnableProfileLoading;
+                this.ScriptAnalysis.Update(settings.ScriptAnalysis, workspaceRootPath);
             }
         }
     }
@@ -34,17 +40,31 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.Enable = true;
         }
 
-        public void Update(ScriptAnalysisSettings settings)
+        public void Update(ScriptAnalysisSettings settings, string workspaceRootPath)
         {
             if (settings != null)
             {
+                Validate.IsNotNullOrEmptyString(nameof(workspaceRootPath), workspaceRootPath);
+
                 this.Enable = settings.Enable;
-                this.SettingsPath = settings.SettingsPath;
+
+                string settingsPath = settings.SettingsPath;
+
+                if (string.IsNullOrWhiteSpace(settingsPath))
+                {
+                    settingsPath = null;
+                }
+                else if (!Path.IsPathRooted(settingsPath))
+                {
+                    settingsPath = Path.GetFullPath(Path.Combine(workspaceRootPath, settingsPath));
+                }
+
+                this.SettingsPath = settingsPath;
             }
         }
     }
 
-    public class SettingsWrapper
+    public class LanguageServerSettingsWrapper
     {
         // NOTE: This property is capitalized as 'Powershell' because the
         // mode name sent from the client is written as 'powershell' and

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -27,6 +27,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     {
         public bool? Enable { get; set; }
 
+        public string SettingsPath { get; set; }
+
         public ScriptAnalysisSettings()
         {
             this.Enable = true;
@@ -37,6 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             if (settings != null)
             {
                 this.Enable = settings.Enable;
+                this.SettingsPath = settings.SettingsPath;
             }
         }
     }

--- a/src/PowerShellEditorServices/Analysis/AnalysisOutputWriter.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisOutputWriter.cs
@@ -3,8 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.Windows.PowerShell.ScriptAnalyzer;
+using System;
 using System.Management.Automation;
+using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -14,31 +16,36 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     internal class AnalysisOutputWriter : IOutputWriter
     {
+        private IConsoleHost consoleHost;
+
+        public AnalysisOutputWriter(IConsoleHost consoleHost)
+        {
+            this.consoleHost = consoleHost;
+        }
+
         #region IOutputWriter Implementation
 
         void IOutputWriter.WriteError(ErrorRecord error)
         {
-            // TODO: Find a way to trace out this output!
+            this.consoleHost?.WriteOutput(error.ToString(), true, OutputType.Error, ConsoleColor.Red, ConsoleColor.Black);
         }
 
         void IOutputWriter.WriteWarning(string message)
         {
-            // TODO: Find a way to trace out this output!
+            this.consoleHost?.WriteOutput(message, true, OutputType.Warning, ConsoleColor.Yellow, ConsoleColor.Black);
         }
 
         void IOutputWriter.WriteVerbose(string message)
         {
-            // TODO: Find a way to trace out this output!
         }
 
         void IOutputWriter.WriteDebug(string message)
         {
-            // TODO: Find a way to trace out this output!
         }
 
         void IOutputWriter.ThrowTerminatingError(ErrorRecord record)
         {
-            // TODO: Find a way to trace out this output!
+            this.consoleHost?.WriteOutput(record.ToString(), true, OutputType.Error, ConsoleColor.Red, ConsoleColor.Black);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         /// <summary>
         /// Defines the list of Script Analyzer rules to include by default if
-        /// no settings file can be found.
+        /// no settings file is specified.
         /// </summary>
         private static readonly string[] IncludedRules = {
             "PSUseApprovedVerbs",

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Management.Automation.Runspaces;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Console;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -26,11 +27,10 @@ namespace Microsoft.PowerShell.EditorServices
         private ScriptAnalyzer scriptAnalyzer;
 
         /// <summary>
-        /// Defines the list of Script Analyzer rules to include by default.
-        /// In the future, a default rule set from Script Analyzer may be used.
+        /// Defines the list of Script Analyzer rules to include by default if
+        /// no settings file can be found.
         /// </summary>
-        private static readonly string[] IncludedRules = new string[]
-        {
+        private static readonly string[] IncludedRules = {
             "PSUseApprovedVerbs",
             "PSReservedCmdletChar",
             "PSReservedParams",
@@ -47,7 +47,10 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Creates an instance of the AnalysisService class.
         /// </summary>
-        public AnalysisService()
+        /// <param name="consoleHost">An object that implements IConsoleHost in which to write errors/warnings 
+        /// from analyzer.</param>
+        /// <param name="settingsPath">Path to a PSScriptAnalyzer settings file.</param>
+        public AnalysisService(IConsoleHost consoleHost, string settingsPath = null)
         {
             try
             {
@@ -63,9 +66,10 @@ namespace Microsoft.PowerShell.EditorServices
 
                 this.scriptAnalyzer.Initialize(
                     this.analysisRunspace,
-                    new AnalysisOutputWriter(),
-                    includeRuleNames: IncludedRules,
-                    includeDefaultRules: true);
+                    new AnalysisOutputWriter(consoleHost),
+                    includeRuleNames: settingsPath == null ? IncludedRules : null,
+                    includeDefaultRules: true,
+                    profile: settingsPath);
             }
             catch (FileNotFoundException)
             {

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -5,12 +5,7 @@
 
 using Microsoft.PowerShell.EditorServices.Console;
 using Microsoft.PowerShell.EditorServices.Utility;
-using System;
 using System.IO;
-using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using System.Reflection;
-using System.Threading;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -68,6 +63,24 @@ namespace Microsoft.PowerShell.EditorServices
             this.DebugService = new DebugService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
 
+            this.InstantiateAnalysisService();
+
+            // Create a workspace to contain open files
+            this.Workspace = new Workspace(this.PowerShellContext.PowerShellVersion);
+        }
+
+        /// <summary>
+        /// Restarts the AnalysisService so it can be configured with a new settings file.
+        /// </summary>
+        /// <param name="settingsPath">Path to the settings file.</param>
+        public void RestartAnalysisService(string settingsPath)
+        {
+            this.AnalysisService?.Dispose();
+            InstantiateAnalysisService(settingsPath);
+        }
+
+        internal void InstantiateAnalysisService(string settingsPath = null)
+        {
             // Only enable the AnalysisService if the machine has PowerShell
             // v5 installed.  Script Analyzer works on earlier PowerShell
             // versions but our hard dependency on their binaries complicates
@@ -81,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices
                 // Script Analyzer binaries are not included.
                 try
                 {
-                    this.AnalysisService = new AnalysisService();
+                    this.AnalysisService = new AnalysisService(this.PowerShellContext.ConsoleHost, settingsPath);
                 }
                 catch (FileNotFoundException)
                 {
@@ -97,9 +110,6 @@ namespace Microsoft.PowerShell.EditorServices
                     "Script Analyzer cannot be loaded due to unsupported PowerShell version " +
                     this.PowerShellContext.PowerShellVersion.ToString());
             }
-
-            // Create a workspace to contain open files
-            this.Workspace = new Workspace(this.PowerShellContext.PowerShellVersion);
         }
 
         #endregion


### PR DESCRIPTION
Please check over when I'm converting an empty string settings path to the `null` that the ScriptAnalyzer.Initialize method is expecting.  I can either do it early in LanguageServerSettings or wait until right before we call Initialize.  Right now I'm doing it early but don't mind changing that strategy to defer the conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/209)
<!-- Reviewable:end -->
