### PR TITLE
Added OS info to log file.

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -86,17 +86,22 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
 #endif
 
+            var newLine = Environment.NewLine;
+
             Logger.Write(
                 LogLevel.Normal,
                 string.Format(
-                    "PowerShell Editor Services Host v{0} starting (pid {1})...\r\n\r\n" +
-                    "  Host application details:\r\n\r\n" +
-                    "    Name: {2}\r\n    ProfileId: {3}\r\n    Version: {4}",
-                    fileVersionInfo.FileVersion,
-                    Process.GetCurrentProcess().Id,
-                    this.hostDetails.Name,
-                    this.hostDetails.ProfileId,
-                    this.hostDetails.Version));
+                    $"PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (pid {Process.GetCurrentProcess().Id})..." + newLine + newLine +
+                     "  Host application details:" + newLine + newLine +
+                    $"    Name:      {this.hostDetails.Name}" + newLine +
+                    $"    ProfileId: {this.hostDetails.ProfileId}" + newLine +
+                    $"    Version:   {this.hostDetails.Version}" + newLine +
+                     "    Arch:      {0}" + newLine + newLine +
+                     "  Operating system details:" + newLine + newLine +
+                    $"    Version: {Environment.OSVersion.VersionString}" + newLine +
+                     "    Arch:    {1}",
+                    Environment.Is64BitProcess ? "64-bit" : "32-bit",
+                    Environment.Is64BitOperatingSystem ? "64-bit" : "32-bit"));
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
 #endif
 
-            var newLine = Environment.NewLine;
+            string newLine = Environment.NewLine;
 
             Logger.Write(
                 LogLevel.Normal,


### PR DESCRIPTION
It is handy to know which version of the OS we are running on and what architecture for both the extension hosts and the OS.  Also, converted from \r\n to Environment.NewLine just in case this code runs on Linux/MacOSX someday.  :-)

This outputs to the log file:
```
    PowerShell Editor Services Host v0.0.0.0 starting (pid 2864)...
    
      Host application details:
    
        Name:      Visual Studio Code Host
        ProfileId: Microsoft.VSCode
        Version:   0.6.1
        Arch:      64-bit
    
      Operating system details:
    
        Version: Microsoft Windows NT 10.0.10586.0
        Arch:    64-bit
```

BTW this does use the C# 6 string interpolation feature but I think we already agreed that using C# 6 features was fair game, right?  There are some places where the `null conditional` operator would be real handy - like `session?.Dispose();`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/261)
<!-- Reviewable:end -->
