### PR TITLE
Fix evaluation of prompt function output to remove unneeded "PS>"

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -224,7 +224,8 @@ namespace Microsoft.PowerShell.EditorServices.Console
             PSCommand promptCommand = new PSCommand().AddScript("prompt");
 
             string promptString =
-                (await this.powerShellContext.ExecuteCommand<object>(promptCommand, false, false))
+                (await this.powerShellContext.ExecuteCommand<PSObject>(promptCommand, false, false))
+                    .Select(pso => pso.BaseObject)
                     .OfType<string>()
                     .FirstOrDefault() ?? "PS> ";
 


### PR DESCRIPTION
This change fixes an issue in the integrated console where the result of
a user's custom prompt function would not be interpreted correctly,
causing the default prompt string of "PS>" to be written out when it
wasn't needed.  The fix is to expect a PSObject result rather than
object so that we can evaluate the inner object's type correctly.

Resolves PowerShell/vscode-powershell#808.