### PR TITLE
Modify ExecuteScriptAtPath to handle arb script.

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -9,6 +9,7 @@ using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -625,26 +626,46 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Executes a script file at the specified path.
         /// </summary>
-        /// <param name="scriptPath">The path to the script file to execute.</param>
+        /// <param name="script">The script execute.</param>
         /// <param name="arguments">Arguments to pass to the script.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task ExecuteScriptAtPath(string scriptPath, string arguments = null)
+        public async Task ExecuteScriptWithArgs(string script, string arguments = null)
         {
             PSCommand command = new PSCommand();
 
             if (arguments != null)
             {
-                // If we don't escape wildcard characters in the script path, the script can
-                // fail to execute if say the script name was foo][.ps1.
-                // Related to issue #123.
-                string escapedScriptPath = EscapePath(scriptPath, escapeSpaces: true);
-                string scriptWithArgs = escapedScriptPath + " " + arguments;
+                // Need to determine If the script string is a path to a script file.
+                string scriptAbsPath = string.Empty;
+                try
+                {
+                    // Assume we can only debug scripts from the FileSystem provider
+                    string workingDir =
+                        this.CurrentRunspace.Runspace.SessionStateProxy.Path.CurrentFileSystemLocation.ProviderPath;
+                    workingDir = workingDir.TrimEnd(Path.DirectorySeparatorChar);
+                    scriptAbsPath = workingDir + Path.DirectorySeparatorChar + script;
+                }
+                catch (System.Management.Automation.DriveNotFoundException e)
+                {
+                    Logger.Write(
+                        LogLevel.Error,
+                        "Could not determine current filesystem location:\r\n\r\n" + e.ToString());
+                }
 
+                // If we don't escape wildcard characters in a path to a script file, the script can
+                // fail to execute if say the script filename was foo][.ps1.
+                // Related to issue #123.
+                if (File.Exists(script) || File.Exists(scriptAbsPath))
+                {
+                    script = EscapePath(script, escapeSpaces: true);
+                }
+
+                string scriptWithArgs = script + " " + arguments;
                 command.AddScript(scriptWithArgs);
             }
             else
             {
-                command.AddCommand(scriptPath);
+                command.AddCommand(script);
             }
 
             await this.ExecuteCommand<object>(command, true);

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     debugWithParamsFile.FilePath, arguments);
 
             await this.AssertDebuggerStopped(debugWithParamsFile.FilePath);
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             var = variables.FirstOrDefault(v => v.Name == "$Param2");
             Assert.NotNull(var);
             Assert.True(var.IsExpandable);
-            
+
             var childVars = debugService.GetVariables(var.Id);
             Assert.Equal(9, childVars.Length);
             Assert.Equal("\"Bar\"", childVars[0].ValueString);
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     this.debugScriptFile.FilePath);
 
             // Wait for function breakpoint to hit
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     this.debugScriptFile.FilePath);
 
             // Wait for a couple breakpoints
@@ -303,7 +303,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -353,7 +353,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -389,7 +389,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptAtPath(
+                this.powerShellContext.ExecuteScriptWithArgs(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -466,7 +466,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             this.debugService.Break();
 
             // File path is an empty string when paused while running
-            await this.AssertDebuggerStopped(string.Empty); 
+            await this.AssertDebuggerStopped(string.Empty);
             await this.AssertStateChange(
                 PowerShellContextState.Ready,
                 PowerShellExecutionResult.Stopped);
@@ -545,7 +545,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
 
-            VariableDetailsBase[] variables = 
+            VariableDetailsBase[] variables =
                 debugService.GetVariables(stackFrames[0].LocalVariables.Id);
 
             // TODO: Add checks for correct value strings as well
@@ -604,7 +604,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal(newStrValue, setStrValue);
 
             VariableScope[] scopes = this.debugService.GetVariableScopes(0);
-            
+
             // Test set of script scope int variable (not strongly typed)
             VariableScope scriptScope = scopes.FirstOrDefault(s => s.Name == VariableContainerDetails.ScriptScopeName);
             string newIntValue = "49";

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         private readonly ProfilePaths TestProfilePaths =
             new ProfilePaths(
-                TestHostDetails.ProfileId, 
+                TestHostDetails.ProfileId,
                     Path.GetFullPath(
                         @"..\..\..\..\PowerShellEditorServices.Test.Shared\Profile"),
                     Path.GetFullPath(
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 Task.Run(
                     async () =>
                     {
-                        var unusedTask = this.powerShellContext.ExecuteScriptAtPath(DebugTestFilePath);
+                        var unusedTask = this.powerShellContext.ExecuteScriptWithArgs(DebugTestFilePath);
                         await Task.Delay(50);
                         this.powerShellContext.AbortExecution();
                     });


### PR DESCRIPTION
Renamed to ExecuteScriptWithArgs and check if "script" is a filename before attempting to escape wildcard chars in path.