### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PowerShell Editor Services Release History
 
+## 0.7.1
+### Tuesday, August 23, 2016
+
+- Fixed PowerShell/vscode-powerShell#246: Restore default PSScriptAnalyzer ruleset
+- Fixed PowerShell/vscode-powershell#248: Extension fails to load on Windows 7 with PowerShell v3
+
 ## 0.7.0
 ### Thursday, August 18, 2016
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_depth: 10
 skip_tags: true
 
 environment:
-  core_version: '0.7.0'
+  core_version: '0.7.1'
   prerelease_name: '-beta'
 
 branches:

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerShellEditorServices.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.0'
+ModuleVersion = '0.7.1'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'
@@ -33,7 +33,7 @@ Copyright = '(c) 2016 Microsoft. All rights reserved.'
 # PowerShellVersion = ''
 
 # Name of the Windows PowerShell host required by this module
-#PowerShellHostName = ''
+# PowerShellHostName = ''
 
 # Minimum version of the Windows PowerShell host required by this module
 # PowerShellHostVersion = ''
@@ -72,7 +72,7 @@ FunctionsToExport = @('Start-EditorServicesHost')
 CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = '*'
+VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
 AliasesToExport = @()

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -50,17 +50,17 @@ function Start-EditorServicesHost {
     )
 
     $editorServicesHost = $null
-    $hostDetails = [Microsoft.PowerShell.EditorServices.Session.HostDetails]::new($HostName, $HostProfileId, [System.Version]::new($HostVersion))
+    $hostDetails = New-Object Microsoft.PowerShell.EditorServices.Session.HostDetails @($HostName, $HostProfileId, (New-Object System.Version @($HostVersion)))
 
     try {
         $editorServicesHost =
-            [Microsoft.PowerShell.EditorServices.Host.EditorServicesHost]::new(
+            New-Object Microsoft.PowerShell.EditorServices.Host.EditorServicesHost @(
                 $hostDetails,
                 $BundledModulesPath,
-                $WaitForDebugger.IsPresent);
+                $WaitForDebugger.IsPresent)
 
         # Build the profile paths using the root paths of the current $profile variable
-        $profilePaths = [Microsoft.PowerShell.EditorServices.Session.ProfilePaths]::new(
+        $profilePaths = New-Object Microsoft.PowerShell.EditorServices.Session.ProfilePaths @(
             $hostDetails.ProfileId,
             [System.IO.Path]::GetDirectoryName($profile.AllUsersAllHosts),
             [System.IO.Path]::GetDirectoryName($profile.CurrentUserAllHosts));

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -96,11 +96,20 @@ namespace Microsoft.PowerShell.EditorServices.Host
         {
             Logger.Initialize(logFilePath, logLevel);
 
-            FileVersionInfo fileVersionInfo =
 #if NanoServer
+            FileVersionInfo fileVersionInfo =
                 FileVersionInfo.GetVersionInfo(this.GetType().GetTypeInfo().Assembly.Location);
+
+            // TODO #278: Need the correct dependency package for this to work correctly
+            //string osVersionString = RuntimeInformation.OSDescription;
+            //string processArchitecture = RuntimeInformation.ProcessArchitecture == Architecture.X64 ? "64-bit" : "32-bit";
+            //string osArchitecture = RuntimeInformation.OSArchitecture == Architecture.X64 ? "64-bit" : "32-bit";
 #else
+            FileVersionInfo fileVersionInfo =
                 FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
+            string osVersionString = Environment.OSVersion.VersionString;
+            string processArchitecture = Environment.Is64BitProcess ? "64-bit" : "32-bit";
+            string osArchitecture = Environment.Is64BitOperatingSystem ? "64-bit" : "32-bit";
 #endif
 
             string newLine = Environment.NewLine;
@@ -113,12 +122,14 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     $"    Name:      {this.hostDetails.Name}" + newLine +
                     $"    ProfileId: {this.hostDetails.ProfileId}" + newLine +
                     $"    Version:   {this.hostDetails.Version}" + newLine +
-                     "    Arch:      {0}" + newLine + newLine +
+#if !NanoServer
+                    $"    Arch:      {processArchitecture}" + newLine + newLine +
                      "  Operating system details:" + newLine + newLine +
-                    $"    Version: {Environment.OSVersion.VersionString}" + newLine +
-                     "    Arch:    {1}",
-                    Environment.Is64BitProcess ? "64-bit" : "32-bit",
-                    Environment.Is64BitOperatingSystem ? "64-bit" : "32-bit"));
+                    $"    Version: {osVersionString}" + newLine +
+                    $"    Arch:    {osArchitecture}"));
+#else
+                    ""));
+#endif
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Scope.cs
@@ -30,7 +30,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
                 Name = scope.Name,
                 VariablesReference = scope.Id,
                 // Temporary fix for #95 to get debug hover tips to work well at least for the local scope.
-                Expensive = (scope.Name != VariableContainerDetails.LocalScopeName)
+                Expensive = ((scope.Name != VariableContainerDetails.LocalScopeName) &&
+                             (scope.Name != VariableContainerDetails.AutoVariablesName))
             };
         }
     }

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -130,10 +130,12 @@ namespace Microsoft.PowerShell.EditorServices
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.Runspace = this.analysisRunspace;
+
                 var modules = ps.AddCommand("Get-Module")
                     .AddParameter("List")
                     .AddParameter("Name", "PSScriptAnalyzer")
                     .Invoke();
+
                 var psModule = modules == null ? null : modules.FirstOrDefault();
                 if (psModule != null)
                 {
@@ -160,10 +162,12 @@ namespace Microsoft.PowerShell.EditorServices
                 using (var ps = System.Management.Automation.PowerShell.Create())
                 {
                     ps.Runspace = this.analysisRunspace;
-                    var module = ps.AddCommand("Import-Module").
-                        AddParameter("ModuleInfo", scriptAnalyzerModuleInfo)
+
+                    var module = ps.AddCommand("Import-Module")
+                        .AddParameter("ModuleInfo", scriptAnalyzerModuleInfo)
                         .AddParameter("PassThru")
                         .Invoke();
+
                     if (module == null)
                     {
                         this.scriptAnalyzerModuleInfo = null;
@@ -186,13 +190,16 @@ namespace Microsoft.PowerShell.EditorServices
                 using (var ps = System.Management.Automation.PowerShell.Create())
                 {
                     ps.Runspace = this.analysisRunspace;
+
                     var rules = ps.AddCommand("Get-ScriptAnalyzerRule").Invoke();
                     var sb = new StringBuilder();
                     sb.AppendLine("Available PSScriptAnalyzer Rules:");
+
                     foreach (var rule in rules)
                     {
                         sb.AppendLine((string)rule.Members["RuleName"].Value);
                     }
+
                     Logger.Write(LogLevel.Verbose, sb.ToString());
                 }
             }
@@ -209,6 +216,7 @@ namespace Microsoft.PowerShell.EditorServices
         private IEnumerable<PSObject> GetDiagnosticRecords(ScriptFile file)
         {
             IEnumerable<PSObject> diagnosticRecords = Enumerable.Empty<PSObject>();
+
             if (this.scriptAnalyzerModuleInfo != null)
             {
                 using (var ps = System.Management.Automation.PowerShell.Create())
@@ -218,15 +226,17 @@ namespace Microsoft.PowerShell.EditorServices
                         LogLevel.Verbose,
                         String.Format("Running PSScriptAnalyzer against {0}", file.FilePath));
 
-                    // currently not working with include rules
                     diagnosticRecords = ps.AddCommand("Invoke-ScriptAnalyzer")
                         .AddParameter("ScriptDefinition", file.Contents)
+                        .AddParameter("IncludeRule", IncludedRules)
                         .Invoke();
                 }
             }
+
             Logger.Write(
                 LogLevel.Verbose,
                 String.Format("Found {0} violations", diagnosticRecords.Count()));
+
             return diagnosticRecords;
         }
 

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -197,15 +197,17 @@ namespace Microsoft.PowerShell.EditorServices
         {
             IEnumerable<SymbolReference> symbolReferences = null;
 
-            if (powerShellVersion >= new Version(5,0))
-            {
-#if PowerShellv5
-                FindSymbolsVisitor2 findSymbolsVisitor = new FindSymbolsVisitor2();
-                scriptAst.Visit(findSymbolsVisitor);
-                symbolReferences = findSymbolsVisitor.SymbolReferences;
-#endif
-            }
-            else
+            // TODO: Restore this when we figure out how to support multiple
+            //       PS versions in the new PSES-as-a-module world (issue #276)
+//            if (powerShellVersion >= new Version(5,0))
+//            {
+//#if PowerShellv5
+//                FindSymbolsVisitor2 findSymbolsVisitor = new FindSymbolsVisitor2();
+//                scriptAst.Visit(findSymbolsVisitor);
+//                symbolReferences = findSymbolsVisitor.SymbolReferences;
+//#endif
+//            }
+//            else
             {
                 FindSymbolsVisitor findSymbolsVisitor = new FindSymbolsVisitor();
                 scriptAst.Visit(findSymbolsVisitor);

--- a/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
+++ b/src/PowerShellEditorServices/Language/FindSymbolsVisitor2.cs
@@ -9,70 +9,75 @@ using System.Management.Automation.Language;
 namespace Microsoft.PowerShell.EditorServices
 {
 #if PowerShellv5
-    /// <summary>
-    /// The visitor used to find all the symbols (function and class defs) in the AST. 
-    /// </summary>
-    /// <remarks>
-    /// Requires PowerShell v5 or higher
-    /// </remarks>
-    internal class FindSymbolsVisitor2 : AstVisitor2
-    {
-        private FindSymbolsVisitor findSymbolsVisitor;
 
-        public List<SymbolReference> SymbolReferences
-        {
-            get
-            {
-                return this.findSymbolsVisitor.SymbolReferences;
-            }
-        }
+    // TODO: Restore this when we figure out how to support multiple
+    //       PS versions in the new PSES-as-a-module world (issue #276)
 
-        public FindSymbolsVisitor2()
-        {
-            this.findSymbolsVisitor = new FindSymbolsVisitor();
-        }
+    ///// <summary>
+    ///// The visitor used to find all the symbols (function and class defs) in the AST. 
+    ///// </summary>
+    ///// <remarks>
+    ///// Requires PowerShell v5 or higher
+    ///// </remarks>
+    ///// 
+    //internal class FindSymbolsVisitor2 : AstVisitor2
+    //{
+    //    private FindSymbolsVisitor findSymbolsVisitor;
 
-        /// <summary>
-        /// Adds each function defintion as a 
-        /// </summary>
-        /// <param name="functionDefinitionAst">A functionDefinitionAst object in the script's AST</param>
-        /// <returns>A decision to stop searching if the right symbol was found, 
-        /// or a decision to continue if it wasn't found</returns>
-        public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
-        {
-            return this.findSymbolsVisitor.VisitFunctionDefinition(functionDefinitionAst);
-        }
+    //    public List<SymbolReference> SymbolReferences
+    //    {
+    //        get
+    //        {
+    //            return this.findSymbolsVisitor.SymbolReferences;
+    //        }
+    //    }
 
-        /// <summary>
-        ///  Checks to see if this variable expression is the symbol we are looking for.
-        /// </summary>
-        /// <param name="variableExpressionAst">A VariableExpressionAst object in the script's AST</param>
-        /// <returns>A descion to stop searching if the right symbol was found, 
-        /// or a decision to continue if it wasn't found</returns>
-        public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
-        {
-            return this.findSymbolsVisitor.VisitVariableExpression(variableExpressionAst);
-        }
+    //    public FindSymbolsVisitor2()
+    //    {
+    //        this.findSymbolsVisitor = new FindSymbolsVisitor();
+    //    }
 
-        public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst)
-        {
-            IScriptExtent nameExtent = new ScriptExtent()
-            {
-                Text = configurationDefinitionAst.InstanceName.Extent.Text,
-                StartLineNumber = configurationDefinitionAst.Extent.StartLineNumber,
-                EndLineNumber = configurationDefinitionAst.Extent.EndLineNumber,
-                StartColumnNumber = configurationDefinitionAst.Extent.StartColumnNumber,
-                EndColumnNumber = configurationDefinitionAst.Extent.EndColumnNumber
-            };
+    //    /// <summary>
+    //    /// Adds each function defintion as a 
+    //    /// </summary>
+    //    /// <param name="functionDefinitionAst">A functionDefinitionAst object in the script's AST</param>
+    //    /// <returns>A decision to stop searching if the right symbol was found, 
+    //    /// or a decision to continue if it wasn't found</returns>
+    //    public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
+    //    {
+    //        return this.findSymbolsVisitor.VisitFunctionDefinition(functionDefinitionAst);
+    //    }
 
-            this.findSymbolsVisitor.SymbolReferences.Add(
-                new SymbolReference(
-                    SymbolType.Configuration,
-                    nameExtent));
+    //    /// <summary>
+    //    ///  Checks to see if this variable expression is the symbol we are looking for.
+    //    /// </summary>
+    //    /// <param name="variableExpressionAst">A VariableExpressionAst object in the script's AST</param>
+    //    /// <returns>A descion to stop searching if the right symbol was found, 
+    //    /// or a decision to continue if it wasn't found</returns>
+    //    public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
+    //    {
+    //        return this.findSymbolsVisitor.VisitVariableExpression(variableExpressionAst);
+    //    }
 
-            return AstVisitAction.Continue;
-        }
-    }
+    //    public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst)
+    //    {
+    //        IScriptExtent nameExtent = new ScriptExtent()
+    //        {
+    //            Text = configurationDefinitionAst.InstanceName.Extent.Text,
+    //            StartLineNumber = configurationDefinitionAst.Extent.StartLineNumber,
+    //            EndLineNumber = configurationDefinitionAst.Extent.EndLineNumber,
+    //            StartColumnNumber = configurationDefinitionAst.Extent.StartColumnNumber,
+    //            EndColumnNumber = configurationDefinitionAst.Extent.EndColumnNumber
+    //        };
+
+    //        this.findSymbolsVisitor.SymbolReferences.Add(
+    //            new SymbolReference(
+    //                SymbolType.Configuration,
+    //                nameExtent));
+
+    //        return AstVisitAction.Continue;
+    //    }
+    //}
 #endif
 }
 

--- a/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
+++ b/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
@@ -34,16 +34,19 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             string scriptPath = Path.Combine(modulePath, "Start-EditorServices.ps1");
 
             // TODO: Need to determine the right module version programmatically!
+            string editorServicesModuleVersion = "0.7.1";
 
             string scriptArgs =
-                "\"" + scriptPath + "\" " +
-                "-EditorServicesVersion \"0.7.0\" " +
-                "-HostName \\\"PowerShell Editor Services Test Host\\\" " +
-                "-HostProfileId \"Test.PowerShellEditorServices\" " +
-                "-HostVersion \"1.0.0\" " +
-                "-BundledModulesPath \\\"" + modulePath + "\\\" " +
-                "-LogLevel \"Verbose\" " +
-                "-LogPath \"" + logPath + "\" ";
+                string.Format(
+                    "\"" + scriptPath + "\" " +
+                    "-EditorServicesVersion \"{0}\" " +
+                    "-HostName \\\"PowerShell Editor Services Test Host\\\" " +
+                    "-HostProfileId \"Test.PowerShellEditorServices\" " +
+                    "-HostVersion \"1.0.0\" " +
+                    "-BundledModulesPath \\\"" + modulePath + "\\\" " +
+                    "-LogLevel \"Verbose\" " +
+                    "-LogPath \"" + logPath + "\" ",
+                   editorServicesModuleVersion);
 
             if (waitForDebugger)
             {

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -265,7 +265,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.Equal(4, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Function).Count());
             Assert.Equal(3, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Variable).Count());
             Assert.Equal(1, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Workflow).Count());
-            Assert.Equal(1, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Configuration).Count());
 
             SymbolReference firstFunctionSymbol = symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Function).First();
             Assert.Equal("AFunction", firstFunctionSymbol.SymbolName);
@@ -282,10 +281,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.Equal(23, firstWorkflowSymbol.ScriptRegion.StartLineNumber);
             Assert.Equal(1, firstWorkflowSymbol.ScriptRegion.StartColumnNumber);
 
-            SymbolReference firstConfigurationSymbol = symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Configuration).First();
-            Assert.Equal("AConfiguration", firstConfigurationSymbol.SymbolName);
-            Assert.Equal(25, firstConfigurationSymbol.ScriptRegion.StartLineNumber);
-            Assert.Equal(1, firstConfigurationSymbol.ScriptRegion.StartColumnNumber);
+            // TODO: Bring this back when we can use AstVisitor2 again (#276)
+            //Assert.Equal(1, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Configuration).Count());
+            //SymbolReference firstConfigurationSymbol = symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Configuration).First();
+            //Assert.Equal("AConfiguration", firstConfigurationSymbol.SymbolName);
+            //Assert.Equal(25, firstConfigurationSymbol.ScriptRegion.StartLineNumber);
+            //Assert.Equal(1, firstConfigurationSymbol.ScriptRegion.StartColumnNumber);
         }
 
         [Fact]


### PR DESCRIPTION
- Fixed PowerShell/vscode-powerShell#246: Restore default PSScriptAnalyzer ruleset
- Fixed PowerShell/vscode-powershell#248: Extension fails to load on Windows 7 with PowerShell v3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershelleditorservices/277)
<!-- Reviewable:end -->
