### PR TITLE
Fix issue with loading PSES in PowerShell Core 6.0.0-beta3

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -9,6 +9,7 @@ if (!$PSVersionTable.PSEdition -or $PSVersionTable.PSEdition -eq "Desktop") {
 }
 else {
     Add-Type -Path "$PSScriptRoot/bin/Core/Microsoft.PowerShell.EditorServices.dll"
+    Add-Type -Path "$PSScriptRoot/bin/Core/Microsoft.PowerShell.EditorServices.Protocol.dll"
     Add-Type -Path "$PSScriptRoot/bin/Core/Microsoft.PowerShell.EditorServices.Host.dll"
 }
 


### PR DESCRIPTION
This change fixes an issue caused by PowerShell Core 6.0.0-beta3's
AssemblyLoadContext changes where the Protocol assembly isn't being
auto-loaded when the Host assembly gets loaded.  The fix is to
explicitly load that assembly when loaded inside of PowerShell Core.

Resolves #529