### PR TITLE
Implement GetCommands() on $psEditor

### DIFF
--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -91,6 +91,14 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         }
 
         /// <summary>
+        /// Returns all registered EditorCommands.
+        /// </summary>
+        /// <returns>An Array of all registered EditorCommands.</return>
+        public EditorCommand[] GetCommands()
+        {
+            return this.extensionService.GetCommands();
+        }
+        /// <summary>
         /// Gets the EditorContext which contains the state of the editor
         /// at the time this method is invoked.
         /// </summary>

--- a/src/PowerShellEditorServices/Extensions/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Extensions/ExtensionService.cs
@@ -170,6 +170,16 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             }
         }
 
+        /// <summary>
+        /// Returns all registered EditorCommands.
+        /// </summary>
+        /// <returns>An Array of all registered EditorCommands.</return>
+        public EditorCommand[] GetCommands()
+        {
+            EditorCommand[] commands = new EditorCommand[this.editorCommands.Count];
+            this.editorCommands.Values.CopyTo(commands,0);
+            return commands;
+        }
         #endregion
 
         #region Events


### PR DESCRIPTION
With this method you are able to receive all registered EditorCommand´s, and then unregister them or expose all commands through the HTML-ContentView and and be able to execute them once [this](https://github.com/PowerShell/vscode-powershell/issues/910) is implemented.