### PR TITLE
Add PSMisleadingBacktick rule to the default ruleset.

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -38,7 +38,8 @@ namespace Microsoft.PowerShell.EditorServices
             "PSShouldProcess",
             "PSMissingModuleManifestField",
             "PSAvoidDefaultValueSwitchParameter",
-            "PSUseDeclaredVarsMoreThanAssigments"
+            "PSUseDeclaredVarsMoreThanAssigments",
+            "PSMisleadingBacktick",
         };
 
         #endregion // Private Fields


### PR DESCRIPTION
This request came in on the VSCode-powershell project: https://github.com/PowerShell/vscode-powershell/issues/336.  Seems reasonable to me.