### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PowerShell Editor Services Release History
 
+## 0.7.2
+### Friday, September 2, 2016
+
+- Fixed #284: PowerShellContext.AbortException crashes when called more than once
+- Fixed #285: PSScriptAnalyzer settings are not being passed to Invoke-ScriptAnalyzer
+- Fixed #287: Language service crashes when invalid path chars are used in dot-sourced script reference
+
 ## 0.7.1
 ### Tuesday, August 23, 2016
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_depth: 10
 skip_tags: true
 
 environment:
-  core_version: '0.7.1'
+  core_version: '0.7.2'
   prerelease_name: '-beta'
 
 branches:

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerShellEditorServices.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.7.1'
+ModuleVersion = '0.7.2'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
@@ -331,6 +331,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         {
             if (listenTask.IsFaulted)
             {
+                Logger.Write(
+                    LogLevel.Error,
+                    string.Format(
+                        "MessageDispatcher loop terminated due to unhandled exception:\r\n\r\n{0}",
+                        listenTask.Exception.ToString()));
+
                 this.OnUnhandledException(listenTask.Exception);
             }
             else if (listenTask.IsCompleted || listenTask.IsCanceled)

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -201,15 +201,20 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     if (e.NewSessionState == PowerShellContextState.Ready)
                     {
                         await requestContext.SendResult(null);
-                        editorSession.PowerShellContext.SessionStateChanged -= handler;
+                        this.editorSession.PowerShellContext.SessionStateChanged -= handler;
 
                         // Stop the server
                         await this.Stop();
                     }
                 };
 
-            editorSession.PowerShellContext.SessionStateChanged += handler;
-            editorSession.PowerShellContext.AbortExecution();
+            // In some rare cases, the EditorSession will already be disposed
+            // so we shouldn't try to abort because PowerShellContext will be null
+            if (this.editorSession != null && this.editorSession.PowerShellContext != null)
+            {
+                this.editorSession.PowerShellContext.SessionStateChanged += handler;
+                this.editorSession.PowerShellContext.AbortExecution();
+            }
 
             return Task.FromResult(true);
         }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -366,7 +366,7 @@ function __Expand-Alias {
             string newSettingsPath = this.currentSettings.ScriptAnalysis.SettingsPath;
             if (!string.Equals(oldScriptAnalysisSettingsPath, newSettingsPath, StringComparison.OrdinalIgnoreCase))
             {
-                this.editorSession.RestartAnalysisService(newSettingsPath);
+                this.editorSession.AnalysisService.SettingsPath = newSettingsPath;
                 settingsPathChanged = true;
             }
 

--- a/src/PowerShellEditorServices/Language/FindDotSourcedVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDotSourcedVisitor.cs
@@ -34,9 +34,11 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (commandAst.InvocationOperator.Equals(TokenKind.Dot))
             {
-                string fileName = commandAst.CommandElements[0].Extent.Text;
+                // Strip any quote characters off of the string
+                string fileName = commandAst.CommandElements[0].Extent.Text.Trim('\'', '"');
                 DotSourcedFiles.Add(fileName);
             }
+
             return base.VisitCommand(commandAst);
         }
     }

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -104,16 +104,6 @@ namespace Microsoft.PowerShell.EditorServices
             this.Workspace = new Workspace(this.PowerShellContext.PowerShellVersion);
         }
 
-        /// <summary>
-        /// Restarts the AnalysisService so it can be configured with a new settings file.
-        /// </summary>
-        /// <param name="settingsPath">Path to the settings file.</param>
-        public void RestartAnalysisService(string settingsPath)
-        {
-            this.AnalysisService?.Dispose();
-            InstantiateAnalysisService(settingsPath);
-        }
-
         internal void InstantiateAnalysisService(string settingsPath = null)
         {
             // Only enable the AnalysisService if the machine has PowerShell

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -571,7 +571,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public void AbortExecution()
         {
-            if (this.SessionState != PowerShellContextState.Aborting)
+            if (this.SessionState != PowerShellContextState.Aborting &&
+                this.SessionState != PowerShellContextState.Disposed)
             {
                 Logger.Write(LogLevel.Verbose, "Execution abort requested...");
 
@@ -587,7 +588,8 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 Logger.Write(
                     LogLevel.Verbose,
-                    "Execution abort requested while already aborting");
+                    string.Format(
+                        $"Execution abort requested when already aborted (SessionState = {this.SessionState})"));
             }
         }
 

--- a/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
+++ b/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             string scriptPath = Path.Combine(modulePath, "Start-EditorServices.ps1");
 
             // TODO: Need to determine the right module version programmatically!
-            string editorServicesModuleVersion = "0.7.1";
+            string editorServicesModuleVersion = "0.7.2";
 
             string scriptArgs =
                 string.Format(


### PR DESCRIPTION
Fixes for bugs that users reported in the 0.7.0 and 0.7.1 releases:

- Fix #284: PowerShellContext.AbortException crashes when called more than once
- Fix #285: PSScriptAnalyzer settings are not being passed to Invoke-ScriptAnalyzer
- Fix #287: Language service crashes when invalid path chars are used in dot-sourced script reference
