### PR TITLE
Make analysis service methods async

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             ScriptFileMarkerRequestParams requestParams,
             RequestContext<ScriptFileMarkerRequestResultParams> requestContext)
         {
-            var markers = editorSession.AnalysisService.GetSemanticMarkers(
+            var markers = await editorSession.AnalysisService.GetSemanticMarkersAsync(
                 editorSession.Workspace.GetFile(requestParams.filePath),
                 editorSession.AnalysisService.GetPSSASettingsHashtable(requestParams.settings));
             await requestContext.SendResult(new ScriptFileMarkerRequestResultParams {
@@ -1247,9 +1247,7 @@ function __Expand-Alias {
                 {
                     Logger.Write(LogLevel.Verbose, "Analyzing script file: " + scriptFile.FilePath);
 
-                    semanticMarkers =
-                        editorSession.AnalysisService.GetSemanticMarkers(
-                            scriptFile);
+                    semanticMarkers = await editorSession.AnalysisService.GetSemanticMarkersAsync(scriptFile);
 
                     Logger.Write(LogLevel.Verbose, "Analysis complete.");
                 }

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -27,7 +27,6 @@ namespace Microsoft.PowerShell.EditorServices
 
         private Runspace analysisRunspace;
         private PSModuleInfo scriptAnalyzerModuleInfo;
-        private Object runspaceLock;
         private string[] activeRules;
         private string settingsPath;
 
@@ -67,10 +66,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             set
             {
-                lock (runspaceLock)
-                {
-                    activeRules = value;
-                }
+                activeRules = value;
             }
         }
 
@@ -86,10 +82,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
             set
             {
-                lock (runspaceLock)
-                {
-                    settingsPath = value;
-                }
+                settingsPath = value;
             }
         }
 
@@ -107,7 +100,6 @@ namespace Microsoft.PowerShell.EditorServices
         {
             try
             {
-                this.runspaceLock = new Object();
                 this.SettingsPath = settingsPath;
                 this.analysisRunspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault2());
                 this.analysisRunspace.ThreadOptions = PSThreadOptions.ReuseThread;


### PR DESCRIPTION
Also improves the code formatting experience as the diagnostics now potentially run in a separate runspace and hence do not block code formatting request. 