### PR TITLE
Implement psedit command for remote file loading

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -343,7 +343,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             SetBreakpointsRequestArguments setBreakpointsParams,
             RequestContext<SetBreakpointsResponseBody> requestContext)
         {
-            ScriptFile scriptFile;
+            ScriptFile scriptFile = null;
+            Exception notFoundException = null;
 
             // Fix for issue #195 - user can change name of file outside of VSCode in which case
             // VSCode sends breakpoint requests with the original filename that doesn't exist anymore.
@@ -351,7 +352,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             {
                 scriptFile = editorSession.Workspace.GetFile(setBreakpointsParams.Source.Path);
             }
-            catch (FileNotFoundException)
+            catch (DirectoryNotFoundException e)
+            {
+                notFoundException = e;
+            }
+            catch (FileNotFoundException e)
+            {
+                notFoundException = e;
+            }
+
+            if (notFoundException != null)
             {
                 Logger.Write(
                     LogLevel.Warning, 

--- a/src/PowerShellEditorServices/Utility/Logger.cs
+++ b/src/PowerShellEditorServices/Utility/Logger.cs
@@ -96,6 +96,69 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerFilePath] string callerSourceFile = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
+            InnerWrite(
+                logLevel,
+                logMessage,
+                callerName,
+                callerSourceFile,
+                callerLineNumber);
+        }
+
+        /// <summary>
+        /// Writes an error message and exception to the log file.
+        /// </summary>
+        /// <param name="errorMessage">The error message text to be written.</param>
+        /// <param name="errorException">The exception to be written..</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public static void WriteException(
+            string errorMessage,
+            Exception errorException,
+            [CallerMemberName] string callerName = null, 
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
+            InnerWrite(
+                LogLevel.Error,
+                $"{errorMessage}\r\n\r\n{errorException.ToString()}",
+                callerName,
+                callerSourceFile,
+                callerLineNumber);
+        }
+
+        /// <summary>
+        /// Writes an error message and exception to the log file.
+        /// </summary>
+        /// <param name="logLevel">The level at which the message will be written.</param>
+        /// <param name="errorMessage">The error message text to be written.</param>
+        /// <param name="errorException">The exception to be written..</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public static void WriteException(
+            LogLevel logLevel,
+            string errorMessage,
+            Exception errorException,
+            [CallerMemberName] string callerName = null, 
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
+            InnerWrite(
+                logLevel,
+                $"{errorMessage}\r\n\r\n{errorException.ToString()}",
+                callerName,
+                callerSourceFile,
+                callerLineNumber);
+        }
+
+        private static void InnerWrite(
+            LogLevel logLevel,
+            string logMessage,
+            string callerName,
+            string callerSourceFile,
+            int callerLineNumber)
+        {
             if (logWriter != null)
             {
                 logWriter.Write(


### PR DESCRIPTION
This change adds new behavior to RemoteFileManager so that a 'psedit'
command will be added to all sessions for the purpose of loading local or
remote files in the debugging experience.  For now the remotely opened
files do not have saved contents propagated to the remote machine but that
will be added shortly.