### PR TITLE
Enable debug-only PowerShell Editor Services sessions

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -49,7 +49,7 @@ function Start-EditorServicesHost {
         [switch]
         $EnableConsoleRepl,
 
-        [string]
+        [switch]
         $DebugServiceOnly,
 
         [string[]]


### PR DESCRIPTION
This change finishes the work necessary to enable debug-only sessions
where a new PowerShell process is launched strictly for the purpose of
providing a fresh debugging session.  This is useful when debugging
modules which use PowerShell classes or binary components which cannot
be reloaded in the same process.

Part of the implementation for PowerShell/vscode-powershell#367.