### PR TITLE
Temporarily mitigate intermittent IntelliSense slowness

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -758,10 +758,13 @@ function __Expand-Alias {
                         completionItem.Label,
                         this.editorSession.PowerShellContext);
 
-                completionItem.Documentation =
-                    await CommandHelpers.GetCommandSynopsis(
-                        commandInfo,
-                        this.editorSession.PowerShellContext);
+                if (commandInfo != null)
+                {
+                    completionItem.Documentation =
+                        await CommandHelpers.GetCommandSynopsis(
+                            commandInfo,
+                            this.editorSession.PowerShellContext);
+                }
             }
 
             // Send back the updated CompletionItem


### PR DESCRIPTION
This change mitigates seemingly intermittent IntelliSense slowness by
preventing Get-Command and Get-Help from being called on cmdlets from
the PowerShellGet and PackageManagement modules.  Something in the
PackageManagement module is causing completions to be returned at 10x
delay when that module is loaded.  If the module is removed from the
session, completions go back to their normal duration.

By avoiding calling Get-Command on these cmdlets, we avoid loading
PackageManagement when the user types a string like `Get-P` which
incidentally happens to make VS Code see the `Get-Package` cmdlet and
try to resolve its details.

This fix is temporary and will be removed in the future once
https://github.com/OneGet/oneget/issues/275 is fixed.

Related to PowerShell/vscode-powershell#647