### PR TITLE
Fix crash caused when formatting document

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -27,6 +27,15 @@ namespace Microsoft.PowerShell.EditorServices
         private const int NumRunspaces = 2;
         private RunspacePool analysisRunspacePool;
         private PSModuleInfo scriptAnalyzerModuleInfo;
+
+        private bool hasScriptAnalyzerModule
+        {
+            get
+            {
+                return scriptAnalyzerModuleInfo != null;
+            }
+        }
+
         private string[] activeRules;
         private string settingsPath;
 
@@ -160,7 +169,7 @@ namespace Microsoft.PowerShell.EditorServices
         public IEnumerable<string> GetPSScriptAnalyzerRules()
         {
             List<string> ruleNames = new List<string>();
-            if (scriptAnalyzerModuleInfo != null)
+            if (hasScriptAnalyzerModule)
             {
                 var ruleObjects = InvokePowerShell("Get-ScriptAnalyzerRule", new Dictionary<string, object>());
                 foreach (var rule in ruleObjects)
@@ -215,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices
             string[] rules,
             TSettings settings) where TSettings : class
         {
-            if (this.scriptAnalyzerModuleInfo != null
+            if (hasScriptAnalyzerModule
                 && file.IsAnalysisEnabled
                 && (typeof(TSettings) == typeof(string) || typeof(TSettings) == typeof(Hashtable))
                 && (rules != null || settings != null))
@@ -246,16 +255,16 @@ namespace Microsoft.PowerShell.EditorServices
                   .AddParameter("First", 1);
 
                 var modules = ps.Invoke<PSModuleInfo>();
-                var scriptAnalyzerModuleInfo = modules == null ? null : modules.FirstOrDefault();
-                if (scriptAnalyzerModuleInfo != null)
+                var psModuleInfo = modules == null ? null : modules.FirstOrDefault();
+                if (psModuleInfo != null)
                 {
                     Logger.Write(
                         LogLevel.Normal,
                             string.Format(
                                 "PSScriptAnalyzer found at {0}",
-                                scriptAnalyzerModuleInfo.Path));
+                                psModuleInfo.Path));
 
-                    return scriptAnalyzerModuleInfo;
+                    return psModuleInfo;
                 }
 
                 Logger.Write(
@@ -267,7 +276,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         private void EnumeratePSScriptAnalyzerRules()
         {
-            if (scriptAnalyzerModuleInfo != null)
+            if (hasScriptAnalyzerModule)
             {
                 var rules = GetPSScriptAnalyzerRules();
                 var sb = new StringBuilder();
@@ -288,7 +297,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             var diagnosticRecords = new PSObject[0];
 
-            if (this.scriptAnalyzerModuleInfo != null
+            if (hasScriptAnalyzerModule
                 && (typeof(TSettings) == typeof(string)
                     || typeof(TSettings) == typeof(Hashtable)))
             {

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -334,12 +334,12 @@ namespace Microsoft.PowerShell.EditorServices
             EnumeratePSScriptAnalyzerRules();
         }
 
-        private async Task<IEnumerable<PSObject>> GetDiagnosticRecordsAsync<TSettings>(
+        private async Task<PSObject[]> GetDiagnosticRecordsAsync<TSettings>(
             ScriptFile file,
             string[] rules,
             TSettings settings) where TSettings : class
         {
-            IEnumerable<PSObject> diagnosticRecords = Enumerable.Empty<PSObject>();
+            var diagnosticRecords = new PSObject[0];
 
             if (this.scriptAnalyzerModuleInfo != null
                 && (typeof(TSettings) == typeof(string)
@@ -375,14 +375,14 @@ namespace Microsoft.PowerShell.EditorServices
             return diagnosticRecords;
         }
 
-        private IEnumerable<PSObject> InvokePowerShell(string command, IDictionary<string, object> paramArgMap)
+        private PSObject[] InvokePowerShell(string command, IDictionary<string, object> paramArgMap)
         {
             var task = InvokePowerShellAsync(command, paramArgMap);
             task.Wait();
             return task.Result;
         }
 
-        private async Task<IEnumerable<PSObject>> InvokePowerShellAsync(string command, IDictionary<string, object> paramArgMap)
+        private async Task<PSObject[]> InvokePowerShellAsync(string command, IDictionary<string, object> paramArgMap)
         {
             using (var powerShell = System.Management.Automation.PowerShell.Create())
             {
@@ -396,10 +396,10 @@ namespace Microsoft.PowerShell.EditorServices
                 var result = await Task.Factory.FromAsync(powerShell.BeginInvoke(), powerShell.EndInvoke);
                 if (result == null)
                 {
-                    return Enumerable.Empty<PSObject>();
+                    return new PSObject[0];
                 }
 
-                return result;
+                return result.ToArray();;
             }
         }
 

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -118,6 +118,7 @@ namespace Microsoft.PowerShell.EditorServices
                 this.analysisRunspacePool.Open();
 
                 ActiveRules = IncludedRules.ToArray();
+                EnumeratePSScriptAnalyzerRules();
             }
             catch (Exception e)
             {

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Linq;
 using System.Management.Automation.Runspaces;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Console;
 using System.Management.Automation;


### PR DESCRIPTION
The crash was very likely due to deferred execution when enumerating through the diagnostic records returned by PowerShell invocation.