### PR TITLE
Fix PSScriptAnalyzer module loading in new async AnalysisService

### DIFF
--- a/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/Nano.PowerShellEditorServices.csproj
@@ -202,6 +202,7 @@
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\DocumentHighlight.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\ExpandAliasRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\Hover.cs" />
+    <Compile Include="..\PowerShellEditorServices.Protocol\LanguageServer\GetPSHostProcessesRequest.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\Client\LanguageClientBase.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\Server\LanguageServer.cs" />
     <Compile Include="..\PowerShellEditorServices.Protocol\Server\LanguageServerBase.cs" />


### PR DESCRIPTION
This change fixes the way that the PSScriptAnalyzer module gets loaded in
the new asynchronous AnalysisService.  Since we changed to using the
InitialSessionState to load the module, we were unable to specify the
exact version of the module we needed.  This change goes back to an
explicit Import-Module across the runspaces in the RunspacePool.