### PR TITLE
Refactor runspace creation to enable more design improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,8 +1,8 @@
 {
-	"version": "0.1.0",
+	"version": "2.0.0",
 
     "windows": {
-        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe",
+        "command": "powershell.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
@@ -14,7 +14,6 @@
         "args": [ "-NoProfile" ]
     },
 
-	"isShellCommand": true,
 	"showOutput": "always",
 
     // Associate with test task runner
@@ -35,6 +34,18 @@
             "suppressTaskName": true,
             "isTestCommand": true,
             "args": [ "Invoke-Build Test" ]
+        },
+        {
+            "taskName": "Test Language Service",
+            "suppressTaskName": true,
+            "isTestCommand": true,
+            "args": [ "Invoke-Build TestServer" ]
+        },
+        {
+            "taskName": "Test Host",
+            "suppressTaskName": true,
+            "isTestCommand": true,
+            "args": [ "Invoke-Build TestHost" ]
         }
 	]
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PowerShell Editor Services
 
-PowerShell Editor Services provides common functionality that is needed
-to enable a consistent and robust PowerShell development experience
-across multiple editors.
+PowerShell Editor Services is a PowerShell module that provides common
+functionality needed to enable a consistent and robust PowerShell development
+experience in almost any editor or integrated development environment (IDE).
 
 ## Features
 
@@ -10,22 +10,29 @@ across multiple editors.
   - Code navigation actions (find references, go to definition)
   - Statement completions (IntelliSense)
   - Real-time semantic analysis of scripts using PowerShell Script Analyzer
-  - Basic script evaluation
 - The Debugging Service simplifies interaction with the PowerShell debugger (breakpoints, variables, call stack, etc)
-- The Console Service provides a simplified interactive console interface which implements a rich PSHost implementation:
-  - Interactive command execution support, including basic use of native console applications
-  - Choice prompt support
-  - Input prompt support
-  - Get-Credential support (coming soon)
-- The Extension Service provides a generalized extensibility model that allows you to
-  write new functionality for any host editor that uses PowerShell Editor Services
+- The [$psEditor API](http://powershell.github.io/PowerShellEditorServices/guide/extensions.html) enables scripting of the host editor
+- A full, terminal-based Integrated Console experience for interactive development and debugging
 
-The core Editor Services library is intended to be consumed in any type of host application, whether
-it is a WPF UI, console application, or web service.  A standard console application host is included
-so that you can easily consume Editor Services functionality in any editor using the JSON API that it
-exposes.
+### Important note regarding the .NET APIs in Microsoft.PowerShell.EditorServices.dll
 
-## Build status of master branches
+With the 1.0 release of PowerShell Editor Services, we have deprecated the public APIs
+of the following classes:
+
+- EditorSession
+- LanguageService
+- DebugService
+- ConsoleService
+- AnalysisService
+- ExtensionService
+- TemplateService
+
+The intended usage model is now to host PowerShell Editor Services within powershell.exe
+and communicate with it over TCP sockets via the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md)
+and [Debug Adapter Protocol](https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts).
+Detailed usage documentation for this module is coming soon!
+
+## Build Status
 
 | AppVeyor (Windows)                                                                                                                                                                        | Travis CI (Linux / macOS)                                                                                                                                 |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -43,13 +50,13 @@ how to use this project. You can also read our plans for future feature developm
 
 ## Development
 
-
 ### 1. Install PowerShell if necessary
 
 If you are using Windows, skip this step.  If you are using Linux or macOS, you will need to
 install PowerShell by following [these instructions](https://github.com/PowerShell/PowerShell#get-powershell).
 
-If you are using macOS you will need to download the latest version of OpenSSL. The easiest way to get this is from [Homebrew](http://brew.sh/). After installing Homebrew execute the following commands:
+If you are using macOS you will need to download the latest version of OpenSSL. The easiest way to get this is from
+[Homebrew](http://brew.sh/). After installing Homebrew execute the following commands:
 
 ```
   brew update

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -63,34 +63,28 @@ function Start-EditorServicesHost {
     $editorServicesHost = $null
     $hostDetails = New-Object Microsoft.PowerShell.EditorServices.Session.HostDetails @($HostName, $HostProfileId, (New-Object System.Version @($HostVersion)))
 
-    try {
-        $editorServicesHost =
-            New-Object Microsoft.PowerShell.EditorServices.Host.EditorServicesHost @(
-                $hostDetails,
-                $BundledModulesPath,
-                $EnableConsoleRepl.IsPresent,
-                $WaitForDebugger.IsPresent,
-                $FeatureFlags)
+    $editorServicesHost =
+        New-Object Microsoft.PowerShell.EditorServices.Host.EditorServicesHost @(
+            $hostDetails,
+            $BundledModulesPath,
+            $EnableConsoleRepl.IsPresent,
+            $WaitForDebugger.IsPresent,
+            $FeatureFlags)
 
-        # Build the profile paths using the root paths of the current $profile variable
-        $profilePaths = New-Object Microsoft.PowerShell.EditorServices.Session.ProfilePaths @(
-            $hostDetails.ProfileId,
-            [System.IO.Path]::GetDirectoryName($profile.AllUsersAllHosts),
-            [System.IO.Path]::GetDirectoryName($profile.CurrentUserAllHosts));
+    # Build the profile paths using the root paths of the current $profile variable
+    $profilePaths = New-Object Microsoft.PowerShell.EditorServices.Session.ProfilePaths @(
+        $hostDetails.ProfileId,
+        [System.IO.Path]::GetDirectoryName($profile.AllUsersAllHosts),
+        [System.IO.Path]::GetDirectoryName($profile.CurrentUserAllHosts));
 
-        $editorServicesHost.StartLogging($LogPath, $LogLevel);
+    $editorServicesHost.StartLogging($LogPath, $LogLevel);
 
-        if ($DebugServiceOnly.IsPresent) {
-            $editorServicesHost.StartDebugService($DebugServicePort, $profilePaths, $false);
-        }
-        else {
-            $editorServicesHost.StartLanguageService($LanguageServicePort, $profilePaths);
-            $editorServicesHost.StartDebugService($DebugServicePort, $profilePaths, $true);
-        }
+    if ($DebugServiceOnly.IsPresent) {
+        $editorServicesHost.StartDebugService($DebugServicePort, $profilePaths, $false);
     }
-    catch {
-        Write-Error "PowerShell Editor Services host initialization failed, terminating."
-        Write-Error $_.Exception
+    else {
+        $editorServicesHost.StartLanguageService($LanguageServicePort, $profilePaths);
+        $editorServicesHost.StartDebugService($DebugServicePort, $profilePaths, $true);
     }
 
     return $editorServicesHost

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -271,7 +271,9 @@ namespace Microsoft.PowerShell.EditorServices.Host
             bool enableConsoleRepl)
         {
             EditorSession editorSession = new EditorSession();
-            editorSession.StartSession(hostDetails, profilePaths, enableConsoleRepl);
+            editorSession.StartSession(
+                CreatePowerShellContext(hostDetails, profilePaths, enableConsoleRepl),
+                enableConsoleRepl);
 
             return editorSession;
         }
@@ -282,9 +284,19 @@ namespace Microsoft.PowerShell.EditorServices.Host
             IEditorOperations editorOperations)
         {
             EditorSession editorSession = new EditorSession();
-            editorSession.StartDebugSession(hostDetails, profilePaths, editorOperations);
+            editorSession.StartDebugSession(
+                CreatePowerShellContext(hostDetails, profilePaths, enableConsoleRepl),
+                editorOperations);
 
             return editorSession;
+        }
+
+        private PowerShellContext CreatePowerShellContext(
+            HostDetails hostDetails,
+            ProfilePaths profilePaths,
+            bool enableConsoleRepl)
+        {
+            return new PowerShellContext(hostDetails, profilePaths, enableConsoleRepl);
         }
 
 #if !CoreCLR

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
+using Microsoft.PowerShell.EditorServices.Extensions;
 
 namespace Microsoft.PowerShell.EditorServices.Host
 {
@@ -34,6 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
         private HostDetails hostDetails;
         private string bundledModulesPath;
         private DebugAdapter debugAdapter;
+        private EditorSession editorSession;
         private HashSet<string> featureFlags;
         private LanguageServer languageServer;
 
@@ -82,7 +84,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 else
                 {
                     Debugger.Launch();
-                }                
+                }
             }
 #endif
 
@@ -148,11 +150,15 @@ namespace Microsoft.PowerShell.EditorServices.Host
         /// <param name="profilePaths">The object containing the profile paths to load for this session.</param>
         public void StartLanguageService(int languageServicePort, ProfilePaths profilePaths)
         {
+            this.editorSession =
+                CreateSession(
+                    this.hostDetails,
+                    profilePaths,
+                    this.enableConsoleRepl);
+
             this.languageServer =
                 new LanguageServer(
-                    hostDetails,
-                    profilePaths,
-                    this.enableConsoleRepl,
+                    this.editorSession,
                     new TcpSocketServerChannel(languageServicePort));
 
             this.languageServer.Start().Wait();
@@ -177,17 +183,23 @@ namespace Microsoft.PowerShell.EditorServices.Host
             {
                 this.debugAdapter =
                     new DebugAdapter(
-                        this.languageServer.EditorSession,
-                        new TcpSocketServerChannel(debugServicePort));
+                        this.editorSession,
+                        new TcpSocketServerChannel(debugServicePort),
+                        false);
             }
             else
             {
+                EditorSession debugSession =
+                    this.CreateDebugSession(
+                        this.hostDetails,
+                        profilePaths,
+                        this.languageServer.EditorOperations);
+
                 this.debugAdapter =
                     new DebugAdapter(
-                        hostDetails,
-                        profilePaths,
+                        debugSession,
                         new TcpSocketServerChannel(debugServicePort),
-                        this.languageServer?.EditorOperations);
+                        true);
             }
 
             this.debugAdapter.SessionEnded +=
@@ -252,6 +264,28 @@ namespace Microsoft.PowerShell.EditorServices.Host
         #endregion
 
         #region Private Methods
+
+        private EditorSession CreateSession(
+            HostDetails hostDetails,
+            ProfilePaths profilePaths,
+            bool enableConsoleRepl)
+        {
+            EditorSession editorSession = new EditorSession();
+            editorSession.StartSession(hostDetails, profilePaths, enableConsoleRepl);
+
+            return editorSession;
+        }
+
+        private EditorSession CreateDebugSession(
+            HostDetails hostDetails,
+            ProfilePaths profilePaths,
+            IEditorOperations editorOperations)
+        {
+            EditorSession editorSession = new EditorSession();
+            editorSession.StartDebugSession(hostDetails, profilePaths, editorOperations);
+
+            return editorSession;
+        }
 
 #if !CoreCLR
         static void CurrentDomain_UnhandledException(

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -37,39 +37,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         private bool isInteractiveDebugSession;
         private RequestContext<object> disconnectRequestContext = null;
 
-        public DebugAdapter(HostDetails hostDetails, ProfilePaths profilePaths)
-            : this(hostDetails, profilePaths, new StdioServerChannel(), null)
-        {
-        }
-
-        public DebugAdapter(EditorSession editorSession, ChannelBase serverChannel)
-            : base(serverChannel)
+        public DebugAdapter(
+            EditorSession editorSession,
+            ChannelBase serverChannel,
+            bool ownsEditorSession)
+                : base(serverChannel)
         {
             this.editorSession = editorSession;
+            this.ownsEditorSession = ownsEditorSession;
+            this.enableConsoleRepl = editorSession.UsesConsoleHost;
         }
-
-        public DebugAdapter(
-            HostDetails hostDetails,
-            ProfilePaths profilePaths,
-            ChannelBase serverChannel,
-            IEditorOperations editorOperations)
-            : this(hostDetails, profilePaths, serverChannel, editorOperations, false)
-        {
-        }
-
-        public DebugAdapter(
-            HostDetails hostDetails,
-            ProfilePaths profilePaths,
-            ChannelBase serverChannel,
-            IEditorOperations editorOperations,
-            bool enableConsoleRepl)
-            : base(serverChannel)
-        {
-            this.ownsEditorSession = true;
-            this.editorSession = new EditorSession();
-            this.editorSession.StartDebugSession(hostDetails, profilePaths, editorOperations);
-            this.enableConsoleRepl = enableConsoleRepl;
-       }
 
         protected override void Initialize()
         {
@@ -325,6 +302,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             if (this.editorSession.ConsoleService.EnableConsoleRepl)
             {
+                // TODO: Write this during DebugSession init
                 await this.WriteUseIntegratedConsoleMessage();
             }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -70,12 +70,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.editorSession.StartDebugService(this.editorOperations);
             this.editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStopped;
 
-            if (this.editorSession.UsesConsoleHost)
+            if (!this.editorSession.ConsoleService.EnableConsoleRepl)
             {
-                this.editorSession.ConsoleService.EnableConsoleRepl = true;
-            }
-            else
-            {
+                // TODO: This should be handled in ProtocolPSHost
                 this.editorSession.ConsoleService.OutputWritten += this.powerShellContext_OutputWritten;
 
                 // Always send console prompts through the UI in the language service
@@ -144,6 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         protected override async Task Shutdown()
         {
             // Stop the interactive terminal
+            // TODO: This can happen at the host level
             this.editorSession.ConsoleService.CancelReadLoop();
 
             // Make sure remaining output is flushed before exiting
@@ -578,6 +576,7 @@ function __Expand-Alias {
             if (!this.consoleReplStarted)
             {
                 // Start the interactive terminal
+                // TODO: This can happen at the host level
                 this.editorSession.ConsoleService.StartReadLoop();
                 this.consoleReplStarted = true;
             }
@@ -1160,6 +1159,7 @@ function __Expand-Alias {
                 (task) =>
                 {
                     // Start the command loop again
+                    // TODO: This can happen inside the PSHost
                     this.editorSession.ConsoleService.StartReadLoop();
 
                     // Return an empty result since the result value is irrelevant

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -102,10 +102,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Creates an instance of the AnalysisService class.
         /// </summary>
-        /// <param name="consoleHost">An object that implements IConsoleHost in which to write errors/warnings
-        /// from analyzer.</param>
         /// <param name="settingsPath">Path to a PSScriptAnalyzer settings file.</param>
-        public AnalysisService(IConsoleHost consoleHost, string settingsPath = null)
+        public AnalysisService(string settingsPath = null)
         {
             try
             {

--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -76,7 +76,6 @@ namespace Microsoft.PowerShell.EditorServices.Console
         {
             // Register this instance as the IConsoleHost for the PowerShellContext
             this.powerShellContext = powerShellContext;
-            this.powerShellContext.ConsoleHost = this;
             this.powerShellContext.DebuggerStop += PowerShellContext_DebuggerStop;
             this.powerShellContext.DebuggerResumed += PowerShellContext_DebuggerResumed;
             this.powerShellContext.ExecutionStatusChanged += PowerShellContext_ExecutionStatusChanged;

--- a/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Check if the left hand side of an assignmentStatementAst is a VariableExpressionAst
         /// with the same name as that of symbolRef.
         /// </summary>
-        /// <param name="assignmentStatementAst">An AssignmentStatementAst/param>
+        /// <param name="assignmentStatementAst">An AssignmentStatementAst</param>
         /// <returns>A decision to stop searching if the right VariableExpressionAst was found,
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst)

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -84,15 +84,16 @@ namespace Microsoft.PowerShell.EditorServices
         /// </param>
         public void StartSession(
             PowerShellContext powerShellContext,
-            bool enableConsoleRepl)
+            ConsoleService consoleService)
         {
             // Initialize all services
             this.PowerShellContext = powerShellContext;
+            this.ConsoleService = consoleService;
+            this.UsesConsoleHost = this.ConsoleService.EnableConsoleRepl;
+
             this.LanguageService = new LanguageService(this.PowerShellContext);
-            this.ConsoleService = new ConsoleService(this.PowerShellContext);
             this.ExtensionService = new ExtensionService(this.PowerShellContext);
             this.TemplateService = new TemplateService(this.PowerShellContext);
-            this.UsesConsoleHost = enableConsoleRepl;
 
             this.InstantiateAnalysisService();
 
@@ -109,11 +110,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// </param>
         public void StartDebugSession(
             PowerShellContext powerShellContext,
+            ConsoleService consoleService,
             IEditorOperations editorOperations)
         {
             // Initialize all services
             this.PowerShellContext = powerShellContext;
-            this.ConsoleService = new ConsoleService(this.PowerShellContext);
+            this.ConsoleService = consoleService;
+
             this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations);
             this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager);
 
@@ -142,7 +145,7 @@ namespace Microsoft.PowerShell.EditorServices
             // Script Analyzer binaries are not included.
             try
             {
-                this.AnalysisService = new AnalysisService(this.PowerShellContext.ConsoleHost, settingsPath);
+                this.AnalysisService = new AnalysisService(settingsPath);
             }
             catch (FileNotFoundException)
             {

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -65,6 +65,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public RemoteFileManager RemoteFileManager { get; private set; }
 
+        /// <summary>
+        /// Gets a boolean which is true if the integrated console host is
+        /// active in this session.
+        /// </summary>
+        public bool UsesConsoleHost { get; private set; }
+
         #endregion
 
         #region Public Methods
@@ -93,6 +99,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
             this.ExtensionService = new ExtensionService(this.PowerShellContext);
             this.TemplateService = new TemplateService(this.PowerShellContext);
+            this.UsesConsoleHost = enableConsoleRepl;
 
             this.InstantiateAnalysisService();
 

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -79,9 +79,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// Starts the session using the provided IConsoleHost implementation
         /// for the ConsoleService.
         /// </summary>
-        /// <param name="enableConsoleRepl">
-        /// Enables a terminal-based REPL for this session.
-        /// </param>
+        /// <param name="powerShellContext"></param>
+        /// <param name="consoleService"></param>
         public void StartSession(
             PowerShellContext powerShellContext,
             ConsoleService consoleService)
@@ -105,6 +104,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// Starts a debug-only session using the provided IConsoleHost implementation
         /// for the ConsoleService.
         /// </summary>
+        /// <param name="powerShellContext"></param>
+        /// <param name="consoleService"></param>
         /// <param name="editorOperations">
         /// An IEditorOperations implementation used to interact with the editor.
         /// </param>

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -79,22 +79,15 @@ namespace Microsoft.PowerShell.EditorServices
         /// Starts the session using the provided IConsoleHost implementation
         /// for the ConsoleService.
         /// </summary>
-        /// <param name="hostDetails">
-        /// Provides details about the host application.
-        /// </param>
-        /// <param name="profilePaths">
-        /// An object containing the profile paths for the session.
-        /// </param>
         /// <param name="enableConsoleRepl">
         /// Enables a terminal-based REPL for this session.
         /// </param>
         public void StartSession(
-            HostDetails hostDetails,
-            ProfilePaths profilePaths,
+            PowerShellContext powerShellContext,
             bool enableConsoleRepl)
         {
             // Initialize all services
-            this.PowerShellContext = new PowerShellContext(hostDetails, profilePaths, enableConsoleRepl);
+            this.PowerShellContext = powerShellContext;
             this.LanguageService = new LanguageService(this.PowerShellContext);
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
             this.ExtensionService = new ExtensionService(this.PowerShellContext);
@@ -111,22 +104,15 @@ namespace Microsoft.PowerShell.EditorServices
         /// Starts a debug-only session using the provided IConsoleHost implementation
         /// for the ConsoleService.
         /// </summary>
-        /// <param name="hostDetails">
-        /// Provides details about the host application.
-        /// </param>
-        /// <param name="profilePaths">
-        /// An object containing the profile paths for the session.
-        /// </param>
         /// <param name="editorOperations">
         /// An IEditorOperations implementation used to interact with the editor.
         /// </param>
         public void StartDebugSession(
-            HostDetails hostDetails,
-            ProfilePaths profilePaths,
+            PowerShellContext powerShellContext,
             IEditorOperations editorOperations)
         {
             // Initialize all services
-            this.PowerShellContext = new PowerShellContext(hostDetails, profilePaths);
+            this.PowerShellContext = powerShellContext;
             this.ConsoleService = new ConsoleService(this.PowerShellContext);
             this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations);
             this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager);

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -38,9 +38,7 @@ namespace Microsoft.PowerShell.EditorServices
         private RunspaceDetails initialRunspace;
         private SessionDetails mostRecentSessionDetails;
 
-        private IConsoleHost consoleHost;
         private ProfilePaths profilePaths;
-        private ConsoleServicePSHost psHost;
 
         private IVersionSpecificOperations versionSpecificOperations;
 
@@ -94,15 +92,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets or sets an IConsoleHost implementation for use in
         /// writing output to the console.
         /// </summary>
-        internal IConsoleHost ConsoleHost
-        {
-            get { return this.consoleHost; }
-            set
-            {
-                this.consoleHost = value;
-                this.psHost.ConsoleHost = value;
-            }
-        }
+        private IConsoleHost ConsoleHost { get; set; }
 
         /// <summary>
         /// Gets details pertaining to the current runspace.
@@ -125,42 +115,18 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Constructors
 
-        /// <summary>
-        /// Initializes a new instance of the PowerShellContext class and
-        /// opens a runspace to be used for the session.
-        /// </summary>
-        public PowerShellContext() : this((HostDetails)null, null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the PowerShellContext class and
-        /// opens a runspace to be used for the session.
-        /// </summary>
-        /// <param name="hostDetails">Provides details about the host application.</param>
-        /// <param name="profilePaths">An object containing the profile paths for the session.</param>
-        public PowerShellContext(HostDetails hostDetails, ProfilePaths profilePaths)
-            : this(hostDetails, profilePaths, false)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the PowerShellContext class and
-        /// opens a runspace to be used for the session.
-        /// </summary>
-        /// <param name="hostDetails">Provides details about the host application.</param>
-        /// <param name="profilePaths">An object containing the profile paths for the session.</param>
-        /// <param name="enableConsoleRepl">
-        /// Enables a terminal-based REPL for this session.
-        /// </param>
-        public PowerShellContext(
+        public static Runspace CreateRunspace(
             HostDetails hostDetails,
-            ProfilePaths profilePaths,
+            PowerShellContext powerShellContext,
             bool enableConsoleRepl)
         {
-            hostDetails = hostDetails ?? HostDetails.Default;
+            var psHost = new ConsoleServicePSHost(powerShellContext, hostDetails, enableConsoleRepl);
+            powerShellContext.ConsoleHost = psHost.ConsoleService;
+            return CreateRunspace(psHost);
+        }
 
-            this.psHost = new ConsoleServicePSHost(hostDetails, this, enableConsoleRepl);
+        public static Runspace CreateRunspace(PSHost psHost)
+        {
             var initialSessionState = InitialSessionState.CreateDefault2();
 
             Runspace runspace = RunspaceFactory.CreateRunspace(psHost, initialSessionState);
@@ -170,9 +136,7 @@ namespace Microsoft.PowerShell.EditorServices
             runspace.ThreadOptions = PSThreadOptions.ReuseThread;
             runspace.Open();
 
-            this.ownsInitialRunspace = true;
-
-            this.Initialize(profilePaths, runspace);
+            return runspace;
         }
 
         /// <summary>
@@ -181,16 +145,34 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="profilePaths">An object containing the profile paths for the session.</param>
         /// <param name="initialRunspace">The initial runspace to use for this instance.</param>
-        public PowerShellContext(ProfilePaths profilePaths, Runspace initialRunspace)
+        /// <param name="ownsInitialRunspace">If true, the PowerShellContext owns this runspace.</param>
+        public void Initialize(
+            ProfilePaths profilePaths,
+            Runspace initialRunspace,
+            bool ownsInitialRunspace)
         {
-            this.Initialize(profilePaths, initialRunspace);
+            this.Initialize(profilePaths, initialRunspace, ownsInitialRunspace, null);
         }
 
-        private void Initialize(ProfilePaths profilePaths, Runspace initialRunspace)
+        /// <summary>
+        /// Initializes a new instance of the PowerShellContext class using
+        /// an existing runspace for the session.
+        /// </summary>
+        /// <param name="profilePaths">An object containing the profile paths for the session.</param>
+        /// <param name="initialRunspace">The initial runspace to use for this instance.</param>
+        /// <param name="ownsInitialRunspace">If true, the PowerShellContext owns this runspace.</param>
+        /// <param name="consoleHost">An IConsoleHost implementation.  Optional.</param>
+        public void Initialize(
+            ProfilePaths profilePaths,
+            Runspace initialRunspace,
+            bool ownsInitialRunspace,
+            IConsoleHost consoleHost)
         {
             Validate.IsNotNull("initialRunspace", initialRunspace);
 
+            this.ownsInitialRunspace = ownsInitialRunspace;
             this.SessionState = PowerShellContextState.NotStarted;
+            this.ConsoleHost = consoleHost;
 
             // Get the PowerShell runtime version
             this.LocalPowerShellVersion =

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -115,6 +115,13 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Constructors
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="hostDetails"></param>
+        /// <param name="powerShellContext"></param>
+        /// <param name="enableConsoleRepl"></param>
+        /// <returns></returns>
         public static Runspace CreateRunspace(
             HostDetails hostDetails,
             PowerShellContext powerShellContext,
@@ -125,6 +132,11 @@ namespace Microsoft.PowerShell.EditorServices
             return CreateRunspace(psHost);
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="psHost"></param>
+        /// <returns></returns>
         public static Runspace CreateRunspace(PSHost psHost)
         {
             var initialSessionState = InitialSessionState.CreateDefault2();

--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.EditorServices
     /// ConsoleService and routes its calls to an IConsoleHost
     /// implementation.
     /// </summary>
-    internal class ConsoleServicePSHost : PSHost, IHostSupportsInteractiveSession
+    public class ConsoleServicePSHost : PSHost, IHostSupportsInteractiveSession
     {
         #region Private Fields
 
@@ -42,6 +42,8 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        public ConsoleService ConsoleService { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -50,23 +52,27 @@ namespace Microsoft.PowerShell.EditorServices
         /// Creates a new instance of the ConsoleServicePSHost class
         /// with the given IConsoleHost implementation.
         /// </summary>
+        /// <param name="powerShellContext">
+        /// An implementation of IHostSupportsInteractiveSession for runspace management.
+        /// </param>
         /// <param name="hostDetails">
         /// Provides details about the host application.
-        /// </param>
-        /// <param name="hostSupportsInteractiveSession">
-        /// An implementation of IHostSupportsInteractiveSession for runspace management.
         /// </param>
         /// <param name="enableConsoleRepl">
         /// Enables a terminal-based REPL for this session.
         /// </param>
         public ConsoleServicePSHost(
+            PowerShellContext powerShellContext,
             HostDetails hostDetails,
-            IHostSupportsInteractiveSession hostSupportsInteractiveSession,
             bool enableConsoleRepl)
         {
             this.hostDetails = hostDetails;
             this.hostUserInterface = new ConsoleServicePSHostUserInterface(enableConsoleRepl);
-            this.hostSupportsInteractiveSession = hostSupportsInteractiveSession;
+            this.hostSupportsInteractiveSession = powerShellContext;
+
+            this.ConsoleService = new ConsoleService(powerShellContext);
+            this.ConsoleService.EnableConsoleRepl = enableConsoleRepl;
+            this.ConsoleHost = this.ConsoleService;
 
             System.Console.CancelKeyPress +=
                 (obj, args) =>

--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -42,6 +42,9 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        /// <summary>
+        /// Gets the ConsoleServices owned by this host.
+        /// </summary>
         public ConsoleService ConsoleService { get; private set; }
 
         #endregion
@@ -93,16 +96,25 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region PSHost Implementation
 
+        /// <summary>
+        ///
+        /// </summary>
         public override Guid InstanceId
         {
             get { return this.instanceId; }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override string Name
         {
             get { return this.hostDetails.Name; }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override Version Version
         {
             get { return this.hostDetails.Version; }
@@ -110,43 +122,68 @@ namespace Microsoft.PowerShell.EditorServices
 
         // TODO: Pull these from IConsoleHost
 
+        /// <summary>
+        ///
+        /// </summary>
         public override System.Globalization.CultureInfo CurrentCulture
         {
             get { return System.Globalization.CultureInfo.CurrentCulture; }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override System.Globalization.CultureInfo CurrentUICulture
         {
             get { return System.Globalization.CultureInfo.CurrentUICulture; }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override PSHostUserInterface UI
         {
             get { return this.hostUserInterface; }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override void EnterNestedPrompt()
         {
             Logger.Write(LogLevel.Verbose, "EnterNestedPrompt() called.");
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override void ExitNestedPrompt()
         {
             Logger.Write(LogLevel.Verbose, "ExitNestedPrompt() called.");
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override void NotifyBeginApplication()
         {
             Logger.Write(LogLevel.Verbose, "NotifyBeginApplication() called.");
             this.isNativeApplicationRunning = true;
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public override void NotifyEndApplication()
         {
             Logger.Write(LogLevel.Verbose, "NotifyEndApplication() called.");
             this.isNativeApplicationRunning = false;
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="exitCode"></param>
         public override void SetShouldExit(int exitCode)
         {
             if (this.consoleHost != null)
@@ -164,6 +201,10 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region IHostSupportsInteractiveSession Implementation
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
         public bool IsRunspacePushed
         {
             get
@@ -179,6 +220,10 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
         public Runspace Runspace
         {
             get
@@ -194,6 +239,10 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="runspace"></param>
         public void PushRunspace(Runspace runspace)
         {
             if (this.hostSupportsInteractiveSession != null)
@@ -206,6 +255,9 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        /// <summary>
+        ///
+        /// </summary>
         public void PopRunspace()
         {
             if (this.hostSupportsInteractiveSession != null)

--- a/test/PowerShellEditorServices.Test/Console/ConsoleServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ConsoleServiceTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         private PowerShellContext powerShellContext;
         private TestConsolePromptHandlerContext promptHandlerContext;
 
-        private Dictionary<OutputType, string> outputPerType = 
+        private Dictionary<OutputType, string> outputPerType =
             new Dictionary<OutputType, string>();
 
         const string TestOutputString = "This is a test.";
@@ -50,21 +50,30 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         public ConsoleServiceTests()
         {
             this.powerShellContext = new PowerShellContext();
+            ConsoleServicePSHost psHost =
+                new ConsoleServicePSHost(
+                    powerShellContext,
+                    PowerShellContextTests.TestHostDetails,
+                    false);
 
-            this.promptHandlerContext = 
+            this.consoleService = psHost.ConsoleService;
+
+            this.powerShellContext.Initialize(
+                null,
+                PowerShellContext.CreateRunspace(psHost),
+                true);
+
+            this.promptHandlerContext =
                 new TestConsolePromptHandlerContext();
 
-            this.consoleService =
-                new ConsoleService(
-                    this.powerShellContext,
-                    promptHandlerContext);
-
+            this.consoleService.PushPromptHandlerContext(this.promptHandlerContext);
             this.consoleService.OutputWritten += OnOutputWritten;
             promptHandlerContext.ConsoleHost = this.consoleService;
         }
 
         public void Dispose()
         {
+            this.powerShellContext.Dispose();
         }
 
         [Fact]
@@ -211,7 +220,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     .Split(
                         new string[] { Environment.NewLine },
                         StringSplitOptions.None);
-            
+
             Assert.Equal(PromptCaption, outputLines[0]);
             Assert.Equal(PromptMessage, outputLines[1]);
             Assert.Equal("[A] Apple [N] Banana [] Orange [?] Help (default is \"Banana\"): ", outputLines[2]);
@@ -550,7 +559,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         public TestConsoleChoicePromptHandler(
             IConsoleHost consoleHost,
-            TaskCompletionSource<TestConsoleChoicePromptHandler> promptShownTask) 
+            TaskCompletionSource<TestConsoleChoicePromptHandler> promptShownTask)
             : base(consoleHost)
         {
             this.consoleHost = consoleHost;
@@ -612,7 +621,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         public TestConsoleInputPromptHandler(
             IConsoleHost consoleHost,
-            TaskCompletionSource<TestConsoleInputPromptHandler> promptShownTask) 
+            TaskCompletionSource<TestConsoleInputPromptHandler> promptShownTask)
             : base(consoleHost)
         {
             this.consoleHost = consoleHost;

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         public DebugServiceTests()
         {
-            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext = PowerShellContextFactory.Create();
             this.powerShellContext.SessionStateChanged += powerShellContext_SessionStateChanged;
 
             this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version);

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
 
         public async Task InitializeAsync()
         {
-            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext = PowerShellContextFactory.Create();
             this.extensionService = new ExtensionService(this.powerShellContext);
             this.editorOperations = new TestEditorOperations();
 

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
         public LanguageServiceTests()
         {
-            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext = PowerShellContextFactory.Create();
             this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version);
             this.languageService = new LanguageService(this.powerShellContext);
         }

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -1,0 +1,27 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Session;
+using Microsoft.PowerShell.EditorServices.Test.Console;
+using System;
+using System.IO;
+
+namespace Microsoft.PowerShell.EditorServices.Test
+{
+    internal static class PowerShellContextFactory
+    {
+
+        public static PowerShellContext Create()
+        {
+            PowerShellContext powerShellContext = new PowerShellContext();
+            powerShellContext.Initialize(
+                PowerShellContextTests.TestProfilePaths,
+                PowerShellContext.CreateRunspace(PowerShellContextTests.TestHostDetails, powerShellContext, false),
+                true);
+
+            return powerShellContext;
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         private const string DebugTestFilePath =
             @"..\..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1";
 
-        private static readonly HostDetails TestHostDetails =
+        public static readonly HostDetails TestHostDetails =
             new HostDetails(
                 "PowerShell Editor Services Test Host",
                 "Test.PowerShellEditorServices",
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         // NOTE: These paths are arbitrarily chosen just to verify that the profile paths
         //       can be set to whatever they need to be for the given host.
 
-        private readonly ProfilePaths TestProfilePaths =
+        public static readonly ProfilePaths TestProfilePaths =
             new ProfilePaths(
                 TestHostDetails.ProfileId,
                     Path.GetFullPath(
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         public PowerShellContextTests()
         {
-            this.powerShellContext = new PowerShellContext(TestHostDetails, TestProfilePaths);
+            this.powerShellContext = PowerShellContextFactory.Create();
             this.powerShellContext.SessionStateChanged += OnSessionStateChanged;
             this.stateChangeQueue = new AsyncQueue<SessionStateChangedEventArgs>();
         }


### PR DESCRIPTION
This change kicks off a larger refactoring of how PowerShell Editor Services is initialized.  The goal here is to move toward a more granular interface design which can be exposed as an extensibility API.  I'll be working toward this incrementally over the next few releases.