### PR TITLE
Add custom HTML views to VSCode module

### DIFF
--- a/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psd1
+++ b/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psd1
@@ -69,7 +69,11 @@ Description = 'Provides added functionality to PowerShell Editor Services for th
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @()
+FunctionsToExport = @('New-VSCodeHtmlContentView',
+                      'Show-VSCodeHtmlContentView',
+                      'Close-VSCodeHtmlContentView',
+                      'Set-VSCodeHtmlContentView',
+                      'Write-VSCodeHtmlContentView')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psm1
+++ b/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psm1
@@ -16,3 +16,7 @@ if ($psEditor -is [Microsoft.PowerShell.EditorServices.Extensions.EditorObject])
 else {
     Write-Verbose '$psEditor object not found in the session, components will not be registered.'
 }
+
+Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse | ForEach-Object {
+    . $PSItem.FullName
+}

--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Close-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Close-VSCodeHtmlContentView.ps1
@@ -1,0 +1,33 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function Close-VSCodeHtmlContentView {
+    <#
+    .SYNOPSIS
+    Closes an HtmlContentView.
+
+    .DESCRIPTION
+    Closes an HtmlContentView inside of Visual Studio Code if
+    it is displayed.
+
+    .PARAMETER HtmlContentView
+    The HtmlContentView to be closed.
+
+    .EXAMPLE
+    Close-VSCodeHtmlContentView -HtmlContentView $htmlContentView
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Alias("View")]
+        [ValidateNotNull()]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView]
+        $HtmlContentView
+    )
+
+    process {
+        $HtmlContentView.Close().Wait();
+    }
+}

--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/New-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/New-VSCodeHtmlContentView.ps1
@@ -1,0 +1,55 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function New-VSCodeHtmlContentView {
+    <#
+    .SYNOPSIS
+    Creates a custom view in Visual Studio Code which displays HTML content.
+
+    .DESCRIPTION
+    Creates a custom view in Visual Studio Code which displays HTML content.
+
+    .PARAMETER Title
+    The title of the view.
+
+    .PARAMETER ShowInColumn
+    If specified, causes the new view to be displayed in the specified column.
+    If unspecified, the Show-VSCodeHtmlContentView cmdlet will need to be used
+    to display the view.
+
+    .EXAMPLE
+    # Create a new view called "My Custom View"
+    $htmlContentView = New-VSCodeHtmlContentView -Title "My Custom View"
+
+    .EXAMPLE
+    # Create a new view and show it in the second view column
+    $htmlContentView = New-VSCodeHtmlContentView -Title "My Custom View" -ShowInColumn Two
+    #>
+    [CmdletBinding()]
+    [OutputType([Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Title,
+
+        [Parameter(Mandatory = $false)]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.ViewColumn]
+        $ShowInColumn
+    )
+
+    process {
+        if ($psEditor -is [Microsoft.PowerShell.EditorServices.Extensions.EditorObject]) {
+            $viewFeature = $psEditor.Components.Get([Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentViews])
+            $view = $viewFeature.CreateHtmlContentView($Title).Result
+
+            if ($ShowInColumn) {
+                $view.Show($ShowInColumn).Wait();
+            }
+
+            return $view
+        }
+    }
+}

--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Set-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Set-VSCodeHtmlContentView.ps1
@@ -1,0 +1,48 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function Set-VSCodeHtmlContentView {
+    <#
+    .SYNOPSIS
+    Sets the content of an HtmlContentView.
+
+    .DESCRIPTION
+    Sets the content of an HtmlContentView.  If an empty string
+    is passed, it causes the view's content to be cleared.
+
+    .PARAMETER HtmlContentView
+    The HtmlContentView where content will be set.
+
+    .PARAMETER HtmlBodyContent
+    The HTML content that will be placed inside the <body> tag
+    of the view.
+
+    .EXAMPLE
+    # Set the view content with an h1 header
+    Set-VSCodeHtmlContentView -HtmlContentView $htmlContentView -HtmlBodyContent "<h1>Hello world!</h1>"
+
+    .EXAMPLE
+    # Clear the view
+    Set-VSCodeHtmlContentView -View $htmlContentView -Content ""
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Alias("View")]
+        [ValidateNotNull()]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView]
+        $HtmlContentView,
+
+        [Parameter(Mandatory = $true)]
+        [Alias("Content")]
+        [AllowEmptyString()]
+        [string]
+        $HtmlBodyContent
+    )
+
+    process {
+        $HtmlContentView.SetContent($HtmlBodyContent).Wait();
+    }
+}

--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Show-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Show-VSCodeHtmlContentView.ps1
@@ -1,0 +1,47 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function Show-VSCodeHtmlContentView {
+    <#
+    .SYNOPSIS
+    Shows an HtmlContentView.
+
+    .DESCRIPTION
+    Shows an HtmlContentView that has been created and not shown
+    yet or has previously been closed.
+
+    .PARAMETER HtmlContentView
+    The HtmlContentView that will be shown.
+
+    .PARAMETER ViewColumn
+    If specified, causes the new view to be displayed in the specified column.
+
+    .EXAMPLE
+    # Shows the view in the first editor column
+    Show-VSCodeHtmlContentView -HtmlContentView $htmlContentView
+
+    .EXAMPLE
+    # Shows the view in the third editor column
+    Show-VSCodeHtmlContentView -View $htmlContentView -Column Three
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Alias("View")]
+        [ValidateNotNull()]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView]
+        $HtmlContentView,
+
+        [Parameter(Mandatory = $false)]
+        [Alias("Column")]
+        [ValidateNotNull()]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.ViewColumn]
+        $ViewColumn = [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.ViewColumn]::One
+    )
+
+    process {
+        $HtmlContentView.Show($ViewColumn).Wait()
+    }
+}

--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Write-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Write-VSCodeHtmlContentView.ps1
@@ -1,0 +1,46 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function Write-VSCodeHtmlContentView {
+    <#
+    .SYNOPSIS
+    Writes an HTML fragment to an HtmlContentView.
+
+    .DESCRIPTION
+    Writes an HTML fragment to an HtmlContentView.  This new fragment
+    is appended to the existing content, useful in cases where the
+    output will be appended to an ongoing output stream.
+
+    .PARAMETER HtmlContentView
+    The HtmlContentView where content will be appended.
+
+    .PARAMETER AppendedHtmlBodyContent
+    The HTML content that will be appended to the view's <body> element content.
+
+    .EXAMPLE
+    Write-VSCodeHtmlContentView -HtmlContentView $htmlContentView -AppendedHtmlBodyContent "<h3>Appended content</h3>"
+
+    .EXAMPLE
+    Write-VSCodeHtmlContentView -View $htmlContentView -Content "<h3>Appended content</h3>"
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Alias("View")]
+        [ValidateNotNull()]
+        [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView]
+        $HtmlContentView,
+
+        [Parameter(Mandatory = $true)]
+        [Alias("Content")]
+        [ValidateNotNull()]
+        [string]
+        $AppendedHtmlBodyContent
+    )
+
+    process {
+        $HtmlContentView.AppendContent($AppendedHtmlBodyContent).Wait();
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/ComponentRegistration.cs
+++ b/src/PowerShellEditorServices.VSCode/ComponentRegistration.cs
@@ -5,16 +5,37 @@
 
 using System;
 using Microsoft.PowerShell.EditorServices.Components;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using Microsoft.PowerShell.EditorServices.Utility;
+using Microsoft.PowerShell.EditorServices.VSCode.CustomViews;
 
 namespace Microsoft.PowerShell.EditorServices.VSCode
 {
+    /// <summary>
+    /// Methods for registering components from this module into
+    /// the editor session.
+    /// </summary>
     public static class ComponentRegistration
     {
+        /// <summary>
+        /// Registers the feature components in this module with the
+        /// host editor.
+        /// </summary>
+        /// <param name="components">
+        /// The IComponentRegistry where feature components will be registered.
+        /// </param>
         public static void Register(IComponentRegistry components)
         {
             ILogger logger = components.Get<ILogger>();
-            logger.Write(LogLevel.Normal, "PowerShell Editor Services VS Code module loaded.");
+
+            components.Register<IHtmlContentViews>(
+                new HtmlContentViewsFeature(
+                    components.Get<IMessageSender>(),
+                    logger));
+
+            logger.Write(
+                LogLevel.Normal,
+                "PowerShell Editor Services VS Code module loaded.");
         }
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
@@ -1,0 +1,73 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    internal abstract class CustomViewBase : ICustomView
+    {
+        protected IMessageSender messageSender;
+        protected ILogger logger;
+
+        public Guid Id { get; private set; }
+
+        public string Title { get; private set; }
+
+        protected CustomViewType ViewType { get; private set; }
+
+        public CustomViewBase(
+            string viewTitle,
+            CustomViewType viewType,
+            IMessageSender messageSender,
+            ILogger logger)
+        {
+            this.Id = Guid.NewGuid();
+            this.Title = viewTitle;
+            this.ViewType = viewType;
+            this.messageSender = messageSender;
+            this.logger = logger;
+        }
+
+        internal Task Create()
+        {
+            return
+                this.messageSender.SendRequest(
+                    NewCustomViewRequest.Type,
+                    new NewCustomViewRequest
+                    {
+                        Id = this.Id,
+                        Title = this.Title,
+                        ViewType = this.ViewType,
+                    }, true);
+        }
+
+        public Task Show(ViewColumn viewColumn)
+        {
+            return
+                this.messageSender.SendRequest(
+                    ShowCustomViewRequest.Type,
+                    new ShowCustomViewRequest
+                    {
+                        Id = this.Id,
+                        ViewColumn = viewColumn
+                    }, true);
+        }
+
+        public Task Close()
+        {
+            return
+                this.messageSender.SendRequest(
+                    CloseCustomViewRequest.Type,
+                    new CloseCustomViewRequest
+                    {
+                        Id = this.Id,
+                    }, true);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    internal abstract class CustomViewFeatureBase<TView>
+        where TView : ICustomView
+    {
+        protected IMessageSender messageSender;
+        protected ILogger logger;
+        private Dictionary<string, TView> viewIndex;
+
+        public CustomViewFeatureBase(
+            IMessageSender messageSender,
+            ILogger logger)
+        {
+            this.viewIndex = new Dictionary<string, TView>();
+            this.messageSender = messageSender;
+            this.logger = logger;
+        }
+
+        protected void AddView(TView view)
+        {
+            this.viewIndex.Add(view.Title, view);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines a message for creating a custom view in the editor.
+    /// </summary>
+    public class NewCustomViewRequest
+    {
+        /// <summary>
+        /// The RequestType for this request.
+        /// </summary>
+        public static readonly
+            RequestType<NewCustomViewRequest, object, object, object> Type =
+            RequestType<NewCustomViewRequest, object, object, object>.Create("powerShell/newCustomView");
+
+        /// <summary>
+        /// Gets or sets the Id of the view.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the title of the view.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the view's type.
+        /// </summary>
+        public CustomViewType ViewType { get; set;}
+    }
+
+    /// <summary>
+    /// Defines a message for showing a custom view in the editor.
+    /// </summary>
+    public class ShowCustomViewRequest
+    {
+        /// <summary>
+        /// The RequestType for this request.
+        /// </summary>
+        public static readonly
+            RequestType<ShowCustomViewRequest, object, object, object> Type =
+            RequestType<ShowCustomViewRequest, object, object, object>.Create("powerShell/showCustomView");
+
+        /// <summary>
+        /// Gets or sets the Id of the view.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the column in which the view should be shown.
+        /// </summary>
+        public ViewColumn ViewColumn { get; set; }
+    }
+
+    /// <summary>
+    /// Defines a message for closing a custom view in the editor.
+    /// </summary>
+    public class CloseCustomViewRequest
+    {
+        /// <summary>
+        /// The RequestType for this request.
+        /// </summary>
+        public static readonly
+            RequestType<CloseCustomViewRequest, object, object, object> Type =
+            RequestType<CloseCustomViewRequest, object, object, object>.Create("powerShell/closeCustomView");
+
+        /// <summary>
+        /// Gets or sets the Id of the view.
+        /// </summary>
+        public Guid Id { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewType.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewType.cs
@@ -1,0 +1,18 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Enumerates the available custom view types.
+    /// </summary>
+    public enum CustomViewType
+    {
+        /// <summary>
+        /// An IHtmlContentView.
+        /// </summary>
+        HtmlContent = 1
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    internal class HtmlContentView : CustomViewBase, IHtmlContentView
+    {
+        public HtmlContentView(
+            string viewTitle,
+            IMessageSender messageSender,
+            ILogger logger)
+                : base(
+                    viewTitle,
+                    CustomViewType.HtmlContent,
+                    messageSender,
+                    logger)
+        {
+        }
+
+        public Task SetContent(string htmlBodyContent)
+        {
+            return
+                this.messageSender.SendRequest(
+                    SetHtmlContentViewRequest.Type,
+                    new SetHtmlContentViewRequest
+                    {
+                        Id = this.Id,
+                        HtmlBodyContent = htmlBodyContent
+                    }, true);
+        }
+
+        public Task AppendContent(string appendedHtmlBodyContent)
+        {
+            return
+                this.messageSender.SendRequest(
+                    AppendHtmlContentViewRequest.Type,
+                    new AppendHtmlContentViewRequest
+                    {
+                        Id = this.Id,
+                        AppendedHtmlBodyContent = appendedHtmlBodyContent
+                    }, true);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines a message for setting the content of a HtmlContentView.
+    /// </summary>
+    public class SetHtmlContentViewRequest
+    {
+        /// <summary>
+        /// The RequestType for this request.
+        /// </summary>
+        public static readonly
+            RequestType<SetHtmlContentViewRequest, object, object, object> Type =
+            RequestType<SetHtmlContentViewRequest, object, object, object>.Create("powerShell/setHtmlViewContent");
+
+        /// <summary>
+        /// Gets or sets the Id of the view.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML body content to set in the view.
+        /// </summary>
+        public string HtmlBodyContent { get; set; }
+    }
+
+    /// <summary>
+    /// Defines a message for appending to the content of an IHtmlContentView.
+    /// </summary>
+    public class AppendHtmlContentViewRequest
+    {
+        /// <summary>
+        /// The RequestType for this request.
+        /// </summary>
+        public static readonly
+            RequestType<AppendHtmlContentViewRequest, object, object, object> Type =
+            RequestType<AppendHtmlContentViewRequest, object, object, object>.Create("powerShell/appendHtmlViewContent");
+
+        /// <summary>
+        /// Gets or sets the Id of the view.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTML body content to append to the view.
+        /// </summary>
+        public string AppendedHtmlBodyContent { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    internal class HtmlContentViewsFeature : CustomViewFeatureBase<IHtmlContentView>, IHtmlContentViews
+    {
+        public HtmlContentViewsFeature(
+            IMessageSender messageSender,
+            ILogger logger)
+                : base(messageSender, logger)
+        {
+        }
+
+        public async Task<IHtmlContentView> CreateHtmlContentView(string viewTitle)
+        {
+            HtmlContentView htmlView =
+                new HtmlContentView(
+                    viewTitle,
+                    this.messageSender,
+                    this.logger);
+
+            await htmlView.Create();
+            this.AddView(htmlView);
+
+            return htmlView;
+        }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/ICustomView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/ICustomView.cs
@@ -1,0 +1,42 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines the interface for an arbitrary custom view that
+    /// can be shown in Visual Studio Code.
+    /// </summary>
+    public interface ICustomView
+    {
+        /// <summary>
+        /// Gets the unique ID of the view.
+        /// </summary>
+        Guid Id { get; }
+
+        /// <summary>
+        /// Gets the display title of the view.
+        /// </summary>
+        string Title { get; }
+
+        /// <summary>
+        /// Shows the view in the specified column.
+        /// </summary>
+        /// <param name="viewColumn">The column in which the view will be shown.</param>
+        /// <returns>A Task which can be awaited for completion.</returns>
+        Task Show(ViewColumn viewColumn);
+
+        /// <summary>
+        /// Closes the view in the editor.
+        /// </summary>
+        /// <returns>A Task which can be awaited for completion.</returns>
+        Task Close();
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines the interface for a custom view which displays
+    /// rendered HTML content in an editor tab.
+    /// </summary>
+    public interface IHtmlContentView : ICustomView
+    {
+        /// <summary>
+        /// Sets the HTML body content of the view.
+        /// </summary>
+        /// <param name="htmlBodyContent">
+        /// The HTML content that is placed inside of the page's body tag.
+        /// </param>
+        /// <returns>A Task which can be awaited for completion.</returns>
+        Task SetContent(string htmlBodyContent);
+
+        /// <summary>
+        /// Appends HTML body content to the view.
+        /// </summary>
+        /// <param name="appendedHtmlBodyContent">
+        /// The HTML fragment to be appended to the output stream.
+        /// </param>
+        /// <returns>A Task which can be awaited for completion.</returns>
+        Task AppendContent(string appendedHtmlBodyContent);
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines an interface for a component which can create
+    /// new IHtmlContentView implementation instances.
+    /// </summary>
+    public interface IHtmlContentViews
+    {
+        /// <summary>
+        /// Creates an instance of an IHtmlContentView implementation.
+        /// </summary>
+        /// <param name="viewTitle">The title of the view to create.</param>
+        /// <returns>
+        /// A Task to await for completion, returns the IHtmlContentView instance.
+        /// </returns>
+        Task<IHtmlContentView> CreateHtmlContentView(string viewTitle);
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/ViewColumn.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/ViewColumn.cs
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Defines the possible columns in which a custom view
+    /// can be displayed.
+    /// </summary>
+    public enum ViewColumn
+    {
+        /// <summary>
+        /// The first view column.
+        /// </summary>
+        One = 1,
+
+        /// <summary>
+        /// The second view column.
+        /// </summary>
+        Two,
+
+        /// <summary>
+        /// The third view column.
+        /// </summary>
+        Three
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
+++ b/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
@@ -9,6 +9,12 @@
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
+  <!-- Fail the release build if there are missing public API documentation comments -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <WarningsAsErrors>1591,1573,1572</WarningsAsErrors>
+    <DocumentationFile>bin\$(TargetFramework)\$(Configuration)\Microsoft.PowerShell.EditorServices.VSCode.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\PowerShellEditorServices\PowerShellEditorServices.csproj" />
     <ProjectReference Include="..\PowerShellEditorServices.Protocol\PowerShellEditorServices.Protocol.csproj" />


### PR DESCRIPTION
This change adds support for custom HTML views in the VSCode module
which forms the basis for UI extensions in the PowerShell extension in
Visual Studio Code.  This change includes both .NET PowerShell
cmdlet APIs for interacting with custom HTML UI in the editor.