### PR TITLE
Added NoNano dir to .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ csx/
 
 # Don't include ScriptAnalyzer binaries
 PowerShellEditorServices/**
-
+PowerShellEditorServices.NoNano/**
 
 PowerShellEditorServices.sln.ide/edb.chk
 PowerShellEditorServices.sln.ide/edbres00001.jrs


### PR DESCRIPTION
The generated PowerShellEditorServices.NoNano module folder kept showing up as untracked.  I see you have the root level PowerShellEditorServices folder excluded so I just added another entry for the PowerShellEditorServices.NoNano folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/259)
<!-- Reviewable:end -->
