### PR TITLE
Server should crash on unhandled exceptions in message loop

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -193,6 +193,8 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     messageDispatcher,
                     this.logger);
 
+            protocolEndpoint.UnhandledException += ProtocolEndpoint_UnhandledException;
+
             this.editorSession =
                 CreateSession(
                     this.hostDetails,
@@ -251,6 +253,8 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     serverChannel,
                     messageDispatcher,
                     this.logger);
+
+            protocolEndpoint.UnhandledException += ProtocolEndpoint_UnhandledException;
 
             if (this.enableConsoleRepl)
             {
@@ -392,6 +396,15 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 editorOperations);
 
             return editorSession;
+        }
+
+        private void ProtocolEndpoint_UnhandledException(object sender, Exception e)
+        {
+            this.logger.Write(
+                LogLevel.Error,
+                "PowerShell Editor Services is terminating due to an unhandled exception, see previous logs for details.");
+
+            this.serverCompletedTask.SetException(e);
         }
 
 #if !CoreCLR


### PR DESCRIPTION
This change causes all unhandled exceptions to crash the server so that
the user is not left with an inoperative language service.  This was the
expected behavior before the recent redesign changed how the exception
gets propagated all the way back to the EditorServicesHost.  The host
will now throw the unhandled exception from the WaitForCompletion
method causing the process to exit.