### PR TITLE
Fix #323: DSC IntelliSense can cause language service to crash

### DIFF
--- a/scripts/FetchLatestBuild.ps1
+++ b/scripts/FetchLatestBuild.ps1
@@ -38,18 +38,13 @@ function Install-BuildPackage($packageName, $extension) {
 	mkdir $binariesToSignPath -Force | Out-Null
 	cp "$packageContentPath\lib\net45\$packageName.$extension" -Force -Destination $binariesToSignPath
 
-    # Don't forget the x86 exe
-    if ($extension -eq "exe") {
-        cp "$packageContentPath\lib\net45\$packageName.x86.$extension" -Force -Destination $binariesToSignPath
-    }
-
 	Write-Output "Extracted package $packageName ($buildVersion)"
 }
 
 # Pull the build packages from AppVeyor
 Install-BuildPackage "Microsoft.PowerShell.EditorServices" "dll"
 Install-BuildPackage "Microsoft.PowerShell.EditorServices.Protocol" "dll"
-Install-BuildPackage "Microsoft.PowerShell.EditorServices.Host" "exe"
+Install-BuildPackage "Microsoft.PowerShell.EditorServices.Host" "dll"
 
 # Open the BinariesToSign folder
 & start $binariesToSignPath

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -102,23 +102,33 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (commandCompletion != null)
             {
-                CompletionResults completionResults =
-                    CompletionResults.Create(
-                        scriptFile,
-                        commandCompletion);
+                try
+                {
+                    CompletionResults completionResults =
+                        CompletionResults.Create(
+                            scriptFile,
+                            commandCompletion);
 
-                // save state of most recent completion
-                mostRecentCompletions = completionResults;
-                mostRecentRequestFile = scriptFile.Id;
-                mostRecentRequestLine = lineNumber;
-                mostRecentRequestOffest = columnNumber;
+                    // save state of most recent completion
+                    mostRecentCompletions = completionResults;
+                    mostRecentRequestFile = scriptFile.Id;
+                    mostRecentRequestLine = lineNumber;
+                    mostRecentRequestOffest = columnNumber;
 
-                return completionResults;
+                    return completionResults;
+                }
+                catch(ArgumentException e)
+                {
+                    // Bad completion results could return an invalid
+                    // replacement range, catch that here
+                    Logger.Write(
+                        LogLevel.Error,
+                        $"Caught exception while trying to create CompletionResults:\n\n{e.ToString()}");
+                }
             }
-            else
-            {
-                return new CompletionResults();
-            }
+
+            // If all else fails, return empty results
+            return new CompletionResults();
         }
 
         /// <summary>


### PR DESCRIPTION
This change fixes an issue which appears sometimes when getting
IntelliSense results within a DSC resource.  The completion results return
a replacement range of -1 which causes an exception in our BufferRange
class.  This fix catches and logs this exception so that the session may
continue.