### PR TITLE
Add Diagnostic logging level for protocol message JSON

### DIFF
--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageReader.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageReader.cs
@@ -112,13 +112,20 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
             // Load the message
             this.logger.Write(
-                LogLevel.Verbose,
+                LogLevel.Diagnostic,
                 string.Format(
                     "READ MESSAGE:\r\n\r\n{0}",
                     messageObject.ToString(Formatting.Indented)));
 
             // Return the parsed message
-            return this.messageSerializer.DeserializeMessage(messageObject);
+            Message parsedMessage = this.messageSerializer.DeserializeMessage(messageObject);
+
+            this.logger.Write(
+                LogLevel.Verbose,
+                $"Received {parsedMessage.MessageType} '{parsedMessage.Method}'" +
+                (!string.IsNullOrEmpty(parsedMessage.Id) ? $" with id {parsedMessage.Id}" : string.Empty));
+
+            return parsedMessage;
         }
 
         #endregion

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
@@ -58,9 +58,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 this.messageSerializer.SerializeMessage(
                     messageToWrite);
 
-            // Log the JSON representation of the message
             this.logger.Write(
                 LogLevel.Verbose,
+                $"Writing {messageToWrite.MessageType} '{messageToWrite.Method}'" +
+                (!string.IsNullOrEmpty(messageToWrite.Id) ? $" with id {messageToWrite.Id}" : string.Empty));
+
+            // Log the JSON representation of the message
+            this.logger.Write(
+                LogLevel.Diagnostic,
                 string.Format(
                     "WRITE MESSAGE:\r\n\r\n{0}",
                     JsonConvert.SerializeObject(

--- a/src/PowerShellEditorServices/Utility/ILogger.cs
+++ b/src/PowerShellEditorServices/Utility/ILogger.cs
@@ -17,6 +17,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     public enum LogLevel
     {
         /// <summary>
+        /// Indicates a diagnostic log message.
+        /// </summary>
+        Diagnostic,
+
+        /// <summary>
         /// Indicates a verbose log message.
         /// </summary>
         Verbose,


### PR DESCRIPTION
This change adds a new "Diagnostic" logging level which is used for
logging the JSON contents of protocol messages that are read or written.
This will provide two benefits:

1. Increase the privacy of user logs that are transmitted over GitHub
2. Increase the performance of writing Verbose logs

We still log the high-level message details like message type, method,
and ID so that we can keep track of the message sequence.