### PR TITLE
Add Editor Commands for opening Profiles

### DIFF
--- a/src/PowerShellEditorServices/Extensions/BuiltInCommands.ps1
+++ b/src/PowerShellEditorServices/Extensions/BuiltInCommands.ps1
@@ -15,7 +15,8 @@ Register-EditorCommand `
     -ScriptBlock {
         param([Microsoft.PowerShell.EditorServices.Extensions.EditorContext]$context)
         
-        $List = @('Microsoft.VSCode_profile.ps1','Microsoft.PowerShell_profile.ps1','Microsoft.PowerShellISE_profile.ps1','Profile.ps1')
+        $Current = Split-Path -Path $profile -Leaf        
+        $List = @($Current,'Microsoft.VSCode_profile.ps1','Microsoft.PowerShell_profile.ps1','Microsoft.PowerShellISE_profile.ps1','Profile.ps1') | Select-Object -Unique
         $Choices = [System.Management.Automation.Host.ChoiceDescription[]] @($List)
         $Selection = $host.ui.PromptForChoice('Please Select a Profile', '(Current User)', $choices,'0')
         $Name = $List[$Selection]

--- a/src/PowerShellEditorServices/Extensions/BuiltInCommands.ps1
+++ b/src/PowerShellEditorServices/Extensions/BuiltInCommands.ps1
@@ -1,0 +1,29 @@
+Register-EditorCommand `
+    -Name 'PowerShellEditorServices.OpenEditorProfile' `
+    -DisplayName 'Open Editor Profile' `
+    -SuppressOutput `
+    -ScriptBlock {
+        param([Microsoft.PowerShell.EditorServices.Extensions.EditorContext]$context)
+        If (!(Test-Path -Path $Profile)) { New-Item -Path $Profile -ItemType File }
+        $psEditor.Workspace.OpenFile($Profile)
+    }
+
+Register-EditorCommand `
+    -Name 'PowerShellEditorServices.OpenProfileList' `
+    -DisplayName 'Open Profile from List (Current User)' `
+    -SuppressOutput `
+    -ScriptBlock {
+        param([Microsoft.PowerShell.EditorServices.Extensions.EditorContext]$context)
+        
+        $List = @('Microsoft.VSCode_profile.ps1','Microsoft.PowerShell_profile.ps1','Microsoft.PowerShellISE_profile.ps1','Profile.ps1')
+        $Choices = [System.Management.Automation.Host.ChoiceDescription[]] @($List)
+        $Selection = $host.ui.PromptForChoice('Please Select a Profile', '(Current User)', $choices,'0')
+        $Name = $List[$Selection]
+        
+        $ProfileDir = Split-Path $Profile -Parent
+        $ProfileName = Join-Path -Path $ProfileDir -ChildPath $Name
+        
+        If (!(Test-Path -Path $ProfileName)) { New-Item -Path $ProfileName -ItemType File }
+        
+        $psEditor.Workspace.OpenFile($ProfileName)
+    }


### PR DESCRIPTION
This change adds the following built-in Editor Commands

- PowerShellEditorServices.OpenEditorProfile: Opens the current
Editor's profile. Uses $profile so should work when other Editors use
PSES.
- PowerShellEditorServices.OpenProfileList: Prompts user with a list of
 Profiles to open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/254)
<!-- Reviewable:end -->
