### PR TITLE
Fix return value of EditorObject.RegisterCommand

### DIFF
--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -58,9 +58,10 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// Registers a new command in the editor.
         /// </summary>
         /// <param name="editorCommand">The EditorCommand to be registered.</param>
-        public void RegisterCommand(EditorCommand editorCommand)
+        /// <returns>True if the command is newly registered, false if the command already exists.</returns>
+        public bool RegisterCommand(EditorCommand editorCommand)
         {
-            this.extensionService.RegisterCommand(editorCommand);
+            return this.extensionService.RegisterCommand(editorCommand);
         }
 
         /// <summary>


### PR DESCRIPTION
This change fixes the EditorObject.RegisterCommand function to pass
through the return value of the ExtensionService.RegisterCommand function
so that the Register-EditorCommand cmdlet writes the correct verbose
output depending on whether the command was already registered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/217)
<!-- Reviewable:end -->
