### PR TITLE
Enable debugging of PowerShell Editor Services using VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Full: Attach to Process",
+            "type": "clr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        },
+        {
+            "name": ".NET Core: Attach to Process",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -9,5 +9,6 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PowerShell/PowerShellEditorServices</RepositoryUrl>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change turns on the portable PDB format for the primary assemblies
in the project so that they can be debugged in VS Code.  Version 1.9 of
the C# extension added a new debugger type, `clr`, which allows you to
debug 64-bit Full CLR apps when portable PDBs are in use.