### PR TITLE
Fix for vscode-powershell #837 callstack missing line info. 

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
@@ -47,11 +47,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public int? EndColumn { get; set; }
 
         /// <summary>
-        /// Gets the module associated with this frame, if any.
-        /// </summary>
-        public object ModuleId { get; set; }
-
-        /// <summary>
         /// Gets an optional hint for how to present this frame in the UI. A value of 'label' 
         /// can be used to indicate that the frame is an artificial frame that is used as a 
         /// visual label or separator. A value of 'subtle' can be used to change the appearance 

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StackFrame.cs
@@ -7,32 +7,57 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 {
     public class StackFrame
     {
+        /// <summary>
+        /// Gets or sets an identifier for the stack frame. It must be unique across all threads.
+        /// This id can be used to retrieve the scopes of the frame with the 'scopesRequest' or 
+        /// to restart the execution of a stackframe. */
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of the stack frame, typically a method name
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the optional source of the frame.
+        /// </summary>
         public Source Source { get; set; }
 
+        /// <summary>
+        /// Gets or sets line within the file of the frame. If source is null or doesn't exist, 
+        /// line is 0 and must be ignored.
+        /// </summary>
         public int Line { get; set; }
 
+        /// <summary>
+        /// Gets or sets an optional end line of the range covered by the stack frame.
+        /// </summary>
         public int? EndLine { get; set; }
 
+        /// <summary>
+        /// Gets or sets the column within the line. If source is null or doesn't exist, 
+        /// column is 0 and must be ignored.
+        /// </summary>
         public int Column { get; set; }
 
+        /// <summary>
+        /// Gets or sets an optional end column of the range covered by the stack frame.
+        /// </summary>
         public int? EndColumn { get; set; }
 
-        //        /** An identifier for the stack frame. */
-        //id: number;
-        ///** The name of the stack frame, typically a method name */
-        //name: string;
-        ///** The source of the frame. */
-        //source: Source;
-        ///** The line within the file of the frame. */
-        //line: number;
-        ///** The column within the line. */
-        //column: number;
-        ///** All arguments and variables declared in this stackframe. */
-        //scopes: Scope[];
+        /// <summary>
+        /// Gets the module associated with this frame, if any.
+        /// </summary>
+        public object ModuleId { get; set; }
+
+        /// <summary>
+        /// Gets an optional hint for how to present this frame in the UI. A value of 'label' 
+        /// can be used to indicate that the frame is an artificial frame that is used as a 
+        /// visual label or separator. A value of 'subtle' can be used to change the appearance 
+        /// of a frame in a 'subtle' way.
+        /// </summary>
+        public string PresentationHint { get; private set; }
 
         public static StackFrame Create(
             StackFrameDetails stackFrame,
@@ -43,9 +68,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
                 Id = id,
                 Name = stackFrame.FunctionName,
                 Line = stackFrame.StartLineNumber,
-                EndLine = stackFrame.EndLineNumber > 0 ? (int?)stackFrame.EndLineNumber : null,
+                EndLine = stackFrame.EndLineNumber,
                 Column = stackFrame.StartColumnNumber,
-                EndColumn = stackFrame.EndColumnNumber > 0 ? (int?)stackFrame.EndColumnNumber : null,
+                EndColumn = stackFrame.EndColumnNumber,
+                PresentationHint = stackFrame.PresentationHint.ToString().ToLower(),
                 Source = new Source
                 {
                     Path = stackFrame.ScriptPath

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/StackTraceRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/StackTraceRequest.cs
@@ -18,16 +18,38 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
     [DebuggerDisplay("ThreadId = {ThreadId}, Levels = {Levels}")]
     public class StackTraceRequestArguments
     {
-        public int ThreadId { get; private set; }
+        /// <summary>
+        /// Gets or sets the ThreadId of this stacktrace.
+        /// </summary>
+        public int ThreadId { get; set; }
 
         /// <summary>
-        /// Gets the maximum number of frames to return. If levels is not specified or 0, all frames are returned.
+        /// Gets or sets the index of the first frame to return. If omitted frames start at 0.
         /// </summary>
-        public int Levels { get; private set; }
+        public int? StartFrame { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of frames to return. If levels is not specified or 0, all frames are returned.
+        /// </summary>
+        public int? Levels { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format string that specifies details on how to format the stack frames.
+        /// </summary>
+        public string Format { get; set; }
     }
 
     public class StackTraceResponseBody
     {
+        /// <summary>
+        /// Gets the frames of the stackframe. If the array has length zero, there are no stackframes available.
+        /// This means that there is no location information available.
+        /// </summary>
         public StackFrame[] StackFrames { get; set; }
+
+        /// <summary>
+        /// Gets the total number of frames available.
+        /// </summary>
+        public int? TotalFrames { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -643,7 +643,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             List<StackFrame> newStackFrames = new List<StackFrame>();
 
-            for (int i = 0; i < stackFrames.Length; i++)
+            int startFrameIndex = stackTraceParams.StartFrame ?? 0;
+            int maxFrameCount = stackFrames.Length;
+
+            // If the number of requested levels == 0 (or null), that means get all stack frames 
+            // after the specified startFrame index. Otherwise get all the stack frames.
+            int requestedFrameCount = (stackTraceParams.Levels ?? 0);
+            if (requestedFrameCount > 0)
+            {
+                maxFrameCount = Math.Min(maxFrameCount, startFrameIndex + requestedFrameCount);
+            }
+
+            for (int i = startFrameIndex; i < maxFrameCount; i++)
             {
                 // Create the new StackFrame object with an ID that can
                 // be referenced back to the current list of stack frames
@@ -656,7 +667,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             await requestContext.SendResult(
                 new StackTraceResponseBody
                 {
-                    StackFrames = newStackFrames.ToArray()
+                    StackFrames = newStackFrames.ToArray(),
+                    TotalFrames = newStackFrames.Count
                 });
         }
 

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -842,8 +842,12 @@ namespace Microsoft.PowerShell.EditorServices
                 VariableContainerDetails localVariables =
                     await FetchVariableContainer(i.ToString(), autoVariables);
 
+                // When debugging, this is the best way I can find to get what is likely the workspace root.
+                // This is controlled by the "cwd:" setting in the launch config.
+                string workspaceRootPath = this.powerShellContext.InitialWorkingDirectory;
+
                 this.stackFrameDetails[i] =
-                    StackFrameDetails.Create(callStackFrames[i], autoVariables, localVariables);
+                    StackFrameDetails.Create(callStackFrames[i], autoVariables, localVariables, workspaceRootPath);
 
                 string stackFrameScriptPath = this.stackFrameDetails[i].ScriptPath;
                 if (scriptNameOverride != null &&

--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -3,10 +3,30 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Management.Automation;
 
 namespace Microsoft.PowerShell.EditorServices
 {
+    public enum StackFramePresentationHint
+    {
+        /// <summary>
+        /// Dispays the stack frame as a normal stack frame.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// Used to label an entry in the call stack that doesn't actually correspond to a stack frame.
+        /// This is typically used to label transitions to/from "external" code.
+        /// </summary>
+        Label,
+
+        /// <summary>
+        /// Displays the stack frame in a subtle way, typically used from loctaions outside of the current project or workspace.
+        /// </summary>
+        Subtle
+    }
+
     /// <summary>
     /// Contains details pertaining to a single stack frame in
     /// the current debugging session.
@@ -43,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Gets the line number of the script where the stack frame occurred.
         /// </summary>
-        public int EndLineNumber { get; internal set; }
+        public int? EndLineNumber { get; internal set; }
 
         /// <summary>
         /// Gets the start column number of the line where the stack frame occurred.
@@ -53,7 +73,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Gets the end column number of the line where the stack frame occurred.
         /// </summary>
-        public int EndColumnNumber { get; internal set; }
+        public int? EndColumnNumber { get; internal set; }
+
+        /// <summary>
+        /// Gets a hint value that determines how the stack frame should be displayed.
+        /// </summary>
+        public StackFramePresentationHint PresentationHint { get; internal set; }
 
         /// <summary>
         /// Gets or sets the VariableContainerDetails that contains the auto variables.
@@ -86,16 +111,34 @@ namespace Microsoft.PowerShell.EditorServices
         static internal StackFrameDetails Create(
             PSObject callStackFrameObject,
             VariableContainerDetails autoVariables,
-            VariableContainerDetails localVariables)
+            VariableContainerDetails localVariables,
+            string workspaceRootPath = null)
         {
+            string moduleId = string.Empty;
+            var presentationHint = StackFramePresentationHint.Normal;
+
+            var invocationInfo = callStackFrameObject.Properties["InvocationInfo"].Value as InvocationInfo;
+            string scriptPath = (callStackFrameObject.Properties["ScriptName"].Value as string) ?? NoFileScriptPath;
+            int startLineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0);
+
+            if (workspaceRootPath != null && 
+                invocationInfo != null &&
+                !scriptPath.StartsWith(workspaceRootPath, StringComparison.OrdinalIgnoreCase))
+            {
+                presentationHint = StackFramePresentationHint.Subtle;
+            }
+
             return new StackFrameDetails
             {
-                ScriptPath = (callStackFrameObject.Properties["ScriptName"].Value as string) ?? NoFileScriptPath,
+                ScriptPath = scriptPath,
                 FunctionName = callStackFrameObject.Properties["FunctionName"].Value as string,
-                StartLineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0),
+                StartLineNumber = startLineNumber,
+                EndLineNumber = startLineNumber, // End line number isn't given in PowerShell stack frames
                 StartColumnNumber = 0,   // Column number isn't given in PowerShell stack frames
+                EndColumnNumber = 0,
                 AutoVariables = autoVariables,
-                LocalVariables = localVariables
+                LocalVariables = localVariables,
+                PresentationHint = presentationHint
             };
         }
 

--- a/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Debugging/StackFrameDetails.cs
@@ -8,6 +8,9 @@ using System.Management.Automation;
 
 namespace Microsoft.PowerShell.EditorServices
 {
+    /// <summary>
+    /// An optional hint for how to present a stack frame in the UI. 
+    /// </summary>
     public enum StackFramePresentationHint
     {
         /// <summary>
@@ -107,6 +110,10 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="localVariables">
         /// A variable container with all the local variables for this stack frame.
         /// </param>
+        /// <param name="workspaceRootPath">
+        /// Specifies the path to the root of an open workspace, if one is open. This path is used to
+        /// determine whether individua stack frames are external to the workspace.
+        /// </param>
         /// <returns>A new instance of the StackFrameDetails class.</returns>
         static internal StackFrameDetails Create(
             PSObject callStackFrameObject,
@@ -117,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices
             string moduleId = string.Empty;
             var presentationHint = StackFramePresentationHint.Normal;
 
-            var invocationInfo = callStackFrameObject.Properties["InvocationInfo"].Value as InvocationInfo;
+            var invocationInfo = callStackFrameObject.Properties["InvocationInfo"]?.Value as InvocationInfo;
             string scriptPath = (callStackFrameObject.Properties["ScriptName"].Value as string) ?? NoFileScriptPath;
             int startLineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0);
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -103,6 +103,12 @@ namespace Microsoft.PowerShell.EditorServices
             private set;
         }
 
+        /// <summary>
+        /// Gets the working directory path the PowerShell context was inititially set when the debugger launches.
+        /// This path is used to determine whether a script in the call stack is an "external" script.
+        /// </summary>
+        public string InitialWorkingDirectory { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -1073,6 +1079,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="path"></param>
         public async Task SetWorkingDirectory(string path)
         {
+            this.InitialWorkingDirectory = path;
+
             using (RunspaceHandle runspaceHandle = await this.GetRunspaceHandle())
             {
                 runspaceHandle.Runspace.SessionStateProxy.Path.SetLocation(path);


### PR DESCRIPTION
This PR addresses two bugs.  First the missing line info was due to use passing back null when we didn't have end line/col info.  The protocol claims that should work.  But when I changed the end line/col to reflect the same values as the start line/col (assuming the end values were null - not set) then the callstack started to display the line info.  It is  a bit weird but the very first frame in some cases contains a col other than 0.

The second bug was that the call stack was getting duplicated.  I implemented the new stackTraceRequest for paging stack frames back to VSCode and now that bug is fixed.

I tried to implement StackFrame.PresentationHint == "subtle" for script outside the initial working directory.  Do you have a better way to get the workspaceRoot path in the debugger?  I had to cache the working dir when SetWorkingDirectory() gets called.  And when you attach to a process, there isn't a way to set the "cwd".

Finally, I ran into one bug I'll file later that has to do with the base of the call stack sometimes showing "<ScriptBlock> <No File> 1".  If you click on that you get an error telling you <No File> can't be opened.