### PR TITLE
Need to escape regex pattern with external component.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1128,7 +1128,7 @@ function __Expand-Alias {
                 // from the ToolTipText - if there is any ToolTipText.
                 if (completionDetails.ToolTipText != null)
                 {
-                    // Fix for #193 - notepad++.exe in tooltip text caused regex parser to throw.
+                    // Fix for #240 - notepad++.exe in tooltip text caused regex parser to throw.
                     string escapedToolTipText = Regex.Escape(completionDetails.ToolTipText);
 
                     // Don't display ToolTipText if it is the same as the ListItemText.

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1128,13 +1128,16 @@ function __Expand-Alias {
                 // from the ToolTipText - if there is any ToolTipText.
                 if (completionDetails.ToolTipText != null)
                 {
+                    // Fix for #193 - notepad++.exe in tooltip text caused regex parser to throw.
+                    string escapedToolTipText = Regex.Escape(completionDetails.ToolTipText);
+
                     // Don't display ToolTipText if it is the same as the ListItemText.
                     // Reject command syntax ToolTipText - it's too much to display as a detailString.
                     if (!completionDetails.ListItemText.Equals(
                             completionDetails.ToolTipText,
                             StringComparison.OrdinalIgnoreCase) &&
                         !Regex.IsMatch(completionDetails.ToolTipText, 
-                            @"^\s*" + completionDetails.ListItemText + @"\s+\["))
+                            @"^\s*" + escapedToolTipText + @"\s+\["))
                     {
                         detailString = completionDetails.ToolTipText;
                     }


### PR DESCRIPTION
LanguageServer.CreateCompletionItem was causing a editor host crash because it (er *I*) was injecting tooltip text (returned by the PS engine) into a regex pattern without escaping it.  One of the completion items was 'Notepad++.exe' which resulted in a regex parsing error.  Would like to add a test for this at some point but need to think on it.  CreateCompletionItem is private.

Fixes #240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/241)
<!-- Reviewable:end -->
