### PR TITLE
Allow inclusion of JavaScript and CSS file paths in the HtmlContentView

### DIFF
--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Set-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Set-VSCodeHtmlContentView.ps1
@@ -19,6 +19,14 @@ function Set-VSCodeHtmlContentView {
     The HTML content that will be placed inside the <body> tag
     of the view.
 
+    .PARAMETER JavaScriptPaths
+    An array of paths to JavaScript files that will be loaded
+    into the view.
+
+    .PARAMETER StyleSheetPaths
+    An array of paths to stylesheet (CSS) files that will be
+    loaded into the view.
+
     .EXAMPLE
     # Set the view content with an h1 header
     Set-VSCodeHtmlContentView -HtmlContentView $htmlContentView -HtmlBodyContent "<h1>Hello world!</h1>"
@@ -39,10 +47,23 @@ function Set-VSCodeHtmlContentView {
         [Alias("Content")]
         [AllowEmptyString()]
         [string]
-        $HtmlBodyContent
+        $HtmlBodyContent,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $JavaScriptPaths,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $StyleSheetPaths
     )
 
     process {
-        $HtmlContentView.SetContent($HtmlBodyContent).Wait();
+        $htmlContent = New-Object Microsoft.PowerShell.EditorServices.VSCode.CustomViews.HtmlContent
+        $htmlContent.BodyContent = $HtmlBodyContent
+        $htmlContent.JavaScriptPaths = $JavaScriptPaths
+        $htmlContent.StyleSheetPaths = $StyleSheetPaths
+
+        $HtmlContentView.SetContent($htmlContent).Wait();
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
@@ -1,0 +1,31 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
+{
+    /// <summary>
+    /// Contains details about the HTML content to be
+    /// displayed in an IHtmlContentView.
+    /// </summary>
+    public class HtmlContent
+    {
+        /// <summary>
+        /// Gets or sets the HTML body content.
+        /// </summary>
+        public string BodyContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the array of JavaScript file paths
+        /// to be used in the HTML content.
+        /// </summary>
+        public string[] JavaScriptPaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the array of stylesheet (CSS) file
+        /// paths to be used in the HTML content.
+        /// </summary>
+        public string[] StyleSheetPaths { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// <summary>
         /// Gets or sets the HTML body content to set in the view.
         /// </summary>
-        public string HtmlBodyContent { get; set; }
+        public HtmlContent HtmlContent { get; set; }
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
@@ -24,6 +24,15 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         Task SetContent(string htmlBodyContent);
 
         /// <summary>
+        /// Sets the HTML content of the view.
+        /// </summary>
+        /// <param name="htmlContent">
+        /// The HTML content that is placed inside of the page's body tag.
+        /// </param>
+        /// <returns>A Task which can be awaited for completion.</returns>
+        Task SetContent(HtmlContent htmlContent);
+
+        /// <summary>
         /// Appends HTML body content to the view.
         /// </summary>
         /// <param name="appendedHtmlBodyContent">


### PR DESCRIPTION
This change adds new parameters to Set-VSCodeHtmlContentView which allow
the user to specify JavaScriptPaths and StyleSheetPaths to include local
JavaScript and CSS files into their HTML views.

Part of the fix for PowerShell/vscode-powershell#910.