### PR TITLE
Fix debugger startup hang when session still initializing

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // TODO: What's the right approach here?
             if (this.editorSession.PowerShellContext.CurrentRunspace.Location == RunspaceLocation.Local)
             {
-                editorSession.PowerShellContext.SetWorkingDirectory(workingDir);
+                await editorSession.PowerShellContext.SetWorkingDirectory(workingDir);
                 Logger.Write(LogLevel.Verbose, "Working dir set to: " + workingDir);
             }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Set the working directory of the PowerShell session to the workspace path
             if (editorSession.Workspace.WorkspacePath != null)
             {
-                editorSession.PowerShellContext.SetWorkingDirectory(
+                await editorSession.PowerShellContext.SetWorkingDirectory(
                     editorSession.Workspace.WorkspacePath);
             }
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -1048,9 +1048,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// unescaped before calling this method.
         /// </summary>
         /// <param name="path"></param>
-        public void SetWorkingDirectory(string path)
+        public async Task SetWorkingDirectory(string path)
         {
-            this.CurrentRunspace.Runspace.SessionStateProxy.Path.SetLocation(path);
+            using (RunspaceHandle runspaceHandle = await this.GetRunspaceHandle())
+            {
+                runspaceHandle.Runspace.SessionStateProxy.Path.SetLocation(path);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This change fixes a hang that occurs when the user starts the debugger
right when the PowerShell session is still initializing.  This is caused
by a call to PowerShellContext.SetWorkingDirectory which isn't
respecting the current state of the runspace.  The fix is to ask for a
RunspaceHandle to ensure that the runspace is free before attempting to
set the working directory.

Resolves PowerShell/vscode-powershell#632