### PR TITLE
Fix occasional crash when requesting IntelliSense while debugging

### DIFF
--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -90,9 +90,24 @@ namespace Microsoft.PowerShell.EditorServices
                 command.AddParameter("PositionOfCursor", cursorPosition);
                 command.AddParameter("Options", null);
 
-                commandCompletion =
-                    (await powerShellContext.ExecuteCommand<CommandCompletion>(command, false, false))
+                PSObject outputObject =
+                    (await powerShellContext.ExecuteCommand<PSObject>(command, false, false))
                         .FirstOrDefault();
+
+                if (outputObject != null)
+                {
+                    ErrorRecord errorRecord = outputObject.BaseObject as ErrorRecord;
+                    if (errorRecord != null)
+                    {
+                        Logger.WriteException(
+                            "Encountered an error while invoking TabExpansion2 in the debugger",
+                            errorRecord.Exception);
+                    }
+                    else
+                    {
+                        commandCompletion = outputObject.BaseObject as CommandCompletion;
+                    }
+                }
             }
             else if (powerShellContext.CurrentRunspace.Runspace.RunspaceAvailability ==
                         RunspaceAvailability.Available)


### PR DESCRIPTION
This change fixes an issue where calling TabExpansion2 while debugging
will sometimes cause a crash due to it returning an ErrorRecord instead
of a CommandCompletion.  The fix is to expect the possibility of the
ErrorRecord and log it when it occurs.

Resolves #427.