### PR TITLE
Don't add empty input lines to command history

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -314,16 +314,19 @@ namespace Microsoft.PowerShell.EditorServices.Console
                 {
                     Console.Write(Environment.NewLine);
 
-                    var unusedTask =
-                        this.powerShellContext
-                            .ExecuteScriptString(
-                                commandString,
-                                false,
-                                true,
-                                true)
-                            .ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(commandString))
+                    {
+                        var unusedTask =
+                            this.powerShellContext
+                                .ExecuteScriptString(
+                                    commandString,
+                                    false,
+                                    true,
+                                    true)
+                                .ConfigureAwait(false);
 
-                    break;
+                        break;
+                    }
                 }
             }
             while (!cancellationToken.IsCancellationRequested);


### PR DESCRIPTION
This change fixes PowerShell/vscode-powershell#618 which reports that
empty input lines are being added to command history in the integrated
console.  This change updates the command input logic to skip sending
empty lines to the command executor.