### PR TITLE
Remove static Logger API in favor of ILogger instance usage

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
     {
         #region Private Fields
 
+        private ILogger logger;
         private bool enableConsoleRepl;
         private HostDetails hostDetails;
         private ProfilePaths profilePaths;
@@ -114,7 +115,8 @@ namespace Microsoft.PowerShell.EditorServices.Host
         /// <param name="logLevel">The minimum level of log messages to be written.</param>
         public void StartLogging(string logFilePath, LogLevel logLevel)
         {
-            Logger.Initialize(logFilePath, logLevel);
+            this.logger = new FileLogger(logFilePath, logLevel);
+            Logger.Initialize(this.logger);
 
 #if CoreCLR
             FileVersionInfo fileVersionInfo =

--- a/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
@@ -7,16 +7,18 @@ using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Client
 {
     public class DebugAdapterClient : ProtocolEndpoint
     {
-        public DebugAdapterClient(ChannelBase clientChannel)
+        public DebugAdapterClient(ChannelBase clientChannel, ILogger logger)
             : base(
                 clientChannel,
-                new MessageDispatcher(),
-                MessageProtocolType.DebugAdapter)
+                new MessageDispatcher(logger),
+                MessageProtocolType.DebugAdapter,
+                logger)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Client
 {
@@ -20,11 +21,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
         /// specified channel for communication.
         /// </summary>
         /// <param name="clientChannel">The channel to use for communication with the server.</param>
-        public LanguageClientBase(ChannelBase clientChannel)
+        public LanguageClientBase(ChannelBase clientChannel, ILogger logger)
             : base(
                 clientChannel,
-                new MessageDispatcher(),
-                MessageProtocolType.LanguageServer)
+                new MessageDispatcher(logger),
+                MessageProtocolType.LanguageServer,
+                logger)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Client
 {
@@ -18,8 +19,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
         private Dictionary<string, ScriptFileMarker[]> cachedDiagnostics =
             new Dictionary<string, ScriptFileMarker[]>();
 
-        public LanguageServiceClient(ChannelBase clientChannel)
-            : base(clientChannel)
+        public LanguageServiceClient(ChannelBase clientChannel, ILogger logger)
+            : base(clientChannel, logger)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
@@ -10,11 +10,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
     public class NamedPipeServerChannel : ChannelBase
     {
+        private ILogger logger;
         private NamedPipeServerStream pipeServer;
 
-        public NamedPipeServerChannel(NamedPipeServerStream pipeServer)
+        public NamedPipeServerChannel(
+            NamedPipeServerStream pipeServer,
+            ILogger logger)
         {
             this.pipeServer = pipeServer;
+            this.logger = logger;
         }
 
         protected override void Initialize(IMessageSerializer messageSerializer)
@@ -22,12 +26,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.MessageReader =
                 new MessageReader(
                     this.pipeServer,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
 
             this.MessageWriter =
                 new MessageWriter(
                     this.pipeServer,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
         }
 
         protected override void Shutdown()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioClientChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioClientChannel.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
@@ -19,6 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         private string serviceProcessPath;
         private string serviceProcessArguments;
 
+        private ILogger logger;
         private Stream inputStream;
         private Stream outputStream;
         private Process serviceProcess;
@@ -35,8 +37,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         /// <param name="serverProcessArguments">Optional arguments to pass to the service process executable.</param>
         public StdioClientChannel(
             string serverProcessPath,
+            ILogger logger,
             params string[] serverProcessArguments)
         {
+            this.logger = logger;
             this.serviceProcessPath = serverProcessPath;
 
             if (serverProcessArguments != null)
@@ -46,11 +50,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
                         " ",
                         serverProcessArguments);
             }
-        }
-
-        public StdioClientChannel(Process serviceProcess)
-        {
-            this.serviceProcess = serviceProcess;
         }
 
         protected override void Initialize(IMessageSerializer messageSerializer)
@@ -84,12 +83,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.MessageReader =
                 new MessageReader(
                     this.inputStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
 
             this.MessageWriter =
                 new MessageWriter(
                     this.outputStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
         }
 
         protected override void Shutdown()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerChannel.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using System.Text;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
@@ -15,8 +16,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
     /// </summary>
     public class StdioServerChannel : ChannelBase
     {
+        private ILogger logger;
         private Stream inputStream;
         private Stream outputStream;
+
+        public StdioServerChannel(ILogger logger)
+        {
+            this.logger = logger;
+        }
 
         protected override void Initialize(IMessageSerializer messageSerializer)
         {
@@ -34,12 +41,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.MessageReader =
                 new MessageReader(
                     this.inputStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
 
             this.MessageWriter =
                 new MessageWriter(
                     this.outputStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
         }
 
         protected override void Shutdown()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/StdioServerListener.cs
@@ -4,21 +4,29 @@
 //
 
 using System.IO;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
     public class StdioServerListener : ServerListenerBase<StdioServerChannel>
     {
-        public StdioServerListener(MessageProtocolType messageProtocolType) :
-            base(messageProtocolType)
+        private ILogger logger;
+
+        public StdioServerListener(
+            MessageProtocolType messageProtocolType,
+            ILogger logger)
+                : base(messageProtocolType)
         {
+            this.logger = logger;
         }
 
         public override void Start()
         {
             // Client is connected immediately because stdio
             // will buffer all I/O until we get to it
-            this.OnClientConnect(new StdioServerChannel());
+            this.OnClientConnect(
+                new StdioServerChannel(
+                    this.logger));
         }
 
         public override void Stop()

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerChannel.cs
@@ -12,13 +12,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
     public class TcpSocketServerChannel : ChannelBase
     {
+        private ILogger logger;
         private TcpClient tcpClient;
         private NetworkStream networkStream;
 
-        public TcpSocketServerChannel(TcpClient tcpClient)
+        public TcpSocketServerChannel(TcpClient tcpClient, ILogger logger)
         {
             this.tcpClient = tcpClient;
             this.networkStream = this.tcpClient.GetStream();
+            this.logger = logger;
         }
 
         protected override void Initialize(IMessageSerializer messageSerializer)
@@ -26,12 +28,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             this.MessageReader =
                 new MessageReader(
                     this.networkStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
 
             this.MessageWriter =
                 new MessageWriter(
                     this.networkStream,
-                    messageSerializer);
+                    messageSerializer,
+                    this.logger);
         }
 
         protected override void Shutdown()
@@ -47,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 #endif
                 this.tcpClient = null;
 
-                Logger.Write(LogLevel.Verbose, "TCP client has been closed");
+                this.logger.Write(LogLevel.Verbose, "TCP client has been closed");
             }
         }
     }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/TcpSocketServerListener.cs
@@ -13,15 +13,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 {
     public class TcpSocketServerListener : ServerListenerBase<TcpSocketServerChannel>
     {
+        private ILogger logger;
         private int portNumber;
         private TcpListener tcpListener;
 
         public TcpSocketServerListener(
             MessageProtocolType messageProtocolType,
-            int portNumber)
+            int portNumber,
+            ILogger logger)
                 : base(messageProtocolType)
         {
             this.portNumber = portNumber;
+            this.logger = logger;
         }
 
         public override void Start()
@@ -43,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
                 this.tcpListener.Stop();
                 this.tcpListener = null;
 
-                Logger.Write(LogLevel.Verbose, "TCP listener has been stopped");
+                this.logger.Write(LogLevel.Verbose, "TCP listener has been stopped");
             }
         }
 
@@ -57,11 +60,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
                         TcpClient tcpClient = await this.tcpListener.AcceptTcpClientAsync();
                         this.OnClientConnect(
                             new TcpSocketServerChannel(
-                                tcpClient));
+                                tcpClient,
+                                this.logger));
                     }
                     catch (Exception e)
                     {
-                        Logger.WriteException(
+                        this.logger.WriteException(
                             "An unhandled exception occurred while listening for a TCP client connection",
                             e);
 

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
@@ -17,11 +17,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
     {
         #region Fields
 
+        private ILogger logger;
+
         private Dictionary<string, Func<Message, MessageWriter, Task>> requestHandlers =
             new Dictionary<string, Func<Message, MessageWriter, Task>>();
 
         private Dictionary<string, Func<Message, MessageWriter, Task>> eventHandlers =
             new Dictionary<string, Func<Message, MessageWriter, Task>>();
+
+        #endregion
+
+        #region Constructors
+
+        public MessageDispatcher(ILogger logger)
+        {
+            this.logger = logger;
+        }
 
         #endregion
 
@@ -126,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 else
                 {
                     // TODO: Message not supported error
-                    Logger.Write(LogLevel.Error, $"MessageDispatcher: No handler registered for Request type '{messageToDispatch.Method}'");
+                    this.logger.Write(LogLevel.Error, $"MessageDispatcher: No handler registered for Request type '{messageToDispatch.Method}'");
                 }
             }
             else if (messageToDispatch.MessageType == MessageType.Event)
@@ -139,13 +150,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 else
                 {
                     // TODO: Message not supported error
-                    Logger.Write(LogLevel.Error, $"MessageDispatcher: No handler registered for Event type '{messageToDispatch.Method}'");
+                    this.logger.Write(LogLevel.Error, $"MessageDispatcher: No handler registered for Event type '{messageToDispatch.Method}'");
                 }
             }
             else
             {
                 // TODO: Return message not supported
-                Logger.Write(LogLevel.Error, $"MessageDispatcher received unknown message type of method '{messageToDispatch.Method}'");
+                this.logger.Write(LogLevel.Error, $"MessageDispatcher received unknown message type of method '{messageToDispatch.Method}'");
             }
 
             if (handlerToAwait != null)

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
     {
         #region Private Fields
 
+        private ILogger logger;
         private Stream outputStream;
         private IMessageSerializer messageSerializer;
         private AsyncLock writeLock = new AsyncLock();
@@ -31,11 +32,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         public MessageWriter(
             Stream outputStream,
-            IMessageSerializer messageSerializer)
+            IMessageSerializer messageSerializer,
+            ILogger logger)
         {
             Validate.IsNotNull("streamWriter", outputStream);
             Validate.IsNotNull("messageSerializer", messageSerializer);
 
+            this.logger = logger;
             this.outputStream = outputStream;
             this.messageSerializer = messageSerializer;
         }
@@ -56,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     messageToWrite);
 
             // Log the JSON representation of the message
-            Logger.Write(
+            this.logger.Write(
                 LogLevel.Verbose,
                 string.Format(
                     "WRITE MESSAGE:\r\n\r\n{0}",

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -40,8 +40,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public DebugAdapter(
             EditorSession editorSession,
             ChannelBase serverChannel,
-            bool ownsEditorSession)
-                : base(serverChannel, new MessageDispatcher())
+            bool ownsEditorSession,
+            ILogger logger)
+                : base(serverChannel, new MessageDispatcher(logger), logger)
         {
             this.editorSession = editorSession;
             this.ownsEditorSession = ownsEditorSession;

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapterBase.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
@@ -14,11 +15,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
     {
         public DebugAdapterBase(
             ChannelBase serverChannel,
-            MessageDispatcher messageDispatcher)
+            MessageDispatcher messageDispatcher,
+            ILogger logger)
             : base(
                 serverChannel,
                 messageDispatcher,
-                MessageProtocolType.DebugAdapter)
+                MessageProtocolType.DebugAdapter,
+                logger)
         {
         }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -49,8 +49,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         /// </param>
         public LanguageServer(
             EditorSession editorSession,
-            ChannelBase serverChannel)
-            : base(serverChannel, new MessageDispatcher())
+            ChannelBase serverChannel,
+            ILogger logger)
+            : base(serverChannel, new MessageDispatcher(logger), logger)
         {
             this.editorSession = editorSession;
             this.editorSession.PowerShellContext.RunspaceChanged += PowerShellContext_RunspaceChanged;
@@ -560,7 +561,8 @@ function __Expand-Alias {
 
             this.currentSettings.Update(
                 configChangeParams.Settings.Powershell,
-                this.editorSession.Workspace.WorkspacePath);
+                this.editorSession.Workspace.WorkspacePath,
+                this.Logger);
 
             if (!this.profilesLoaded &&
                 this.currentSettings.EnableProfileLoading &&
@@ -1342,6 +1344,7 @@ function __Expand-Alias {
                         this.codeActionsPerFile,
                         editorSession,
                         eventSender,
+                        this.Logger,
                         existingRequestCancellation.Token),
                 CancellationToken.None,
                 TaskCreationOptions.None,
@@ -1357,6 +1360,7 @@ function __Expand-Alias {
             Dictionary<string, Dictionary<string, MarkerCorrection>> correctionIndex,
             EditorSession editorSession,
             EventContext eventContext,
+            ILogger Logger,
             CancellationToken cancellationToken)
         {
             await DelayThenInvokeDiagnostics(
@@ -1366,6 +1370,7 @@ function __Expand-Alias {
                 correctionIndex,
                 editorSession,
                 eventContext.SendEvent,
+                Logger,
                 cancellationToken);
         }
 
@@ -1377,6 +1382,7 @@ function __Expand-Alias {
             Dictionary<string, Dictionary<string, MarkerCorrection>> correctionIndex,
             EditorSession editorSession,
             Func<NotificationType<PublishDiagnosticsNotification, object>, PublishDiagnosticsNotification, Task> eventSender,
+            ILogger Logger,
             CancellationToken cancellationToken)
         {
             // First of all, wait for the desired delay period before

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerBase.cs
@@ -6,6 +6,7 @@
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel;
+using Microsoft.PowerShell.EditorServices.Utility;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Server
@@ -16,11 +17,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         public LanguageServerBase(
             ChannelBase serverChannel,
-            MessageDispatcher messageDispatcher)
+            MessageDispatcher messageDispatcher,
+            ILogger logger)
             : base(
                 serverChannel,
                 messageDispatcher,
-                MessageProtocolType.LanguageServer)
+                MessageProtocolType.LanguageServer,
+                logger)
         {
             this.serverChannel = serverChannel;
         }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -19,12 +19,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.ScriptAnalysis = new ScriptAnalysisSettings();
         }
 
-        public void Update(LanguageServerSettings settings, string workspaceRootPath)
+        public void Update(
+            LanguageServerSettings settings,
+            string workspaceRootPath,
+            ILogger logger)
         {
             if (settings != null)
             {
                 this.EnableProfileLoading = settings.EnableProfileLoading;
-                this.ScriptAnalysis.Update(settings.ScriptAnalysis, workspaceRootPath);
+                this.ScriptAnalysis.Update(
+                    settings.ScriptAnalysis,
+                    workspaceRootPath,
+                    logger);
             }
         }
     }
@@ -40,7 +46,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.Enable = true;
         }
 
-        public void Update(ScriptAnalysisSettings settings, string workspaceRootPath)
+        public void Update(
+            ScriptAnalysisSettings settings,
+            string workspaceRootPath,
+            ILogger logger)
         {
             if (settings != null)
             {
@@ -62,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         // In this case we should just log an error and let
                         // the specified settings path go through even though
                         // it will fail to load.
-                        Logger.Write(
+                        logger.Write(
                             LogLevel.Error,
                             "Could not resolve Script Analyzer settings path due to null or empty workspaceRootPath.");
                     }

--- a/src/PowerShellEditorServices.Protocol/Server/PromptHandlers.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/PromptHandlers.cs
@@ -31,7 +31,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             return new ProtocolChoicePromptHandler(
                 this.messageSender,
-                this.consoleService);
+                this.consoleService,
+                Logger.CurrentLogger);
         }
 
         public InputPromptHandler GetInputPromptHandler()
@@ -50,8 +51,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         public ProtocolChoicePromptHandler(
             IMessageSender messageSender,
-            ConsoleService consoleService)
-                : base(consoleService)
+            ConsoleService consoleService,
+            ILogger logger)
+                : base(consoleService, logger)
         {
             this.messageSender = messageSender;
             this.consoleService = consoleService;
@@ -131,7 +133,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public ProtocolInputPromptHandler(
             IMessageSender messageSender,
             ConsoleService consoleService)
-                : base(consoleService)
+                : base(
+                    consoleService,
+                    Microsoft.PowerShell.EditorServices.Utility.Logger.CurrentLogger)
         {
             this.messageSender = messageSender;
             this.consoleService = consoleService;

--- a/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -46,6 +47,14 @@ namespace Microsoft.PowerShell.EditorServices.Console
             new TaskCompletionSource<Dictionary<string, object>>();
 
         #endregion
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public ChoicePromptHandler(ILogger logger) : base(logger)
+        {
+        }
 
         #region Properties
 

--- a/src/PowerShellEditorServices/Console/ConsoleChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleChoicePromptHandler.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -30,7 +31,9 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// The IConsoleHost implementation to use for writing to the
         /// console.
         /// </param>
-        public ConsoleChoicePromptHandler(IConsoleHost consoleHost)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public ConsoleChoicePromptHandler(IConsoleHost consoleHost, ILogger logger)
+            : base(logger)
         {
             this.consoleHost = consoleHost;
         }

--- a/src/PowerShellEditorServices/Console/ConsoleInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleInputPromptHandler.cs
@@ -7,6 +7,7 @@ using System;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -31,7 +32,9 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// The IConsoleHost implementation to use for writing to the
         /// console.
         /// </param>
-        public ConsoleInputPromptHandler(IConsoleHost consoleHost)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public ConsoleInputPromptHandler(IConsoleHost consoleHost, ILogger logger)
+            : base(logger)
         {
             this.consoleHost = consoleHost;
         }

--- a/src/PowerShellEditorServices/Console/ConsolePromptHandlerContext.cs
+++ b/src/PowerShellEditorServices/Console/ConsolePromptHandlerContext.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -15,6 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
     {
         #region Private Fields
 
+        private ILogger logger;
         private IConsoleHost consoleHost;
 
         #endregion
@@ -29,9 +31,13 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// The IConsoleHost implementation to use for writing to the
         /// console.
         /// </param>
-        public ConsolePromptHandlerContext(IConsoleHost consoleHost)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public ConsolePromptHandlerContext(
+            IConsoleHost consoleHost,
+            ILogger logger)
         {
             this.consoleHost = consoleHost;
+            this.logger = logger;
         }
 
         #endregion
@@ -47,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// </returns>
         public ChoicePromptHandler GetChoicePromptHandler()
         {
-            return new ConsoleChoicePromptHandler(this.consoleHost);
+            return new ConsoleChoicePromptHandler(this.consoleHost, this.logger);
         }
 
         /// <summary>
@@ -59,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// </returns>
         public InputPromptHandler GetInputPromptHandler()
         {
-            return new ConsoleInputPromptHandler(this.consoleHost);
+            return new ConsoleInputPromptHandler(this.consoleHost, this.logger);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Console/ConsoleService.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleService.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             if (defaultPromptHandlerContext == null)
             {
                 defaultPromptHandlerContext =
-                    new ConsolePromptHandlerContext(this);
+                    new ConsolePromptHandlerContext(this, Logger.CurrentLogger);
             }
 
             this.promptHandlerContextStack.Push(
@@ -288,7 +288,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                 }
                 else
                 {
-                    Logger.Write(LogLevel.Verbose, "InnerStartReadLoop called while read loop is already running");
+                    Logger.CurrentLogger.Write(LogLevel.Verbose, "InnerStartReadLoop called while read loop is already running");
                 }
             }
         }
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                         true,
                         OutputType.Error);
 
-                    Logger.WriteException("Caught exception while reading command line", e);
+                    Logger.CurrentLogger.WriteException("Caught exception while reading command line", e);
                 }
 
                 if (commandString != null)
@@ -434,7 +434,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         {
             if (this.activePromptHandler != null)
             {
-                Logger.Write(
+                Logger.CurrentLogger.Write(
                     LogLevel.Error,
                     "Prompt handler requested while another prompt is already active.");
             }

--- a/src/PowerShellEditorServices/Console/FieldDetails.cs
+++ b/src/PowerShellEditorServices/Console/FieldDetails.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// complete.
         /// </summary>
         /// <returns>The field's final value.</returns>
-        public object GetValue()
+        public object GetValue(ILogger logger)
         {
             object fieldValue = this.OnGetValue();
 
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                 else
                 {
                     // This "shoudln't" happen, so log in case it does
-                    Logger.Write(
+                    logger.Write(
                         LogLevel.Error,
                         $"Cannot retrieve value for field {this.Label}");
                 }
@@ -170,9 +170,14 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
         #region Internal Methods
 
-        internal static FieldDetails Create(FieldDescription fieldDescription)
+        internal static FieldDetails Create(
+            FieldDescription fieldDescription,
+            ILogger logger)
         {
-            Type fieldType = GetFieldTypeFromTypeName(fieldDescription.ParameterAssemblyFullName);
+            Type fieldType =
+                GetFieldTypeFromTypeName(
+                    fieldDescription.ParameterAssemblyFullName,
+                    logger);
 
             if (typeof(IList).GetTypeInfo().IsAssignableFrom(fieldType.GetTypeInfo()))
             {
@@ -203,15 +208,17 @@ namespace Microsoft.PowerShell.EditorServices.Console
             }
         }
 
-        private static Type GetFieldTypeFromTypeName(string assemblyFullName)
+        private static Type GetFieldTypeFromTypeName(
+            string assemblyFullName,
+            ILogger logger)
         {
-            Type fieldType = typeof(string); 
+            Type fieldType = typeof(string);
 
             if (!string.IsNullOrEmpty(assemblyFullName))
             {
                 if (!LanguagePrimitives.TryConvertTo<Type>(assemblyFullName, out fieldType))
                 {
-                    Logger.Write(
+                    logger.Write(
                         LogLevel.Warning,
                         string.Format(
                             "Could not resolve type of field: {0}",

--- a/src/PowerShellEditorServices/Console/InputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/InputPromptHandler.cs
@@ -10,6 +10,7 @@ using System.Management.Automation;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -30,6 +31,14 @@ namespace Microsoft.PowerShell.EditorServices.Console
             new TaskCompletionSource<Dictionary<string, object>>();
 
         #endregion
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public InputPromptHandler(ILogger logger) : base(logger)
+        {
+        }
 
         #region Properties
 
@@ -312,7 +321,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
             foreach (FieldDetails field in this.Fields)
             {
-                fieldValues.Add(field.OriginalName, field.GetValue());
+                fieldValues.Add(field.OriginalName, field.GetValue(this.Logger));
             }
 
             return fieldValues;
@@ -321,4 +330,3 @@ namespace Microsoft.PowerShell.EditorServices.Console
         #endregion
     }
 }
-

--- a/src/PowerShellEditorServices/Console/PromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/PromptHandler.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Console
 {
@@ -12,6 +13,20 @@ namespace Microsoft.PowerShell.EditorServices.Console
     /// </summary>
     public abstract class PromptHandler
     {
+        /// <summary>
+        /// Gets the ILogger used for this instance.
+        /// </summary>
+        protected ILogger Logger { get; private set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public PromptHandler(ILogger logger)
+        {
+            this.Logger = logger;
+        }
+
         /// <summary>
         /// Called when the active prompt should be cancelled.
         /// </summary>

--- a/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableContainerDetails.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Returns the details of the variable container's children.  If empty, returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public override VariableDetailsBase[] GetChildren()
+        public override VariableDetailsBase[] GetChildren(ILogger logger)
         {
             var variablesArray = new VariableDetailsBase[this.children.Count];
             this.children.Values.CopyTo(variablesArray, 0);

--- a/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Utility;
+
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>
-    /// Defines the common details between a variable and a variable container such as a scope 
+    /// Defines the common details between a variable and a variable container such as a scope
     /// in the current debugging session.
     /// </summary>
     public abstract class VariableDetailsBase
@@ -47,6 +49,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// details of its children.  Otherwise it returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public abstract VariableDetailsBase[] GetChildren();
+        public abstract VariableDetailsBase[] GetChildren(ILogger logger);
     }
 }

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="powerShellContext">
         /// The PowerShellContext to use for gathering completions.
         /// </param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         /// <param name="cancellationToken">
         /// A CancellationToken to cancel completion requests.
         /// </param>
@@ -51,6 +52,7 @@ namespace Microsoft.PowerShell.EditorServices
             Token[] currentTokens,
             int fileOffset,
             PowerShellContext powerShellContext,
+            ILogger logger,
             CancellationToken cancellationToken)
         {
             var type = scriptAst.Extent.StartScriptPosition.GetType();
@@ -72,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices
                     scriptAst.Extent.StartScriptPosition,
                     new object[] { fileOffset });
 
-            Logger.Write(
+            logger.Write(
                 LogLevel.Verbose,
                 string.Format(
                     "Getting completions at offset {0} (line: {1}, column: {2})",
@@ -99,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices
                     ErrorRecord errorRecord = outputObject.BaseObject as ErrorRecord;
                     if (errorRecord != null)
                     {
-                        Logger.WriteException(
+                        logger.WriteException(
                             "Encountered an error while invoking TabExpansion2 in the debugger",
                             errorRecord.Exception);
                     }
@@ -130,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices
 
                     stopwatch.Stop();
 
-                    Logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
+                    logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
                 }
             }
 

--- a/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
@@ -79,7 +79,8 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
 
         public static DscBreakpointCapability CheckForCapability(
             RunspaceDetails runspaceDetails,
-            PowerShellContext powerShellContext)
+            PowerShellContext powerShellContext,
+            ILogger logger)
         {
             DscBreakpointCapability capability = null;
 
@@ -103,12 +104,12 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
                     }
                     catch (CmdletInvocationException e)
                     {
-                        Logger.WriteException("Could not load the DSC module!", e);
+                        logger.WriteException("Could not load the DSC module!", e);
                     }
 
                     if (moduleInfo != null)
                     {
-                        Logger.Write(LogLevel.Verbose, "Side-by-side DSC module found, gathering DSC resource paths...");
+                        logger.Write(LogLevel.Verbose, "Side-by-side DSC module found, gathering DSC resource paths...");
 
                         // The module was loaded, add the breakpoint capability
                         capability = new DscBreakpointCapability();
@@ -132,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
                         }
                         catch (CmdletInvocationException e)
                         {
-                            Logger.WriteException("Get-DscResource failed!", e);
+                            logger.WriteException("Get-DscResource failed!", e);
                         }
 
                         if (resourcePaths != null)
@@ -142,16 +143,16 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
                                     .Select(o => (string)o.BaseObject)
                                     .ToArray();
 
-                            Logger.Write(LogLevel.Verbose, $"DSC resources found: {resourcePaths.Count}");
+                            logger.Write(LogLevel.Verbose, $"DSC resources found: {resourcePaths.Count}");
                         }
                         else
                         {
-                            Logger.Write(LogLevel.Verbose, $"No DSC resources found.");
+                            logger.Write(LogLevel.Verbose, $"No DSC resources found.");
                         }
                     }
                     else
                     {
-                        Logger.Write(LogLevel.Verbose, $"Side-by-side DSC module was not found.");
+                        logger.Write(LogLevel.Verbose, $"Side-by-side DSC module was not found.");
                     }
                 }
             }

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -18,6 +18,12 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     public class EditorSession
     {
+        #region Private Fields
+
+        private ILogger logger;
+
+        #endregion
+
         #region Properties
 
         /// <summary>
@@ -73,6 +79,19 @@ namespace Microsoft.PowerShell.EditorServices
 
         #endregion
 
+        #region Constructors
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public EditorSession(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        #endregion
+
         #region Public Methods
 
         /// <summary>
@@ -90,14 +109,14 @@ namespace Microsoft.PowerShell.EditorServices
             this.ConsoleService = consoleService;
             this.UsesConsoleHost = this.ConsoleService.EnableConsoleRepl;
 
-            this.LanguageService = new LanguageService(this.PowerShellContext);
+            this.LanguageService = new LanguageService(this.PowerShellContext, this.logger);
             this.ExtensionService = new ExtensionService(this.PowerShellContext);
-            this.TemplateService = new TemplateService(this.PowerShellContext);
+            this.TemplateService = new TemplateService(this.PowerShellContext, this.logger);
 
             this.InstantiateAnalysisService();
 
             // Create a workspace to contain open files
-            this.Workspace = new Workspace(this.PowerShellContext.LocalPowerShellVersion.Version);
+            this.Workspace = new Workspace(this.PowerShellContext.LocalPowerShellVersion.Version, this.logger);
         }
 
         /// <summary>
@@ -118,11 +137,11 @@ namespace Microsoft.PowerShell.EditorServices
             this.PowerShellContext = powerShellContext;
             this.ConsoleService = consoleService;
 
-            this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations);
-            this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager);
+            this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations, logger);
+            this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager, logger);
 
             // Create a workspace to contain open files
-            this.Workspace = new Workspace(this.PowerShellContext.LocalPowerShellVersion.Version);
+            this.Workspace = new Workspace(this.PowerShellContext.LocalPowerShellVersion.Version, this.logger);
         }
 
         /// <summary>
@@ -135,8 +154,8 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (this.DebugService == null)
             {
-                this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations);
-                this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager);
+                this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations, logger);
+                this.DebugService = new DebugService(this.PowerShellContext, this.RemoteFileManager, logger);
             }
         }
 
@@ -146,11 +165,11 @@ namespace Microsoft.PowerShell.EditorServices
             // Script Analyzer binaries are not included.
             try
             {
-                this.AnalysisService = new AnalysisService(settingsPath);
+                this.AnalysisService = new AnalysisService(settingsPath, this.logger);
             }
             catch (FileNotFoundException)
             {
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Warning,
                     "Script Analyzer binaries not found, AnalysisService will be disabled.");
             }

--- a/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// Gets the version of the PowerShell runtime.
         /// </summary>
         public Version Version { get; private set; }
-        
+
         /// <summary>
         /// Gets the full version string, either the ToString of the Version
         /// property or the GitCommitId for open-source PowerShell releases.
@@ -90,8 +90,9 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// Gets the PowerShell version details for the given runspace.
         /// </summary>
         /// <param name="runspace">The runspace for which version details will be gathered.</param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         /// <returns>A new PowerShellVersionDetails instance.</returns>
-        public static PowerShellVersionDetails GetVersionDetails(Runspace runspace)
+        public static PowerShellVersionDetails GetVersionDetails(Runspace runspace, ILogger logger)
         {
             Version powerShellVersion = new Version(5, 0);
             string versionString = null;
@@ -149,7 +150,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             }
             catch (Exception ex)
             {
-                Logger.Write(
+                logger.Write(
                     LogLevel.Warning,
                     "Failed to look up PowerShell version, defaulting to version 5.\r\n\r\n" + ex.ToString());
             }

--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
     {
         #region Fields
 
+        private ILogger logger;
         private string remoteFilesPath;
         private string processTempPath;
         private PowerShellContext powerShellContext;
@@ -100,12 +101,15 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// <param name="editorOperations">
         /// The IEditorOperations instance to use for opening/closing files in the editor.
         /// </param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         public RemoteFileManager(
             PowerShellContext powerShellContext,
-            IEditorOperations editorOperations)
+            IEditorOperations editorOperations,
+            ILogger logger)
         {
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
+            this.logger = logger;
             this.powerShellContext = powerShellContext;
             this.powerShellContext.RunspaceChanged += HandleRunspaceChanged;
 
@@ -176,7 +180,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                             }
                             else
                             {
-                                Logger.Write(
+                                this.logger.Write(
                                     LogLevel.Warning,
                                     $"Could not load contents of remote file '{remoteFilePath}'");
                             }
@@ -185,7 +189,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 }
                 catch (IOException e)
                 {
-                    Logger.Write(
+                    this.logger.Write(
                         LogLevel.Error,
                         $"Caught {e.GetType().Name} while attempting to get remote file at path '{remoteFilePath}'\r\n\r\n{e.ToString()}");
                 }
@@ -211,7 +215,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     localFilePath,
                     this.powerShellContext.CurrentRunspace);
 
-            Logger.Write(
+            this.logger.Write(
                 LogLevel.Verbose,
                 $"Saving remote file {remoteFilePath} (local path: {localFilePath})");
 
@@ -222,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             }
             catch (IOException e)
             {
-                Logger.WriteException(
+                this.logger.WriteException(
                     "Failed to read contents of local copy of remote file",
                     e);
 
@@ -245,7 +249,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
 
             if (errorMessages.Length > 0)
             {
-                Logger.Write(LogLevel.Error, $"Remote file save failed due to an error:\r\n\r\n{errorMessages}");
+                this.logger.Write(LogLevel.Error, $"Remote file save failed due to an error:\r\n\r\n{errorMessages}");
             }
         }
 
@@ -276,7 +280,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             }
             catch (IOException e)
             {
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Error,
                     $"Caught {e.GetType().Name} while attempting to write temporary file at path '{temporaryFilePath}'\r\n\r\n{e.ToString()}");
 
@@ -432,7 +436,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 }
                 catch (NullReferenceException e)
                 {
-                    Logger.WriteException("Could not store null remote file content", e);
+                    this.logger.WriteException("Could not store null remote file content", e);
                 }
             }
         }
@@ -474,7 +478,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 }
                 catch (RemoteException e)
                 {
-                    Logger.WriteException("Could not create psedit function.", e);
+                    this.logger.WriteException("Could not create psedit function.", e);
                 }
             }
         }
@@ -503,7 +507,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 }
                 catch (Exception e) when (e is RemoteException || e is PSInvalidOperationException)
                 {
-                    Logger.WriteException("Could not remove psedit function.", e);
+                    this.logger.WriteException("Could not remove psedit function.", e);
                 }
             }
         }
@@ -521,7 +525,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             }
             catch (IOException e)
             {
-                Logger.WriteException(
+                this.logger.WriteException(
                     $"Could not delete temporary folder for current process: {this.processTempPath}", e);
             }
         }

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -183,10 +183,12 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// <param name="sessionDetails">
         /// The SessionDetails for the runspace.
         /// </param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         /// <returns>A new RunspaceDetails instance.</returns>
         internal static RunspaceDetails CreateFromRunspace(
             Runspace runspace,
-            SessionDetails sessionDetails)
+            SessionDetails sessionDetails,
+            ILogger logger)
         {
             Validate.IsNotNull(nameof(runspace), runspace);
             Validate.IsNotNull(nameof(sessionDetails), sessionDetails);
@@ -194,7 +196,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             var runspaceId = runspace.InstanceId;
             var runspaceLocation = RunspaceLocation.Local;
             var runspaceContext = RunspaceContext.Original;
-            var versionDetails = PowerShellVersionDetails.GetVersionDetails(runspace);
+            var versionDetails = PowerShellVersionDetails.GetVersionDetails(runspace, logger);
 
             string connectionString = null;
 

--- a/src/PowerShellEditorServices/Session/SessionPSHost.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHost.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void EnterNestedPrompt()
         {
-            Logger.Write(LogLevel.Verbose, "EnterNestedPrompt() called.");
+            Logger.CurrentLogger.Write(LogLevel.Verbose, "EnterNestedPrompt() called.");
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void ExitNestedPrompt()
         {
-            Logger.Write(LogLevel.Verbose, "ExitNestedPrompt() called.");
+            Logger.CurrentLogger.Write(LogLevel.Verbose, "ExitNestedPrompt() called.");
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void NotifyBeginApplication()
         {
-            Logger.Write(LogLevel.Verbose, "NotifyBeginApplication() called.");
+            Logger.CurrentLogger.Write(LogLevel.Verbose, "NotifyBeginApplication() called.");
             this.isNativeApplicationRunning = true;
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void NotifyEndApplication()
         {
-            Logger.Write(LogLevel.Verbose, "NotifyEndApplication() called.");
+            Logger.CurrentLogger.Write(LogLevel.Verbose, "NotifyEndApplication() called.");
             this.isNativeApplicationRunning = false;
         }
 

--- a/src/PowerShellEditorServices/Session/SessionPSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostRawUserInterface.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A KeyInfo struct with details about the current keypress.</returns>
         public override KeyInfo ReadKey(ReadKeyOptions options)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.ReadKey was called");
 
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void FlushInputBuffer()
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.FlushInputBuffer was called");
         }
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A BufferCell array with the requested buffer contents.</returns>
         public override BufferCell[,] GetBufferContents(Rectangle rectangle)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.GetBufferContents was called");
 
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell.EditorServices
             Rectangle clip,
             BufferCell fill)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.ScrollBufferContents was called");
         }
@@ -236,7 +236,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
             else
             {
-                Logger.Write(
+                Logger.CurrentLogger.Write(
                     LogLevel.Warning,
                     "PSHostRawUserInterface.SetBufferContents was called with a specific region");
             }
@@ -251,7 +251,7 @@ namespace Microsoft.PowerShell.EditorServices
             Coordinates origin,
             BufferCell[,] contents)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.SetBufferContents was called");
         }

--- a/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SessionPSHostUserInterface.cs
@@ -13,6 +13,7 @@ using System.Security;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Console;
 using System.Threading;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -89,7 +90,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 FieldDetails[] fields =
                     fieldDescriptions
-                        .Select(FieldDetails.Create)
+                        .Select(f => { return FieldDetails.Create(f, Logger.CurrentLogger); })
                         .ToArray();
 
                 CancellationTokenSource cancellationToken = new CancellationTokenSource();

--- a/src/PowerShellEditorServices/Session/SimplePSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/SimplePSHostRawUserInterface.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A KeyInfo struct with details about the current keypress.</returns>
         public override KeyInfo ReadKey(ReadKeyOptions options)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.ReadKey was called");
 
@@ -171,7 +171,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public override void FlushInputBuffer()
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.FlushInputBuffer was called");
         }
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A BufferCell array with the requested buffer contents.</returns>
         public override BufferCell[,] GetBufferContents(Rectangle rectangle)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.GetBufferContents was called");
 
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.EditorServices
             Rectangle clip,
             BufferCell fill)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.ScrollBufferContents was called");
         }
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.EditorServices
             Rectangle rectangle,
             BufferCell fill)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.SetBufferContents was called");
         }
@@ -231,7 +231,7 @@ namespace Microsoft.PowerShell.EditorServices
             Coordinates origin,
             BufferCell[,] contents)
         {
-            Logger.Write(
+            Logger.CurrentLogger.Write(
                 LogLevel.Warning,
                 "PSHostRawUserInterface.SetBufferContents was called");
         }

--- a/src/PowerShellEditorServices/Templates/TemplateService.cs
+++ b/src/PowerShellEditorServices/Templates/TemplateService.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
     {
         #region Private Fields
 
+        private ILogger logger;
         private bool isPlasterLoaded;
         private bool? isPlasterInstalled;
         private PowerShellContext powerShellContext;
@@ -32,10 +33,12 @@ namespace Microsoft.PowerShell.EditorServices.Templates
         /// Creates a new instance of the TemplateService class.
         /// </summary>
         /// <param name="powerShellContext">The PowerShellContext to use for this service.</param>
-        public TemplateService(PowerShellContext powerShellContext)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public TemplateService(PowerShellContext powerShellContext, ILogger logger)
         {
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
+            this.logger = logger;
             this.powerShellContext = powerShellContext;
         }
 
@@ -67,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
                     .AddCommand("Select-Object")
                     .AddParameter("First", 1);
 
-                Logger.Write(LogLevel.Verbose, "Checking if Plaster is installed...");
+                this.logger.Write(LogLevel.Verbose, "Checking if Plaster is installed...");
 
                 var getResult =
                     await this.powerShellContext.ExecuteCommand<PSObject>(
@@ -75,18 +78,18 @@ namespace Microsoft.PowerShell.EditorServices.Templates
 
                 PSObject moduleObject = getResult.First();
                 this.isPlasterInstalled = moduleObject != null;
-                string installedQualifier = 
+                string installedQualifier =
                     this.isPlasterInstalled.Value
                         ? string.Empty : "not ";
 
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Verbose,
                     $"Plaster is {installedQualifier}installed!");
 
                 // Attempt to load plaster
                 if (this.isPlasterInstalled.Value && this.isPlasterLoaded == false)
                 {
-                    Logger.Write(LogLevel.Verbose, "Loading Plaster...");
+                    this.logger.Write(LogLevel.Verbose, "Loading Plaster...");
 
                     psCommand = new PSCommand();
                     psCommand
@@ -103,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
                         this.isPlasterInstalled.Value
                             ? "was" : "could not be";
 
-                    Logger.Write(
+                    this.logger.Write(
                         LogLevel.Verbose,
                         $"Plaster {loadedQualifier} loaded successfully!");
                 }
@@ -141,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
                 await this.powerShellContext.ExecuteCommand<PSObject>(
                     psCommand, false, false);
 
-            Logger.Write(
+            this.logger.Write(
                 LogLevel.Verbose,
                 $"Found {templateObjects.Count()} Plaster templates");
 
@@ -163,7 +166,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
             string templatePath,
             string destinationPath)
         {
-            Logger.Write(
+            this.logger.Write(
                 LogLevel.Verbose,
                 $"Invoking Plaster...\n\n    TemplatePath: {templatePath}\n    DestinationPath: {destinationPath}");
 

--- a/src/PowerShellEditorServices/Utility/AsyncContext.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncContext.cs
@@ -23,7 +23,8 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// The Task-returning Func which represents the "main" function
         /// for the thread.
         /// </param>
-        public static void Start(Func<Task> asyncMainFunc)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public static void Start(Func<Task> asyncMainFunc, ILogger logger)
         {
             // Is there already a synchronization context?
             if (SynchronizationContext.Current != null)
@@ -33,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             }
 
             // Create and register a synchronization context for this thread
-            var threadSyncContext = new ThreadSynchronizationContext();
+            var threadSyncContext = new ThreadSynchronizationContext(logger);
             SynchronizationContext.SetSynchronizationContext(threadSyncContext);
 
             // Get the main task and act on its completion

--- a/src/PowerShellEditorServices/Utility/AsyncContextThread.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncContextThread.cs
@@ -47,10 +47,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="taskReturningFunc">
         /// A Func which returns the task to be run on the thread.
         /// </param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         /// <returns>
         /// A Task which can be used to monitor the thread for completion.
         /// </returns>
-        public Task Run(Func<Task> taskReturningFunc)
+        public Task Run(Func<Task> taskReturningFunc, ILogger logger)
         {
             // Start up a long-running task with the action as the
             // main entry point for the thread
@@ -62,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                         Thread.CurrentThread.Name = "AsyncContextThread: " + this.threadName;
 
                         // Set up an AsyncContext to run the task
-                        AsyncContext.Start(taskReturningFunc);
+                        AsyncContext.Start(taskReturningFunc, logger);
                     },
                     this.threadCancellationToken.Token,
                     TaskCreationOptions.LongRunning,

--- a/src/PowerShellEditorServices/Utility/FileLogger.cs
+++ b/src/PowerShellEditorServices/Utility/FileLogger.cs
@@ -1,0 +1,174 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides an implementation of ILogger for writing messages to
+    /// a log file on disk.
+    /// </summary>
+    public class FileLogger : ILogger, IDisposable
+    {
+        private TextWriter textWriter;
+        private LogLevel minimumLogLevel = LogLevel.Verbose;
+
+        /// <summary>
+        /// Creates an ILogger implementation that writes to the specified file.
+        /// </summary>
+        /// <param name="logFilePath">
+        /// Specifies the path at which log messages will be written.
+        /// </param>
+        /// <param name="minimumLogLevel">
+        /// Specifies the minimum log message level to write to the log file.
+        /// </param>
+        public FileLogger(string logFilePath, LogLevel minimumLogLevel)
+        {
+            this.minimumLogLevel = minimumLogLevel;
+
+            // Ensure that we have a usable log file path
+            if (!Path.IsPathRooted(logFilePath))
+            {
+                logFilePath =
+                    Path.Combine(
+#if CoreCLR
+                        AppContext.BaseDirectory,
+#else
+                        AppDomain.CurrentDomain.BaseDirectory,
+#endif
+                        logFilePath);
+            }
+
+            if (!this.TryOpenLogFile(logFilePath))
+            {
+                // If the log file couldn't be opened at this location,
+                // try opening it in a more reliable path
+                this.TryOpenLogFile(
+                    Path.Combine(
+#if CoreCLR
+                        Environment.GetEnvironmentVariable("TEMP"),
+#else
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+#endif
+                        Path.GetFileName(logFilePath)));
+            }
+        }
+
+        /// <summary>
+        /// Writes a message to the log file.
+        /// </summary>
+        /// <param name="logLevel">The level at which the message will be written.</param>
+        /// <param name="logMessage">The message text to be written.</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public void Write(
+            LogLevel logLevel,
+            string logMessage,
+            string callerName = null,
+            string callerSourceFile = null,
+            int callerLineNumber = 0)
+        {
+            if (this.textWriter != null &&
+                logLevel >= this.minimumLogLevel)
+            {
+                // Print the timestamp and log level
+                this.textWriter.WriteLine(
+                    "{0} [{1}] - Method \"{2}\" at line {3} of {4}\r\n",
+                    DateTime.Now,
+                    logLevel.ToString().ToUpper(),
+                    callerName,
+                    callerLineNumber,
+                    callerSourceFile);
+
+                // Print out indented message lines
+                foreach (var messageLine in logMessage.Split('\n'))
+                {
+                    this.textWriter.WriteLine("    " + messageLine.TrimEnd());
+                }
+
+                // Finish with a newline and flush the writer
+                this.textWriter.WriteLine();
+                this.textWriter.Flush();
+            }
+        }
+
+        /// <summary>
+        /// Writes an error message and exception to the log file.
+        /// </summary>
+        /// <param name="errorMessage">The error message text to be written.</param>
+        /// <param name="errorException">The exception to be written..</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public void WriteException(
+            string errorMessage,
+            Exception errorException,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
+            this.Write(
+                LogLevel.Error,
+                $"{errorMessage}\r\n\r\n{errorException.ToString()}",
+                callerName,
+                callerSourceFile,
+                callerLineNumber);
+        }
+
+        /// <summary>
+        /// Flushes any remaining log write and closes the log file.
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.textWriter != null)
+            {
+                this.textWriter.Flush();
+                this.textWriter.Dispose();
+                this.textWriter = null;
+            }
+        }
+
+        private bool TryOpenLogFile(string logFilePath)
+        {
+            try
+            {
+                // Make sure the log directory exists
+                Directory.CreateDirectory(
+                    Path.GetDirectoryName(
+                        logFilePath));
+
+                // Open the log file for writing with UTF8 encoding
+                this.textWriter =
+                    new StreamWriter(
+                        new FileStream(
+                            logFilePath,
+                            FileMode.Create),
+                        Encoding.UTF8);
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                if (e is UnauthorizedAccessException ||
+                    e is IOException)
+                {
+                    // This exception is thrown when we can't open the file
+                    // at the path in logFilePath.  Return false to indicate
+                    // that the log file couldn't be created.
+                    return false;
+                }
+
+                // Unexpected exception, rethrow it
+                throw;
+            }
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Utility/ILogger.cs
+++ b/src/PowerShellEditorServices/Utility/ILogger.cs
@@ -1,0 +1,75 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Defines the level indicators for log messages.
+    /// </summary>
+    public enum LogLevel
+    {
+        /// <summary>
+        /// Indicates a verbose log message.
+        /// </summary>
+        Verbose,
+
+        /// <summary>
+        /// Indicates a normal, non-verbose log message.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// Indicates a warning message.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Indicates an error message.
+        /// </summary>
+        Error
+    }
+
+    /// <summary>
+    /// Defines an interface for writing messages to a logging implementation.
+    /// </summary>
+    public interface ILogger : IDisposable
+    {
+        /// <summary>
+        /// Writes a message to the log file.
+        /// </summary>
+        /// <param name="logLevel">The level at which the message will be written.</param>
+        /// <param name="logMessage">The message text to be written.</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        void Write(
+            LogLevel logLevel,
+            string logMessage,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0);
+
+        /// <summary>
+        /// Writes an error message and exception to the log file.
+        /// </summary>
+        /// <param name="errorMessage">The error message text to be written.</param>
+        /// <param name="errorException">The exception to be written..</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        void WriteException(
+            string errorMessage,
+            Exception errorException,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0);
+    }
+}

--- a/src/PowerShellEditorServices/Utility/Logger.cs
+++ b/src/PowerShellEditorServices/Utility/Logger.cs
@@ -3,12 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-
 namespace Microsoft.PowerShell.EditorServices.Utility
 {
     /// <summary>
@@ -17,7 +11,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     /// </summary>
     public static class Logger
     {
-        private static ILogger staticLogger;
+        /// <summary>
+        /// Gets the current static ILogger instance.  This property
+        /// is temporary and will be removed in an upcoming commit.
+        /// </summary>
+        public static ILogger CurrentLogger { get; private set; }
 
         /// <summary>
         /// Initializes the Logger for the current session.
@@ -25,17 +23,14 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="logger">
         /// Specifies the ILogger implementation to use for the static interface.
         /// </param>
-        /// <param name="minimumLogLevel">
-        /// Optional. Specifies the minimum log message level to write to the log file.
-        /// </param>
         public static void Initialize(ILogger logger)
         {
-            if (staticLogger != null)
+            if (CurrentLogger != null)
             {
-                staticLogger.Dispose();
+                CurrentLogger.Dispose();
             }
 
-            staticLogger = logger;
+            CurrentLogger = logger;
         }
 
         /// <summary>
@@ -43,98 +38,9 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         public static void Close()
         {
-            if (staticLogger != null)
+            if (CurrentLogger != null)
             {
-                staticLogger.Dispose();
-            }
-        }
-
-        /// <summary>
-        /// Writes a message to the log file.
-        /// </summary>
-        /// <param name="logLevel">The level at which the message will be written.</param>
-        /// <param name="logMessage">The message text to be written.</param>
-        /// <param name="callerName">The name of the calling method.</param>
-        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
-        /// <param name="callerLineNumber">The line number of the calling method.</param>
-        public static void Write(
-            LogLevel logLevel,
-            string logMessage,
-            [CallerMemberName] string callerName = null,
-            [CallerFilePath] string callerSourceFile = null,
-            [CallerLineNumber] int callerLineNumber = 0)
-        {
-            InnerWrite(
-                logLevel,
-                logMessage,
-                callerName,
-                callerSourceFile,
-                callerLineNumber);
-        }
-
-        /// <summary>
-        /// Writes an error message and exception to the log file.
-        /// </summary>
-        /// <param name="errorMessage">The error message text to be written.</param>
-        /// <param name="errorException">The exception to be written..</param>
-        /// <param name="callerName">The name of the calling method.</param>
-        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
-        /// <param name="callerLineNumber">The line number of the calling method.</param>
-        public static void WriteException(
-            string errorMessage,
-            Exception errorException,
-            [CallerMemberName] string callerName = null,
-            [CallerFilePath] string callerSourceFile = null,
-            [CallerLineNumber] int callerLineNumber = 0)
-        {
-            InnerWrite(
-                LogLevel.Error,
-                $"{errorMessage}\r\n\r\n{errorException.ToString()}",
-                callerName,
-                callerSourceFile,
-                callerLineNumber);
-        }
-
-        /// <summary>
-        /// Writes an error message and exception to the log file.
-        /// </summary>
-        /// <param name="logLevel">The level at which the message will be written.</param>
-        /// <param name="errorMessage">The error message text to be written.</param>
-        /// <param name="errorException">The exception to be written..</param>
-        /// <param name="callerName">The name of the calling method.</param>
-        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
-        /// <param name="callerLineNumber">The line number of the calling method.</param>
-        public static void WriteException(
-            LogLevel logLevel,
-            string errorMessage,
-            Exception errorException,
-            [CallerMemberName] string callerName = null,
-            [CallerFilePath] string callerSourceFile = null,
-            [CallerLineNumber] int callerLineNumber = 0)
-        {
-            InnerWrite(
-                logLevel,
-                $"{errorMessage}\r\n\r\n{errorException.ToString()}",
-                callerName,
-                callerSourceFile,
-                callerLineNumber);
-        }
-
-        private static void InnerWrite(
-            LogLevel logLevel,
-            string logMessage,
-            string callerName,
-            string callerSourceFile,
-            int callerLineNumber)
-        {
-            if (staticLogger != null)
-            {
-                staticLogger.Write(
-                    logLevel,
-                    logMessage,
-                    callerName,
-                    callerSourceFile,
-                    callerLineNumber);
+                CurrentLogger.Dispose();
             }
         }
     }

--- a/src/PowerShellEditorServices/Utility/NullLogger.cs
+++ b/src/PowerShellEditorServices/Utility/NullLogger.cs
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Provides an implementation of ILogger that throws away all log messages,
+    /// typically used when logging isn't needed.
+    /// </summary>
+    public class NullLogger : ILogger, IDisposable
+    {
+        /// <summary>
+        /// Writes a message to the log file.
+        /// </summary>
+        /// <param name="logLevel">The level at which the message will be written.</param>
+        /// <param name="logMessage">The message text to be written.</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public void Write(
+            LogLevel logLevel,
+            string logMessage,
+            string callerName = null,
+            string callerSourceFile = null,
+            int callerLineNumber = 0)
+        {
+        }
+
+        /// <summary>
+        /// Writes an error message and exception to the log file.
+        /// </summary>
+        /// <param name="errorMessage">The error message text to be written.</param>
+        /// <param name="errorException">The exception to be written..</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The source file path where the calling method exists.</param>
+        /// <param name="callerLineNumber">The line number of the calling method.</param>
+        public void WriteException(
+            string errorMessage,
+            Exception errorException,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
+        }
+
+        /// <summary>
+        /// Flushes any remaining log write and closes the log file.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Utility/ThreadSynchronizationContext.cs
+++ b/src/PowerShellEditorServices/Utility/ThreadSynchronizationContext.cs
@@ -18,12 +18,26 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     {
         #region Private Fields
 
+        private ILogger logger;
         private BlockingCollection<Tuple<SendOrPostCallback, object>> requestQueue =
             new BlockingCollection<Tuple<SendOrPostCallback, object>>();
 
         #endregion
 
         #region Constructors
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public ThreadSynchronizationContext(ILogger logger)
+        {
+            this.logger = logger;
+        }
+
+        #endregion
+
+        #region Public Methods
 
         /// <summary>
         /// Posts a request for execution to the SynchronizationContext.
@@ -47,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             }
             else
             {
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Verbose,
                     "Attempted to post message to synchronization context after it's already completed");
             }

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
+        private ILogger logger;
         private Version powerShellVersion;
         private Dictionary<string, ScriptFile> workspaceFiles = new Dictionary<string, ScriptFile>();
 
@@ -41,9 +42,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// Creates a new instance of the Workspace class.
         /// </summary>
         /// <param name="powerShellVersion">The version of PowerShell for which scripts will be parsed.</param>
-        public Workspace(Version powerShellVersion)
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public Workspace(Version powerShellVersion, ILogger logger)
         {
             this.powerShellVersion = powerShellVersion;
+            this.logger = logger;
         }
 
         #endregion
@@ -88,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices
                     this.workspaceFiles.Add(keyName, scriptFile);
                 }
 
-                Logger.Write(LogLevel.Verbose, "Opened file on disk: " + resolvedFilePath);
+                this.logger.Write(LogLevel.Verbose, "Opened file on disk: " + resolvedFilePath);
             }
 
             return scriptFile;
@@ -132,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices
 
                 this.workspaceFiles.Add(keyName, scriptFile);
 
-                Logger.Write(LogLevel.Verbose, "Opened file as in-memory buffer: " + resolvedFilePath);
+                this.logger.Write(LogLevel.Verbose, "Opened file as in-memory buffer: " + resolvedFilePath);
             }
 
             return scriptFile;
@@ -248,7 +251,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
             catch (UnauthorizedAccessException e)
             {
-                Logger.WriteException(
+                this.logger.WriteException(
                     $"Could not enumerate files in the path '{folderPath}' due to the path not being accessible",
                     e);
             }
@@ -265,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
                 catch (UnauthorizedAccessException e)
                 {
-                    Logger.WriteException(
+                    this.logger.WriteException(
                         $"Could not enumerate files in the path '{folderPath}' due to a file not being accessible",
                         e);
                 }
@@ -303,7 +306,7 @@ namespace Microsoft.PowerShell.EditorServices
                     continue;
                 }
 
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Verbose,
                     string.Format(
                         "Resolved relative path '{0}' to '{1}'",
@@ -348,7 +351,7 @@ namespace Microsoft.PowerShell.EditorServices
                 filePath = Path.GetFullPath(filePath);
             }
 
-            Logger.Write(LogLevel.Verbose, "Resolved path: " + filePath);
+            this.logger.Write(LogLevel.Verbose, "Resolved path: " + filePath);
 
             return filePath;
         }
@@ -428,7 +431,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (resolveException != null)
             {
-                Logger.Write(
+                this.logger.Write(
                     LogLevel.Error,
                     $"Could not resolve relative script path\r\n" +
                     $"    baseFilePath = {baseFilePath}\r\n    " +

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -35,8 +35,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     Guid.NewGuid().ToString().Substring(0, 8));
 
             Logger.Initialize(
-                testLogPath + "-client.log",
-                LogLevel.Verbose);
+                new FileLogger(
+                    testLogPath + "-client.log",
+                    LogLevel.Verbose));
 
             testLogPath += "-server.log";
             System.Console.WriteLine("        Output log at path: {0}", testLogPath);

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 {
     public class DebugAdapterTests : ServerTestsBase, IAsyncLifetime
     {
+        private ILogger logger;
         private DebugAdapterClient debugAdapterClient;
         private string DebugScriptPath =
             Path.GetFullPath(@"..\..\..\..\PowerShellEditorServices.Test.Shared\Debugging\DebugTest.ps1");
@@ -34,10 +35,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     this.GetType().Name,
                     Guid.NewGuid().ToString().Substring(0, 8));
 
-            Logger.Initialize(
+            this.logger =
                 new FileLogger(
                     testLogPath + "-client.log",
-                    LogLevel.Verbose));
+                    LogLevel.Verbose);
+
+            Logger.Initialize(this.logger);
 
             testLogPath += "-server.log";
             System.Console.WriteLine("        Output log at path: {0}", testLogPath);
@@ -53,7 +56,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     new DebugAdapterClient(
                         await TcpSocketClientChannel.Connect(
                             portNumbers.Item2,
-                            MessageProtocolType.DebugAdapter));
+                            MessageProtocolType.DebugAdapter,
+                            this.logger),
+                        this.logger);
 
             await this.debugAdapterClient.Start();
         }

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -38,8 +38,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     Guid.NewGuid().ToString().Substring(0, 8));
 
             Logger.Initialize(
-                testLogPath + "-client.log",
-                LogLevel.Verbose);
+                new FileLogger(
+                    testLogPath + "-client.log",
+                    LogLevel.Verbose));
 
             testLogPath += "-server.log";
             System.Console.WriteLine("        Output log at path: {0}", testLogPath);

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 {
     public class LanguageServerTests : ServerTestsBase, IAsyncLifetime
     {
+        private ILogger logger;
         private LanguageServiceClient languageServiceClient;
 
         public async Task InitializeAsync()
@@ -37,10 +38,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     this.GetType().Name,
                     Guid.NewGuid().ToString().Substring(0, 8));
 
-            Logger.Initialize(
+            this.logger =
                 new FileLogger(
                     testLogPath + "-client.log",
-                    LogLevel.Verbose));
+                    LogLevel.Verbose);
+
+            Logger.Initialize(this.logger);
 
             testLogPath += "-server.log";
             System.Console.WriteLine("        Output log at path: {0}", testLogPath);
@@ -56,7 +59,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     new LanguageServiceClient(
                         await TcpSocketClientChannel.Connect(
                             portNumbers.Item1,
-                            MessageProtocolType.LanguageServer));
+                            MessageProtocolType.LanguageServer,
+                            this.logger),
+                        this.logger);
 
             await this.languageServiceClient.Start();
         }

--- a/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerShell.EditorServices.Console;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Console
 {
@@ -70,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         [Fact]
         public void ChoicePromptRepromptsOnInvalidInput()
         {
-            TestChoicePromptHandler choicePromptHandler = 
+            TestChoicePromptHandler choicePromptHandler =
                 new TestChoicePromptHandler();
 
             Task<int> promptTask =
@@ -94,6 +95,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         private TaskCompletionSource<string> linePromptTask;
 
         public int TimesPrompted { get; private set; }
+
+        public TestChoicePromptHandler() : base(new NullLogger())
+        {
+        }
 
         public void ReturnInputString(string inputString)
         {

--- a/test/PowerShellEditorServices.Test/Console/ConsoleServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ConsoleServiceTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         public ConsoleServiceTests()
         {
-            this.powerShellContext = new PowerShellContext();
+            this.powerShellContext = new PowerShellContext(new NullLogger());
             ConsoleServicePSHost psHost =
                 new ConsoleServicePSHost(
                     powerShellContext,
@@ -560,7 +560,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         public TestConsoleChoicePromptHandler(
             IConsoleHost consoleHost,
             TaskCompletionSource<TestConsoleChoicePromptHandler> promptShownTask)
-            : base(consoleHost)
+            : base(consoleHost, new NullLogger())
         {
             this.consoleHost = consoleHost;
             this.promptShownTask = promptShownTask;
@@ -622,7 +622,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         public TestConsoleInputPromptHandler(
             IConsoleHost consoleHost,
             TaskCompletionSource<TestConsoleInputPromptHandler> promptShownTask)
-            : base(consoleHost)
+            : base(consoleHost, new NullLogger())
         {
             this.consoleHost = consoleHost;
             this.promptShownTask = promptShownTask;

--- a/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 using System;
 using System.Threading;
 using System.Security;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Console
 {
@@ -130,6 +131,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         public FieldDetails LastField { get; private set; }
 
         public Exception LastError { get; private set; }
+
+        public TestInputPromptHandler() : base(new NullLogger())
+        {
+        }
 
         public void ReturnInputString(string inputString)
         {

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -31,10 +31,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         public DebugServiceTests()
         {
-            this.powerShellContext = PowerShellContextFactory.Create();
+            var logger = new NullLogger();
+
+            this.powerShellContext = PowerShellContextFactory.Create(logger);
             this.powerShellContext.SessionStateChanged += powerShellContext_SessionStateChanged;
 
-            this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version);
+            this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version, logger);
 
             // Load the test debug file
             this.debugScriptFile =
@@ -45,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 this.workspace.GetFile(
                     @"..\..\..\..\PowerShellEditorServices.Test.Shared\Debugging\VariableTest.ps1");
 
-            this.debugService = new DebugService(this.powerShellContext);
+            this.debugService = new DebugService(this.powerShellContext, logger);
             this.debugService.DebuggerStopped += debugService_DebuggerStopped;
             this.debugService.BreakpointUpdated += debugService_BreakpointUpdated;
             this.runnerContext = SynchronizationContext.Current;

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -35,7 +35,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
 
         public async Task InitializeAsync()
         {
-            this.powerShellContext = PowerShellContextFactory.Create();
+            var logger = new NullLogger();
+            this.powerShellContext = PowerShellContextFactory.Create(logger);
             await this.powerShellContext.ImportCommandsModule(@"..\..\..\..\..\module\PowerShellEditorServices\Commands");
 
             this.extensionService = new ExtensionService(this.powerShellContext);

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Language
 {
@@ -25,12 +26,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         private PowerShellContext powerShellContext;
         private const string baseSharedScriptPath = @"..\..\..\..\PowerShellEditorServices.Test.Shared\";
 
-
         public LanguageServiceTests()
         {
-            this.powerShellContext = PowerShellContextFactory.Create();
-            this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version);
-            this.languageService = new LanguageService(this.powerShellContext);
+            var logger = new NullLogger();
+            this.powerShellContext = PowerShellContextFactory.Create(logger);
+            this.workspace = new Workspace(this.powerShellContext.LocalPowerShellVersion.Version, logger);
+            this.languageService = new LanguageService(this.powerShellContext, logger);
         }
 
         public void Dispose()
@@ -163,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             var definitionResult =
                 await this.GetDefinition(
                     FindsFunctionDefinitionInWorkspace.SourceDetails,
-                    new Workspace(this.powerShellContext.LocalPowerShellVersion.Version)
+                    new Workspace(this.powerShellContext.LocalPowerShellVersion.Version, new NullLogger())
                     {
                         WorkspacePath = Path.Combine(baseSharedScriptPath, @"References")
                     });

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -7,15 +7,16 @@ using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Test.Console;
 using System;
 using System.IO;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Test
 {
     internal static class PowerShellContextFactory
     {
 
-        public static PowerShellContext Create()
+        public static PowerShellContext Create(ILogger logger)
         {
-            PowerShellContext powerShellContext = new PowerShellContext();
+            PowerShellContext powerShellContext = new PowerShellContext(logger);
             powerShellContext.Initialize(
                 PowerShellContextTests.TestProfilePaths,
                 PowerShellContext.CreateRunspace(PowerShellContextTests.TestHostDetails, powerShellContext, false),

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 
         public PowerShellContextTests()
         {
-            this.powerShellContext = PowerShellContextFactory.Create();
+            this.powerShellContext = PowerShellContextFactory.Create(new NullLogger());
             this.powerShellContext.SessionStateChanged += OnSessionStateChanged;
             this.stateChangeQueue = new AsyncQueue<SessionStateChangedEventArgs>();
         }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -8,12 +8,13 @@ using System;
 using System.IO;
 using System.Linq;
 using Xunit;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Session
 {
     public class WorkspaceTests
     {
-        private static readonly Version PowerShellVersion = new Version("5.0"); 
+        private static readonly Version PowerShellVersion = new Version("5.0");
 
         [Fact]
         public void CanResolveWorkspaceRelativePath()
@@ -23,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             string testPathOutside = @"c:\Test\PeerPath\FilePath.ps1";
             string testPathAnotherDrive = @"z:\TryAndFindMe\FilePath.ps1";
 
-            Workspace workspace = new Workspace(PowerShellVersion);
+            Workspace workspace = new Workspace(PowerShellVersion, new NullLogger());
 
             // Test without a workspace path
             Assert.Equal(testPathOutside, workspace.GetRelativePath(testPathOutside));

--- a/test/PowerShellEditorServices.Test/Utility/LoggerTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/LoggerTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
                 AppContext.BaseDirectory,
 #else
                 AppDomain.CurrentDomain.BaseDirectory,
-#endif                
+#endif
                 "Test.log");
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         private void AssertWritesMessageAtLevel(LogLevel logLevel)
         {
             // Write a message at the desired level
-            Logger.Initialize(logFilePath, LogLevel.Verbose);
+            Logger.Initialize(new FileLogger(logFilePath, LogLevel.Verbose));
             Logger.Write(logLevel, testMessage);
 
             // Read the contents and verify that it's there
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
 
         private void AssertExcludesMessageBelowLevel(LogLevel minimumLogLevel)
         {
-            Logger.Initialize(logFilePath, minimumLogLevel);
+            Logger.Initialize(new FileLogger(logFilePath, minimumLogLevel));
 
             // Get all possible log levels
             LogLevel[] allLogLevels =


### PR DESCRIPTION
This is a pretty big change because it touches every usage of `Logger.Write` in the codebase and adds new parameters to pass around an ILogger instance to individual components.  This is another incremental change toward the new PSES-as-a-framework model so that third-party extension modules will be able to add logs to the EditorServices.log file.