### PR TITLE
Errors and output written during profile loading don't show in host

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -838,7 +838,7 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     command = new PSCommand();
                     command.AddCommand(profilePath, false);
-                    await this.ExecuteCommand(command);
+                    await this.ExecuteCommand<object>(command, true, true);
                 }
 
                 // Gather the session details (particularly the prompt) after


### PR DESCRIPTION
This change causes both errors and object output to be written to the
host when profiles are being loaded.  Users who had issues in their
profile scripts thought that the scripts weren't being loaded when in
fact there were errors not being displayed.  Also, users using
Write-Output in their profile scripts did not see that output.  This
change makes the PSES host consistent with the PowerShell ConsoleHost,
writing both forms of output when loading profile scripts.

Resolves PowerShell/vscode-powershell#689
Resolves PowerShell/vscode-powershell#663