### PR TITLE
Enable editor IntelliSense while stopped at a breakpoint

### DIFF
--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -89,18 +89,13 @@ namespace Microsoft.PowerShell.EditorServices
                     lineNumber,
                     columnNumber);
 
-            RunspaceHandle runspaceHandle =
-                await this.powerShellContext.GetRunspaceHandle(
-                    new CancellationTokenSource(DefaultWaitTimeoutMilliseconds).Token);
-
             CommandCompletion commandCompletion =
-                AstOperations.GetCompletions(
+                await AstOperations.GetCompletions(
                     scriptFile.ScriptAst,
                     scriptFile.ScriptTokens,
                     fileOffset,
-                    runspaceHandle.Runspace);
-
-            runspaceHandle.Dispose();
+                    this.powerShellContext,
+                    new CancellationTokenSource(DefaultWaitTimeoutMilliseconds).Token);
 
             if (commandCompletion != null)
             {


### PR DESCRIPTION
This change adds IntelliSense (code completion) capabilities while the
debugger is stopped through invoking the TabCompletion2 command.

Resolves PowerShell/vscode-powershell#566.