### PR TITLE
Provide symbol outline for psd1 files

### DIFF
--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 if (IsPowerShellDataFileAst(scriptAst))
                 {
-                    var findHashtableSymbolsVisitor = new FindHashtabeSymbolsVisitor();
+                    var findHashtableSymbolsVisitor = new FindHashtableSymbolsVisitor();
                     scriptAst.Visit(findHashtableSymbolsVisitor);
                     symbolReferences = findHashtableSymbolsVisitor.SymbolReferences;
                 }

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -209,10 +209,12 @@ namespace Microsoft.PowerShell.EditorServices
 //            }
 //            else
             {
-                // we don't have reliable access to the filename here
-                // so we employ the following heuristic to check if the
-                // contents are part of a psd1 file.
-                if (IsPowerShellDataFile(scriptAst))
+                // sometimes we don't have reliable access to the filename
+                // so we employ heuristics to check if the contents are
+                // part of a psd1 file.
+                if ((scriptAst.Extent.File != null
+                        && scriptAst.Extent.File.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase))
+                    || IsPowerShellDataFile(scriptAst))
                 {
                     var findHashtableSymbolsVisitor = new FindHashtabeSymbolsVisitor();
                     scriptAst.Visit(findHashtableSymbolsVisitor);

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -209,12 +209,94 @@ namespace Microsoft.PowerShell.EditorServices
 //            }
 //            else
             {
-                FindSymbolsVisitor findSymbolsVisitor = new FindSymbolsVisitor();
-                scriptAst.Visit(findSymbolsVisitor);
-                symbolReferences = findSymbolsVisitor.SymbolReferences;
+                // we don't have reliable access to the filename here
+                // so we employ the following heuristic to check if the
+                // contents are part of a psd1 file.
+                if (IsPowerShellDataFile(scriptAst))
+                {
+                    var findHashtableSymbolsVisitor = new FindHashtabeSymbolsVisitor();
+                    scriptAst.Visit(findHashtableSymbolsVisitor);
+                    symbolReferences = findHashtableSymbolsVisitor.SymbolReferences;
+                }
+                else
+                {
+                    FindSymbolsVisitor findSymbolsVisitor = new FindSymbolsVisitor();
+                    scriptAst.Visit(findSymbolsVisitor);
+                    symbolReferences = findSymbolsVisitor.SymbolReferences;
+                }
             }
 
             return symbolReferences;
+        }
+
+        static private bool IsPowerShellDataFile(Ast ast)
+        {
+            //var node = new { Item = ast, Children = new List<dynamic>() };
+            //GenerateTree(node);
+            //return node.Children.Count == 1 && node.Children[0].Item is NamedBlockAst
+            //    && node.Children[0].Children.Count == 1 && node.Children[0].Children[0].Item is PipelineAst
+            //    && node.Children[0].Children[0].Children.Count == 1 && ;
+
+            return IsPowerShellDataFile(
+                new { Item = ast, Children = new List<dynamic>() },
+                new Type[] {
+                    typeof(ScriptBlockAst),
+                    typeof(NamedBlockAst),
+                    typeof(PipelineAst),
+                    typeof(CommandExpressionAst),
+                    typeof(HashtableAst) },
+                0);
+        }
+
+        static private bool IsPowerShellDataFile(dynamic node, Type[] levelAstMap, int level)
+        {
+            var levelAstTypeMatch = node.Item.GetType().Equals(levelAstMap[level]);
+            if (!levelAstTypeMatch)
+            {
+                return false;
+            }
+
+            if (level == levelAstMap.Length - 1)
+            {
+                return levelAstTypeMatch;
+            }
+
+            var astsFound = (node.Item as Ast).FindAll(a => a is Ast, false);
+            if (astsFound != null)
+            {
+                foreach (var astFound in astsFound)
+                {
+                    if (!astFound.Equals(node.Item) && node.Item.Equals(astFound.Parent))
+                    {
+                        if (IsPowerShellDataFile(new { Item = astFound, Children = new List<dynamic>() }, levelAstMap, level + 1))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        static private void GenerateTree(dynamic node)
+        {
+            var astsFound = (node.Item as Ast).FindAll(a => a is Ast, false);
+            if (astsFound != null)
+            {
+                foreach (var astFound in astsFound)
+                {
+                    if (!astFound.Equals(node.Item) && node.Item.Equals(astFound.Parent))
+                    {
+                        node.Children.Add(new { Item = astFound, Children = new List<dynamic>() });
+                    }
+                }
+            }
+
+            foreach (var child in node.Children)
+            {
+                GenerateTree(child);
+            }
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Language/FindSymbolsVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindSymbolsVisitor.cs
@@ -90,15 +90,27 @@ namespace Microsoft.PowerShell.EditorServices
         }
     }
 
-    internal class FindHashtabeSymbolsVisitor : AstVisitor
+    /// <summary>
+    /// Visitor to find all the keys in Hashtable AST
+    /// </summary>
+    internal class FindHashtableSymbolsVisitor : AstVisitor
     {
+        /// <summary>
+        /// List of symbols (keys) found in the hashtable
+        /// </summary>
         public List<SymbolReference> SymbolReferences { get; private set; }
 
-        public FindHashtabeSymbolsVisitor()
+        /// <summary>
+        /// Initializes a new instance of FindHashtableSymbolsVisitor class
+        /// </summary>
+        public FindHashtableSymbolsVisitor()
         {
             SymbolReferences = new List<SymbolReference>();
         }
 
+        /// <summary>
+        /// Adds keys in the input hashtable to the symbol reference
+        /// </summary>
         public override AstVisitAction VisitHashtable(HashtableAst hashtableAst)
         {
             if (hashtableAst.KeyValuePairs == null)

--- a/src/PowerShellEditorServices/Language/SymbolType.cs
+++ b/src/PowerShellEditorServices/Language/SymbolType.cs
@@ -14,17 +14,17 @@ namespace Microsoft.PowerShell.EditorServices
         /// The symbol type is unknown
         /// </summary>
         Unknown = 0,
-        
+
         /// <summary>
         /// The symbol is a vairable
         /// </summary>
         Variable,
-        
+
         /// <summary>
         /// The symbol is a function
         /// </summary>
         Function,
-        
+
         /// <summary>
         /// The symbol is a parameter
         /// </summary>
@@ -39,6 +39,10 @@ namespace Microsoft.PowerShell.EditorServices
         /// The symbol is a workflow
         /// </summary>
         Workflow,
+
+        /// <summary>
+        /// The symbol is a hashtable key
+        /// </summary>
+        HashtableKey
     }
 }
-


### PR DESCRIPTION
This update will show the list of keys present in a psd1 file when a user invokes `Go to Symbols in File... (Ctrl+Shift+O)` on an psd1 file. 