### PR TITLE
Include PSScriptAnalyzer rule name in marker message

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     public class LanguageServer : LanguageServerBase
     {
         private static CancellationTokenSource existingRequestCancellation;
-        private readonly static string DiagnosticSourceName = "PowerShellEditorServices";
 
         private bool profilesLoaded;
         private bool consoleReplStarted;
@@ -1119,8 +1118,7 @@ function __Expand-Alias {
             {
                 foreach (var diagnostic in codeActionParams.Context.Diagnostics)
                 {
-                    if (string.Equals(diagnostic.Source, DiagnosticSourceName, StringComparison.CurrentCultureIgnoreCase) &&
-                        !string.IsNullOrEmpty(diagnostic.Code) &&
+                    if (!string.IsNullOrEmpty(diagnostic.Code) &&
                         markerIndex.TryGetValue(diagnostic.Code, out correction))
                     {
                         codeActionCommands.Add(
@@ -1482,8 +1480,8 @@ function __Expand-Alias {
             {
                 Severity = MapDiagnosticSeverity(scriptFileMarker.Level),
                 Message = scriptFileMarker.Message,
-                Code = Guid.NewGuid().ToString(),
-                Source = DiagnosticSourceName,
+                Code = scriptFileMarker.Source + Guid.NewGuid().ToString(),
+                Source = scriptFileMarker.Source,
                 Range = new Range
                 {
                     Start = new Position

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -78,6 +78,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public MarkerCorrection Correction { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the marker's source like "PowerShell"
+        /// or "PSScriptAnalyzer".
+        /// </summary>
+        public string Source { get; set; }
+
         #endregion
 
         #region Public Methods
@@ -91,7 +97,8 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 Message = parseError.Message,
                 Level = ScriptFileMarkerLevel.Error,
-                ScriptRegion = ScriptRegion.Create(parseError.Extent)
+                ScriptRegion = ScriptRegion.Create(parseError.Extent),
+                Source = "PowerShell"
             };
         }
         private static string GetIfExistsString(PSObject psobj, string memberName)
@@ -153,10 +160,11 @@ namespace Microsoft.PowerShell.EditorServices
 
             return new ScriptFileMarker
             {
-                Message = diagnosticRecord.Message as string,
+                Message = $"{diagnosticRecord.Message as string} ({ruleName})",
                 Level = GetMarkerLevelFromDiagnosticSeverity((diagnosticRecord.Severity as Enum).ToString()),
                 ScriptRegion = ScriptRegion.Create(diagnosticRecord.Extent as IScriptExtent),
-                Correction = correction
+                Correction = correction,
+                Source = "PSScriptAnalyzer"
             };
         }
 


### PR DESCRIPTION
This change adds the PSScriptAnalyzer rule name to any marker messages
that are returned so that it's easy to know which rule to suppress or
disable in settings.  It also makes the rule source more clear in marker
messages, distinguishing between PowerShell syntax markers and
PSScriptAnalyzer's semantic markers.

Resolves PowerShell/vscode-powershell#781.