### PR TITLE
Introduce new editor extensibility API

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
 - git submodule -q update --init
 
 before_build:
+- ps: if (Test-Path 'C:\Tools\NuGet3') { $nugetDir = 'C:\Tools\NuGet3' } else { $nugetDir = 'C:\Tools\NuGet' }; (New-Object Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe', "$nugetDir\NuGet.exe")
 - nuget restore
 
 build:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,112 @@
+# PowerShell Editor Services Extensibility Model
+
+PowerShell Editor Services exposes a common extensibility model which allows
+a user to write extension code in PowerShell that works across any editor that
+uses PowerShell Editor Services.
+
+## Using Extensions
+
+**TODO**
+
+- Enable-EditorExtension -Name "SomeExtension.CustomAnalyzer"
+- Disable-EditorExtension -Name "SomeExtension.CustomAnalyzer"
+
+## Writing Extensions
+
+Here are some examples of writing editor extensions:
+
+### Command Extensions
+
+#### Executing a cmdlet or function
+
+```powershell
+function MyExtensionFunction {
+    Write-Output "My extension function was invoked!"
+}
+
+Register-EditorExtension `
+    -Command
+    -Name "MyExt.MyExtensionFunction" `
+    -DisplayName "My extension function" `
+    -Function MyExtensionFunction
+```
+
+#### Executing a script block
+
+```powershell
+Register-EditorExtension `
+    -Command
+    -Name "MyExt.MyExtensionScriptBlock" `
+    -DisplayName "My extension script block" `
+    -ScriptBlock { Write-Output "My extension script block was invoked!" }
+```
+
+#### Additional Parameters
+
+##### ExecuteInSession [switch]
+
+Causes the command to be executed in the user's current session.  By default,
+commands are executed in a global session that isn't affected by script
+execution.  Adding this parameter will cause the command to be executed in the
+context of the user's session.
+
+### Analyzer Extensions
+
+```powershell
+function Invoke-MyAnalyzer {
+    param(
+        $FilePath,
+        $Ast,
+        $StartLine,
+        $StartColumn,
+        $EndLine,
+        $EndColumn
+    )
+}
+
+Register-EditorExtension `
+    -Analyzer
+    -Name "MyExt.MyAnalyzer" `
+    -DisplayName "My analyzer extension" `
+    -Function Invoke-MyAnalyzer
+```
+
+#### Additional Parameters
+
+##### DelayInterval [int]
+
+Specifies the interval after which this analyzer will be run when the
+user finishes typing in the script editor.
+
+### Formatter Extensions
+
+```powershell
+function Invoke-MyFormatter {
+    param(
+        $FilePath,
+        $ScriptText,
+        $StartLine,
+        $StartColumn,
+        $EndLine,
+        $EndColumn
+    )
+}
+
+Register-EditorExtension `
+    -Formatter
+    -Name "MyExt.MyFormatter" `
+    -DisplayName "My formatter extension" `
+    -Function Invoke-MyFormatter
+```
+
+#### Additional Parameters
+
+##### SupportsSelections [switch]
+
+Indicates that this formatter extension can format selections in a larger
+file rather than formatting the entire file.  If this parameter is not
+specified then the entire file will be sent to the extension for every
+call.
+
+## Examples
+

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    public class ExtensionCommandAddedNotification
+    {
+        public static readonly
+            EventType<ExtensionCommandAddedNotification> Type =
+            EventType<ExtensionCommandAddedNotification>.Create("powerShell/extensionCommandAdded");
+
+        public string Name { get; set; }
+
+        public string DisplayName { get; set; }
+    }
+
+    public class ExtensionCommandUpdatedNotification
+    {
+        public static readonly
+            EventType<ExtensionCommandUpdatedNotification> Type =
+            EventType<ExtensionCommandUpdatedNotification>.Create("powerShell/extensionCommandUpdated");
+
+        public string Name { get; set; }
+    }
+
+    public class ExtensionCommandRemovedNotification
+    {
+        public static readonly
+            EventType<ExtensionCommandRemovedNotification> Type =
+            EventType<ExtensionCommandRemovedNotification>.Create("powerShell/extensionCommandRemoved");
+
+        public string Name { get; set; }
+    }
+
+    public class ClientEditorContext
+    {
+        public string CurrentFilePath { get; set; }
+
+        public Position CursorPosition { get; set; }
+
+        public Range SelectionRange { get; set; }
+
+    }
+
+    public class InvokeExtensionCommandRequest
+    {
+        public static readonly
+            RequestType<InvokeExtensionCommandRequest, string> Type =
+            RequestType<InvokeExtensionCommandRequest, string>.Create("powerShell/invokeExtensionCommand");
+
+        public string Name { get; set; }
+
+        public ClientEditorContext Context { get; set; }
+    }
+
+    public class GetEditorContextRequest
+    {
+        public static readonly
+            RequestType<GetEditorContextRequest, ClientEditorContext> Type =
+            RequestType<GetEditorContextRequest, ClientEditorContext>.Create("editor/getEditorContext");
+    }
+
+    public enum EditorCommandResponse
+    {
+        Unsupported,
+        OK
+    }
+
+    public class InsertTextRequest
+    {
+        public static readonly
+            RequestType<InsertTextRequest, EditorCommandResponse> Type =
+            RequestType<InsertTextRequest, EditorCommandResponse>.Create("editor/insertText");
+
+        public string FilePath { get; set; }
+
+        public string InsertText { get; set; }
+
+        public Range InsertRange { get; set; }
+    }
+
+    public class SetSelectionRequest
+    {
+        public static readonly
+            RequestType<SetSelectionRequest, EditorCommandResponse> Type =
+            RequestType<SetSelectionRequest, EditorCommandResponse>.Create("editor/setSelection");
+
+        public Range SelectionRange { get; set; }
+    }
+
+    public class SetCursorPositionRequest
+    {
+        public static readonly
+            RequestType<SetCursorPositionRequest, EditorCommandResponse> Type =
+            RequestType<SetCursorPositionRequest, EditorCommandResponse>.Create("editor/setCursorPosition");
+
+        public Position CursorPosition { get; set; }
+    }
+
+    public class OpenFileRequest
+    {
+        public static readonly
+            RequestType<string, EditorCommandResponse> Type =
+            RequestType<string, EditorCommandResponse>.Create("editor/openFile");
+    }
+}
+

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -53,6 +53,7 @@
     <Compile Include="DebugAdapter\ConfigurationDoneRequest.cs" />
     <Compile Include="DebugAdapter\ContinueRequest.cs" />
     <Compile Include="DebugAdapter\SetFunctionBreakpointsRequest.cs" />
+    <Compile Include="LanguageServer\EditorCommands.cs" />
     <Compile Include="LanguageServer\FindModuleRequest.cs" />
     <Compile Include="LanguageServer\InstallModuleRequest.cs" />
     <Compile Include="MessageProtocol\IMessageSender.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="MessageProtocol\Channel\StdioServerChannel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="LanguageServer\References.cs" />
+    <Compile Include="Server\LanguageServerEditorOperations.cs" />
     <Compile Include="Server\LanguageServerSettings.cs" />
     <Compile Include="Server\OutputDebouncer.cs" />
     <Compile Include="Server\PromptHandlers.cs" />

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -360,7 +360,7 @@ function __Expand-Alias {
             // If there is a new settings file path, restart the analyzer with the new settigs.
             bool settingsPathChanged = false;
             string newSettingsPath = this.currentSettings.ScriptAnalysis.SettingsPath;
-            if (!(oldScriptAnalysisSettingsPath?.Equals(newSettingsPath, StringComparison.OrdinalIgnoreCase) ?? false))
+            if (!string.Equals(oldScriptAnalysisSettingsPath, newSettingsPath, StringComparison.OrdinalIgnoreCase))
             {
                 this.editorSession.RestartAnalysisService(newSettingsPath);
                 settingsPathChanged = true;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -1,0 +1,113 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Extensions;
+using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.Server
+{
+    internal class LanguageServerEditorOperations : IEditorOperations
+    {
+        private EditorSession editorSession;
+        private IMessageSender messageSender;
+
+        public LanguageServerEditorOperations(
+            EditorSession editorSession,
+            IMessageSender messageSender)
+        {
+            this.editorSession = editorSession;
+            this.messageSender = messageSender;
+        }
+
+        public async Task<EditorContext> GetEditorContext()
+        {
+            ClientEditorContext clientContext =
+                await this.messageSender.SendRequest(
+                    GetEditorContextRequest.Type,
+                    new GetEditorContextRequest(),
+                    true);
+
+            return this.ConvertClientEditorContext(clientContext);
+        }
+
+        public async Task InsertText(string filePath, string text, BufferRange insertRange)
+        {
+            await this.messageSender.SendRequest(
+                InsertTextRequest.Type,
+                new InsertTextRequest
+                {
+                    FilePath = filePath,
+                    InsertText = text,
+                    InsertRange =
+                        new Range
+                        {
+                            Start = new Position
+                            {
+                                Line = insertRange.Start.Line - 1,
+                                Character = insertRange.Start.Column - 1
+                            },
+                            End = new Position
+                            {
+                                Line = insertRange.End.Line - 1,
+                                Character = insertRange.End.Column - 1
+                            }
+                        }
+                }, false);
+
+            // TODO: Set the last param back to true!
+        }
+
+        public Task SetSelection(BufferRange selectionRange)
+        {
+            return this.messageSender.SendRequest(
+                SetSelectionRequest.Type,
+                new SetSelectionRequest
+                {
+                    SelectionRange =
+                        new Range
+                        {
+                            Start = new Position
+                            {
+                                Line = selectionRange.Start.Line - 1,
+                                Character = selectionRange.Start.Column - 1
+                            },
+                            End = new Position
+                            {
+                                Line = selectionRange.End.Line - 1,
+                                Character = selectionRange.End.Column - 1
+                            }
+                        }
+                }, true);
+        }
+
+        public EditorContext ConvertClientEditorContext(
+            ClientEditorContext clientContext)
+        {
+            return
+                new EditorContext(
+                    this,
+                    this.editorSession.Workspace.GetFile(clientContext.CurrentFilePath),
+                    new BufferPosition(
+                        clientContext.CursorPosition.Line + 1,
+                        clientContext.CursorPosition.Character + 1),
+                    new BufferRange(
+                        clientContext.SelectionRange.Start.Line + 1,
+                        clientContext.SelectionRange.Start.Character + 1,
+                        clientContext.SelectionRange.End.Line + 1,
+                        clientContext.SelectionRange.End.Character + 1));
+        }
+
+        public Task OpenFile(string filePath)
+        {
+            return
+                this.messageSender.SendRequest(
+                    OpenFileRequest.Type,
+                    filePath,
+                    true);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -44,8 +44,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             if (settings != null)
             {
-                Validate.IsNotNullOrEmptyString(nameof(workspaceRootPath), workspaceRootPath);
-
                 this.Enable = settings.Enable;
 
                 string settingsPath = settings.SettingsPath;
@@ -56,7 +54,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
                 else if (!Path.IsPathRooted(settingsPath))
                 {
-                    settingsPath = Path.GetFullPath(Path.Combine(workspaceRootPath, settingsPath));
+                    if (string.IsNullOrEmpty(workspaceRootPath))
+                    {
+                        // The workspace root path could be an empty string
+                        // when the user has opened a PowerShell script file
+                        // without opening an entire folder (workspace) first.
+                        // In this case we should just log an error and let
+                        // the specified settings path go through even though
+                        // it will fail to load.
+                        Logger.Write(
+                            LogLevel.Error,
+                            "Could not resolve Script Analyzer settings path due to null or empty workspaceRootPath.");
+                    }
+                    else
+                    {
+                        settingsPath = Path.GetFullPath(Path.Combine(workspaceRootPath, settingsPath));
+                    }
                 }
 
                 this.SettingsPath = settingsPath;

--- a/src/PowerShellEditorServices/Extensions/CmdletInterface.ps1
+++ b/src/PowerShellEditorServices/Extensions/CmdletInterface.ps1
@@ -1,0 +1,140 @@
+﻿<#
+ .SYNOPSIS
+ Registers a command which can be executed in the host editor.
+
+ .DESCRIPTION
+ Registers a command which can be executed in the host editor.  This
+ command will be shown to the user either in a menu or command palette.
+ Upon invoking this command, either a function/cmdlet or ScriptBlock will
+ be executed depending on whether the -Function or -ScriptBlock parameter
+ was used when the command was registered.
+
+ This command can be run multiple times for the same command so that its
+ details can be updated.  However, re-registration of commands should only
+ be used for development purposes, not for dynamic behavior.
+
+ .PARAMETER Name
+ Specifies a unique name which can be used to identify this command.
+ This name is not displayed to the user.
+
+ .PARAMETER DisplayName
+ Specifies a display name which is displayed to the user.
+
+ .PARAMETER Function
+ Specifies a function or cmdlet name which will be executed when the user
+ invokes this command.  This function may take a parameter called $context
+ which will be populated with an EditorContext object containing information
+ about the host editor's state at the time the command was executed.
+
+ .PARAMETER ScriptBlock
+ Specifies a ScriptBlock which will be executed when the user invokes this
+ command.  This ScriptBlock may take a parameter called $context
+ which will be populated with an EditorContext object containing information
+ about the host editor's state at the time the command was executed.
+
+ .PARAMETER SuppressOutput
+ If provided, causes the output of the editor command to be suppressed when
+ it is run.  Errors that occur while running this command will still be
+ written to the host.
+
+ .EXAMPLE
+ PS> Register-EditorCommand -Name "MyModule.MyFunctionCommand" -DisplayName "My function command" -Function Invoke-MyCommand -SuppressOutput
+
+ .EXAMPLE
+ PS> Register-EditorCommand -Name "MyModule.MyScriptBlockCommand" -DisplayName "My ScriptBlock command" -ScriptBlock { Write-Output "Hello from my command!" }
+
+ .LINK
+ Unregister-EditorCommand
+#>
+function Register-EditorCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DisplayName,
+
+        [Parameter(
+            Mandatory=$true,
+            ParameterSetName="Function")]
+        [ValidateNotNullOrEmpty()]
+        [string]$Function,
+
+        [Parameter(
+            Mandatory=$true,
+            ParameterSetName="ScriptBlock")]
+        [ValidateNotNullOrEmpty()]
+        [ScriptBlock]$ScriptBlock,
+
+        [switch]$SuppressOutput
+    )
+
+    Process
+    {
+        $commandArgs = @($Name, $DisplayName, $SuppressOutput.IsPresent)
+
+        if ($ScriptBlock -ne $null)
+        {
+            Write-Verbose "Registering command '$Name' which executes a ScriptBlock"
+            $commandArgs += $ScriptBlock
+        }
+        else
+        {
+            Write-Verbose "Registering command '$Name' which executes a function"
+            $commandArgs += $Function
+        }
+
+        $editorCommand = New-Object Microsoft.PowerShell.EditorServices.Extensions.EditorCommand -ArgumentList $commandArgs
+        if ($psEditor.RegisterCommand($editorCommand))
+        {
+            Write-Verbose "Registered new command '$Name'"
+        }
+        else
+        {
+            Write-Verbose "Updated existing command '$Name'"
+        }
+    }
+}
+
+<#
+ .SYNOPSIS
+ Unregisters a command which has already been registered in the host editor.
+
+ .DESCRIPTION
+ Unregisters a command which has already been registered in the host editor.
+ An error will be thrown if the specified Name is unknown.
+
+ .PARAMETER Name
+ Specifies a unique name which identifies a command which has already been registered.
+
+ .EXAMPLE
+ PS> Unregister-EditorCommand -Name "MyModule.MyFunctionCommand"
+
+ .LINK
+ Register-EditorCommand
+#>
+function Unregister-EditorCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name
+    )
+
+    Process
+    {
+        Write-Verbose "Unregistering command '$Name'"
+        $psEditor.UnregisterCommand($Name);
+    }
+}
+
+function psedit {
+    param([Parameter(Mandatory=$true)]$FilePaths)
+
+    dir $FilePaths | where { !$_.PSIsContainer } | % {
+        $psEditor.Workspace.OpenFile($_.FullName)
+    }
+}

--- a/src/PowerShellEditorServices/Extensions/EditorCommand.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorCommand.cs
@@ -1,0 +1,89 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides details about a command that has been registered
+    /// with the editor.
+    /// </summary>
+    public class EditorCommand
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the name which uniquely identifies the command.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the display name for the command.
+        /// </summary>
+        public string DisplayName { get; private set; }
+
+        /// <summary>
+        /// Gets the boolean which determines whether this command's
+        /// output should be suppressed.
+        /// </summary>
+        public bool SuppressOutput { get; private set; }
+
+        /// <summary>
+        /// Gets the ScriptBlock which can be used to execute the command.
+        /// </summary>
+        public ScriptBlock ScriptBlock { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new EditorCommand instance that invokes a cmdlet or
+        /// function by name.
+        /// </summary>
+        /// <param name="commandName">The unique identifier name for the command.</param>
+        /// <param name="displayName">The display name for the command.</param>
+        /// <param name="suppressOutput">If true, causes output to be suppressed for this command.</param>
+        /// <param name="cmdletName">The name of the cmdlet or function which will be invoked by this command.</param>
+        public EditorCommand(
+            string commandName,
+            string displayName,
+            bool suppressOutput,
+            string cmdletName)
+            : this(
+                  commandName,
+                  displayName,
+                  suppressOutput,
+                  ScriptBlock.Create(
+                      string.Format(
+                          "param($context) {0} $context",
+                          cmdletName)))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new EditorCommand instance that invokes a ScriptBlock.
+        /// </summary>
+        /// <param name="commandName">The unique identifier name for the command.</param>
+        /// <param name="displayName">The display name for the command.</param>
+        /// <param name="suppressOutput">If true, causes output to be suppressed for this command.</param>
+        /// <param name="scriptBlock">The ScriptBlock which will be invoked by this command.</param>
+        public EditorCommand(
+            string commandName,
+            string displayName,
+            bool suppressOutput,
+            ScriptBlock scriptBlock)
+        {
+            this.Name = commandName;
+            this.DisplayName = displayName;
+            this.SuppressOutput = suppressOutput;
+            this.ScriptBlock = scriptBlock;
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/EditorContext.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorContext.cs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides context for the host editor at the time of creation.
+    /// </summary>
+    public class EditorContext
+    {
+        #region Private Fields
+
+        private IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the FileContext for the active file.
+        /// </summary>
+        public FileContext CurrentFile { get; private set; }
+
+        /// <summary>
+        /// Gets the BufferRange representing the current selection in the file.
+        /// </summary>
+        public BufferRange SelectedRange { get; private set; }
+
+        /// <summary>
+        /// Gets the FilePosition representing the current cursor position.
+        /// </summary>
+        public FilePosition CursorPosition { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the EditorContext class.
+        /// </summary>
+        /// <param name="editorOperations">An IEditorOperations implementation which performs operations in the editor.</param>
+        /// <param name="currentFile">The ScriptFile that is in the active editor buffer.</param>
+        /// <param name="cursorPosition">The position of the user's cursor in the active editor buffer.</param>
+        /// <param name="selectedRange">The range of the user's selection in the active editor buffer.</param>
+        public EditorContext(
+            IEditorOperations editorOperations,
+            ScriptFile currentFile,
+            BufferPosition cursorPosition,
+            BufferRange selectedRange)
+        {
+            this.editorOperations = editorOperations;
+            this.CurrentFile = new FileContext(currentFile, this, editorOperations);
+            this.SelectedRange = selectedRange;
+            this.CursorPosition = new FilePosition(currentFile, cursorPosition);
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Sets a selection in the host editor's active buffer.
+        /// </summary>
+        /// <param name="startLine">The 1-based starting line of the selection.</param>
+        /// <param name="startColumn">The 1-based starting column of the selection.</param>
+        /// <param name="endLine">The 1-based ending line of the selection.</param>
+        /// <param name="endColumn">The 1-based ending column of the selection.</param>
+        public void SetSelection(
+            int startLine,
+            int startColumn,
+            int endLine,
+            int endColumn)
+        {
+            this.SetSelection(
+                new BufferRange(
+                    startLine, startColumn,
+                    endLine, endColumn));
+        }
+
+        /// <summary>
+        /// Sets a selection in the host editor's active buffer.
+        /// </summary>
+        /// <param name="startPosition">The starting position of the selection.</param>
+        /// <param name="endPosition">The ending position of the selection.</param>
+        public void SetSelection(
+            BufferPosition startPosition,
+            BufferPosition endPosition)
+        {
+            this.SetSelection(
+                new BufferRange(
+                    startPosition,
+                    endPosition));
+        }
+
+        /// <summary>
+        /// Sets a selection in the host editor's active buffer.
+        /// </summary>
+        /// <param name="selectionRange">The range of the selection.</param>
+        public void SetSelection(BufferRange selectionRange)
+        {
+            this.editorOperations
+                .SetSelection(selectionRange)
+                .Wait();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -1,0 +1,86 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides the entry point of the extensibility API, inserted into
+    /// the PowerShell session as the "$psEditor" variable.
+    /// </summary>
+    public class EditorObject
+    {
+        #region Private Fields
+
+        private ExtensionService extensionService;
+        private IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the version of PowerShell Editor Services.
+        /// </summary>
+        public Version EditorServicesVersion
+        {
+            get { return this.GetType().Assembly.GetName().Version; }
+        }
+
+        /// <summary>
+        /// Gets the workspace interface for the editor API.
+        /// </summary>
+        public EditorWorkspace Workspace { get; private set; }
+
+        #endregion
+
+        /// <summary>
+        /// Creates a new instance of the EditorObject class.
+        /// </summary>
+        /// <param name="extensionService">An ExtensionService which handles command registration.</param>
+        /// <param name="editorOperations">An IEditorOperations implementation which handles operations in the host editor.</param>
+        public EditorObject(
+            ExtensionService extensionService,
+            IEditorOperations editorOperations)
+        {
+            this.extensionService = extensionService;
+            this.editorOperations = editorOperations;
+
+            // Create API area objects
+            this.Workspace = new EditorWorkspace(this.editorOperations);
+        }
+
+        /// <summary>
+        /// Registers a new command in the editor.
+        /// </summary>
+        /// <param name="editorCommand">The EditorCommand to be registered.</param>
+        public void RegisterCommand(EditorCommand editorCommand)
+        {
+            this.extensionService.RegisterCommand(editorCommand);
+        }
+
+        /// <summary>
+        /// Unregisters an existing EditorCommand based on its registered name.
+        /// </summary>
+        /// <param name="commandName">The name of the command to be unregistered.</param>
+        public void UnregisterCommand(string commandName)
+        {
+            this.extensionService.UnregisterCommand(commandName);
+        }
+
+        /// <summary>
+        /// Gets the EditorContext which contains the state of the editor
+        /// at the time this method is invoked.
+        /// </summary>
+        /// <returns>A instance of the EditorContext class.</returns>
+        public EditorContext GetEditorContext()
+        {
+            return this.editorOperations.GetEditorContext().Result;
+       }
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -1,0 +1,44 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides a PowerShell-facing API which allows scripts to
+    /// interact with the editor's workspace.
+    /// </summary>
+    public class EditorWorkspace
+    {
+        #region Private Fields
+
+        private IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Constructors
+
+        internal EditorWorkspace(IEditorOperations editorOperations)
+        {
+            this.editorOperations = editorOperations;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Opens a file in the workspace.  If the file is already open
+        /// its buffer will be made active.
+        /// </summary>
+        /// <param name="filePath">The path to the file to be opened.</param>
+        public void OpenFile(string filePath)
+        {
+            this.editorOperations.OpenFile(filePath).Wait();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Extensions/ExtensionService.cs
@@ -1,0 +1,241 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides a high-level service which enables PowerShell scripts
+    /// and modules to extend the behavior of the host editor.
+    /// </summary>
+    public class ExtensionService
+    {
+        #region Fields
+
+        private Dictionary<string, EditorCommand> editorCommands =
+            new Dictionary<string, EditorCommand>();
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the IEditorOperations implementation used to invoke operations
+        /// in the host editor.
+        /// </summary>
+        public IEditorOperations EditorOperations { get; private set; }
+
+        /// <summary>
+        /// Gets the EditorObject which exists in the PowerShell session as the
+        /// '$psEditor' variable.
+        /// </summary>
+        public EditorObject EditorObject { get; private set; }
+
+        /// <summary>
+        /// Gets the PowerShellContext in which extension code will be executed.
+        /// </summary>
+        public PowerShellContext PowerShellContext { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the ExtensionService which uses the provided
+        /// PowerShellContext for loading and executing extension code.
+        /// </summary>
+        /// <param name="powerShellContext">A PowerShellContext used to execute extension code.</param>
+        public ExtensionService(PowerShellContext powerShellContext)
+        {
+            this.PowerShellContext = powerShellContext;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Initializes this ExtensionService using the provided IEditorOperations
+        /// implementation for future interaction with the host editor.
+        /// </summary>
+        /// <param name="editorOperations">An IEditorOperations implementation.</param>
+        /// <returns>A Task that can be awaited for completion.</returns>
+        public async Task Initialize(IEditorOperations editorOperations)
+        {
+            this.EditorObject = new EditorObject(this, editorOperations);
+
+            // Register the editor object in the runspace
+            PSCommand variableCommand = new PSCommand();
+            using (RunspaceHandle handle = await this.PowerShellContext.GetRunspaceHandle())
+            {
+                handle.Runspace.SessionStateProxy.PSVariable.Set(
+                    "psEditor",
+                    this.EditorObject);
+            }
+
+            // Load the cmdlet interface
+            Type thisType = this.GetType();
+            Stream resourceStream =
+                thisType.Assembly.GetManifestResourceStream(
+                    thisType.Namespace + ".CmdletInterface.ps1");
+
+            using (StreamReader reader = new StreamReader(resourceStream))
+            {
+                // Create a temporary folder path
+                string randomFileNamePart =
+                    Path.GetFileNameWithoutExtension(
+                        Path.GetRandomFileName());
+
+                string tempScriptPath =
+                    Path.Combine(
+                        Path.GetTempPath(),
+                        "PSES_ExtensionCmdlets_" + randomFileNamePart + ".ps1");
+
+                Logger.Write(
+                    LogLevel.Verbose,
+                    "Executing extension API cmdlet script at path: " + tempScriptPath);
+
+                // Read the cmdlet interface script and write it to a temporary
+                // file so that we don't have to execute the full file contents
+                // directly.  This keeps the script execution from creating a
+                // lot of noise in the verbose logs.
+                string cmdletInterfaceScript = reader.ReadToEnd();
+                File.WriteAllText(
+                    tempScriptPath,
+                    cmdletInterfaceScript);
+
+                await this.PowerShellContext.ExecuteScriptString(
+                    ". " + tempScriptPath,
+                    writeInputToHost: false,
+                    writeOutputToHost: false);
+
+                // Delete the temporary file
+                File.Delete(tempScriptPath);
+            }
+        }
+
+        /// <summary>
+        /// Invokes the specified editor command against the provided EditorContext.
+        /// </summary>
+        /// <param name="commandName">The unique name of the command to be invoked.</param>
+        /// <param name="editorContext">The context in which the command is being invoked.</param>
+        /// <returns>A Task that can be awaited for completion.</returns>
+        public async Task InvokeCommand(string commandName, EditorContext editorContext)
+        {
+            EditorCommand editorCommand;
+
+            if (this.editorCommands.TryGetValue(commandName, out editorCommand))
+            {
+                PSCommand executeCommand = new PSCommand();
+                executeCommand.AddCommand("Invoke-Command");
+                executeCommand.AddParameter("ScriptBlock", editorCommand.ScriptBlock);
+                executeCommand.AddParameter("ArgumentList", new object[] { editorContext });
+
+                await this.PowerShellContext.ExecuteCommand<object>(
+                    executeCommand,
+                    !editorCommand.SuppressOutput,
+                    true);
+            }
+            else
+            {
+                throw new KeyNotFoundException(
+                    string.Format(
+                        "Editor command not found: '{0}'",
+                        commandName));
+            }
+        }
+
+        /// <summary>
+        /// Registers a new EditorCommand with the ExtensionService and
+        /// causes its details to be sent to the host editor.
+        /// </summary>
+        /// <param name="editorCommand">The details about the editor command to be registered.</param>
+        /// <returns>True if the command is newly registered, false if the command already exists.</returns>
+        public bool RegisterCommand(EditorCommand editorCommand)
+        {
+            bool commandExists =
+                this.editorCommands.ContainsKey(
+                    editorCommand.Name);
+
+            // Add or replace the editor command
+            this.editorCommands[editorCommand.Name] = editorCommand;
+
+            if (!commandExists)
+            {
+                this.OnCommandAdded(editorCommand);
+            }
+            else
+            {
+                this.OnCommandUpdated(editorCommand);
+            }
+
+            return !commandExists;
+        }
+
+        /// <summary>
+        /// Unregisters an existing EditorCommand based on its registered name.
+        /// </summary>
+        /// <param name="commandName">The name of the command to be unregistered.</param>
+        public void UnregisterCommand(string commandName)
+        {
+            EditorCommand existingCommand = null;
+            if (this.editorCommands.TryGetValue(commandName, out existingCommand))
+            {
+                this.editorCommands.Remove(commandName);
+                this.OnCommandRemoved(existingCommand);
+            }
+            else
+            {
+                throw new KeyNotFoundException(
+                    string.Format(
+                        "Command '{0}' is not registered",
+                        commandName));
+            }
+        }
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Raised when a new editor command is added.
+        /// </summary>
+        public event EventHandler<EditorCommand> CommandAdded;
+
+        private void OnCommandAdded(EditorCommand command)
+        {
+            this.CommandAdded?.Invoke(this, command);
+        }
+
+        /// <summary>
+        /// Raised when an existing editor command is updated.
+        /// </summary>
+        public event EventHandler<EditorCommand> CommandUpdated;
+
+        private void OnCommandUpdated(EditorCommand command)
+        {
+            this.CommandUpdated?.Invoke(this, command);
+        }
+
+        /// <summary>
+        /// Raised when an existing editor command is removed.
+        /// </summary>
+        public event EventHandler<EditorCommand> CommandRemoved;
+
+        private void OnCommandRemoved(EditorCommand command)
+        {
+            this.CommandRemoved?.Invoke(this, command);
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -1,0 +1,220 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Linq;
+using System.Management.Automation.Language;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides context for a file that is open in the editor.
+    /// </summary>
+    public class FileContext
+    {
+        #region Private Fields
+
+        private ScriptFile scriptFile;
+        private EditorContext editorContext;
+        private IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Gets the filesystem path of the file.
+        /// </summary>
+        public string Path
+        {
+            get { return this.scriptFile.FilePath; }
+        }
+
+        /// <summary>
+        /// Gets the parsed abstract syntax tree for the file.
+        /// </summary>
+        public Ast Ast
+        {
+            get { return this.scriptFile.ScriptAst; }
+        }
+
+        /// <summary>
+        /// Gets the parsed token list for the file.
+        /// </summary>
+        public Token[] Tokens
+        {
+            get { return this.scriptFile.ScriptTokens; }
+        }
+
+        /// <summary>
+        /// Gets a BufferRange which represents the entire content
+        /// range of the file.
+        /// </summary>
+        public BufferRange FileRange
+        {
+            get { return this.scriptFile.FileRange; }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the FileContext class.
+        /// </summary>
+        /// <param name="scriptFile">The ScriptFile to which this file refers.</param>
+        /// <param name="editorContext">The EditorContext to which this file relates.</param>
+        /// <param name="editorOperations">An IEditorOperations implementation which performs operations in the editor.</param>
+        public FileContext(
+            ScriptFile scriptFile,
+            EditorContext editorContext,
+            IEditorOperations editorOperations)
+        {
+            this.scriptFile = scriptFile;
+            this.editorContext = editorContext;
+            this.editorOperations = editorOperations;
+        }
+
+        #endregion
+
+        #region Text Accessors
+
+        /// <summary>
+        /// Gets the complete file content as a string.
+        /// </summary>
+        /// <returns>A string containing the complete file content.</returns>
+        public string GetText()
+        {
+            return this.scriptFile.Contents;
+        }
+
+        /// <summary>
+        /// Gets the file content in the specified range as a string.
+        /// </summary>
+        /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
+        /// <returns>A string with the specified range of content.</returns>
+        public string GetText(BufferRange bufferRange)
+        {
+            return
+                string.Join(
+                    Environment.NewLine,
+                    this.GetTextLines(bufferRange));
+        }
+
+        /// <summary>
+        /// Gets the complete file content as an array of strings.
+        /// </summary>
+        /// <returns>An array of strings, each representing a line in the file.</returns>
+        public string[] GetTextLines()
+        {
+            return this.scriptFile.FileLines.ToArray();
+        }
+
+        /// <summary>
+        /// Gets the file content in the specified range as an array of strings.
+        /// </summary>
+        /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
+        /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
+        public string[] GetTextLines(BufferRange bufferRange)
+        {
+            return this.scriptFile.GetLinesInRange(bufferRange);
+        }
+
+        #endregion
+
+        #region Text Manipulation
+
+        /// <summary>
+        /// Inserts a text string at the current cursor position represented by
+        /// the parent EditorContext's CursorPosition property.
+        /// </summary>
+        /// <param name="textToInsert">The text string to insert.</param>
+        public void InsertText(string textToInsert)
+        {
+            // Is there a selection?
+            if (this.editorContext.SelectedRange.HasRange)
+            {
+                this.InsertText(
+                    textToInsert,
+                    this.editorContext.SelectedRange);
+            }
+            else
+            {
+                this.InsertText(
+                    textToInsert,
+                    this.editorContext.CursorPosition);
+            }
+        }
+
+        /// <summary>
+        /// Inserts a text string at the specified buffer position.
+        /// </summary>
+        /// <param name="textToInsert">The text string to insert.</param>
+        /// <param name="insertPosition">The position at which the text will be inserted.</param>
+        public void InsertText(string textToInsert, BufferPosition insertPosition)
+        {
+            this.InsertText(
+                textToInsert,
+                new BufferRange(insertPosition, insertPosition));
+        }
+
+        /// <summary>
+        /// Inserts a text string at the specified line and column numbers.
+        /// </summary>
+        /// <param name="textToInsert">The text string to insert.</param>
+        /// <param name="insertLine">The 1-based line number at which the text will be inserted.</param>
+        /// <param name="insertColumn">The 1-based column number at which the text will be inserted.</param>
+        public void InsertText(string textToInsert, int insertLine, int insertColumn)
+        {
+            this.InsertText(
+                textToInsert,
+                new BufferPosition(insertLine, insertColumn));
+        }
+
+        /// <summary>
+        /// Inserts a text string to replace the specified range, represented
+        /// by starting and ending line and column numbers.  Can be used to
+        /// insert, replace, or delete text depending on the specified range
+        /// and text to insert.
+        /// </summary>
+        /// <param name="textToInsert">The text string to insert.</param>
+        /// <param name="startLine">The 1-based starting line number where text will be replaced.</param>
+        /// <param name="startColumn">The 1-based starting column number where text will be replaced.</param>
+        /// <param name="endLine">The 1-based ending line number where text will be replaced.</param>
+        /// <param name="endColumn">The 1-based ending column number where text will be replaced.</param>
+        public void InsertText(
+            string textToInsert,
+            int startLine,
+            int startColumn,
+            int endLine,
+            int endColumn)
+        {
+            this.InsertText(
+                textToInsert,
+                new BufferRange(
+                    startLine,
+                    startColumn,
+                    endLine,
+                    endColumn));
+        }
+
+        /// <summary>
+        /// Inserts a text string to replace the specified range. Can be
+        /// used to insert, replace, or delete text depending on the specified
+        /// range and text to insert.
+        /// </summary>
+        /// <param name="textToInsert">The text string to insert.</param>
+        /// <param name="insertRange">The buffer range which will be replaced by the string.</param>
+        public void InsertText(string textToInsert, BufferRange insertRange)
+        {
+            this.editorOperations
+                .InsertText(this.scriptFile.ClientFilePath, textToInsert, insertRange)
+                .Wait();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Extensions
+{
+    /// <summary>
+    /// Provides an interface that must be implemented by an editor
+    /// host to perform operations invoked by extensions written in
+    /// PowerShell.
+    /// </summary>
+    public interface IEditorOperations
+    {
+        /// <summary>
+        /// Gets the EditorContext for the editor's current state.
+        /// </summary>
+        /// <returns>A new EditorContext object.</returns>
+        Task<EditorContext> GetEditorContext();
+
+        /// <summary>
+        /// Causes a file to be opened in the editor.  If the file is
+        /// already open, the editor must switch to the file.
+        /// </summary>
+        /// <param name="filePath">The path of the file to be opened.</param>
+        /// <returns>A Task that can be tracked for completion.</returns>
+        Task OpenFile(string filePath);
+
+        /// <summary>
+        /// Inserts text into the specified range for the file at the specified path.
+        /// </summary>
+        /// <param name="filePath">The path of the file which will have text inserted.</param>
+        /// <param name="insertText">The text to insert into the file.</param>
+        /// <param name="insertRange">The range in the file to be replaced.</param>
+        /// <returns>A Task that can be tracked for completion.</returns>
+        Task InsertText(string filePath, string insertText, BufferRange insertRange);
+
+        /// <summary>
+        /// Causes the selection to be changed in the editor's active file buffer.
+        /// </summary>
+        /// <param name="selectionRange">The range over which the selection will be made.</param>
+        /// <returns>A Task that can be tracked for completion.</returns>
+        Task SetSelection(BufferRange selectionRange);
+    }
+}
+

--- a/src/PowerShellEditorServices/Language/CompletionResults.cs
+++ b/src/PowerShellEditorServices/Language/CompletionResults.cs
@@ -41,20 +41,28 @@ namespace Microsoft.PowerShell.EditorServices
         public CompletionResults()
         {
             this.Completions = new CompletionDetails[0];
-            this.ReplacedRange = new BufferRange();
+            this.ReplacedRange = new BufferRange(0, 0, 0, 0);
         }
 
         internal static CompletionResults Create(
             ScriptFile scriptFile,
             CommandCompletion commandCompletion)
         {
+            BufferRange replacedRange = null;
+
+            // Only calculate the replacement range if there are completion results
+            if (commandCompletion.CompletionMatches.Count > 0)
+            {
+                replacedRange =
+                    scriptFile.GetRangeBetweenOffsets(
+                        commandCompletion.ReplacementIndex,
+                        commandCompletion.ReplacementIndex + commandCompletion.ReplacementLength);
+            }
+
             return new CompletionResults
             {
                 Completions = GetCompletionsArray(commandCompletion),
-                ReplacedRange = 
-                    scriptFile.GetRangeBetweenOffsets(
-                        commandCompletion.ReplacementIndex,
-                        commandCompletion.ReplacementIndex + commandCompletion.ReplacementLength)
+                ReplacedRange = replacedRange
             };
         }
 

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -75,6 +75,13 @@
     <Compile Include="Debugging\VariableDetailsBase.cs" />
     <Compile Include="Debugging\VariableScope.cs" />
     <Compile Include="Debugging\VariableContainerDetails.cs" />
+    <Compile Include="Extensions\EditorContext.cs" />
+    <Compile Include="Extensions\EditorObject.cs" />
+    <Compile Include="Extensions\EditorWorkspace.cs" />
+    <Compile Include="Extensions\EditorCommand.cs" />
+    <Compile Include="Extensions\ExtensionService.cs" />
+    <Compile Include="Extensions\FileContext.cs" />
+    <Compile Include="Extensions\IEditorOperations.cs" />
     <Compile Include="Language\AstOperations.cs" />
     <Compile Include="Language\CommandHelpers.cs" />
     <Compile Include="Language\CompletionResults.cs" />
@@ -127,6 +134,7 @@
     <Compile Include="Workspace\BufferRange.cs" />
     <Compile Include="Workspace\FileChange.cs" />
     <Compile Include="Workspace\BufferPosition.cs" />
+    <Compile Include="Workspace\FilePosition.cs" />
     <Compile Include="Workspace\ScriptFile.cs" />
     <Compile Include="Workspace\ScriptFileMarker.cs" />
     <Compile Include="Workspace\ScriptRegion.cs" />
@@ -138,7 +146,9 @@
       <Name>ScriptAnalyzerEngine</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="Extensions\CmdletInterface.ps1" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -4,6 +4,7 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Console;
+using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System.IO;
@@ -48,6 +49,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public ConsoleService ConsoleService { get; private set; }
 
+        /// <summary>
+        /// Gets the ExtensionService instance for this session.
+        /// </summary>
+        public ExtensionService ExtensionService { get; private set; }
+
         #endregion
 
         #region Public Methods
@@ -75,6 +81,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.LanguageService = new LanguageService(this.PowerShellContext);
             this.DebugService = new DebugService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
+            this.ExtensionService = new ExtensionService(this.PowerShellContext);
 
             this.InstantiateAnalysisService();
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -168,6 +168,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             this.initialRunspace = initialRunspace;
             this.currentRunspace = initialRunspace;
+            this.psHost.Runspace = initialRunspace;
 
             this.currentRunspace.Debugger.BreakpointUpdated += OnBreakpointUpdated;
             this.currentRunspace.Debugger.DebuggerStop += OnDebuggerStop;
@@ -721,12 +722,23 @@ namespace Microsoft.PowerShell.EditorServices
 
         internal void WriteOutput(string outputString, bool includeNewLine)
         {
+            this.WriteOutput(
+                outputString,
+                includeNewLine,
+                OutputType.Normal);
+        }
+
+        internal void WriteOutput(
+            string outputString,
+            bool includeNewLine,
+            OutputType outputType)
+        {
             if (this.ConsoleHost != null)
             {
                 this.ConsoleHost.WriteOutput(
                     outputString,
                     includeNewLine,
-                    OutputType.Normal);
+                    outputType);
             }
         }
 

--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -16,7 +17,7 @@ namespace Microsoft.PowerShell.EditorServices
     /// ConsoleService and routes its calls to an IConsoleHost
     /// implementation.
     /// </summary>
-    internal class ConsoleServicePSHost : PSHost
+    internal class ConsoleServicePSHost : PSHost, IHostSupportsInteractiveSession
     {
         #region Private Fields
 
@@ -92,6 +93,16 @@ namespace Microsoft.PowerShell.EditorServices
             get { return this.hostUserInterface; }
         }
 
+        public bool IsRunspacePushed
+        {
+            get { return false; }
+        }
+
+        public Runspace Runspace
+        {
+            get; internal set;
+        }
+
         public override void EnterNestedPrompt()
         {
             Logger.Write(LogLevel.Verbose, "EnterNestedPrompt() called.");
@@ -118,6 +129,16 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 this.consoleHost.ExitSession(exitCode);
             }
+        }
+
+        public void PushRunspace(Runspace runspace)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void PopRunspace()
+        {
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Workspace/BufferPosition.cs
+++ b/src/PowerShellEditorServices/Workspace/BufferPosition.cs
@@ -3,13 +3,25 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Diagnostics;
+
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
-    /// Provides details about a position in a file buffer.
+    /// Provides details about a position in a file buffer.  All
+    /// positions are expressed in 1-based positions (i.e. the
+    /// first line and column in the file is position 1,1).
     /// </summary>
-    public struct BufferPosition
+    [DebuggerDisplay("Position = {Line}:{Column}")]
+    public class BufferPosition
     {
+        #region Properties
+
+        /// <summary>
+        /// Provides an instance that represents a position that has not been set.
+        /// </summary>
+        public static readonly BufferPosition None = new BufferPosition(-1, -1);
+
         /// <summary>
         /// Gets the line number of the position in the buffer.
         /// </summary>
@@ -19,6 +31,10 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the column number of the position in the buffer.
         /// </summary>
         public int Column { get; private set; }
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the BufferPosition class.
@@ -30,6 +46,66 @@ namespace Microsoft.PowerShell.EditorServices
             this.Line = line;
             this.Column = column;
         }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Compares two instances of the BufferPosition class.
+        /// </summary>
+        /// <param name="obj">The object to which this instance will be compared.</param>
+        /// <returns>True if the positions are equal, false otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BufferPosition))
+            {
+                return false;
+            }
+
+            BufferPosition other = (BufferPosition)obj;
+
+            return
+                this.Line == other.Line &&
+                this.Column == other.Column;
+        }
+
+        /// <summary>
+        /// Calculates a unique hash code that represents this instance.
+        /// </summary>
+        /// <returns>A hash code representing this instance.</returns>
+        public override int GetHashCode()
+        {
+            return this.Line.GetHashCode() ^ this.Column.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compares two positions to check if one is greater than the other.
+        /// </summary>
+        /// <param name="positionOne">The first position to compare.</param>
+        /// <param name="positionTwo">The second position to compare.</param>
+        /// <returns>True if positionOne is greater than positionTwo.</returns>
+        public static bool operator >(BufferPosition positionOne, BufferPosition positionTwo)
+        {
+            return
+                (positionOne != null && positionTwo == null) ||
+                (positionOne.Line > positionTwo.Line) ||
+                (positionOne.Line == positionTwo.Line &&
+                 positionOne.Column > positionTwo.Column);
+        }
+
+        /// <summary>
+        /// Compares two positions to check if one is less than the other.
+        /// </summary>
+        /// <param name="positionOne">The first position to compare.</param>
+        /// <param name="positionTwo">The second position to compare.</param>
+        /// <returns>True if positionOne is less than positionTwo.</returns>
+        public static bool operator <(BufferPosition positionOne, BufferPosition positionTwo)
+        {
+            return positionTwo > positionOne;
+        }
+
+        #endregion
     }
 }
 

--- a/src/PowerShellEditorServices/Workspace/BufferRange.cs
+++ b/src/PowerShellEditorServices/Workspace/BufferRange.cs
@@ -3,14 +3,25 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Diagnostics;
+
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
     /// Provides details about a range between two positions in
     /// a file buffer.
     /// </summary>
-    public struct BufferRange
+    [DebuggerDisplay("Start = {Start.Line}:{Start.Column}, End = {End.Line}:{End.Column}")]
+    public class BufferRange
     {
+        #region Properties
+
+        /// <summary>
+        /// Provides an instance that represents a range that has not been set.
+        /// </summary>
+        public static readonly BufferRange None = new BufferRange(0, 0, 0, 0);
+
         /// <summary>
         /// Gets the start position of the range in the buffer.
         /// </summary>
@@ -22,15 +33,91 @@ namespace Microsoft.PowerShell.EditorServices
         public BufferPosition End { get; private set; }
 
         /// <summary>
+        /// Returns true if the current range is non-zero, i.e.
+        /// contains valid start and end positions.
+        /// </summary>
+        public bool HasRange
+        {
+            get
+            {
+                return this.Equals(BufferRange.None);
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
         /// Creates a new instance of the BufferRange class.
         /// </summary>
         /// <param name="start">The start position of the range.</param>
         /// <param name="end">The end position of the range.</param>
         public BufferRange(BufferPosition start, BufferPosition end)
         {
+            if (start > end)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        "Start position ({0}, {1}) must come before or be equal to the end position ({2}, {3}).",
+                        start.Line, start.Column,
+                        end.Line, end.Column));
+            }
+
             this.Start = start;
             this.End = end;
         }
+
+        /// <summary>
+        /// Creates a new instance of the BufferRange class.
+        /// </summary>
+        /// <param name="startLine">The 1-based starting line number of the range.</param>
+        /// <param name="startColumn">The 1-based starting column number of the range.</param>
+        /// <param name="endLine">The 1-based ending line number of the range.</param>
+        /// <param name="endColumn">The 1-based ending column number of the range.</param>
+        public BufferRange(
+            int startLine,
+            int startColumn,
+            int endLine,
+            int endColumn)
+        {
+            this.Start = new BufferPosition(startLine, startColumn);
+            this.End = new BufferPosition(endLine, endColumn);
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Compares two instances of the BufferRange class.
+        /// </summary>
+        /// <param name="obj">The object to which this instance will be compared.</param>
+        /// <returns>True if the ranges are equal, false otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is BufferRange))
+            {
+                return false;
+            }
+
+            BufferRange other = (BufferRange)obj;
+
+            return
+                this.Start.Equals(other.Start) &&
+                this.End.Equals(other.End);
+        }
+
+        /// <summary>
+        /// Calculates a unique hash code that represents this instance.
+        /// </summary>
+        /// <returns>A hash code representing this instance.</returns>
+        public override int GetHashCode()
+        {
+            return this.Start.GetHashCode() ^ this.End.GetHashCode();
+        }
+
+        #endregion
     }
 }
 

--- a/src/PowerShellEditorServices/Workspace/FilePosition.cs
+++ b/src/PowerShellEditorServices/Workspace/FilePosition.cs
@@ -1,0 +1,109 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Provides details and operations for a buffer position in a
+    /// specific file.
+    /// </summary>
+    public class FilePosition : BufferPosition
+    {
+        #region Private Fields
+
+        private ScriptFile scriptFile;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new FilePosition instance for the 1-based line and
+        /// column numbers in the specified file.
+        /// </summary>
+        /// <param name="scriptFile">The ScriptFile in which the position is located.</param>
+        /// <param name="line">The 1-based line number in the file.</param>
+        /// <param name="column">The 1-based column number in the file.</param>
+        public FilePosition(
+            ScriptFile scriptFile,
+            int line,
+            int column)
+                : base(line, column)
+        {
+            this.scriptFile = scriptFile;
+        }
+
+        /// <summary>
+        /// Creates a new FilePosition instance for the specified file by
+        /// copying the specified BufferPosition
+        /// </summary>
+        /// <param name="scriptFile">The ScriptFile in which the position is located.</param>
+        /// <param name="copiedPosition">The original BufferPosition from which the line and column will be copied.</param>
+        public FilePosition(
+            ScriptFile scriptFile,
+            BufferPosition copiedPosition)
+                 : this(scriptFile, copiedPosition.Line, copiedPosition.Column)
+        {
+            scriptFile.ValidatePosition(copiedPosition);
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Gets a FilePosition relative to this position by adding the
+        /// provided line and column offset relative to the contents of
+        /// the current file.
+        /// </summary>
+        /// <param name="lineOffset">The line offset to add to this position.</param>
+        /// <param name="columnOffset">The column offset to add to this position.</param>
+        /// <returns>A new FilePosition instance for the calculated position.</returns>
+        public FilePosition AddOffset(int lineOffset, int columnOffset)
+        {
+            return this.scriptFile.CalculatePosition(
+                this,
+                lineOffset,
+                columnOffset);
+        }
+
+        /// <summary>
+        /// Gets a FilePosition for the line and column position
+        /// of the beginning of the current line after any initial
+        /// whitespace for indentation.
+        /// </summary>
+        /// <returns>A new FilePosition instance for the calculated position.</returns>
+        public FilePosition GetLineStart()
+        {
+            string scriptLine = scriptFile.FileLines[this.Line - 1];
+
+            int lineStartColumn = 1;
+            for (int i = 0; i < scriptLine.Length; i++)
+            {
+                if (!char.IsWhiteSpace(scriptLine[i]))
+                {
+                    lineStartColumn = i + 1;
+                    break;
+                }
+            }
+
+            return new FilePosition(this.scriptFile, this.Line, lineStartColumn);
+        }
+
+        /// <summary>
+        /// Gets a FilePosition for the line and column position
+        /// of the end of the current line.
+        /// </summary>
+        /// <returns>A new FilePosition instance for the calculated position.</returns>
+        public FilePosition GetLineEnd()
+        {
+            string scriptLine = scriptFile.FileLines[this.Line - 1];
+            return new FilePosition(this.scriptFile, this.Line, scriptLine.Length + 1);
+        }
+
+        #endregion
+    }
+}
+

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -1,0 +1,192 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Extensions;
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Extensions
+{
+    public class ExtensionServiceTests : IAsyncLifetime
+    {
+        private ScriptFile currentFile;
+        private EditorContext commandContext;
+        private ExtensionService extensionService;
+        private PowerShellContext powerShellContext;
+        private TestEditorOperations editorOperations;
+
+        private AsyncQueue<Tuple<EventType, EditorCommand>> extensionEventQueue =
+            new AsyncQueue<Tuple<EventType, EditorCommand>>();
+
+        private enum EventType
+        {
+            Add,
+            Update,
+            Remove
+        }
+
+        public async Task InitializeAsync()
+        {
+            this.powerShellContext = new PowerShellContext();
+            this.extensionService = new ExtensionService(this.powerShellContext);
+            this.editorOperations = new TestEditorOperations();
+
+            this.extensionService.CommandAdded += ExtensionService_ExtensionAdded;
+            this.extensionService.CommandUpdated += ExtensionService_ExtensionUpdated;
+            this.extensionService.CommandRemoved += ExtensionService_ExtensionRemoved;
+
+            await this.extensionService.Initialize(this.editorOperations);
+
+            var filePath = @"c:\Test\Test.ps1";
+            this.currentFile = new ScriptFile(filePath, filePath, "This is a test file", new Version("5.0"));
+            this.commandContext =
+                new EditorContext(
+                    this.editorOperations,
+                    currentFile,
+                    new BufferPosition(1, 1),
+                    BufferRange.None);
+        }
+
+        public Task DisposeAsync()
+        {
+            this.powerShellContext.Dispose();
+            return Task.FromResult(true);
+        }
+
+        [Fact]
+        public async Task CanRegisterAndInvokeCommandWithCmdletName()
+        {
+            await extensionService.PowerShellContext.ExecuteScriptString(
+                "function Invoke-Extension { $global:extensionValue = 5 }\r\n" +
+                "Register-EditorCommand -Name \"test.function\" -DisplayName \"Function extension\" -Function \"Invoke-Extension\"");
+
+            // Wait for the add event
+            EditorCommand command = await this.AssertExtensionEvent(EventType.Add, "test.function");
+
+            // Invoke the command
+            await extensionService.InvokeCommand("test.function", this.commandContext);
+
+            // Assert the expected value
+            PSCommand psCommand = new PSCommand();
+            psCommand.AddScript("$global:extensionValue");
+            var results = await powerShellContext.ExecuteCommand<int>(psCommand);
+            Assert.Equal(5, results.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task CanRegisterAndInvokeCommandWithScriptBlock()
+        {
+            await extensionService.PowerShellContext.ExecuteScriptString(
+                "Register-EditorCommand -Name \"test.scriptblock\" -DisplayName \"ScriptBlock extension\" -ScriptBlock { $global:extensionValue = 10 }");
+
+            // Wait for the add event
+            EditorCommand command = await this.AssertExtensionEvent(EventType.Add, "test.scriptblock");
+
+            // Invoke the command
+            await extensionService.InvokeCommand("test.scriptblock", this.commandContext);
+
+            // Assert the expected value
+            PSCommand psCommand = new PSCommand();
+            psCommand.AddScript("$global:extensionValue");
+            var results = await powerShellContext.ExecuteCommand<int>(psCommand);
+            Assert.Equal(10, results.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task CanUpdateRegisteredCommand()
+        {
+            // Register a command and then update it
+            await extensionService.PowerShellContext.ExecuteScriptString(
+                "function Invoke-Extension { Write-Output \"Extension output!\" }\r\n" +
+                "Register-EditorCommand -Name \"test.function\" -DisplayName \"Function extension\" -Function \"Invoke-Extension\"\r\n" +
+                "Register-EditorCommand -Name \"test.function\" -DisplayName \"Updated Function extension\" -Function \"Invoke-Extension\"");
+
+            // Wait for the add and update events
+            await this.AssertExtensionEvent(EventType.Add, "test.function");
+            EditorCommand updatedCommand = await this.AssertExtensionEvent(EventType.Update, "test.function");
+
+            Assert.Equal("Updated Function extension", updatedCommand.DisplayName);
+        }
+
+        [Fact]
+        public async Task CanUnregisterCommand()
+        {
+            // Add the command and wait for the add event
+            await extensionService.PowerShellContext.ExecuteScriptString(
+                "Register-EditorCommand -Name \"test.scriptblock\" -DisplayName \"ScriptBlock extension\" -ScriptBlock { Write-Output \"Extension output!\" }");
+            await this.AssertExtensionEvent(EventType.Add, "test.scriptblock");
+
+            // Remove the command and wait for the remove event
+            await extensionService.PowerShellContext.ExecuteScriptString(
+                "Unregister-EditorCommand -Name \"test.scriptblock\"");
+            await this.AssertExtensionEvent(EventType.Remove, "test.scriptblock");
+
+            // Ensure that the command has been unregistered
+            await Assert.ThrowsAsync(
+                typeof(KeyNotFoundException),
+                () => extensionService.InvokeCommand("test.scriptblock", this.commandContext));
+        }
+
+        private async Task<EditorCommand> AssertExtensionEvent(EventType expectedEventType, string expectedExtensionName)
+        {
+            var eventExtensionTuple =
+                await this.extensionEventQueue.DequeueAsync(
+                    new CancellationTokenSource(5000).Token);
+
+            Assert.Equal(expectedEventType, eventExtensionTuple.Item1);
+            Assert.Equal(expectedExtensionName, eventExtensionTuple.Item2.Name);
+
+            return eventExtensionTuple.Item2;
+        }
+
+        private async void ExtensionService_ExtensionAdded(object sender, EditorCommand e)
+        {
+            await this.extensionEventQueue.EnqueueAsync(
+                new Tuple<EventType, EditorCommand>(EventType.Add, e));
+        }
+
+        private async void ExtensionService_ExtensionUpdated(object sender, EditorCommand e)
+        {
+            await this.extensionEventQueue.EnqueueAsync(
+                new Tuple<EventType, EditorCommand>(EventType.Update, e));
+        }
+
+        private async void ExtensionService_ExtensionRemoved(object sender, EditorCommand e)
+        {
+            await this.extensionEventQueue.EnqueueAsync(
+                new Tuple<EventType, EditorCommand>(EventType.Remove, e));
+        }
+    }
+
+    public class TestEditorOperations : IEditorOperations
+    {
+        public Task OpenFile(string filePath)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task InsertText(string filePath, string text, BufferRange insertRange)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetSelection(BufferRange selectionRange)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<EditorContext> GetEditorContext()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Console\InputPromptHandlerTests.cs" />
+    <Compile Include="Extensions\ExtensionServiceTests.cs" />
     <Compile Include="Session\PowerShellContextTests.cs" />
     <Compile Include="Debugging\DebugServiceTests.cs" />
     <Compile Include="Language\LanguageServiceTests.cs" />

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -6,11 +6,12 @@
 using Microsoft.PowerShell.EditorServices;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace PSLanguageService.Test
 {
-    public class FileChangeTests
+    public class ScriptFileChangeTests
     {
         private static readonly Version PowerShellVersion = new Version("5.0"); 
 
@@ -151,10 +152,28 @@ namespace PSLanguageService.Test
             }
         }
 
-        private void AssertFileChange(
-            string initialString,
-            string expectedString,
-            FileChange fileChange)
+        [Fact]
+        public void ThrowsExceptionWithEditOutsideOfRange()
+        {
+            Assert.Throws(
+                typeof(ArgumentOutOfRangeException),
+                () =>
+                {
+                    this.AssertFileChange(
+                        "first\r\nsecond\r\nREMOVE\r\nTHESE\r\nLINES\r\nthird",
+                        "first\r\nsecond\r\nthird",
+                        new FileChange
+                        {
+                            Line = 3,
+                            EndLine = 7,
+                            Offset = 1,
+                            EndOffset = 1,
+                            InsertString = ""
+                        });
+                });
+        }
+
+        internal static ScriptFile CreateScriptFile(string initialString)
         {
             using (StringReader stringReader = new StringReader(initialString))
             {
@@ -166,10 +185,257 @@ namespace PSLanguageService.Test
                         stringReader,
                         PowerShellVersion);
 
-                // Apply the FileChange and assert the resulting contents
-                fileToChange.ApplyChange(fileChange);
-                Assert.Equal(expectedString, fileToChange.Contents);
+                return fileToChange;
             }
+        }
+
+        private void AssertFileChange(
+            string initialString,
+            string expectedString,
+            FileChange fileChange)
+        {
+            // Create an in-memory file from the StringReader
+            ScriptFile fileToChange = CreateScriptFile(initialString);
+
+            // Apply the FileChange and assert the resulting contents
+            fileToChange.ApplyChange(fileChange);
+            Assert.Equal(expectedString, fileToChange.Contents);
+        }
+    }
+
+    public class ScriptFileGetLinesTests
+    {
+        private ScriptFile scriptFile;
+
+        private const string TestString = "Line One\r\nLine Two\r\nLine Three\r\nLine Four\r\nLine Five";
+        private readonly string[] TestStringLines =
+            TestString.Split(
+                new string[] { "\r\n" },
+                StringSplitOptions.None);
+
+        public ScriptFileGetLinesTests()
+        {
+            this.scriptFile =
+                ScriptFileChangeTests.CreateScriptFile(
+                    "Line One\r\nLine Two\r\nLine Three\r\nLine Four\r\nLine Five\r\n");
+        }
+
+        [Fact]
+        public void CanGetWholeLine()
+        {
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(5, 1, 5, 10));
+
+            Assert.Equal(1, lines.Length);
+            Assert.Equal("Line Five", lines[0]);
+        }
+
+        [Fact]
+        public void CanGetMultipleWholeLines()
+        {
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(2, 1, 4, 10));
+
+            Assert.Equal(TestStringLines.Skip(1).Take(3), lines);
+        }
+
+        [Fact]
+        public void CanGetSubstringInSingleLine()
+        {
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(4, 3, 4, 8));
+
+            Assert.Equal(1, lines.Length);
+            Assert.Equal("ne Fo", lines[0]);
+        }
+
+        [Fact]
+        public void CanGetEmptySubstringRange()
+        {
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(4, 3, 4, 3));
+
+            Assert.Equal(1, lines.Length);
+            Assert.Equal("", lines[0]);
+        }
+
+        [Fact]
+        public void CanGetSubstringInMultipleLines()
+        {
+            string[] expectedLines = new string[]
+            {
+                "Two",
+                "Line Three",
+                "Line Fou"
+            };
+
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(2, 6, 4, 9));
+
+            Assert.Equal(expectedLines, lines);
+        }
+
+        [Fact]
+        public void CanGetRangeAtLineBoundaries()
+        {
+            string[] expectedLines = new string[]
+            {
+                "",
+                "Line Three",
+                ""
+            };
+
+            string[] lines =
+                this.scriptFile.GetLinesInRange(
+                    new BufferRange(2, 9, 4, 1));
+
+            Assert.Equal(expectedLines, lines);
+        }
+    }
+
+    public class ScriptFilePositionTests
+    {
+        private ScriptFile scriptFile;
+
+        public ScriptFilePositionTests()
+        {
+            this.scriptFile =
+                ScriptFileChangeTests.CreateScriptFile(@"
+First line
+  Second line is longer
+    Third line
+");
+        }
+
+        [Fact]
+        public void CanOffsetByLine()
+        {
+            this.AssertNewPosition(
+                1, 1,
+                2, 0,
+                3, 1);
+
+            this.AssertNewPosition(
+                3, 1,
+                -2, 0,
+                1, 1);
+        }
+
+        [Fact]
+        public void CanOffsetByColumn()
+        {
+            this.AssertNewPosition(
+                2, 1,
+                0, 2,
+                2, 3);
+
+            this.AssertNewPosition(
+                2, 5,
+                0, -3,
+                2, 2);
+        }
+
+        [Fact]
+        public void ThrowsWhenPositionOutOfRange()
+        {
+            // Less than line range
+            Assert.Throws(
+                typeof(ArgumentOutOfRangeException),
+                () =>
+                {
+                    scriptFile.CalculatePosition(
+                        new BufferPosition(1, 1),
+                        -10, 0);
+                });
+
+            // Greater than line range
+            Assert.Throws(
+                typeof(ArgumentOutOfRangeException),
+                () =>
+                {
+                    scriptFile.CalculatePosition(
+                        new BufferPosition(1, 1),
+                        10, 0);
+                });
+
+            // Less than column range
+            Assert.Throws(
+                typeof(ArgumentOutOfRangeException),
+                () =>
+                {
+                    scriptFile.CalculatePosition(
+                        new BufferPosition(1, 1),
+                        0, -10);
+                });
+
+            // Greater than column range
+            Assert.Throws(
+                typeof(ArgumentOutOfRangeException),
+                () =>
+                {
+                    scriptFile.CalculatePosition(
+                        new BufferPosition(1, 1),
+                        0, 10);
+                });
+        }
+
+        [Fact]
+        public void CanFindBeginningOfLine()
+        {
+            this.AssertNewPosition(
+                4, 12,
+                pos => pos.GetLineStart(),
+                4, 5);
+        }
+
+        [Fact]
+        public void CanFindEndOfLine()
+        {
+            this.AssertNewPosition(
+                4, 12,
+                pos => pos.GetLineEnd(),
+                4, 15);
+        }
+
+        [Fact]
+        public void CanComposePositionOperations()
+        {
+            this.AssertNewPosition(
+                4, 12,
+                pos => pos.AddOffset(-1, 1).GetLineStart(),
+                3, 3);
+        }
+
+        private void AssertNewPosition(
+            int originalLine, int originalColumn,
+            int lineOffset, int columnOffset,
+            int expectedLine, int expectedColumn)
+        {
+            this.AssertNewPosition(
+                originalLine, originalColumn,
+                pos => pos.AddOffset(lineOffset, columnOffset),
+                expectedLine, expectedColumn);
+        }
+
+        private void AssertNewPosition(
+            int originalLine, int originalColumn,
+            Func<FilePosition, FilePosition> positionOperation,
+            int expectedLine, int expectedColumn)
+        {
+            var newPosition =
+                positionOperation(
+                    new FilePosition(
+                        this.scriptFile,
+                        originalLine,
+                        originalColumn));
+
+            Assert.Equal(expectedLine, newPosition.Line);
+            Assert.Equal(expectedColumn, newPosition.Column);
         }
     }
 }


### PR DESCRIPTION
This change introduces a new PowerShell-based API that allows scripts and
modules to extend the behavior of the host editor.  Scripts can either
automate the editor directly or register commands that can later be
invoked by the user.  The ExtensionService provides this behavior for any
PowerShellContext by injecting a new variable '$psEditor' into the
session.

This version of the API is very early and will be expanded upon in future
releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/214)
<!-- Reviewable:end -->
