### PR TITLE
Use new strategy for ConsoleReadLine.ReadKeyAsync to fix macOS and Linux issues

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -114,14 +114,8 @@ namespace Microsoft.PowerShell.EditorServices.Console
                         Task.Factory.StartNew(
                             async () =>
                             {
-                                // Set the thread's name to help with debugging
-                                Thread.CurrentThread.Name = "Terminal Input Loop Thread";
-
                                 await this.StartReplLoop(this.readLineCancellationToken.Token);
-                            },
-                            CancellationToken.None,
-                            TaskCreationOptions.LongRunning,
-                            TaskScheduler.Default);
+                            });
                 }
                 else
                 {
@@ -313,6 +307,18 @@ namespace Microsoft.PowerShell.EditorServices.Console
                     commandString =
                         await this.consoleReadLine.ReadCommandLine(
                             cancellationToken);
+                }
+                catch (PipelineStoppedException)
+                {
+                    this.WriteOutput(
+                        "^C",
+                        true,
+                        OutputType.Normal,
+                        foregroundColor: ConsoleColor.Red);
+                }
+                catch (TaskCanceledException)
+                {
+                    // Do nothing here, the while loop condition will exit.
                 }
                 catch (Exception e) // Narrow this if possible
                 {

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -23,7 +23,6 @@ namespace Microsoft.PowerShell.EditorServices
     using System.Management.Automation.Runspaces;
     using Microsoft.PowerShell.EditorServices.Session.Capabilities;
     using System.IO;
-    using System.Security;
 
     /// <summary>
     /// Manages the lifetime and usage of a PowerShell session.
@@ -847,11 +846,18 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 // Set the result so that the execution thread resumes.
                 // The execution thread will clean up the task.
-                this.debuggerStoppedTask.SetResult(resumeAction);
+                if (!this.debuggerStoppedTask.TrySetResult(resumeAction))
+                {
+                    Logger.Write(
+                        LogLevel.Error,
+                        $"Tried to resume debugger with action {resumeAction} but the task was already completed.");
+                }
             }
             else
             {
-                // TODO: Throw InvalidOperationException?
+                Logger.Write(
+                    LogLevel.Error,
+                    $"Tried to resume debugger with action {resumeAction} but there was no debuggerStoppedTask.");
             }
         }
 


### PR DESCRIPTION
This change uses a new strategy for providing a quasi-async
Console.ReadKey implementation so that key handling works better on Linux
and macOS.  This should eliminate issues where keys and escape sequences
were being echoed incorrectly.  It should also eliminate the issue where
the backspace key is unusable on these platforms.

Resolves PowerShell/vscode-powershell#533.
Resolves PowerShell/vscode-powershell#542.