### PR TITLE
Decouple MessageDispatcher from ProtocolEndpoint

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
@@ -13,7 +13,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
     public class DebugAdapterClient : ProtocolEndpoint
     {
         public DebugAdapterClient(ChannelBase clientChannel)
-            : base(clientChannel, MessageProtocolType.DebugAdapter)
+            : base(
+                clientChannel,
+                new MessageDispatcher(),
+                MessageProtocolType.DebugAdapter)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
@@ -21,7 +21,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
         /// </summary>
         /// <param name="clientChannel">The channel to use for communication with the server.</param>
         public LanguageClientBase(ChannelBase clientChannel)
-            : base(clientChannel, MessageProtocolType.LanguageServer)
+            : base(
+                clientChannel,
+                new MessageDispatcher(),
+                MessageProtocolType.LanguageServer)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
@@ -17,80 +17,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
     {
         #region Fields
 
-        private ChannelBase protocolChannel;
-        private AsyncContextThread messageLoopThread;
-
         private Dictionary<string, Func<Message, MessageWriter, Task>> requestHandlers =
             new Dictionary<string, Func<Message, MessageWriter, Task>>();
 
         private Dictionary<string, Func<Message, MessageWriter, Task>> eventHandlers =
             new Dictionary<string, Func<Message, MessageWriter, Task>>();
 
-        private Action<Message> responseHandler;
-
-        private CancellationTokenSource messageLoopCancellationToken =
-            new CancellationTokenSource();
-
-        #endregion
-
-        #region Properties
-
-        public SynchronizationContext SynchronizationContext { get; private set; }
-
-        public bool InMessageLoopThread
-        {
-            get
-            {
-                // We're in the same thread as the message loop if the
-                // current synchronization context equals the one we
-                // know.
-                return SynchronizationContext.Current == this.SynchronizationContext;
-            }
-        }
-
-        protected MessageReader MessageReader { get; private set; }
-
-        protected MessageWriter MessageWriter { get; private set; }
-
-
-        #endregion
-
-        #region Constructors
-
-        public MessageDispatcher(ChannelBase protocolChannel)
-        {
-            this.protocolChannel = protocolChannel;
-        }
-
         #endregion
 
         #region Public Methods
-
-        public void Start()
-        {
-            // At this point the MessageReader and MessageWriter should be ready
-            this.MessageReader = protocolChannel.MessageReader;
-            this.MessageWriter = protocolChannel.MessageWriter;
-
-            // Start the main message loop thread.  The Task is
-            // not explicitly awaited because it is running on
-            // an independent background thread.
-            this.messageLoopThread = new AsyncContextThread("Message Dispatcher");
-            this.messageLoopThread
-                .Run(() => this.ListenForMessages(this.messageLoopCancellationToken.Token))
-                .ContinueWith(this.OnListenTaskCompleted);
-        }
-
-        public void Stop()
-        {
-            // Stop the message loop thread
-            if (this.messageLoopThread != null)
-            {
-                this.messageLoopCancellationToken.Cancel();
-                this.messageLoopThread.Stop();
-                SynchronizationContext.SetSynchronizationContext(null);
-            }
-        }
 
         public void SetRequestHandler<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
@@ -171,98 +106,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 });
         }
 
-        public void SetResponseHandler(Action<Message> responseHandler)
-        {
-            this.responseHandler = responseHandler;
-        }
-
-        #endregion
-
-        #region Events
-
-        public event EventHandler<Exception> UnhandledException;
-
-        protected void OnUnhandledException(Exception unhandledException)
-        {
-            if (this.UnhandledException != null)
-            {
-                this.UnhandledException(this, unhandledException);
-            }
-        }
-
         #endregion
 
         #region Private Methods
 
-        private async Task ListenForMessages(CancellationToken cancellationToken)
-        {
-            this.SynchronizationContext = SynchronizationContext.Current;
-
-            // Run the message loop
-            bool isRunning = true;
-            while (isRunning && !cancellationToken.IsCancellationRequested)
-            {
-                Message newMessage = null;
-
-                try
-                {
-                    // Read a message from the channel
-                    newMessage = await this.MessageReader.ReadMessage();
-                }
-                catch (MessageParseException e)
-                {
-                    // TODO: Write an error response
-
-                    Logger.Write(
-                        LogLevel.Error,
-                        "Could not parse a message that was received:\r\n\r\n" +
-                        e.ToString());
-
-                    // Continue the loop
-                    continue;
-                }
-                catch (IOException e)
-                {
-                    // The stream has ended, end the message loop
-                    Logger.Write(
-                        LogLevel.Error,
-                        string.Format(
-                            "Stream terminated unexpectedly, ending MessageDispatcher loop\r\n\r\nException: {0}\r\n{1}",
-                            e.GetType().Name,
-                            e.Message));
-
-                    break;
-                }
-                catch (ObjectDisposedException)
-                {
-                    Logger.Write(
-                        LogLevel.Verbose,
-                        "MessageReader attempted to read from a disposed stream, ending MessageDispatcher loop");
-
-                    break;
-                }
-                catch (Exception e)
-                {
-                    Logger.Write(
-                        LogLevel.Verbose,
-                        "Caught unexpected exception '{0}' in MessageDispatcher loop:\r\n{1}",
-                        e.GetType().Name,
-                        e.Message);
-                }
-
-                // The message could be null if there was an error parsing the
-                // previous message.  In this case, do not try to dispatch it.
-                if (newMessage != null)
-                {
-                    // Process the message
-                    await this.DispatchMessage(
-                        newMessage,
-                        this.MessageWriter);
-                }
-            }
-        }
-
-        protected async Task DispatchMessage(
+        public async Task DispatchMessage(
             Message messageToDispatch,
             MessageWriter messageWriter)
         {
@@ -279,13 +127,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 {
                     // TODO: Message not supported error
                     Logger.Write(LogLevel.Error, $"MessageDispatcher: No handler registered for Request type '{messageToDispatch.Method}'");
-                }
-            }
-            else if (messageToDispatch.MessageType == MessageType.Response)
-            {
-                if (this.responseHandler != null)
-                {
-                    this.responseHandler(messageToDispatch);
                 }
             }
             else if (messageToDispatch.MessageType == MessageType.Event)
@@ -327,24 +168,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                         throw e;
                     }
                 }
-            }
-        }
-
-        private void OnListenTaskCompleted(Task listenTask)
-        {
-            if (listenTask.IsFaulted)
-            {
-                Logger.Write(
-                    LogLevel.Error,
-                    string.Format(
-                        "MessageDispatcher loop terminated due to unhandled exception:\r\n\r\n{0}",
-                        listenTask.Exception.ToString()));
-
-                this.OnUnhandledException(listenTask.Exception);
-            }
-            else if (listenTask.IsCompleted || listenTask.IsCanceled)
-            {
-                // TODO: Dispose of anything?
             }
         }
 

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/ProtocolEndpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/ProtocolEndpoint.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         /// handlers for requests, responses, and events that are
         /// transmitted through the channel.
         /// </summary>
-        protected MessageDispatcher MessageDispatcher { get; set; }
+        private MessageDispatcher MessageDispatcher { get; set; }
 
         /// <summary>
         /// Initializes an instance of the protocol server using the
@@ -71,9 +71,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         /// </param>
         public ProtocolEndpoint(
             ChannelBase protocolChannel,
+            MessageDispatcher messageDispatcher,
             MessageProtocolType messageProtocolType)
         {
             this.protocolChannel = protocolChannel;
+            this.MessageDispatcher = messageDispatcher;
             this.messageProtocolType = messageProtocolType;
             this.originalSynchronizationContext = SynchronizationContext.Current;
         }
@@ -88,12 +90,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             {
                 // Start the provided protocol channel
                 this.protocolChannel.Start(this.messageProtocolType);
-
-                // Start the message dispatcher
-                this.MessageDispatcher = new MessageDispatcher(this.protocolChannel);
-
-                // Set the handler for any message responses that come back
-                this.MessageDispatcher.SetResponseHandler(this.HandleResponse);
 
                 // Listen for unhandled exceptions from the message loop
                 this.UnhandledException += MessageDispatcher_UnhandledException;

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             EditorSession editorSession,
             ChannelBase serverChannel,
             bool ownsEditorSession)
-                : base(serverChannel)
+                : base(serverChannel, new MessageDispatcher())
         {
             this.editorSession = editorSession;
             this.ownsEditorSession = ownsEditorSession;

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -12,8 +12,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     public abstract class DebugAdapterBase : ProtocolEndpoint
     {
-        public DebugAdapterBase(ChannelBase serverChannel)
-            : base (serverChannel, MessageProtocolType.DebugAdapter)
+        public DebugAdapterBase(
+            ChannelBase serverChannel,
+            MessageDispatcher messageDispatcher)
+            : base(
+                serverChannel,
+                messageDispatcher,
+                MessageProtocolType.DebugAdapter)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public LanguageServer(
             EditorSession editorSession,
             ChannelBase serverChannel)
-            : base(serverChannel)
+            : base(serverChannel, new MessageDispatcher())
         {
             this.editorSession = editorSession;
             this.editorSession.PowerShellContext.RunspaceChanged += PowerShellContext_RunspaceChanged;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
@@ -14,8 +14,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     {
         private ChannelBase serverChannel;
 
-        public LanguageServerBase(ChannelBase serverChannel) :
-            base(serverChannel, MessageProtocolType.LanguageServer)
+        public LanguageServerBase(
+            ChannelBase serverChannel,
+            MessageDispatcher messageDispatcher)
+            : base(
+                serverChannel,
+                messageDispatcher,
+                MessageProtocolType.LanguageServer)
         {
             this.serverChannel = serverChannel;
         }


### PR DESCRIPTION
This is a small step in a larger refactoring that I should be sending a PR for today.  Basically I just needed a way to register message handlers without having an established LanguageServer/DebugServer.  Didn't make sense to have all that behavior wrapped up together anyway.