### PR TITLE
Add PowerShellVersionDetails class and PowerShellVersionRequest

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/PowerShellVersionRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/PowerShellVersionRequest.cs
@@ -1,0 +1,40 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Session;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    public class PowerShellVersionRequest
+    {
+        public static readonly
+            RequestType<object, PowerShellVersionResponse> Type =
+            RequestType<object, PowerShellVersionResponse>.Create("powerShell/getVersion");
+    }
+
+    public class PowerShellVersionResponse
+    {
+        public string Version { get; set; }
+
+        public string DisplayVersion { get; set; }
+
+        public string Edition { get; set; }
+
+        public string Architecture { get; set; }
+
+        public PowerShellVersionResponse()
+        {
+        }
+
+        public PowerShellVersionResponse(PowerShellVersionDetails versionDetails)
+        {
+            this.Version = versionDetails.Version.ToString();
+            this.DisplayVersion = versionDetails.VersionString;
+            this.Edition = versionDetails.Edition;
+            this.Architecture = versionDetails.Architecture;
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -58,6 +58,7 @@
     <Compile Include="LanguageServer\EditorCommands.cs" />
     <Compile Include="LanguageServer\FindModuleRequest.cs" />
     <Compile Include="LanguageServer\InstallModuleRequest.cs" />
+    <Compile Include="LanguageServer\PowerShellVersionRequest.cs" />
     <Compile Include="MessageProtocol\Channel\NamedPipeClientChannel.cs" />
     <Compile Include="MessageProtocol\Channel\NamedPipeServerChannel.cs" />
     <Compile Include="MessageProtocol\Channel\TcpSocketClientChannel.cs" />

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -101,6 +101,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             this.SetRequestHandler(InvokeExtensionCommandRequest.Type, this.HandleInvokeExtensionCommandRequest);
 
+            this.SetRequestHandler(PowerShellVersionRequest.Type, this.HandlePowerShellVersionRequest);
+
             this.SetRequestHandler(DebugAdapterMessages.EvaluateRequest.Type, this.HandleEvaluateRequest);
 
             // Initialize the extension service
@@ -797,6 +799,15 @@ function __Expand-Alias {
             }
 
             await requestContext.SendResult(symbols.ToArray());
+        }
+
+        protected async Task HandlePowerShellVersionRequest(
+            object noParams,
+            RequestContext<PowerShellVersionResponse> requestContext)
+        {
+            await requestContext.SendResult(
+                new PowerShellVersionResponse(
+                    this.editorSession.PowerShellContext.PowerShellVersionDetails));
         }
 
         private bool IsQueryMatch(string query, string symbolName)

--- a/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Debugging\BreakpointDetailsBase.cs" />
     <Compile Include="Debugging\DebugService.cs" />
     <Compile Include="Debugging\CommandBreakpointDetails.cs" />
+    <Compile Include="Debugging\InvalidPowerShellExpressionException.cs" />
     <Compile Include="Debugging\StackFrameDetails.cs" />
     <Compile Include="Debugging\VariableDetails.cs" />
     <Compile Include="Debugging\VariableDetailsBase.cs" />
@@ -158,6 +159,7 @@
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\Scope.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\ScopesRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\SetBreakpointsRequest.cs" />
+    <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\SetVariableRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\SetExceptionBreakpointsRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\Source.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\SourceRequest.cs" />

--- a/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Session\PowerShellExecutionResult.cs" />
     <Compile Include="Session\PowerShellContext.cs" />
     <Compile Include="Session\PowerShellContextState.cs" />
+    <Compile Include="Session\PowerShellVersionDetails.cs" />
     <Compile Include="Session\ProfilePaths.cs" />
     <Compile Include="Session\ProgressDetails.cs" />
     <Compile Include="Session\RunspaceHandle.cs" />
@@ -137,6 +138,7 @@
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\EditorCommands.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\FindModuleRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\InstallModuleRequest.cs" />
+    <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\PowerShellVersionRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\MessageProtocol\Channel\NamedPipeClientChannel.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\MessageProtocol\Channel\NamedPipeServerChannel.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\MessageProtocol\Channel\TcpSocketClientChannel.cs" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Session\PowerShellExecutionResult.cs" />
     <Compile Include="Session\PowerShellContext.cs" />
     <Compile Include="Session\PowerShellContextState.cs" />
+    <Compile Include="Session\PowerShellVersionDetails.cs" />
     <Compile Include="Session\ProfilePaths.cs" />
     <Compile Include="Session\ProgressDetails.cs" />
     <Compile Include="Session\RunspaceHandle.cs" />

--- a/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace Microsoft.PowerShell.EditorServices.Session
+{
+    /// <summary>
+    /// Provides details about the version of the PowerShell runtime.
+    /// </summary>
+    public class PowerShellVersionDetails
+    {
+        /// <summary>
+        /// Gets the version of the PowerShell runtime.
+        /// </summary>
+        public Version Version { get; private set; }
+        
+        /// <summary>
+        /// Gets the full version string, either the ToString of the Version
+        /// property or the GitCommitId for open-source PowerShell releases.
+        /// </summary>
+        public string VersionString { get; private set; }
+
+        /// <summary>
+        /// Gets the PowerShell edition (generally Desktop or Core).
+        /// </summary>
+        public string Edition { get; private set; }
+
+        /// <summary>
+        /// Gets the architecture of the PowerShell process, either "x86" or
+        /// "x64".
+        /// </summary>
+        public string Architecture { get; private set; }
+
+        /// <summary>
+        /// Creates an instance of the PowerShellVersionDetails class.
+        /// </summary>
+        /// <param name="powerShellVersion">The version of the PowerShell runtime.</param>
+        /// <param name="versionString">A string representation of the PowerShell version.</param>
+        /// <param name="editionString">The string representation of the PowerShell edition.</param>
+        /// <param name="architectureString">The string representation of the processor architecture.</param>
+        public PowerShellVersionDetails(
+            Version powerShellVersion,
+            string versionString,
+            string editionString,
+            string architectureString)
+        {
+            this.Version = powerShellVersion;
+            this.VersionString = versionString ?? $"{powerShellVersion.Major}.{powerShellVersion.Minor}";
+            this.Edition = editionString;
+            this.Architecture =
+                string.Equals(architectureString, "AMD64", StringComparison.CurrentCultureIgnoreCase)
+                    ? "x64"
+                    : architectureString;
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -702,6 +702,21 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Assert.Equal("PROFILE: True", outputString);
         }
 
+        [Fact]
+        public async Task ServiceReturnsPowerShellVersionDetails()
+        {
+            PowerShellVersionResponse versionDetails =
+                await this.SendRequest(
+                    PowerShellVersionRequest.Type,
+                    new PowerShellVersionRequest());
+
+            // TODO: This should be more robust and predictable.
+            Assert.StartsWith("5.", versionDetails.Version);
+            Assert.StartsWith("5.", versionDetails.DisplayVersion);
+            Assert.Equal("Desktop", versionDetails.Edition);
+            Assert.Equal("x86", versionDetails.Architecture);
+        }
+
         private async Task SendOpenFileEvent(string filePath, bool waitForDiagnostics = true)
         {
             string fileContents = string.Join(Environment.NewLine, File.ReadAllLines(filePath));


### PR DESCRIPTION
This change introduces a new PowerShellVersionDetails class which contains
additional details about the version and runtime of the current PowerShell
session: version, GitCommitId, edition, and processor architecture.  A new
protocol request and response pair was added for gathering this version
information from the editor client.

This will be used to show version information for the current PowerShell session in the host editor.