### PR TITLE
Fix issue with debugger output not being written for short scripts

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -79,7 +79,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     .ExecuteScriptAtPath(this.scriptPathToLaunch, this.arguments)
                     .ContinueWith(
                         async (t) => {
-                            Logger.Write(LogLevel.Verbose, "Execution completed, terminating...");
+                            Logger.Write(LogLevel.Verbose, "Execution completed, flushing output then terminating...");
+
+                            // Make sure remaining output is flushed before exiting
+                            await this.outputDebouncer.Flush();
 
                             await requestContext.SendEvent(
                                 TerminatedEvent.Type,


### PR DESCRIPTION
This change fixes an issue where script output for very small scripts is
not being written out reliably before the debug adapter terminates.  The
fix is to add an extra output flush before sending the TerminatedEvent
back to the client.  This fix is temporary until we get the REPL
integration online.

Resolves #138.
Resolves PowerShell/vscode-powershell#284.