### PR TITLE
Fix before switch parameter for Find-Ast

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Find-Ast.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Find-Ast.ps1
@@ -92,7 +92,7 @@ function Find-Ast {
                 # Need to store so we can reverse the collection.
                 $result = [Linq.Enumerable]::TakeWhile(
                     $topParent.FindAll({ $true }, $true),
-                    $predicate)
+                    $predicate) -as [System.Management.Automation.Language.Ast[]]
 
                 [array]::Reverse($result)
                 return $result


### PR DESCRIPTION
This fixes an issue where the before switch wasn't searching in the correct order.