### PR TITLE
Fix remote prompt ComputerName display

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -10,7 +10,9 @@ using System.Threading;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
+    using Microsoft.PowerShell.EditorServices.Session;
     using System;
+    using System.Globalization;
     using System.Management.Automation;
     using System.Security;
 
@@ -264,10 +266,23 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
         private void WritePromptStringToHost()
         {
+            string promptString = this.powerShellContext.PromptString;
+
+            // Update the stored prompt string if the session is remote
+            if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote)
+            {
+                promptString =
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "[{0}]: {1}",
+                        this.powerShellContext.CurrentRunspace.Runspace.ConnectionInfo != null
+                            ? this.powerShellContext.CurrentRunspace.Runspace.ConnectionInfo.ComputerName
+                            : this.powerShellContext.CurrentRunspace.SessionDetails.ComputerName,
+                        promptString);
+            }
+
             // Write the prompt string
-            this.WriteOutput(
-                this.powerShellContext.PromptString,
-                false);
+            this.WriteOutput(promptString, false);
         }
 
         private void WriteDebuggerBanner(DebuggerStopEventArgs eventArgs)

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -1367,17 +1367,6 @@ namespace Microsoft.PowerShell.EditorServices
                         }
                     });
 
-            if (this.CurrentRunspace != null &&
-                this.CurrentRunspace.Location == RunspaceLocation.Remote)
-            {
-                sessionDetails.PromptString =
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "[{0}]: {1}",
-                        runspace.ConnectionInfo.ComputerName,
-                        sessionDetails.PromptString);
-            }
-
             return sessionDetails;
         }
 


### PR DESCRIPTION
This change fixes the ComputerName prefix for prompts shown in remote
sessions.  Recent changes caused it to be lost.