### PR TITLE
Add TemplateService for Plaster integration

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/ProjectTemplate.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/ProjectTemplate.cs
@@ -1,0 +1,42 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Templates;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    public class NewProjectFromTemplateRequest
+    {
+        public static readonly
+            RequestType<NewProjectFromTemplateRequest, NewProjectFromTemplateResponse> Type =
+            RequestType<NewProjectFromTemplateRequest, NewProjectFromTemplateResponse>.Create("powerShell/newProjectFromTemplate");
+
+        public string DestinationPath { get; set; }
+
+        public string TemplatePath { get; set; }
+    }
+
+    public class NewProjectFromTemplateResponse
+    {
+        public bool CreationSuccessful { get; set; }
+    }
+
+    public class GetProjectTemplatesRequest
+    {
+        public static readonly
+            RequestType<GetProjectTemplatesRequest, GetProjectTemplatesResponse> Type =
+            RequestType<GetProjectTemplatesRequest, GetProjectTemplatesResponse>.Create("powerShell/getProjectTemplates");
+
+        public bool IncludeInstalledModules { get; set; }
+    }
+
+    public class GetProjectTemplatesResponse
+    {
+        public bool NeedsModuleInstall { get; set; }
+
+        public TemplateDetails[] Templates { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/Messages/PromptEvents.cs
+++ b/src/PowerShellEditorServices.Protocol/Messages/PromptEvents.cs
@@ -13,20 +13,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Messages
             RequestType<ShowChoicePromptRequest, ShowChoicePromptResponse> Type =
             RequestType<ShowChoicePromptRequest, ShowChoicePromptResponse>.Create("powerShell/showChoicePrompt");
 
+        public bool IsMultiChoice { get; set; }
+
         public string Caption { get; set; }
 
         public string Message { get; set; }
 
         public ChoiceDetails[] Choices { get; set; }
 
-        public int DefaultChoice { get; set; }
+        public int[] DefaultChoices { get; set; }
     }
 
     public class ShowChoicePromptResponse
     {
         public bool PromptCancelled { get; set; }
 
-        public string ChosenItem { get; set; }
+        public string ResponseText { get; set; }
     }
 
     public class ShowInputPromptRequest

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -62,6 +62,7 @@
     <Compile Include="LanguageServer\InstallModuleRequest.cs" />
     <Compile Include="LanguageServer\PowerShellVersionRequest.cs" />
     <Compile Include="LanguageServer\SetPSSARulesRequest.cs" />
+    <Compile Include="LanguageServer\ProjectTemplate.cs" />
     <Compile Include="MessageProtocol\Channel\NamedPipeClientChannel.cs" />
     <Compile Include="MessageProtocol\Channel\NamedPipeServerChannel.cs" />
     <Compile Include="MessageProtocol\Channel\TcpSocketClientChannel.cs" />

--- a/src/PowerShellEditorServices.Protocol/Server/PromptHandlers.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/PromptHandlers.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         }
     }
 
-    internal class ProtocolChoicePromptHandler : ChoicePromptHandler
+    internal class ProtocolChoicePromptHandler : ConsoleChoicePromptHandler
     {
         private IMessageSender messageSender;
         private ConsoleService consoleService;
@@ -48,6 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public ProtocolChoicePromptHandler(
             IMessageSender messageSender,
             ConsoleService consoleService)
+                : base(consoleService)
         {
             this.messageSender = messageSender;
             this.consoleService = consoleService;
@@ -55,15 +56,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         protected override void ShowPrompt(PromptStyle promptStyle)
         {
+            base.ShowPrompt(promptStyle);
+
             messageSender
                 .SendRequest(
                     ShowChoicePromptRequest.Type,
                     new ShowChoicePromptRequest
                     {
+                        IsMultiChoice = this.IsMultiChoice,
                         Caption = this.Caption,
                         Message = this.Message,
                         Choices = this.Choices,
-                        DefaultChoice = this.DefaultChoice
+                        DefaultChoices = this.DefaultChoices
                     }, true)
                 .ContinueWith(HandlePromptResponse)
                 .ConfigureAwait(false);
@@ -79,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 if (!response.PromptCancelled)
                 {
                     this.consoleService.ReceivePromptResponse(
-                        response.ChosenItem,
+                        response.ResponseText,
                         false);
                 }
                 else

--- a/src/PowerShellEditorServices/Console/ChoiceDetails.cs
+++ b/src/PowerShellEditorServices/Console/ChoiceDetails.cs
@@ -118,6 +118,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>True if the input string is a match for the choice.</returns>
         public bool MatchesInput(string inputString)
         {
+            // Make sure the input string is trimmed of whitespace
+            inputString = inputString.Trim();
+
             // Is it the hotkey?
             return
                 string.Equals(inputString, this.hotKeyString, StringComparison.CurrentCultureIgnoreCase) ||

--- a/src/PowerShellEditorServices/Console/ConsoleChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleChoicePromptHandler.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System.Linq;
+
 namespace Microsoft.PowerShell.EditorServices.Console
 {
     /// <summary>
@@ -71,12 +73,20 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
             this.consoleHost.WriteOutput("[?] Help", false);
 
-            if (this.DefaultChoice > -1 && this.DefaultChoice < this.Choices.Length)
+            var validDefaultChoices =
+                this.DefaultChoices.Where(
+                    choice => choice > -1 && choice < this.Choices.Length);
+
+            if (validDefaultChoices.Any())
             {
+                var choiceString =
+                    string.Join(
+                        ", ",
+                        this.DefaultChoices
+                            .Select(choice => this.Choices[choice].Label));
+
                 this.consoleHost.WriteOutput(
-                    string.Format(
-                        " (default is \"{0}\"):",
-                        this.Choices[this.DefaultChoice].Label));
+                    $" (default is \"{choiceString}\"):");
             }
         }
 

--- a/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
@@ -71,6 +71,8 @@
     <Compile Include="Extensions\ExtensionService.cs" />
     <Compile Include="Extensions\FileContext.cs" />
     <Compile Include="Extensions\IEditorOperations.cs" />
+    <Compile Include="Templates\TemplateService.cs" />
+    <Compile Include="Templates\TemplateDetails.cs" />
     <Compile Include="Language\AstOperations.cs" />
     <Compile Include="Language\CommandHelpers.cs" />
     <Compile Include="Language\CompletionResults.cs" />
@@ -143,6 +145,7 @@
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\ContinueRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\DebugAdapter\SetFunctionBreakpointsRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\EditorCommands.cs" />
+    <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\ProjectTemplate.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\FindModuleRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\InstallModuleRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\PowerShellVersionRequest.cs" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -126,6 +126,8 @@
     <Compile Include="Session\SessionPSHostRawUserInterface.cs" />
     <Compile Include="Session\SessionPSHostUserInterface.cs" />
     <Compile Include="Session\SessionStateChangedEventArgs.cs" />
+    <Compile Include="Templates\TemplateDetails.cs" />
+    <Compile Include="Templates\TemplateService.cs" />
     <Compile Include="Utility\AsyncContextThread.cs" />
     <Compile Include="Utility\AsyncDebouncer.cs" />
     <Compile Include="Utility\AsyncLock.cs" />

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -6,6 +6,7 @@
 using Microsoft.PowerShell.EditorServices.Console;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Session;
+using Microsoft.PowerShell.EditorServices.Templates;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System.IO;
 
@@ -54,6 +55,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public ExtensionService ExtensionService { get; private set; }
 
+        /// <summary>
+        /// Gets the TemplateService instance for this session.
+        /// </summary>
+        public TemplateService TemplateService { get; private set; }
+
         #endregion
 
         #region Public Methods
@@ -76,6 +82,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.DebugService = new DebugService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
             this.ExtensionService = new ExtensionService(this.PowerShellContext);
+            this.TemplateService = new TemplateService(this.PowerShellContext);
 
             this.InstantiateAnalysisService();
 

--- a/src/PowerShellEditorServices/Templates/TemplateDetails.cs
+++ b/src/PowerShellEditorServices/Templates/TemplateDetails.cs
@@ -1,0 +1,43 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices.Templates
+{
+    /// <summary>
+    /// Provides details about a file or project template.
+    /// </summary>
+    public class TemplateDetails
+    {
+        /// <summary>
+        /// Gets or sets the title of the template.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the author of the template.
+        /// </summary>
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the template.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the template.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the template's comma-delimited string of tags.
+        /// </summary>
+        public string Tags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the template's folder path.
+        /// </summary>
+        public string TemplatePath { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices/Templates/TemplateService.cs
+++ b/src/PowerShellEditorServices/Templates/TemplateService.cs
@@ -1,0 +1,194 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Linq;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Templates
+{
+    /// <summary>
+    /// Provides a service for listing PowerShell project templates and creating
+    /// new projects from those templates.  This service leverages the Plaster
+    /// module for creating projects from templates.
+    /// </summary>
+    public class TemplateService
+    {
+        #region Private Fields
+
+        private bool isPlasterLoaded;
+        private bool? isPlasterInstalled;
+        private PowerShellContext powerShellContext;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the TemplateService class.
+        /// </summary>
+        /// <param name="powerShellContext">The PowerShellContext to use for this service.</param>
+        public TemplateService(PowerShellContext powerShellContext)
+        {
+            Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
+
+            this.powerShellContext = powerShellContext;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Checks if Plaster is installed on the user's machine.
+        /// </summary>
+        /// <returns>A Task that can be awaited until the check is complete.  The result will be true if Plaster is installed.</returns>
+        public async Task<bool> ImportPlasterIfInstalled()
+        {
+            if (!this.isPlasterInstalled.HasValue)
+            {
+                PSCommand psCommand = new PSCommand();
+                psCommand.AddCommand("Get-Module");
+                psCommand.AddParameter("ListAvailable");
+                psCommand.AddParameter("Name", "Plaster");
+
+                Logger.Write(LogLevel.Verbose, "Checking if Plaster is installed...");
+
+                var getResult =
+                    await this.powerShellContext.ExecuteCommand<object>(
+                        psCommand, false, false);
+
+                this.isPlasterInstalled = getResult.Any();
+                string installedQualifier = 
+                    this.isPlasterInstalled.Value
+                        ? string.Empty : "not ";
+
+                Logger.Write(
+                    LogLevel.Verbose,
+                    $"Plaster is {installedQualifier}installed!");
+
+                // Attempt to load plaster
+                if (this.isPlasterInstalled.Value && this.isPlasterLoaded == false)
+                {
+                    Logger.Write(LogLevel.Verbose, "Loading Plaster...");
+
+                    psCommand = new PSCommand();
+                    psCommand.AddCommand("Import-Module");
+                    psCommand.AddParameter("Name", "Plaster");
+                    psCommand.AddParameter("PassThru");
+
+                    var importResult =
+                        await this.powerShellContext.ExecuteCommand<object>(
+                            psCommand, false, false);
+
+                    this.isPlasterLoaded = importResult.Any();
+                    string loadedQualifier =
+                        this.isPlasterInstalled.Value
+                            ? "was" : "could not be";
+
+                    Logger.Write(
+                        LogLevel.Verbose,
+                        $"Plaster {loadedQualifier} loaded successfully!");
+                }
+            }
+
+            return this.isPlasterInstalled.Value;
+        }
+
+        /// <summary>
+        /// Gets the available file or project templates on the user's
+        /// machine.
+        /// </summary>
+        /// <param name="includeInstalledModules">
+        /// If true, searches the user's installed PowerShell modules for
+        /// included templates.
+        /// </param>
+        /// <returns>A Task which can be awaited for the TemplateDetails list to be returned.</returns>
+        public async Task<TemplateDetails[]> GetAvailableTemplates(
+            bool includeInstalledModules)
+        {
+            if (!this.isPlasterLoaded)
+            {
+                throw new InvalidOperationException("Plaster is not loaded, templates cannot be accessed.");
+            };
+
+            PSCommand psCommand = new PSCommand();
+            psCommand.AddCommand("Get-PlasterTemplate");
+
+            if (includeInstalledModules)
+            {
+                psCommand.AddParameter("IncludeModules");
+            }
+
+            var templateObjects =
+                await this.powerShellContext.ExecuteCommand<PSObject>(
+                    psCommand, false, false);
+
+            Logger.Write(
+                LogLevel.Verbose,
+                $"Found {templateObjects.Count()} Plaster templates");
+
+            return
+                templateObjects
+                    .Select(CreateTemplateDetails)
+                    .ToArray();
+        }
+
+        /// <summary>
+        /// Creates a new file or project from a specified template and
+        /// places it in the destination path.  This ultimately calls
+        /// Invoke-Plaster in PowerShell.
+        /// </summary>
+        /// <param name="templatePath">The folder path containing the template.</param>
+        /// <param name="destinationPath">The folder path where the files will be created.</param>
+        /// <returns>A boolean-returning Task which communicates success or failure.</returns>
+        public async Task<bool> CreateFromTemplate(
+            string templatePath,
+            string destinationPath)
+        {
+            Logger.Write(
+                LogLevel.Verbose,
+                $"Invoking Plaster...\n\n    TemplatePath: {templatePath}\n    DestinationPath: {destinationPath}");
+
+            PSCommand command = new PSCommand();
+            command.AddCommand("Invoke-Plaster");
+            command.AddParameter("TemplatePath", templatePath);
+            command.AddParameter("DestinationPath", destinationPath);
+
+            var errorString = new System.Text.StringBuilder();
+            await this.powerShellContext.ExecuteCommand<PSObject>(
+                command, errorString, false, true);
+
+            // If any errors were written out, creation was not successful
+            return errorString.Length == 0;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private static TemplateDetails CreateTemplateDetails(PSObject psObject)
+        {
+            object[] tags = psObject.Members["Tags"].Value as object[];
+
+            return new TemplateDetails
+            {
+                Title = psObject.Members["Title"].Value as string,
+                Author = psObject.Members["Author"].Value as string,
+                Version = psObject.Members["Version"].Value.ToString(),
+                Description = psObject.Members["Description"].Value as string,
+                TemplatePath = psObject.Members["TemplatePath"].Value as string,
+                Tags =
+                    tags != null
+                    ? string.Join(", ", tags)
+                    : string.Empty
+            };
+        }
+
+        #endregion
+    }
+}

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -526,17 +526,17 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             ShowChoicePromptRequest showChoicePromptRequest = requestResponseContext.Item1;
             RequestContext<ShowChoicePromptResponse> requestContext = requestResponseContext.Item2;
 
-            Assert.Equal(1, showChoicePromptRequest.DefaultChoice);
+            Assert.Equal(1, showChoicePromptRequest.DefaultChoices[0]);
 
             // Respond to the prompt request
             await requestContext.SendResult(
                 new ShowChoicePromptResponse
                 {
-                    ChosenItem = "a"
+                    ResponseText = "a"
                 });
 
-            // Skip the initial script lines (6 script lines plus 2 blank lines)
-            string[] outputLines = await outputReader.ReadLines(8);
+            // Skip the initial script and prompt lines (6 script lines plus 2 blank lines and 3 prompt lines)
+            string[] outputLines = await outputReader.ReadLines(11);
 
             // Wait for the selection to appear as output
             await evaluateTask;

--- a/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 new ChoiceDetails("&Orange", "")
             };
 
-        private const int DefautlChoice = 1;
+        private const int DefaultChoice = 1;
 
         [Fact]
         public void ChoicePromptReturnsCorrectIdForChoice()
@@ -33,10 +33,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
-                    DefautlChoice,
+                    DefaultChoice,
                     CancellationToken.None);
 
             choicePromptHandler.HandleResponse("apple");
+
+            // Wait briefly for the prompt task to complete
+            promptTask.Wait(1000);
 
             Assert.Equal(TaskStatus.RanToCompletion, promptTask.Status);
             Assert.Equal(0, promptTask.Result);
@@ -52,11 +55,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
-                    DefautlChoice,
+                    DefaultChoice,
                     CancellationToken.None);
 
             // Try adding whitespace to ensure it works
             choicePromptHandler.HandleResponse(" N  ");
+
+            // Wait briefly for the prompt task to complete
+            promptTask.Wait(1000);
 
             Assert.Equal(TaskStatus.RanToCompletion, promptTask.Status);
             Assert.Equal(1, promptTask.Result);
@@ -74,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
-                    DefautlChoice,
+                    DefaultChoice,
                     CancellationToken.None);
 
             // Choice is invalid, should reprompt


### PR DESCRIPTION
This change introduces a new TemplateService which uses the new Plaster
module to provide the following features:

1. Listing available Plaster templates on the user's machine, both
built-in and contained within other PowerShell modules

2. Creating new projects from Plaster templates

This functionality is exposed up through the language service by the
powerShell/getProjectTemplates and powerShell/newProjectFromTemplate
request types.