### PR TITLE
Add initial support for feature flags

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -52,6 +52,10 @@ function Start-EditorServicesHost {
         [string]
         $DebugServiceOnly,
 
+        [string[]]
+        [ValidateNotNull()]
+        $FeatureFlags = @(),
+
         [switch]
         $WaitForDebugger
     )
@@ -65,7 +69,8 @@ function Start-EditorServicesHost {
                 $hostDetails,
                 $BundledModulesPath,
                 $EnableConsoleRepl.IsPresent,
-                $WaitForDebugger.IsPresent)
+                $WaitForDebugger.IsPresent,
+                $FeatureFlags)
 
         # Build the profile paths using the root paths of the current $profile variable
         $profilePaths = New-Object Microsoft.PowerShell.EditorServices.Session.ProfilePaths @(

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Protocol.Server;
 using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
@@ -33,6 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
         private HostDetails hostDetails;
         private string bundledModulesPath;
         private DebugAdapter debugAdapter;
+        private HashSet<string> featureFlags;
         private LanguageServer languageServer;
 
         #endregion
@@ -60,13 +62,15 @@ namespace Microsoft.PowerShell.EditorServices.Host
             HostDetails hostDetails,
             string bundledModulesPath,
             bool enableConsoleRepl,
-            bool waitForDebugger)
+            bool waitForDebugger,
+            string[] featureFlags)
         {
             Validate.IsNotNull(nameof(hostDetails), hostDetails);
 
             this.hostDetails = hostDetails;
             this.enableConsoleRepl = enableConsoleRepl;
             this.bundledModulesPath = bundledModulesPath;
+            this.featureFlags = new HashSet<string>(featureFlags ?? new string[0]);
 
 #if DEBUG
             int waitsRemaining = 10;


### PR DESCRIPTION
This change adds initial support for feature flags in the
EditorServicesHost so that we can enable new experimental features
conditionally while maintaining current behavior for most users.