### PR TITLE
Update help docs for Commands module

### DIFF
--- a/module/docs/ConvertFrom-ScriptExtent.md
+++ b/module/docs/ConvertFrom-ScriptExtent.md
@@ -26,18 +26,20 @@ ConvertFrom-ScriptExtent -Extent <IScriptExtent[]> [-BufferPosition] [-Start] [-
 
 ## DESCRIPTION
 
-Translates IScriptExtent object properties into constructors for some common PowerShell EditorServices types.
+The ConvertFrom-ScriptExtent function converts ScriptExtent objects to types used in methods found in the $psEditor API.
 
 ## EXAMPLES
 
 ### -------------------------- EXAMPLE 1 --------------------------
 
 ```powershell
-$sb = { Get-ChildItem 'Documents' }
-$sb.Ast | Find-Ast { $_ -eq 'Documents' } | ConvertFrom-ScriptExtent -BufferRange
+$range = Find-Ast -First { [System.Management.Automation.Language.CommandAst] } |
+    ConvertFrom-ScriptExtent -BufferRange
+
+$psEditor.GetEditorContext().SetSelection($range)
 ```
 
-Gets the buffer range of the string expression "Documents".
+Convert the extent of the first CommandAst to a BufferRange and use that to select it with the $psEditor API.
 
 ## PARAMETERS
 
@@ -129,7 +131,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.Language.IScriptExtent
 
-You can pipe IScriptExtent objects to be converted.
+You can pass ScriptExtent objects to this function.  You can also pass objects with a property named "Extent" such as ASTs from Find-Ast or tokens from Get-Token.
 
 ## OUTPUTS
 
@@ -137,10 +139,13 @@ You can pipe IScriptExtent objects to be converted.
 
 ### Microsoft.PowerShell.EditorServices.BufferPosition
 
-This function will return an extent converted to one of the above types depending on switch
-choices.
+This function will return the converted object of one of the above types depending on parameter switch choices.
 
 ## NOTES
 
 ## RELATED LINKS
 
+[ConvertTo-ScriptExtent](ConvertTo-ScriptExtent.md)
+[Test-ScriptExtent](Test-ScriptExtent.md)
+[Set-ScriptExtent](Set-ScriptExtent.md)
+[Join-ScriptExtent](Join-ScriptExtent.md)

--- a/module/docs/ConvertTo-ScriptExtent.md
+++ b/module/docs/ConvertTo-ScriptExtent.md
@@ -12,10 +12,10 @@ Converts position and range objects from PowerShellEditorServices to ScriptExten
 
 ## SYNTAX
 
-### ByObject
+### ByExtent
 
 ```powershell
-ConvertTo-ScriptExtent [-InputObject <IScriptExtent>] [<CommonParameters>]
+ConvertTo-ScriptExtent [-Extent <IScriptExtent>] [<CommonParameters>]
 ```
 
 ### ByPosition
@@ -41,7 +41,7 @@ ConvertTo-ScriptExtent [-FilePath <String>] [-StartBuffer <BufferPosition>] [-En
 
 ## DESCRIPTION
 
-Converts position and range objects from PowerShellEditorServices to ScriptExtent objects.
+The ConvertTo-ScriptExtent function can be used to convert any object with position related properties to a ScriptExtent object.  You can also specify the parameters directly to manually create ScriptExtent objects.
 
 ## EXAMPLES
 
@@ -51,17 +51,25 @@ Converts position and range objects from PowerShellEditorServices to ScriptExten
 $psEditor.GetEditorContext().SelectedRange | ConvertTo-ScriptExtent
 ```
 
-Returns a InternalScriptExtent object of the currently selected range.
+Returns a ScriptExtent object of the currently selected range.
+
+### -------------------------- EXAMPLE 2 --------------------------
+
+```powershell
+ConvertTo-ScriptExtent -StartOffset 10 -EndOffset 100
+```
+
+Returns a ScriptExtent object from a start and end offset.
 
 ## PARAMETERS
 
-### -InputObject
+### -Extent
 
-This is here so we can pass script extent objects through without any processing.
+Specifies a ScriptExtent object to use as a base to create a new editor context aware ScriptExtent object.
 
 ```yaml
 Type: IScriptExtent
-Parameter Sets: ByObject
+Parameter Sets: ByExtent
 Aliases:
 
 Required: False
@@ -223,29 +231,23 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Object
 
-You can pass any object with any of the following properties.
+You can pass any object with properties that have position related names.  Below is a list of all the property names that can be bound as parameters through the pipeline.
 
-StartLineNumber, StartLine, Line
-EndLineNumber, EndLine
-StartColumnNumber, StartColumn, Column
-EndColumnNumber, EndColumn
-StartOffsetNumber, StartOffset, Offset
-EndOffsetNumber, EndOffset
-StartBuffer, Start
-EndBuffer, End
+StartLineNumber, StartLine, Line, EndLineNumber, EndLine, StartColumnNumber, StartColumn, Column, EndColumnNumber, EndColumn, StartOffsetNumber, StartOffset, Offset, EndOffsetNumber, EndOffset, StartBuffer, Start, EndBuffer, End
 
-Objects of type IScriptExtent will be passed through with no processing.
+You can also pass IScriptExtent objects to be converted to context aware versions.
 
 ## OUTPUTS
 
-### System.Management.Automation.Language.IScriptExtent
+### Microsoft.PowerShell.EditorServices.FullScriptExtent
 
-### System.Management.Automation.Language.InternalScriptExtent
-
-This function will return any IScriptExtent object passed without processing. Objects created
-by this function will be of type InternalScriptExtent.
+The converted ScriptExtent object will be returned to the pipeline.
 
 ## NOTES
 
 ## RELATED LINKS
 
+[ConvertFrom-ScriptExtent](ConvertFrom-ScriptExtent.md)
+[Test-ScriptExtent](Test-ScriptExtent.md)
+[Set-ScriptExtent](Set-ScriptExtent.md)
+[Join-ScriptExtent](Join-ScriptExtent.md)

--- a/module/docs/Import-EditorCommand.md
+++ b/module/docs/Import-EditorCommand.md
@@ -8,20 +8,20 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Imports commands with the PSEditorCommand attribute into PowerShell Editor Services.
+Imports commands with the EditorCommand attribute into PowerShell Editor Services.
 
 ## SYNTAX
 
 ### ByModule
 
 ```powershell
-Import-EditorCommand [-Module] <PSModuleInfo[]> [-Force] [-PassThru] [<CommonParameters>]
+Import-EditorCommand [-Module] <string[]> [-Force] [-PassThru] [<CommonParameters>]
 ```
 
 ### ByCommand
 
 ```powershell
-Import-EditorCommand [-Command] <CommandInfo[]> [-Force] [-PassThru] [<CommonParameters>]
+Import-EditorCommand [-Command] <string[]> [-Force] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,6 +29,8 @@ Import-EditorCommand [-Command] <CommandInfo[]> [-Force] [-PassThru] [<CommonPar
 The Import-EditorCommand function will search the specified module for functions tagged as editor commands and register them with PowerShell Editor Services. By default, if a module is specified only exported functions will be processed.
 
 Alternatively, you can specify command info objects (like those from the Get-Command cmdlet) to be processed directly.
+
+To tag a command as an editor command, attach the attribute 'Microsoft.PowerShell.EditorServices.Extensions.EditorCommandAttribute' to the function like you would with 'CmdletBindingAttribute'.  The attribute accepts the named parameters 'Name', 'DisplayName', and 'SuppressOutput'.
 
 ## EXAMPLES
 
@@ -47,6 +49,23 @@ Get-Command *Editor* | Import-EditorCommand -PassThru
 ```
 
 Registers all editor commands that contain "Editor" in the name and return all successful imports.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```powershell
+function Invoke-MyEditorCommand {
+    [CmdletBinding()]
+    [Microsoft.PowerShell.EditorServices.Extensions.EditorCommand(DisplayName='My Command', SuppressOutput)]
+    param()
+    end {
+        ConvertTo-ScriptExtent -Offset 0 | Set-ScriptExtent -Text 'My Command!'
+    }
+}
+
+Get-Command Invoke-MyEditorCommand | Import-EditorCommand
+```
+
+This example declares the function Invoke-MyEditorCommand with the EditorCommand attribute and then imports it as an editor command.
 
 ## PARAMETERS
 
@@ -68,7 +87,7 @@ Accept wildcard characters: False
 
 ### -Command
 
-Specifies the functions to register as editor commands. If the function does not have the PSEditorCommand attribute it will be ignored.
+Specifies the functions to register as editor commands. If the function does not have the EditorCommand attribute it will be ignored.
 
 ```yaml
 Type: string[]
@@ -135,3 +154,5 @@ will be returned.  This function does not output to the pipeline otherwise.
 
 ## RELATED LINKS
 
+[Register-EditorCommand](Register-EditorCommand.md)
+[Unregister-EditorCommand](Unregister-EditorCommand.md)

--- a/module/docs/Join-ScriptExtent.md
+++ b/module/docs/Join-ScriptExtent.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Combine script extents.
+Combine multiple ScriptExtent objects into a single ScriptExtent.
 
 ## SYNTAX
 
@@ -18,7 +18,7 @@ Join-ScriptExtent [[-Extent] <IScriptExtent[]>] [<CommonParameters>]
 
 ## DESCRIPTION
 
-The Join-ScriptExtent function will combine all ScriptExtent objects piped to it into a single extent.
+The Join-ScriptExtent function will combine all ScriptExtent objects piped to it into a single extent.  This can be used combine multiple ASTs, tokens, or other script elements into a single object that can then be manipulated or used for more targeted searches.
 
 ## EXAMPLES
 
@@ -57,16 +57,19 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.Language.IScriptExtent
 
-You can pass script extent objects to this function.  You can also pass objects with a property
-named "Extent".
+You can pass ScriptExtent objects to this function.  You can also pass objects with a property named "Extent" such as ASTs from Find-Ast or tokens from Get-Token.
 
 ## OUTPUTS
 
 ### System.Management.Automation.Language.IScriptExtent
 
-The combined extent is returned.
+The combined ScriptExtent object is returned.
 
 ## NOTES
 
 ## RELATED LINKS
 
+[ConvertTo-ScriptExtent](ConvertTo-ScriptExtent.md)
+[ConvertFrom-ScriptExtent](ConvertFrom-ScriptExtent.md)
+[Test-ScriptExtent](Test-ScriptExtent.md)
+[Set-ScriptExtent](Set-ScriptExtent.md)

--- a/module/docs/PowerShellEditorServices.Commands.md
+++ b/module/docs/PowerShellEditorServices.Commands.md
@@ -16,17 +16,15 @@ Module to facilitate easy manipulation of script files and editor features.
 
 ### [ConvertFrom-ScriptExtent](ConvertFrom-ScriptExtent.md)
 
-Translates IScriptExtent object properties into constructors for some common PowerShell EditorServices types.
+The ConvertFrom-ScriptExtent function converts ScriptExtent objects to types used in methods found in the $psEditor API.
 
 ### [ConvertTo-ScriptExtent](ConvertTo-ScriptExtent.md)
 
-Converts position and range objects from PowerShellEditorServices to ScriptExtent objects.
+The ConvertTo-ScriptExtent function can be used to convert any object with position related properties to a ScriptExtent object.  You can also specify the parameters directly to manually create ScriptExtent objects.
 
 ### [Find-Ast](Find-Ast.md)
 
-The Find-Ast function can be used to easily find a specific ast from a starting ast.  By
-default children asts will be searched, but ancestor asts can also be searched by specifying
-the "Ancestor" switch parameter.
+The Find-Ast function can be used to easily find a specific AST within a script file. All ASTs following the inital starting ast will be searched, including those that are not part of the same tree.
 
 ### [Get-Token](Get-Token.md)
 
@@ -40,7 +38,7 @@ Alternatively, you can specify command info objects (like those from the Get-Com
 
 ### [Join-ScriptExtent](Join-ScriptExtent.md)
 
-The Join-ScriptExtent function will combine all ScriptExtent objects piped to it into a single extent.
+The Join-ScriptExtent function will combine all ScriptExtent objects piped to it into a single extent.  This can be used combine multiple ASTs, tokens, or other script elements into a single object that can then be manipulated or used for more targeted searches.
 
 ### [Set-ScriptExtent](Set-ScriptExtent.md)
 

--- a/module/docs/Register-EditorCommand.md
+++ b/module/docs/Register-EditorCommand.md
@@ -150,4 +150,4 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Unregister-EditorCommand](Unregister-EditorCommand.md)
-
+[Import-EditorCommand](Import-EditorCommand.md)

--- a/module/docs/Set-ScriptExtent.md
+++ b/module/docs/Set-ScriptExtent.md
@@ -15,19 +15,19 @@ Replaces text at a specified IScriptExtent object.
 ### __AllParameterSets (Default)
 
 ```powershell
-Set-ScriptExtent [-Text] <PSObject> [-Extent <ElasticExtent>] [<CommonParameters>]
+Set-ScriptExtent [-Text] <PSObject> [-Extent <IScriptExtent>] [<CommonParameters>]
 ```
 
 ### AsString
 
 ```powershell
-Set-ScriptExtent [-Text] <PSObject> [-AsString] [-Extent <ElasticExtent>] [<CommonParameters>]
+Set-ScriptExtent [-Text] <PSObject> [-AsString] [-Extent <IScriptExtent>] [<CommonParameters>]
 ```
 
 ### AsArray
 
 ```powershell
-Set-ScriptExtent [-Text] <PSObject> [-AsArray] [-Extent <ElasticExtent>] [<CommonParameters>]
+Set-ScriptExtent [-Text] <PSObject> [-AsArray] [-Extent <IScriptExtent>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -129,7 +129,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.Language.IScriptExtent
 
-You can pass script extent objects to this function.  You can also pass objects with a property named "Extent".
+You can pass ScriptExtent objects to this function.  You can also pass objects with a property named "Extent" such as ASTs from Find-Ast or tokens from Get-Token.
 
 ## OUTPUTS
 
@@ -139,3 +139,8 @@ You can pass script extent objects to this function.  You can also pass objects 
 
 ## RELATED LINKS
 
+[Find-Ast](Find-Ast.md)
+[ConvertTo-ScriptExtent](ConvertTo-ScriptExtent.md)
+[ConvertFrom-ScriptExtent](ConvertFrom-ScriptExtent.md)
+[Test-ScriptExtent](Test-ScriptExtent.md)
+[Join-ScriptExtent](Join-ScriptExtent.md)

--- a/module/docs/Test-ScriptExtent.md
+++ b/module/docs/Test-ScriptExtent.md
@@ -125,7 +125,7 @@ Accept wildcard characters: False
 
 ### System.Management.Automation.Language.IScriptExtent
 
-You can pass reference script extent objects to this function.
+You can pass ScriptExtent objects to this function.  You can also pass objects with a property named "Extent" such as ASTs from Find-Ast or tokens from Get-Token.
 
 ## OUTPUTS
 
@@ -138,3 +138,8 @@ If the "PassThru" parameter is specified and the test passed, the reference scri
 ## NOTES
 
 ## RELATED LINKS
+
+[ConvertTo-ScriptExtent](ConvertTo-ScriptExtent.md)
+[ConvertFrom-ScriptExtent](ConvertFrom-ScriptExtent.md)
+[Set-ScriptExtent](Set-ScriptExtent.md)
+[Join-ScriptExtent](Join-ScriptExtent.md)

--- a/module/docs/Unregister-EditorCommand.md
+++ b/module/docs/Unregister-EditorCommand.md
@@ -56,4 +56,4 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [Register-EditorCommand](Register-EditorCommand.md)
-
+[Import-EditorCommand](Import-EditorCommand.md)


### PR DESCRIPTION
This change fixes some mistakes in the help documents for the Commands module and adds additional examples.