### PR TITLE
How about popping UI to attach the debugger?

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -73,14 +73,16 @@ namespace Microsoft.PowerShell.EditorServices.Host
             this.featureFlags = new HashSet<string>(featureFlags ?? new string[0]);
 
 #if DEBUG
-            int waitsRemaining = 10;
             if (waitForDebugger)
             {
-                while (waitsRemaining > 0 && !Debugger.IsAttached)
+                if (Debugger.IsAttached)
                 {
-                    Thread.Sleep(1000);
-                    waitsRemaining--;
+                    Debugger.Break();
                 }
+                else
+                {
+                    Debugger.Launch();
+                }                
             }
 #endif
 


### PR DESCRIPTION
Any chance we can go back to this? This is nicer because it pops the attach a debugger UI.  You don't have to track down the PID.  You only have to select which instance of VS you want to use to debug.