### PR TITLE
Fix help completion performance for large files

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1091,7 +1091,7 @@ function __Expand-Alias {
             {
                // todo create a semantic marker api that take only string
                 var analysisResults = await EditorSession.AnalysisService.GetSemanticMarkersAsync(
-                    scriptFile,
+                    functionDefinitionAst.Extent.Text,
                     AnalysisService.GetCommentHelpRuleSettings(
                         true,
                         false,
@@ -1099,14 +1099,15 @@ function __Expand-Alias {
                         true,
                         "before"));
 
-                var analysisResult = analysisResults?.FirstOrDefault(x =>
-                {
-                    return x.Correction != null
-                        && x.Correction.Edits[0].StartLineNumber == expectedFunctionLine;
-                });
-
                 // find the analysis result whose correction starts on
-                result.Content = analysisResult?.Correction.Edits[0].Text.Split('\n').Select(x => x.Trim('\r')).ToArray();
+                result.Content = analysisResults?
+                                    .FirstOrDefault()?
+                                    .Correction?
+                                    .Edits[0]
+                                    .Text
+                                    .Split('\n')
+                                    .Select(x => x.Trim('\r'))
+                                    .ToArray();
             }
 
             await requestContext.SendResult(result);

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Perform semantic analysis on the given script with the given settings.
         /// </summary>
-        /// <param name="file">The script content to be analyzed.</param>
+        /// <param name="scriptContent">The script content to be analyzed.</param>
         /// <param name="settings">ScriptAnalyzer settings</param>
         /// <returns></returns>
         public async Task<ScriptFileMarker[]> GetSemanticMarkersAsync(


### PR DESCRIPTION
This PR partly fixes the performance issue mentioned in PowerShell/vscode-powershell#771. I have identified the following 3 reasons why performance is poor for help completion in large script (having 100+ functions). 

1. Whenever a user makes a change to the file, the server starts analyzing the file for any diagnostic markers. For a large script, `FunctionDefinitionAst.GetCommentHelp()` seems to be the bottleneck, which is called by the `PSProvideCommentHelp` rule. If you disable this rule, analysis results are obtained almost instantaneously, except for the first time when a file is analyzed. 
2. Our implementation for help completion was inefficient, in the sense, that it relies on running `PSProvideCommentHelp` rule to obtain the help snippet. When a user types the trigger characters, we the run the entire file against the `PSProvideCommentHelp` rule, which as I already mentioned is the bottleneck thereby further degrading the performance. 
3. Both, diagnostic marker request and help completion request call PSSA on the same runspace. As such the requests are honored sequentially. So, if the user types the trigger characters and an analysis request is honored before help completion, then the help completion request is kept pending till the file markers are obtained, which further slows down the snippet completion. 

To tackle issue 1, we need to identify the performance issues with `FunctionDefinitionAst.GetCommentHelp()` implementation in PowerShell. We tried tackling issue 3 previously, but it lead to hard-to-solve crash issues. So, this PR addresses only issue 2, as we only need to add an analysis api to get some performance improvement. I did some unscientific experiments on [this](https://github.com/PowerShell/PowerShellGet/blob/development/PowerShellGet/PSModule.psm1) file, which has more than 15k lines, and found out that addressing 2 consistently shaves off more `50%` of the delay in completing the comment help snippet. I also observed that sometimes the completion is even instantaneous, which happens because the completion request gets honored before the marker request. 

I would like to note that if the user disables the `PSProvideCommentHelp` rule, either through the rule picker or a PSSA settings file, comment help completion will be instantaneous even for large files.