### PR TITLE
Add "Diagnostic" to ValidateSet for LogLevel

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -49,7 +49,7 @@ function Start-EditorServicesHost {
         [ValidateNotNullOrEmpty()]
         $LogPath,
 
-        [ValidateSet("Normal", "Verbose", "Error")]
+        [ValidateSet("Normal", "Verbose", "Error", "Diagnostic")]
         $LogLevel = "Normal",
 
         [switch]

--- a/module/Start-EditorServices.ps1
+++ b/module/Start-EditorServices.ps1
@@ -44,7 +44,7 @@ param(
     [ValidateNotNullOrEmpty()]
     $LogPath,
 
-    [ValidateSet("Normal", "Verbose", "Error")]
+    [ValidateSet("Normal", "Verbose", "Error","Diagnostic")]
     $LogLevel,
 
     [switch]


### PR DESCRIPTION
Since the _Diagnostic_ LogLevel was introduced [here](https://github.com/PowerShell/PowerShellEditorServices/pull/519) it wasn´t possible to use it due to the ValidateSet in the scripts.