### PR TITLE
Fix crashes caused by multiple analysis runspaces

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
-        private const int NumRunspaces = 2;
+        private const int NumRunspaces = 1;
         private RunspacePool analysisRunspacePool;
         private PSModuleInfo scriptAnalyzerModuleInfo;
 


### PR DESCRIPTION
Having multiple runspaces crashed scriptanalyzer invocation because of the following two issues:
* PSCmdlet.WriteOutput being called from another thread than Begin/Process
* CompositionContainer.ComposeParts complaining that "...Only one batch can be composed at a time"

We used multiple runspaces in the first place because PSSA was slow and having multiple runspaces sped things up by executing PSSA in a parallel manner. But having multiple runspaces causes a lot of issues which are hard to debug. Also, PSSA has become significantly fast compared to the previous version and thereby having just one runspace should not deteriorate the performance significantly. And on the positive side we do not have to deal with the aforementioned crashes.