### PR TITLE
Add Type field for Variables.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/Variable.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/Variable.cs
@@ -13,6 +13,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the type of the variable's value. Typically shown in the UI when hovering over the value.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Gets or sets the evaluatable name for the variable that will be evaluated by the debugger.
         /// </summary>
         public string EvaluateName { get; set; }
@@ -26,6 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
             {
                 Name = variable.Name,
                 Value = variable.ValueString ?? string.Empty,
+                Type = variable.Type,
                 EvaluateName = variable.Name,
                 VariablesReference = 
                     variable.IsExpandable ?

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -363,6 +363,12 @@ namespace Microsoft.PowerShell.EditorServices
         {
             VariableDetailsBase[] childVariables;
 
+            if ((variableReferenceId < 0) || (variableReferenceId >= this.variables.Count))
+            {
+                logger.Write(LogLevel.Warning, $"Received request for variableReferenceId {variableReferenceId} that is out of range of valid indices.");
+                return new VariableDetailsBase[0];
+            }
+            
             VariableDetailsBase parentVariable = this.variables[variableReferenceId];
             if (parentVariable.IsExpandable)
             {

--- a/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Debugging/VariableDetailsBase.cs
@@ -39,6 +39,11 @@ namespace Microsoft.PowerShell.EditorServices
         public string ValueString { get; protected set; }
 
         /// <summary>
+        /// Gets the type of the variable's value.
+        /// </summary>
+        public string Type { get; protected set; }
+
+        /// <summary>
         /// Returns true if the variable's value is expandable, meaning
         /// that it has child properties or its contents can be enumerated.
         /// </summary>


### PR DESCRIPTION
This implements a debug protocol feature that was added a while ago (but after we did the majority of work on the Variables view).  This will display the variables type if you hover over it e.g.:

![image](https://user-images.githubusercontent.com/5177512/27524274-d3685306-59f0-11e7-84fc-19bee1d7a071.png)

The screen shot didn't capture my cursor.  I'm hovering over the `$InformationPreference` variable.