### PR TITLE
Fix #325: Module dependency loading should pick latest module version

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -179,10 +179,18 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 ps.Runspace = this.analysisRunspace;
 
-                var modules = ps.AddCommand("Get-Module")
-                    .AddParameter("List")
-                    .AddParameter("Name", "PSScriptAnalyzer")
-                    .Invoke();
+                ps.AddCommand("Get-Module")
+                  .AddParameter("ListAvailable")
+                  .AddParameter("Name", "PSScriptAnalyzer");
+
+                ps.AddCommand("Sort-Object")
+                  .AddParameter("Descending")
+                  .AddParameter("Property", "Version");
+
+                ps.AddCommand("Select-Object")
+                  .AddParameter("First", 1);
+
+                var modules = ps.Invoke();
 
                 var psModule = modules == null ? null : modules.FirstOrDefault();
                 if (psModule != null)


### PR DESCRIPTION
This change fixes an issue with the loading of both the PSScriptAnalyzer
and Plaster modules.  We were simply using Import-Module without
specifying a version to be loaded.  Apparently PowerShell prioritizes the
PSModulePath order over the module version order so there are instances
where an older version of one of these module will be loaded even though a
newer version is available at a different location on the machine.

This change adds extra logic to sort the list of returned modules so that
the latest version of the module is always loaded.