### PR TITLE
Fix #232: Language server crashes when ErrorActionPreference is "Stop"

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -528,21 +528,16 @@ function __Expand-Alias {
         {
             if (completionItem.Kind == CompletionItemKind.Function)
             {
-                RunspaceHandle runspaceHandle =
-                    await editorSession.PowerShellContext.GetRunspaceHandle();
-
                 // Get the documentation for the function
                 CommandInfo commandInfo =
-                    CommandHelpers.GetCommandInfo(
+                    await CommandHelpers.GetCommandInfo(
                         completionItem.Label,
-                        runspaceHandle.Runspace);
+                        this.editorSession.PowerShellContext);
 
                 completionItem.Documentation =
-                    CommandHelpers.GetCommandSynopsis(
+                    await CommandHelpers.GetCommandSynopsis(
                         commandInfo,
-                        runspaceHandle.Runspace);
-
-                runspaceHandle.Dispose();
+                        this.editorSession.PowerShellContext);
             }
 
             // Send back the updated CompletionItem

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.EditorServices
             bool sendErrorToHost = true)
         {
             RunspaceHandle runspaceHandle = null;
-            IEnumerable<TResult> executionResult = null;
+            IEnumerable<TResult> executionResult = Enumerable.Empty<TResult>();
 
             // If the debugger is active and the caller isn't on the pipeline 
             // thread, send the command over to that thread to be executed.


### PR DESCRIPTION
This change fixes an issue where the language server can sometimes crash
when the user has configured their $ErrorActionPreference variable to
"Stop" in the language server's session.  The fix is to refactor existing
code to use a common code path that handles RuntimeExceptions
appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/234)
<!-- Reviewable:end -->
