### PR TITLE
Fetch script listings for debugger stop events with no ScriptName

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     {
                         powerShellVersion = (Version)version;
                     }
-                    else if (string.Equals(powerShellEdition, "Core", StringComparison.CurrentCultureIgnoreCase))
+                    else if (version != null)
                     {
                         // Expected version string format is 6.0.0-alpha so build a simpler version from that
                         powerShellVersion = new Version(version.ToString().Split('-')[0]);
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             {
                 Logger.Write(
                     LogLevel.Warning,
-                    "Failed to look up PowerShell version. Defaulting to version 5. " + ex.Message);
+                    "Failed to look up PowerShell version, defaulting to version 5.\r\n\r\n" + ex.ToString());
             }
 
             return new PowerShellVersionDetails(


### PR DESCRIPTION
This change adds new behavior to the DebugService which enables it to
gather the listing of any source code that is being executed outside of a
script file when the debugger hits a breakpoint.  This is useful for
allowing the user to step through code in this type of scenario.

Currently this is being used for an unreleased feature in PowerShell 6.0
which allows you to step into ScriptBlocks run against remote sessions
with Invoke-Command.