### PR TITLE
Various fixes and improvements for 0.8.0

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -141,6 +141,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Grab the workspace path from the parameters
             editorSession.Workspace.WorkspacePath = initializeParams.RootPath;
 
+            // Set the working directory of the PowerShell session to the workspace path
+            if (editorSession.Workspace.WorkspacePath != null)
+            {
+                editorSession.PowerShellContext.SetWorkingDirectory(
+                    editorSession.Workspace.WorkspacePath);
+            }
+
             await requestContext.SendResult(
                 new InitializeResult
                 {

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using System.Threading.Tasks;
-using System;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
@@ -109,6 +108,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     OpenFileRequest.Type,
                     filePath,
                     true);
+        }
+
+        public string GetWorkspacePath()
+        {
+            return this.editorSession.Workspace.WorkspacePath;
+        }
+
+        public string GetWorkspaceRelativePath(string filePath)
+        {
+            return this.editorSession.Workspace.GetRelativePath(filePath);
         }
 
         public Task ShowInformationMessage(string message)

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -17,6 +17,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
 
         #endregion
 
+        #region Properties
+
+        /// <summary>
+        /// Gets the current workspace path if there is one or null otherwise.
+        /// </summary>
+        public string Path
+        {
+            get { return this.editorOperations.GetWorkspacePath(); }
+        }
+
+        #endregion
+
         #region Constructors
 
         internal EditorWorkspace(IEditorOperations editorOperations)

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -33,6 +33,19 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         }
 
         /// <summary>
+        /// Gets the workspace-relative path of the file.
+        /// </summary>
+        public string WorkspacePath
+        {
+            get
+            {
+                return
+                    this.editorOperations.GetWorkspaceRelativePath(
+                        this.scriptFile.FilePath);
+            }
+        }
+
+        /// <summary>
         /// Gets the parsed abstract syntax tree for the file.
         /// </summary>
         public Ast Ast

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -21,6 +21,19 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         Task<EditorContext> GetEditorContext();
 
         /// <summary>
+        /// Gets the path to the editor's active workspace.
+        /// </summary>
+        /// <returns>The workspace path or null if there isn't one.</returns>
+        string GetWorkspacePath();
+
+        /// <summary>
+        /// Resolves the given file path relative to the current workspace path.
+        /// </summary>
+        /// <param name="filePath">The file path to be resolved.</param>
+        /// <returns>The resolved file path.</returns>
+        string GetWorkspaceRelativePath(string filePath);
+
+        /// <summary>
         /// Causes a file to be opened in the editor.  If the file is
         /// already open, the editor must switch to the file.
         /// </summary>

--- a/src/PowerShellEditorServices/Language/FindDotSourcedVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDotSourcedVisitor.cs
@@ -32,7 +32,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
-            if (commandAst.InvocationOperator.Equals(TokenKind.Dot))
+            if (commandAst.InvocationOperator.Equals(TokenKind.Dot) &&
+                commandAst.CommandElements[0] is StringConstantExpressionAst)
             {
                 // Strip any quote characters off of the string
                 string fileName = commandAst.CommandElements[0].Extent.Text.Trim('\'', '"');

--- a/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
@@ -320,10 +320,8 @@ namespace Microsoft.PowerShell.EditorServices
             try
             {
                 // This will synchronously block on the prompt task
-                // method which gets run on another thread.  Use a
-                // 30 second timeout so that everything doesn't get
-                // backed up if the user doesn't respond.
-                promptTask.Wait(15000);
+                // method which gets run on another thread.
+                promptTask.Wait();
 
                 if (promptTask.Status == TaskStatus.WaitingForActivation)
                 {

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -264,10 +264,13 @@ namespace Microsoft.PowerShell.EditorServices
             // When viewing PowerShell files in the Git diff viewer, VS Code
             // sends the contents of the file at HEAD with a URI that starts
             // with 'inmemory'.  Untitled files which have been marked of
-            // type PowerShell have a path starting with 'untitled'.
+            // type PowerShell have a path starting with 'untitled'.  Files
+            // opened from the find/replace view will be prefixed with
+            // 'private'.
             return
                 filePath.StartsWith("inmemory") ||
-                filePath.StartsWith("untitled");
+                filePath.StartsWith("untitled") ||
+                filePath.StartsWith("private");
         }
 
         private string GetBaseFilePath(string filePath)

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -176,6 +176,32 @@ namespace Microsoft.PowerShell.EditorServices
             return expandedReferences.ToArray();
         }
 
+        /// <summary>
+        /// Gets the workspace-relative path of the given file path.
+        /// </summary>
+        /// <param name="filePath">The original full file path.</param>
+        /// <returns>A relative file path</returns>
+        public string GetRelativePath(string filePath)
+        {
+            string resolvedPath = filePath;
+
+            if (!IsPathInMemory(filePath) && !string.IsNullOrEmpty(this.WorkspacePath))
+            {
+                Uri workspaceUri = new Uri(this.WorkspacePath);
+                Uri fileUri = new Uri(filePath);
+
+                resolvedPath = workspaceUri.MakeRelativeUri(fileUri).ToString();
+
+                // Convert the directory separators if necessary
+                if (System.IO.Path.DirectorySeparatorChar == '\\')
+                {
+                    resolvedPath = resolvedPath.Replace('/', '\\');
+                }
+            }
+
+            return resolvedPath;
+        }
+
         #endregion
 
         #region Private Methods

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -168,6 +168,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
 
     public class TestEditorOperations : IEditorOperations
     {
+        public string GetWorkspacePath()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetWorkspaceRelativePath(string filePath)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task OpenFile(string filePath)
         {
             throw new NotImplementedException();

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Console\ConsoleServiceTests.cs" />
     <Compile Include="Console\ChoicePromptHandlerTests.cs" />
     <Compile Include="Session\ScriptFileTests.cs" />
+    <Compile Include="Session\WorkspaceTests.cs" />
     <Compile Include="Utility\AsyncDebouncerTests.cs" />
     <Compile Include="Utility\AsyncLockTests.cs" />
     <Compile Include="Utility\AsyncQueueTests.cs" />

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -1,0 +1,38 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Session
+{
+    public class WorkspaceTests
+    {
+        private static readonly Version PowerShellVersion = new Version("5.0"); 
+
+        [Fact]
+        public void CanResolveWorkspaceRelativePath()
+        {
+            string workspacePath = @"c:\Test\Workspace\";
+            string testPathInside = @"c:\Test\Workspace\SubFolder\FilePath.ps1";
+            string testPathOutside = @"c:\Test\PeerPath\FilePath.ps1";
+            string testPathAnotherDrive = @"z:\TryAndFindMe\FilePath.ps1";
+
+            Workspace workspace = new Workspace(PowerShellVersion);
+
+            // Test without a workspace path
+            Assert.Equal(testPathOutside, workspace.GetRelativePath(testPathOutside));
+
+            // Test with a workspace path
+            workspace.WorkspacePath = workspacePath;
+            Assert.Equal(@"SubFolder\FilePath.ps1", workspace.GetRelativePath(testPathInside));
+            Assert.Equal(@"..\PeerPath\FilePath.ps1", workspace.GetRelativePath(testPathOutside));
+            Assert.Equal(testPathAnotherDrive, workspace.GetRelativePath(testPathAnotherDrive));
+        }
+    }
+}


### PR DESCRIPTION
- File preview Uris crash the language server
- Remove timeout for PSHostUserInterface prompts
- Add workspace path information to psEditor.Workspace API
- Set session's current directory to the workspace path
- Dot-source reference detection should ignore ScriptBlocks
