### PR TITLE
Establish new channel connection model using server listeners

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
@@ -33,11 +33,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
 
         protected override Task OnStart()
         {
-            return Task.FromResult(true);
-        }
-
-        protected override Task OnConnect()
-        {
             // Initialize the debug adapter
             return this.SendRequest(
                 InitializeRequest.Type,

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
@@ -28,11 +28,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
             // Add handlers for common events
             this.SetEventHandler(PublishDiagnosticsNotification.Type, HandlePublishDiagnosticsEvent);
 
-            return Task.FromResult(true);
-        }
-
-        protected override Task OnConnect()
-        {
             // Send the 'initialize' request and wait for the response
             var initializeParams = new InitializeParams
             {

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/ChannelBase.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/ChannelBase.cs
@@ -15,11 +15,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
     public abstract class ChannelBase
     {
         /// <summary>
-        /// Gets a boolean that is true if the channel is connected or false if not.
-        /// </summary>
-        public bool IsConnected { get; protected set; }
-
-        /// <summary>
         /// Gets the MessageReader for reading messages from the channel.
         /// </summary>
         public MessageReader MessageReader { get; protected set; }
@@ -47,14 +42,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 
             this.Initialize(messageSerializer);
         }
-
-        /// <summary>
-        /// Returns a Task that allows the consumer of the ChannelBase
-        /// implementation to wait until a connection has been made to
-        /// the opposite endpoint whether it's a client or server.
-        /// </summary>
-        /// <returns>A Task to be awaited until a connection is made.</returns>
-        public abstract Task WaitForConnection();
 
         /// <summary>
         /// Stops the channel.

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
@@ -1,0 +1,90 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
+{
+    public class NamedPipeServerListener : ServerListenerBase<NamedPipeServerChannel>
+    {
+        private string pipeName;
+        private NamedPipeServerStream pipeServer;
+
+        public NamedPipeServerListener(
+            MessageProtocolType messageProtocolType,
+            string pipeName)
+            : base(messageProtocolType)
+        {
+            this.pipeName = pipeName;
+        }
+
+        public override void Start()
+        {
+            try
+            {
+                this.pipeServer =
+                    new NamedPipeServerStream(
+                        pipeName,
+                        PipeDirection.InOut,
+                        1,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous);
+            }
+            catch (IOException e)
+            {
+                Logger.Write(
+                    LogLevel.Verbose,
+                    "Named pipe server failed to start due to exception:\r\n\r\n" + e.Message);
+
+                throw e;
+            }
+        }
+
+        public override void Stop()
+        {
+            if (this.pipeServer != null)
+            {
+                Logger.Write(LogLevel.Verbose, "Named pipe server shutting down...");
+
+                this.pipeServer.Dispose();
+
+                Logger.Write(LogLevel.Verbose, "Named pipe server has been disposed.");
+            }
+        }
+
+        private void ListenForConnection()
+        {
+            Task.Factory.StartNew(
+                async () =>
+                {
+                    try
+                    {
+#if CoreCLR
+                        await this.pipeServer.WaitForConnectionAsync();
+#else
+                        await Task.Factory.FromAsync(
+                            this.pipeServer.BeginWaitForConnection, 
+                            this.pipeServer.EndWaitForConnection, null);
+#endif
+                        this.OnClientConnect(
+                            new NamedPipeServerChannel(
+                                this.pipeServer));
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.WriteException(
+                            "An unhandled exception occurred while listening for a named pipe client connection",
+                            e);
+
+                        throw e;
+                    }
+                });
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/ServerListenerBase.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/ServerListenerBase.cs
@@ -1,0 +1,33 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
+{
+    public abstract class ServerListenerBase<TChannel>
+        where TChannel : ChannelBase
+    {
+        private MessageProtocolType messageProtocolType;
+
+        public ServerListenerBase(MessageProtocolType messageProtocolType)
+        {
+            this.messageProtocolType = messageProtocolType;
+        }
+
+        public abstract void Start();
+
+        public abstract void Stop();
+
+        public event EventHandler<TChannel> ClientConnect;
+
+        protected void OnClientConnect(TChannel channel)
+        {
+            channel.Start(this.messageProtocolType);
+            this.ClientConnect?.Invoke(this, channel);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioClientChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioClientChannel.cs
@@ -3,12 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Serializers;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
@@ -44,11 +41,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 
             if (serverProcessArguments != null)
             {
-                this.serviceProcessArguments = 
+                this.serviceProcessArguments =
                     string.Join(
-                        " ", 
+                        " ",
                         serverProcessArguments);
             }
+        }
+
+        public StdioClientChannel(Process serviceProcess)
+        {
+            this.serviceProcess = serviceProcess;
         }
 
         protected override void Initialize(IMessageSerializer messageSerializer)
@@ -71,6 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 
             // Start the process
             this.serviceProcess.Start();
+
             this.ProcessId = this.serviceProcess.Id;
 
             // Open the standard input/output streams
@@ -78,23 +81,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.outputStream = this.serviceProcess.StandardInput.BaseStream;
 
             // Set up the message reader and writer
-            this.MessageReader = 
+            this.MessageReader =
                 new MessageReader(
                     this.inputStream,
                     messageSerializer);
 
-            this.MessageWriter = 
+            this.MessageWriter =
                 new MessageWriter(
                     this.outputStream,
                     messageSerializer);
-
-            this.IsConnected = true;
-        }
-
-        public override Task WaitForConnection()
-        {
-            // We're always connected immediately in the stdio channel
-            return Task.FromResult(true);
         }
 
         protected override void Shutdown()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerChannel.cs
@@ -3,11 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Serializers;
 using System.IO;
 using System.Text;
-using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
@@ -34,23 +31,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.outputStream = System.Console.OpenStandardOutput();
 
             // Set up the reader and writer
-            this.MessageReader = 
+            this.MessageReader =
                 new MessageReader(
                     this.inputStream,
                     messageSerializer);
 
-            this.MessageWriter = 
+            this.MessageWriter =
                 new MessageWriter(
                     this.outputStream,
                     messageSerializer);
-
-            this.IsConnected = true;
-        }
-
-        public override Task WaitForConnection()
-        {
-            // We're always connected immediately in the stdio channel
-            return Task.FromResult(true);
         }
 
         protected override void Shutdown()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerListener.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.IO;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
+{
+    public class StdioServerListener : ServerListenerBase<StdioServerChannel>
+    {
+        public StdioServerListener(MessageProtocolType messageProtocolType) :
+            base(messageProtocolType)
+        {
+        }
+
+        public override void Start()
+        {
+            // Client is connected immediately because stdio
+            // will buffer all I/O until we get to it
+            this.OnClientConnect(new StdioServerChannel());
+        }
+
+        public override void Stop()
+        {
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerListener.cs
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
+{
+    public class TcpSocketServerListener : ServerListenerBase<TcpSocketServerChannel>
+    {
+        private int portNumber;
+        private TcpListener tcpListener;
+
+        public TcpSocketServerListener(
+            MessageProtocolType messageProtocolType,
+            int portNumber)
+                : base(messageProtocolType)
+        {
+            this.portNumber = portNumber;
+        }
+
+        public override void Start()
+        {
+            if (this.tcpListener == null)
+            {
+                this.tcpListener = new TcpListener(IPAddress.Loopback, this.portNumber);
+                this.tcpListener.Server.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                this.tcpListener.Start();
+            }
+
+            this.ListenForConnection();
+        }
+
+        public override void Stop()
+        {
+            if (this.tcpListener != null)
+            {
+                this.tcpListener.Stop();
+                this.tcpListener = null;
+
+                Logger.Write(LogLevel.Verbose, "TCP listener has been stopped");
+            }
+        }
+
+        private void ListenForConnection()
+        {
+            Task.Factory.StartNew(
+                async () =>
+                {
+                    try
+                    {
+                        TcpClient tcpClient = await this.tcpListener.AcceptTcpClientAsync();
+                        this.OnClientConnect(
+                            new TcpSocketServerChannel(
+                                tcpClient));
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.WriteException(
+                            "An unhandled exception occurred while listening for a TCP client connection",
+                            e);
+
+                        throw e;
+                    }
+                });
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -105,7 +105,6 @@ namespace Microsoft.PowerShell.EditorServices.Session
             IEditorOperations editorOperations)
         {
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
-            Validate.IsNotNull(nameof(editorOperations), editorOperations);
 
             this.powerShellContext = powerShellContext;
             this.powerShellContext.RunspaceChanged += HandleRunspaceChanged;
@@ -385,7 +384,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     {
                         foreach (string remotePath in remotePathMappings.OpenedPaths)
                         {
-                            await this.editorOperations.CloseFile(remotePath);
+                            await this.editorOperations?.CloseFile(remotePath);
                         }
                     }
                 }
@@ -428,7 +427,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                         }
 
                         // Open the file in the editor
-                        this.editorOperations.OpenFile(localFilePath);
+                        this.editorOperations?.OpenFile(localFilePath);
                     }
                 }
                 catch (NullReferenceException e)


### PR DESCRIPTION
This change refactors our existing channel model to move all connection
logic outside of the ChannelBase implementations so that the
language and debug client/service pairs can be simplified.  This change
also allows us to remove a long-standing hack in our Host unit tests
which added an artifical delay to give the channel and MessageDispatcher
time to get established.