### PR TITLE
Fix integrated console input and output of Unicode characters

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -67,14 +67,6 @@ namespace Microsoft.PowerShell.EditorServices.Console
                         // Break to return the completed string
                         break;
                     }
-                    if ((keyInfo.Modifiers & ConsoleModifiers.Alt) == ConsoleModifiers.Alt)
-                    {
-                        continue;
-                    }
-                    if ((keyInfo.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control)
-                    {
-                        continue;
-                    }
                     if (keyInfo.Key == ConsoleKey.Tab)
                     {
                         continue;
@@ -178,13 +170,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                     consoleWidth,
                     currentCursorIndex);
 
-                if ((keyInfo.Modifiers & ConsoleModifiers.Alt) == ConsoleModifiers.Alt ||
-                    (keyInfo.Modifiers & ConsoleModifiers.Control) == ConsoleModifiers.Control)
-                {
-                    // Ignore any Ctrl or Alt key combinations
-                    continue;
-                }
-                else if (keyInfo.Key == ConsoleKey.Tab && isCommandLine)
+                if (keyInfo.Key == ConsoleKey.Tab && isCommandLine)
                 {
                     if (currentCompletion == null)
                     {

--- a/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
@@ -51,6 +51,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public ConsoleServicePSHostUserInterface(bool enableConsoleRepl)
         {
+            if (enableConsoleRepl)
+            {
+                // Set the output encoding to Unicode so that all
+                // Unicode characters are written correctly
+                System.Console.OutputEncoding = System.Text.Encoding.Unicode;
+            }
+
             this.rawUserInterface =
                 enableConsoleRepl
                     ? (PSHostRawUserInterface)new ConsoleServicePSHostRawUserInterface()


### PR DESCRIPTION
This change resolves PowerShell/vscode-powershell#543 which reports that
characters typed using AltGr combinations cannot be typed into the
integrated console.  It also resolves the console's inability to write
Unicode characters as output by setting the console's OutputEncoding
correctly.