### PR TITLE
Report column number in stack frame when debugger stops

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
@@ -15,7 +15,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public int Line { get; set; }
 
+        public int? EndLine { get; set; }
+
         public int Column { get; set; }
+
+        public int? EndColumn { get; set; }
 
         //        /** An identifier for the stack frame. */
         //id: number;
@@ -38,8 +42,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             {
                 Id = id,
                 Name = stackFrame.FunctionName,
-                Line = stackFrame.LineNumber,
-                Column = stackFrame.ColumnNumber,
+                Line = stackFrame.StartLineNumber,
+                EndLine = stackFrame.EndLineNumber > 0 ? (int?)stackFrame.EndLineNumber : null,
+                Column = stackFrame.StartColumnNumber,
+                EndColumn = stackFrame.EndColumnNumber > 0 ? (int?)stackFrame.EndColumnNumber : null,
                 Source = new Source
                 {
                     Path = stackFrame.ScriptPath

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StoppedEvent.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StoppedEvent.cs
@@ -28,10 +28,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public Source Source { get; set; } 
 
-        public int Line { get; set; }
-
-        public int Column { get; set; }
-
         /// <summary>
         /// Gets or sets additional information such as an error message.
         /// </summary>

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -857,8 +857,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     {
                         Path = e.ScriptPath,
                     },
-                    Line = e.LineNumber,
-                    Column = e.ColumnNumber,
                     ThreadId = 1,
                     Reason = debuggerStoppedReason
                 });

--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -36,14 +36,24 @@ namespace Microsoft.PowerShell.EditorServices
         public string FunctionName { get; private set; }
 
         /// <summary>
-        /// Gets the line number of the script where the stack frame occurred.
+        /// Gets the start line number of the script where the stack frame occurred.
         /// </summary>
-        public int LineNumber { get; private set; }
+        public int StartLineNumber { get; internal set; }
 
         /// <summary>
-        /// Gets the column number of the line where the stack frame occurred.
+        /// Gets the line number of the script where the stack frame occurred.
         /// </summary>
-        public int ColumnNumber { get; private set; }
+        public int EndLineNumber { get; internal set; }
+
+        /// <summary>
+        /// Gets the start column number of the line where the stack frame occurred.
+        /// </summary>
+        public int StartColumnNumber { get; internal set; }
+
+        /// <summary>
+        /// Gets the end column number of the line where the stack frame occurred.
+        /// </summary>
+        public int EndColumnNumber { get; internal set; }
 
         /// <summary>
         /// Gets or sets the VariableContainerDetails that contains the auto variables.
@@ -82,8 +92,8 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 ScriptPath = (callStackFrameObject.Properties["ScriptName"].Value as string) ?? NoFileScriptPath,
                 FunctionName = callStackFrameObject.Properties["FunctionName"].Value as string,
-                LineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0),
-                ColumnNumber = 0,   // Column number isn't given in PowerShell stack frames
+                StartLineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0),
+                StartColumnNumber = 0,   // Column number isn't given in PowerShell stack frames
                 AutoVariables = autoVariables,
                 LocalVariables = localVariables
             };

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -85,13 +85,25 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             // Wait for a couple breakpoints
             StoppedEventBody stoppedDetails = await breakEventTask;
             Assert.Equal(DebugScriptPath, stoppedDetails.Source.Path);
-            Assert.Equal(5, stoppedDetails.Line);
+
+            var stackTraceResponse =
+                await this.SendRequest(
+                    StackTraceRequest.Type,
+                    new StackTraceRequestArguments());
+
+            Assert.Equal(5, stackTraceResponse.StackFrames[0].Line);
 
             breakEventTask = this.WaitForEvent(StoppedEvent.Type);
             await this.SendRequest(ContinueRequest.Type, new object());
             stoppedDetails = await breakEventTask;
             Assert.Equal(DebugScriptPath, stoppedDetails.Source.Path);
-            Assert.Equal(7, stoppedDetails.Line);
+
+            stackTraceResponse =
+                await this.SendRequest(
+                    StackTraceRequest.Type,
+                    new StackTraceRequestArguments());
+
+            Assert.Equal(7, stackTraceResponse.StackFrames[0].Line);
 
             // Abort script execution
             await this.SendRequest(DisconnectRequest.Type, new object());


### PR DESCRIPTION
This change causes the column number of the debugger's currently stopped
position to be passed through with the top stack frame.  This allows VS
Code's debugger UI to show an indicator that points to where the debugger
stopped when stepping through code.

Resolve PowerShell/vscode-powershell#616