### PR TITLE
Interrupt integrated console command prompt when commands are executed

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -100,9 +100,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         protected Task LaunchScript(RequestContext<object> requestContext)
         {
-            // Ensure the read loop is stopped
-            this.editorSession.ConsoleService.CancelReadLoop();
-
             // Is this an untitled script?
             Task launchTask = null;
 
@@ -144,9 +141,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             if (this.isAttachSession)
             {
-                // Ensure the read loop is stopped
-                this.editorSession.ConsoleService.CancelReadLoop();
-
                 // Pop the sessions
                 if (this.editorSession.PowerShellContext.CurrentRunspace.Context == RunspaceContext.EnteredProcess)
                 {
@@ -165,12 +159,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         Logger.WriteException("Caught exception while popping attached process after debugging", e);
                     }
                 }
-
-            }
-
-            if (!this.ownsEditorSession)
-            {
-                this.editorSession.ConsoleService.StartReadLoop();
             }
 
             if (this.disconnectRequestContext != null)

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1108,9 +1108,6 @@ function __Expand-Alias {
             DebugAdapterMessages.EvaluateRequestArguments evaluateParams,
             RequestContext<DebugAdapterMessages.EvaluateResponseBody> requestContext)
         {
-            // Cancel the read loop before executing
-            this.editorSession.ConsoleService.CancelReadLoop();
-
             // We don't await the result of the execution here because we want
             // to be able to receive further messages while the current script
             // is executing.  This important in cases where the pipeline thread

--- a/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
@@ -199,8 +199,15 @@ namespace Microsoft.PowerShell.EditorServices.Console
                     break;
                 }
 
-                // If the handler returns null it means we should prompt again
                 choiceIndexes = this.HandleResponse(responseString);
+
+                // Return the default choice values if no choices were entered
+                if (choiceIndexes == null && string.IsNullOrEmpty(responseString))
+                {
+                    choiceIndexes = this.DefaultChoices;
+                }
+
+                // If the user provided no choices, we should prompt again
                 if (choiceIndexes != null)
                 {
                     break;

--- a/src/PowerShellEditorServices/Session/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Session/ExecutionOptions.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Defines options for the execution of a command.
+    /// </summary>
+    public class ExecutionOptions
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets a boolean that determines whether command output
+        /// should be written to the host.
+        /// </summary>
+        public bool WriteOutputToHost { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean that determines whether command errors
+        /// should be written to the host.
+        /// </summary>
+        public bool WriteErrorsToHost { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean that determines whether the executed
+        /// command should be added to the command history.
+        /// </summary>
+        public bool AddToHistory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean that determines whether the execution
+        /// of the command should interrupt the command prompt.  Should
+        /// only be set if WriteOutputToHost is false but the command
+        /// should still interrupt the command prompt.
+        /// </summary>
+        public bool InterruptCommandPrompt { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates an instance of the ExecutionOptions class with
+        /// default settings configured.
+        /// </summary>
+        public ExecutionOptions()
+        {
+            this.WriteOutputToHost = true;
+            this.WriteErrorsToHost = true;
+            this.AddToHistory = false;
+            this.InterruptCommandPrompt = false;
+        }
+
+        #endregion
+    }
+}

--- a/src/PowerShellEditorServices/Session/ExecutionStatus.cs
+++ b/src/PowerShellEditorServices/Session/ExecutionStatus.cs
@@ -1,0 +1,39 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Enumerates the possible execution results that can occur after
+    /// executing a command or script.
+    /// </summary>
+    public enum ExecutionStatus
+    {
+        /// <summary>
+        /// Indicates that execution has not yet started.
+        /// </summary>
+        Pending,
+
+        /// <summary>
+        /// Indicates that the command is executing.
+        /// </summary>
+        Running,
+
+        /// <summary>
+        /// Indicates that execution has failed.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// Indicates that execution was aborted by the user.
+        /// </summary>
+        Aborted,
+
+        /// <summary>
+        /// Indicates that execution completed successfully.
+        /// </summary>
+        Completed
+    }
+}

--- a/src/PowerShellEditorServices/Session/ExecutionStatusChangedEventArgs.cs
+++ b/src/PowerShellEditorServices/Session/ExecutionStatusChangedEventArgs.cs
@@ -1,0 +1,52 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Contains details about an executed 
+    /// </summary>
+    public class ExecutionStatusChangedEventArgs
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the options used when the command was executed.
+        /// </summary>
+        public ExecutionOptions ExecutionOptions { get; private set; }
+
+        /// <summary>
+        /// Gets the command execution's current status.
+        /// </summary>
+        public ExecutionStatus ExecutionStatus { get; private set; }
+
+        /// <summary>
+        /// If true, the command execution had errors.
+        /// </summary>
+        public bool HadErrors { get; private set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates an instance of the ExecutionStatusChangedEventArgs class.
+        /// </summary>
+        /// <param name="executionStatus">The command execution's current status.</param>
+        /// <param name="executionOptions">The options used when the command was executed.</param>
+        /// <param name="hadErrors">If execution has completed, indicates whether there were errors.</param>
+        public ExecutionStatusChangedEventArgs(
+            ExecutionStatus executionStatus,
+            ExecutionOptions executionOptions,
+            bool hadErrors)
+        {
+            this.ExecutionStatus = executionStatus;
+            this.ExecutionOptions = executionOptions;
+            this.HadErrors = hadErrors || (executionStatus == ExecutionStatus.Failed);
+        }
+
+        #endregion
+    }
+}

--- a/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
@@ -119,7 +119,9 @@ namespace Microsoft.PowerShell.EditorServices
                     {
                         psObjectDict.Add(
                             keyValuePair.Key,
-                            PSObject.AsPSObject(keyValuePair.Value));
+                            keyValuePair.Value != null
+                                ? PSObject.AsPSObject(keyValuePair.Value)
+                                : null);
                     }
                 }
 

--- a/src/PowerShellEditorServices/Templates/TemplateService.cs
+++ b/src/PowerShellEditorServices/Templates/TemplateService.cs
@@ -174,7 +174,14 @@ namespace Microsoft.PowerShell.EditorServices.Templates
 
             var errorString = new System.Text.StringBuilder();
             await this.powerShellContext.ExecuteCommand<PSObject>(
-                command, errorString, false, true);
+                command,
+                errorString,
+                new ExecutionOptions
+                {
+                    WriteOutputToHost = false,
+                    WriteErrorsToHost = true,
+                    InterruptCommandPrompt = true
+                });
 
             // If any errors were written out, creation was not successful
             return errorString.Length == 0;


### PR DESCRIPTION
This change fixes a general class of problems in the integrated console
experience where commands that were executed internally (like extension
commands or running Plaster templates) do not interrupt the command
prompt, causing future input to be written over previous output lines.

The fix is to have the command prompt be interrupted by any commands
which write output or errors to the host.

Fixes #411.