### PR TITLE
Miscellaneous fixes to latest improvements

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Components;
 using Microsoft.PowerShell.EditorServices.CodeLenses;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -334,7 +334,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             EditorServicesPSHostUserInterface hostUserInterface =
                 enableConsoleRepl
                     ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, this.logger)
-                    : new ProtocolPSHostUserInterface(powerShellContext, messageSender, messageHandlers, this.logger);
+                    : new ProtocolPSHostUserInterface(powerShellContext, messageSender, this.logger);
 
             EditorServicesPSHost psHost =
                 new EditorServicesPSHost(
@@ -374,7 +374,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             EditorServicesPSHostUserInterface hostUserInterface =
                 enableConsoleRepl
                     ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, this.logger)
-                    : new ProtocolPSHostUserInterface(powerShellContext, messageSender, messageHandlers, this.logger);
+                    : new ProtocolPSHostUserInterface(powerShellContext, messageSender, this.logger);
 
             EditorServicesPSHost psHost =
                 new EditorServicesPSHost(

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -767,8 +767,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             if (isFromRepl)
             {
-                // TODO: Do we send the input through the command handler?
-                // Send the input through the console service
                 var notAwaited =
                     this.editorSession
                         .PowerShellContext

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -132,7 +132,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Initialize the extension service
             // TODO: This should be made awaited once Initialize is async!
             this.editorSession.ExtensionService.Initialize(
-                this.editorOperations).Wait();
+                this.editorOperations,
+                this.editorSession.Components).Wait();
         }
 
         protected Task Stop()

--- a/src/PowerShellEditorServices/Components/IComponentRegistry.cs
+++ b/src/PowerShellEditorServices/Components/IComponentRegistry.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
+using System;
 
 namespace Microsoft.PowerShell.EditorServices.Components
 {
@@ -19,6 +17,9 @@ namespace Microsoft.PowerShell.EditorServices.Components
         /// or throws an ArgumentException if an instance has
         /// already been registered.
         /// </summary>
+        /// <param name="componentType">
+        /// The component type that the instance represents.
+        /// </param>
         /// <param name="componentInstance">
         /// The instance of the component to be registered.
         /// </param>
@@ -26,30 +27,35 @@ namespace Microsoft.PowerShell.EditorServices.Components
         /// The provided component instance for convenience in assignment
         /// statements.
         /// </returns>
-        TComponent Register<TComponent>(TComponent componentInstance)
-            where TComponent : class;
+        object Register(
+            Type componentType,
+            object componentInstance);
 
         /// <summary>
         /// Gets the registered instance of the specified
         /// component type or throws a KeyNotFoundException if
         /// no instance has been registered.
         /// </summary>
+        /// <param name="componentType">
+        /// The component type for which an instance will be retrieved.
+        /// </param>
         /// <returns>The implementation of the specified type.</returns>
-        TComponent Get<TComponent>()
-            where TComponent : class;
+        object Get(Type componentType);
 
         /// <summary>
         /// Attempts to retrieve the instance of the specified
         /// component type and, if found, stores it in the
         /// componentInstance parameter.
         /// </summary>
+        /// <param name="componentType">
+        /// The component type for which an instance will be retrieved.
+        /// </param>
         /// <param name="componentInstance">
         /// The out parameter in which the found instance will be stored.
         /// </param>
         /// <returns>
         /// True if a registered instance was found, false otherwise.
         /// </returns>
-        bool TryGet<TComponent>(out TComponent componentInstance)
-            where TComponent : class;
+        bool TryGet(Type componentType, out object componentInstance);
     }
 }

--- a/src/PowerShellEditorServices/Components/IComponentRegistryExtensions.cs
+++ b/src/PowerShellEditorServices/Components/IComponentRegistryExtensions.cs
@@ -3,29 +3,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Microsoft.PowerShell.EditorServices.Components
 {
     /// <summary>
-    /// Provides a default implementation for the IComponentRegistry
-    /// interface.
+    /// Provides generic helper methods for working with IComponentRegistry
+    /// methods.
     /// </summary>
-    public class ComponentRegistry : IComponentRegistry
+    public static class IComponentRegistryExtensions
     {
-        private Dictionary<Type, object> componentRegistry =
-            new Dictionary<Type, object>();
-
         /// <summary>
         /// Registers an instance of the specified component type
         /// or throws an ArgumentException if an instance has
         /// already been registered.
         /// </summary>
-        /// <param name="componentType">
-        /// The component type that the instance represents.
+        /// <param name="componentRegistry">
+        /// The IComponentRegistry instance.
         /// </param>
         /// <param name="componentInstance">
         /// The instance of the component to be registered.
@@ -34,25 +26,31 @@ namespace Microsoft.PowerShell.EditorServices.Components
         /// The provided component instance for convenience in assignment
         /// statements.
         /// </returns>
-        public object Register(Type componentType, object componentInstance)
+        public static TComponent Register<TComponent>(
+            this IComponentRegistry componentRegistry,
+            TComponent componentInstance)
+                where TComponent : class
         {
-            this.componentRegistry.Add(componentType, componentInstance);
-            return componentInstance;
+            return
+                (TComponent)componentRegistry.Register(
+                    typeof(TComponent),
+                    componentInstance);
         }
-
 
         /// <summary>
         /// Gets the registered instance of the specified
         /// component type or throws a KeyNotFoundException if
         /// no instance has been registered.
         /// </summary>
-        /// <param name="componentType">
-        /// The component type for which an instance will be retrieved.
+        /// <param name="componentRegistry">
+        /// The IComponentRegistry instance.
         /// </param>
         /// <returns>The implementation of the specified type.</returns>
-        public object Get(Type componentType)
+        public static TComponent Get<TComponent>(
+            this IComponentRegistry componentRegistry)
+                where TComponent : class
         {
-            return this.componentRegistry[componentType];
+            return (TComponent)componentRegistry.Get(typeof(TComponent));
         }
 
         /// <summary>
@@ -60,21 +58,26 @@ namespace Microsoft.PowerShell.EditorServices.Components
         /// component type and, if found, stores it in the
         /// componentInstance parameter.
         /// </summary>
+        /// <param name="componentRegistry">
+        /// The IComponentRegistry instance.
+        /// </param>
         /// <param name="componentInstance">
         /// The out parameter in which the found instance will be stored.
-        /// </param>
-        /// <param name="componentType">
-        /// The component type for which an instance will be retrieved.
         /// </param>
         /// <returns>
         /// True if a registered instance was found, false otherwise.
         /// </returns>
-        public bool TryGet(Type componentType, out object componentInstance)
+        public static bool TryGet<TComponent>(
+            this IComponentRegistry componentRegistry,
+            out TComponent componentInstance)
+                where TComponent : class
         {
+            object componentObject = null;
             componentInstance = null;
 
-            if (this.componentRegistry.TryGetValue(componentType, out componentInstance))
+            if (componentRegistry.TryGet(typeof(TComponent), out componentObject))
             {
+                componentInstance = componentObject as TComponent;
                 return componentInstance != null;
             }
 

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Components;
 using System;
 using System.Management.Automation;
 using System.Reflection;
@@ -42,6 +43,12 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         public EditorWindow Window { get; private set; }
 
+        /// <summary>
+        /// Gets the component registry for the session.
+        /// </summary>
+        /// <returns></returns>
+        public IComponentRegistry Components { get; private set; }
+
         #endregion
 
         /// <summary>
@@ -49,12 +56,15 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         /// <param name="extensionService">An ExtensionService which handles command registration.</param>
         /// <param name="editorOperations">An IEditorOperations implementation which handles operations in the host editor.</param>
+        /// <param name="componentRegistry">An IComponentRegistry instance which provides components in the session.</param>
         public EditorObject(
             ExtensionService extensionService,
-            IEditorOperations editorOperations)
+            IEditorOperations editorOperations,
+            IComponentRegistry componentRegistry)
         {
             this.extensionService = extensionService;
             this.editorOperations = editorOperations;
+            this.Components = componentRegistry;
 
             // Create API area objects
             this.Workspace = new EditorWorkspace(this.editorOperations);

--- a/src/PowerShellEditorServices/Extensions/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Extensions/ExtensionService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Components;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
@@ -68,10 +69,17 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// implementation for future interaction with the host editor.
         /// </summary>
         /// <param name="editorOperations">An IEditorOperations implementation.</param>
+        /// <param name="componentRegistry">An IComponentRegistry instance which provides components in the session.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task Initialize(IEditorOperations editorOperations)
+        public async Task Initialize(
+            IEditorOperations editorOperations,
+            IComponentRegistry componentRegistry)
         {
-            this.EditorObject = new EditorObject(this, editorOperations);
+            this.EditorObject =
+                new EditorObject(
+                    this,
+                    editorOperations,
+                    componentRegistry);
 
             // Register the editor object in the runspace
             PSCommand variableCommand = new PSCommand();

--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -720,8 +720,6 @@ namespace Microsoft.PowerShell.EditorServices
 
                 if (commandString != null)
                 {
-                    this.WriteOutput(string.Empty);
-
                     if (!string.IsNullOrWhiteSpace(commandString))
                     {
                         var unusedTask =
@@ -734,6 +732,10 @@ namespace Microsoft.PowerShell.EditorServices
                                 .ConfigureAwait(false);
 
                         break;
+                    }
+                    else
+                    {
+                        this.WriteOutput(string.Empty);
                     }
                 }
             }

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -715,11 +715,12 @@ namespace Microsoft.PowerShell.EditorServices
             bool writeOutputToHost,
             bool addToHistory)
         {
+            // Get rid of leading and trailing whitespace and newlines
+            scriptString = scriptString.Trim();
+
             if (writeInputToHost)
             {
-                this.WriteOutput(
-                    scriptString + Environment.NewLine,
-                    true);
+                this.WriteOutput(scriptString, false);
             }
 
             PSCommand psCommand = new PSCommand();

--- a/test/PowerShellEditorServices.Test.Host/OutputReader.cs
+++ b/test/PowerShellEditorServices.Test.Host/OutputReader.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -37,7 +38,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                 string nextOutputString = string.Empty;
 
                 // Wait no longer than 7 seconds for output to come back
-                CancellationTokenSource cancellationSource = new CancellationTokenSource(7000);
+                CancellationToken cancellationToken =
+                    Debugger.IsAttached
+                        ? CancellationToken.None
+                        : new CancellationTokenSource(7000).Token;
 
                 // Any lines in the buffer?
                 if (this.bufferedOutput.Count > 0)
@@ -56,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     // Execution reaches this point if a buffered line wasn't available
                     Task<OutputEventBody> outputTask =
                         this.outputQueue.DequeueAsync(
-                            cancellationSource.Token);
+                            cancellationToken);
                     OutputEventBody nextOutputEvent = await outputTask;
 
                     // Verify that the output is of the expected type

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices.Components;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
@@ -46,7 +47,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             this.extensionService.CommandUpdated += ExtensionService_ExtensionUpdated;
             this.extensionService.CommandRemoved += ExtensionService_ExtensionRemoved;
 
-            await this.extensionService.Initialize(this.editorOperations);
+            await this.extensionService.Initialize(
+                this.editorOperations,
+                new ComponentRegistry());
 
             var filePath = @"c:\Test\Test.ps1";
             this.currentFile = new ScriptFile(filePath, filePath, "This is a test file", new Version("5.0"));


### PR DESCRIPTION
- Remove unnecessary newline output in the Integrated Console
- Run Selection (F8) was not wired up correctly (thanks @SeeminglyScience!)
- IComponentRegistry should be exposed on $psEditor as Components property
- Change IComponentRegistry methods to enable non-generic method calls in PowerShell
