### PR TITLE
Fix vscode-powershell issue 872 - watch expandable variables can't be…

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -787,17 +787,25 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
             else
             {
-                VariableDetails result = null;
+                VariableDetailsBase result = null;
 
                 // VS Code might send this request after the debugger
                 // has been resumed, return an empty result in this case.
                 if (editorSession.PowerShellContext.IsDebuggerStopped)
                 {
+                    // First check to see if the watch expression refers to a naked variable reference.
                     result =
-                        await editorSession.DebugService.EvaluateExpression(
-                            evaluateParams.Expression,
-                            evaluateParams.FrameId,
-                            isFromRepl);
+                        editorSession.DebugService.GetVariableFromExpression(evaluateParams.Expression, evaluateParams.FrameId);
+
+                    // If the expression is not a naked variable reference, then evaluate the expression.
+                    if (result == null)
+                    {
+                        result =
+                            await editorSession.DebugService.EvaluateExpression(
+                                evaluateParams.Expression,
+                                evaluateParams.FrameId,
+                                isFromRepl);
+                    }
                 }
 
                 if (result != null)

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -395,6 +395,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A VariableDetailsBase object containing the result.</returns>
         public VariableDetailsBase GetVariableFromExpression(string variableExpression, int stackFrameId)
         {
+            // NOTE: From a watch we will get passed expressions that are not naked variables references.
+            // Probably the right way to do this woudld be to examine the AST of the expr before calling
+            // this method to make sure it is a VariableReference.  But for the most part, non-naked variable
+            // references are very unlikely to find a matching variable e.g. "$i+5.2" will find no var matching "$i+5".
+
             // Break up the variable path
             string[] variablePathParts = variableExpression.Split('.');
 
@@ -414,7 +419,7 @@ namespace Microsoft.PowerShell.EditorServices
                         v =>
                             string.Equals(
                                 v.Name,
-                                variableExpression,
+                                variableName,
                                 StringComparison.CurrentCultureIgnoreCase));
 
                 if (resolvedVariable != null &&


### PR DESCRIPTION
… expanded.

I can't remember if this used to work or not.  But the `GetVariableFromExpression` had no callers which is suspicious.  Anyway, I think this should fix the issue.  You'll see my note that the way 'GetVariableFromExpression` works isn't perhaps 100% foolproof but is probably good enough.