### PR TITLE
Clean up CI tests and build output

### DIFF
--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeClientChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeClientChannel.cs
@@ -12,7 +12,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
     public class NamedPipeClientChannel : ChannelBase
     {
         private string pipeName;
-        private bool isClientConnected;
         private NamedPipeClientStream pipeClient;
 
         public NamedPipeClientChannel(string pipeName)

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
@@ -18,7 +18,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         #region Fields
 
         private ChannelBase protocolChannel;
-        private AsyncQueue<Message> messagesToWrite;
         private AsyncContextThread messageLoopThread;
 
         private Dictionary<string, Func<Message, MessageWriter, Task>> requestHandlers =

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -150,7 +150,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             string workingDir =
                 launchParams.Cwd ??
                 launchParams.Script ??
+#pragma warning disable 618
                 launchParams.Program;
+#pragma warning restore 618
 
             if (workingDir != null)
             {
@@ -192,7 +194,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // Store the launch parameters so that they can be used later
             this.noDebug = launchParams.NoDebug;
+#pragma warning disable 618
             this.scriptPathToLaunch = launchParams.Script ?? launchParams.Program;
+#pragma warning restore 618
             this.arguments = arguments;
 
             await requestContext.SendResult(null);

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -122,10 +122,19 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             if (!string.IsNullOrEmpty(this.scriptPathToLaunch))
             {
-                // Configuration is done, launch the script
-                var nonAwaitedTask =
-                    this.LaunchScript(requestContext)
-                        .ConfigureAwait(false);
+                if (this.editorSession.PowerShellContext.SessionState == PowerShellContextState.Ready)
+                {
+                    // Configuration is done, launch the script
+                    var nonAwaitedTask =
+                        this.LaunchScript(requestContext)
+                            .ConfigureAwait(false);
+                }
+                else
+                {
+                    Logger.Write(
+                        LogLevel.Verbose,
+                        "configurationDone request called after script was already launched, skipping it.");
+                }
             }
 
             await requestContext.SendResult(null);

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                             // Make sure remaining output is flushed before exiting
                             await this.outputDebouncer.Flush();
 
-                            await requestContext.SendEvent(
+                            await this.SendEvent(
                                 TerminatedEvent.Type,
                                 new TerminatedEvent());
 
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // Send the InitializedEvent so that the debugger will continue
             // sending configuration requests
-            await requestContext.SendEvent(
+            await this.SendEvent(
                 InitializedEvent.Type,
                 null);
         }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -324,9 +324,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     {
                         await requestContext.SendResult(null);
                         this.editorSession.PowerShellContext.SessionStateChanged -= handler;
-
-                        // Stop the server
-                        await this.Stop();
                     }
                 };
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -12,7 +12,6 @@ using Microsoft.PowerShell.EditorServices.Templates;
 using Microsoft.PowerShell.EditorServices.Utility;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -232,7 +232,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             await RunScriptDiagnostics(
                     new ScriptFile[] { scripFile },
                         editorSession,
-                        requestContext.SendEvent);
+                        this.SendEvent);
             await sendresult;
         }
 
@@ -1136,7 +1136,7 @@ function __Expand-Alias {
             EditorSession editorSession,
             EventContext eventContext)
         {
-            return RunScriptDiagnostics(filesToAnalyze, editorSession, eventContext.SendEvent);
+            return RunScriptDiagnostics(filesToAnalyze, editorSession, this.SendEvent);
         }
 
         private Task RunScriptDiagnostics(

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
@@ -12,9 +12,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     public abstract class LanguageServerBase : ProtocolEndpoint
     {
-        private bool isStarted;
         private ChannelBase serverChannel;
-        private TaskCompletionSource<bool> serverExitedTask;
 
         public LanguageServerBase(ChannelBase serverChannel) : 
             base(serverChannel, MessageProtocolType.LanguageServer)
@@ -72,12 +70,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             // Stop the server channel
             await this.Stop();
-
-            // Notify any waiter that the server has exited
-            if (this.serverExitedTask != null)
-            {
-                this.serverExitedTask.SetResult(true);
-            }
         }
     }
 }

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -28,11 +28,10 @@
   </PropertyGroup>
 
   <!-- Fail the release build if there are missing public API documentation comments -->
-  <!-- TODO #353: Re-enable this once dotnet doesn't hang on these errors anymore -->
-  <!--<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <WarningsAsErrors>1591,1573,1572</WarningsAsErrors>
     <DocumentationFile>bin\$(TargetFramework)\$(Configuration)\Microsoft.PowerShell.EditorServices.xml</DocumentationFile>
-  </PropertyGroup>-->
+  </PropertyGroup>
 
   <Target Name="PowerShellVersionOutput" BeforeTargets="Compile">
     <Message

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -706,13 +706,16 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 Logger.Write(LogLevel.Verbose, "Execution abort requested...");
 
-                this.powerShell.BeginStop(null, null);
-                this.SessionState = PowerShellContextState.Aborting;
-
                 if (this.IsDebuggerStopped)
                 {
                     this.ResumeDebugger(DebuggerResumeAction.Stop);
                 }
+                else
+                {
+                    this.powerShell.BeginStop(null, null);
+                }
+
+                this.SessionState = PowerShellContextState.Aborting;
             }
             else
             {
@@ -1114,7 +1117,6 @@ namespace Microsoft.PowerShell.EditorServices
                     break;
 
                 case PSInvocationState.Stopping:
-                    // TODO: Collapse this so that the result shows that execution was aborted
                     newState = PowerShellContextState.Aborting;
                     break;
 

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -122,7 +122,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         private async Task LaunchScript(string scriptPath)
         {
             await this.debugAdapterClient.LaunchScript(scriptPath);
-            await this.SendRequest(ConfigurationDoneRequest.Type, null);
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -168,19 +168,22 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         [Fact(Skip = "Skipped until variable documentation gathering is added back.")]
         public async Task CompletesDetailOnVariableDocSuggestion()
         {
-            //await this.SendOpenFileEvent("TestFiles\\CompleteFunctionName.ps1");
+            await this.SendOpenFileEvent("TestFiles\\CompleteFunctionName.ps1");
 
-            //await this.SendRequest(
-            //    CompletionRequest.Type,
-            //    new TextDocumentPosition
-            //    {
-            //        Uri = "TestFiles\\CompleteFunctionName.ps1",
-            //        Position = new Position
-            //        {
-            //            Line = 7,
-            //            Character = 5
-            //        }
-            //    });
+            await this.SendRequest(
+                CompletionRequest.Type,
+                new TextDocumentPosition
+                {
+                    Uri = "TestFiles\\CompleteFunctionName.ps1",
+                    Position = new Position
+                    {
+                        Line = 7,
+                        Character = 5
+                    }
+                });
+
+            // TODO: This section needs to be updated, seems that
+            // CompletionsResponse is missing.
 
             //CompletionsResponse completion = this.WaitForMessage<CompletionsResponse>();
             //List<string> entryName = new List<string>();

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -474,7 +474,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.debugService.Abort();
             await this.AssertStateChange(
                 PowerShellContextState.Ready,
-                PowerShellExecutionResult.Aborted);
+                PowerShellExecutionResult.Completed);
         }
 
         [Fact]
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.debugService.Abort();
             await this.AssertStateChange(
                 PowerShellContextState.Ready,
-                PowerShellExecutionResult.Aborted);
+                PowerShellExecutionResult.Completed);
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -112,8 +112,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             string arguments = string.Join(" ", args);
 
             // Execute the script and wait for the breakpoint to be hit
-            this.powerShellContext.ExecuteScriptAtPath(
-                debugWithParamsFile.FilePath, arguments);
+            Task executeTask =
+                this.powerShellContext.ExecuteScriptAtPath(
+                    debugWithParamsFile.FilePath, arguments);
 
             await this.AssertDebuggerStopped(debugWithParamsFile.FilePath);
 


### PR DESCRIPTION
These changes help the CI build fail far less often and prevent it from spewing compiler warnings.