### PR TITLE
Fix #346: GetVersionDetails failing due to empty environment variable

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
@@ -134,13 +134,16 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     }
 
                     var arch = PowerShellContext.ExecuteScriptAndGetItem<string>("$env:PROCESSOR_ARCHITECTURE", runspace);
-                    if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
+                    if (arch != null)
                     {
-                        architecture = PowerShellProcessArchitecture.X64;
-                    }
-                    else if (string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        architecture = PowerShellProcessArchitecture.X86;
+                        if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            architecture = PowerShellProcessArchitecture.X64;
+                        }
+                        else if (string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
+                        {
+                            architecture = PowerShellProcessArchitecture.X86;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This change fixes an issue caused by a recent change in the VS Code
extension which wiped out all of the environment variables in the process.
That particular issue has now been fixed but it's still good to guard
against this problem in the future.  This change adds a null check to
ensure that we don't throw a NullReferenceException in future occurrences
of the issue.