### PR TITLE
Fix #221: Occasional init hang in LanguageServer

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -74,11 +74,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         protected override void Initialize()
         {
-            // Initialize the extension service
-            // TODO: This should be made awaited once Initialize is async!
-            this.editorSession.ExtensionService.Initialize(
-                this.editorOperations).Wait();
-
             // Register all supported message types
 
             this.SetRequestHandler(InitializeRequest.Type, this.HandleInitializeRequest);
@@ -107,6 +102,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.SetRequestHandler(InvokeExtensionCommandRequest.Type, this.HandleInvokeExtensionCommandRequest);
 
             this.SetRequestHandler(DebugAdapterMessages.EvaluateRequest.Type, this.HandleEvaluateRequest);
+
+            // Initialize the extension service
+            // TODO: This should be made awaited once Initialize is async!
+            this.editorSession.ExtensionService.Initialize(
+                this.editorOperations).Wait();
         }
 
         protected override async Task Shutdown()


### PR DESCRIPTION
This change fixes an issue in the LanguageServer where the length of time
that it takes to evaluate the extension API script can cause the
"initialize" request to not complete.  This leaves the VS Code language
server client in an initializing state where no language features will
work for the rest of the session.  The fix is to execute the extension API
script after the "initialize" handler has been registered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/229)
<!-- Reviewable:end -->
