### PR TITLE
Add command to get pertinent version info.

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -66,7 +66,7 @@ Copyright = '(c) 2016 Microsoft. All rights reserved.'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('Start-EditorServicesHost')
+FunctionsToExport = @('Start-EditorServicesHost', 'Get-PowerShellEditorServicesVersion')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -66,7 +66,7 @@ Copyright = '(c) 2016 Microsoft. All rights reserved.'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('Start-EditorServicesHost', 'Get-PowerShellEditorServicesVersion')
+    FunctionsToExport = @('Start-EditorServicesHost', 'Get-PowerShellEditorServicesVersion', 'Compress-LogDir')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -95,3 +95,32 @@ function Start-EditorServicesHost {
 
     return $editorServicesHost
 }
+
+function Get-PowerShellEditorServicesVersion {
+    $nl = [System.Environment]::NewLine
+
+    $versionInfo = "PSVersionTable:`n$($PSVersionTable | Out-String)" -replace '\n$', ''
+
+    if ($IsLinux) {
+        $versionInfo += "Linux version: $(lsb_release -d)$nl"
+    }
+    elseif ($IsOSX) {
+        $versionInfo += "macOS version: $(lsb_release -d)$nl"
+    }
+    else {
+        $versionInfo += "Windows version: $(Get-CimInstance Win32_OperatingSystem | Foreach-Object Version)$nl"
+    }
+
+    $versionInfo += $nl
+
+    $OFS = ", "
+    $versionInfo += "VSCode version: $(code -v)$nl"
+    $OFS = "$nl    "
+    $versionInfo += "VSCode extensions:$nl    $(code --list-extensions --show-versions)"
+
+    if (!$IsLinux -and !$IsOSX) {
+        $versionInfo | Microsoft.PowerShell.Management\Set-Clipboard
+    }
+
+    $versionInfo
+}

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -99,27 +99,25 @@ function Start-EditorServicesHost {
 function Get-PowerShellEditorServicesVersion {
     $nl = [System.Environment]::NewLine
 
-    $versionInfo = "PSVersionTable:`n$($PSVersionTable | Out-String)" -replace '\n$', ''
+    $versionInfo = "PSES module version: $($MyInvocation.MyCommand.Module.Version)$nl"
 
+    $versionInfo += "PSVersion:           $($PSVersionTable.PSVersion)$nl"
+    if ($PSVersionTable.PSEdition) {
+        $versionInfo += "PSEdition:           $($PSVersionTable.PSEdition)$nl"
+    }
+    $versionInfo += "PSBuildVersion:      $($PSVersionTable.BuildVersion)$nl"
+    $versionInfo += "CLRVersion:          $($PSVersionTable.CLRVersion)$nl"
+
+    $versionInfo += "Operating system:    "
     if ($IsLinux) {
-        $versionInfo += "Linux version: $(lsb_release -d)$nl"
+        $versionInfo += "Linux $(lsb_release -d -s)$nl"
     }
     elseif ($IsOSX) {
-        $versionInfo += "macOS version: $(lsb_release -d)$nl"
+        $versionInfo += "macOS $(lsb_release -d -s)$nl"
     }
     else {
-        $versionInfo += "Windows version: $(Get-CimInstance Win32_OperatingSystem | Foreach-Object Version)$nl"
-    }
-
-    $versionInfo += $nl
-
-    $OFS = ", "
-    $versionInfo += "VSCode version: $(code -v)$nl"
-    $OFS = "$nl    "
-    $versionInfo += "VSCode extensions:$nl    $(code --list-extensions --show-versions)"
-
-    if (!$IsLinux -and !$IsOSX) {
-        $versionInfo | Microsoft.PowerShell.Management\Set-Clipboard
+        $osInfo = Get-CimInstance Win32_OperatingSystem
+        $versionInfo += "Windows $($osInfo.OSArchitecture) $($osInfo.Version)$nl"
     }
 
     $versionInfo


### PR DESCRIPTION
I'm not sure about the noun on this command.  Open to suggestions.  But if we take this then the VSCode-PowerShell issue template simplifies to having folks run the command from the IC and paste results into issue.  Another option would be to have them open the logs and copy the version info from there.

Also, I don't have a Mac so the command to get OS version `lsb_release -d` needs to be tested and potentially replaced with the correct command. 