### PR TITLE
Enable saving remote files opened with psedit

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/TextDocument.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/TextDocument.cs
@@ -52,6 +52,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
             EventType<TextDocumentIdentifier>.Create("textDocument/didClose");
     }
 
+    public class DidSaveTextDocumentNotification
+    {
+        public static readonly
+            EventType<DidSaveTextDocumentParams> Type =
+            EventType<DidSaveTextDocumentParams>.Create("textDocument/didSave");
+    }
+
+    public class DidSaveTextDocumentParams
+    {
+        public TextDocumentIdentifier TextDocument { get; set; }
+    }
+
     public class DidChangeTextDocumentNotification
     {
         public static readonly

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -110,6 +110,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             this.SetEventHandler(DidOpenTextDocumentNotification.Type, this.HandleDidOpenTextDocumentNotification);
             this.SetEventHandler(DidCloseTextDocumentNotification.Type, this.HandleDidCloseTextDocumentNotification);
+            this.SetEventHandler(DidSaveTextDocumentNotification.Type, this.HandleDidSaveTextDocumentNotification);
             this.SetEventHandler(DidChangeTextDocumentNotification.Type, this.HandleDidChangeTextDocumentNotification);
             this.SetEventHandler(DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type, this.HandleDidChangeConfigurationNotification);
 
@@ -515,6 +516,23 @@ function __Expand-Alias {
             }
 
             Logger.Write(LogLevel.Verbose, "Finished closing document.");
+        }
+        protected async Task HandleDidSaveTextDocumentNotification(
+            DidSaveTextDocumentParams saveParams,
+            EventContext eventContext)
+        {
+            ScriptFile savedFile =
+                this.editorSession.Workspace.GetFile(
+                    saveParams.TextDocument.Uri);
+
+            if (savedFile != null)
+            {
+                if (this.editorSession.RemoteFileManager.IsUnderRemoteTempPath(savedFile.FilePath))
+                {
+                    await this.editorSession.RemoteFileManager.SaveRemoteFile(
+                        savedFile.FilePath);
+                }
+            }
         }
 
         protected Task HandleDidChangeTextDocumentNotification(


### PR DESCRIPTION
This change enables the saving of files opened from a remote session using
the psedit command.  When the editor saves the file contents it sends a
DidSaveTextDocumentNotification to the language server which in turn sends
the document's contents back to the remote session to be saved in the
original file.

Resolves PowerShell/vscode-powershell#583.