### PR TITLE
Breakpoints hit when debugger isn't active now notify editor

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/StartDebuggerEvent.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/StartDebuggerEvent.cs
@@ -1,0 +1,16 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    public class StartDebuggerEvent
+    {
+        public static readonly
+            NotificationType<object, object> Type =
+            NotificationType<object, object>.Create("powerShell/startDebugger");
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Debugging;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
@@ -82,6 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     this);
 
             this.editorSession.StartDebugService(this.editorOperations);
+            this.editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStopped;
 
             if (enableConsoleRepl)
             {
@@ -1193,6 +1195,15 @@ function __Expand-Alias {
                 });
         }
 
+        private async void DebugService_DebuggerStopped(object sender, DebuggerStoppedEventArgs e)
+        {
+            if (!this.editorSession.DebugService.IsClientAttached)
+            {
+                await this.SendEvent(
+                    StartDebuggerEvent.Type,
+                    new StartDebuggerEvent());
+            }
+        }
 
         #endregion
 


### PR DESCRIPTION
This change is part of the fix for PowerShell/vscode-powershell#619
which states that hitting a breakpoint in the integrated console does
not activate the debugger in VS Code.  The fix is to check whether a
debugger client is connected when a breakpoint is hit, and if not, send
a notification through the language server to have the editor connect
its debugger client.