### PR TITLE
Set CompletionItemKind for properties.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1467,6 +1467,9 @@ function __Expand-Alias {
                 case CompletionType.Command:
                     return CompletionItemKind.Function;
 
+                case CompletionType.Property:
+                    return CompletionItemKind.Property;
+
                 case CompletionType.Method:
                     return CompletionItemKind.Method;
 


### PR DESCRIPTION
This wasn't being set so our Intellisense was showing props like so:
![image](https://cloud.githubusercontent.com/assets/5177512/25559173/761bb546-2cf3-11e7-9bb7-886966b01b1a.png)

Props show as w/this PR:

![image](https://cloud.githubusercontent.com/assets/5177512/25559195/ab9ec348-2cf3-11e7-966b-c10939023a46.png)

