### PR TITLE
Fix help completion at the beginning of function body

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -193,6 +193,21 @@ namespace Microsoft.PowerShell.EditorServices
         #region Public Methods
 
         /// <summary>
+        /// Get the lines in a string.
+        /// </summary>
+        /// <param name="text">Input string to be split up into lines.</param>
+        /// <returns>The lines in the string.</returns>
+        public static IEnumerable<string> GetLines(string text)
+        {
+            if (text == null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            return text.Split('\n').Select(line => line.TrimEnd('\r'));
+        }
+
+        /// <summary>
         /// Gets a line from the file's contents.
         /// </summary>
         /// <param name="lineNumber">The 1-based line number in the file.</param>
@@ -479,11 +494,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             // Split the file contents into lines and trim
             // any carriage returns from the strings.
-            this.FileLines =
-                fileContents
-                    .Split('\n')
-                    .Select(line => line.TrimEnd('\r'))
-                    .ToList();
+            this.FileLines = GetLines(fileContents).ToList();
 
             // Parse the contents to get syntax tree and errors
             this.ParseFileContents();


### PR DESCRIPTION
Resolves #478

Comment help auto-completion does not work correctly for block comment ('<#') trigger characters at the beginning of function body - the auto-completed help does not contain the parameters. When the user types '<', it invalidates the following param block such that the parser does not recognize it as a param block, which results in the help not containing the parameters. 

```powershell
# the '<' before the param block leads the parser to not recognize the param block.
function foo {
  <    
  param($param1)
}
```