### PR TITLE
Fix #222: Prompt functions hang in editor commands

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -193,6 +193,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             InvokeExtensionCommandRequest commandDetails,
             RequestContext<string> requestContext)
         {
+            // We don't await the result of the execution here because we want
+            // to be able to receive further messages while the editor command
+            // is executing.  This important in cases where the pipeline thread
+            // gets blocked by something in the script like a prompt to the user.
             EditorContext editorContext =
                 this.editorOperations.ConvertClientEditorContext(
                     commandDetails.Context);
@@ -207,7 +211,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 return requestContext.SendResult(null);
             });
 
-            return commandTask;
+            return Task.FromResult(true);
         }
 
         private async Task HandleExpandAliasRequest(


### PR DESCRIPTION
This change fixes an issue where $host.UI prompt functions do not return
the user's response when run inside of PowerShell editor commands.  This
was caused by the HandleInvokeExtensionCommand method returning a Task
that did not complete until after the command completed.  The fix was to
not await on completion of the command so that the prompt response has a
chance to come through.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/230)
<!-- Reviewable:end -->
