### PR TITLE
Remove submodule instructions from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,10 @@ how to use this project. You can also read our plans for future feature developm
 
 ## Cloning the Code
 
-To clone the repository and initialize all the submodules at once you can run:
+To clone the repository execute:
 
 ```
-git clone --recursive https://github.com/PowerShell/PowerShellEditorServices.git
-```
-
-If you have already cloned the repository without `--recursive` option, you can run following commands to initialize the submodules:
-
-```
-git submodule init
-git submodule update
+git clone https://github.com/PowerShell/PowerShellEditorServices.git
 ```
 
 ## Contributions Welcome!


### PR DESCRIPTION
... Or we could just remove the whole section on cloning since it is just a simple clone operation now.  What do you think?