### PR TITLE
Fix missing prompt when launching temporary interactive debug session

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -407,6 +407,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
 
             editorSession.StartDebugSession(
                 powerShellContext,
+                hostUserInterface,
                 editorOperations);
 
             return editorSession;

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -217,14 +217,23 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             await requestContext.SendResult(null);
 
-            if (this.isInteractiveDebugSession &&
-                this.editorSession.DebugService.IsDebuggerStopped)
+            if (this.isInteractiveDebugSession)
             {
-                // If this is an interactive session and there's a pending breakpoint,
-                // send that information along to the debugger client
-                this.DebugService_DebuggerStopped(
-                    this,
-                    this.editorSession.DebugService.CurrentDebuggerStoppedEventArgs);
+                if (this.ownsEditorSession)
+                {
+                    // If this is a debug-only session, we need to start
+                    // the command loop manually
+                    this.editorSession.HostInput.StartCommandLoop();
+                }
+
+                if (this.editorSession.DebugService.IsDebuggerStopped)
+                {
+                    // If this is an interactive session and there's a pending breakpoint,
+                    // send that information along to the debugger client
+                    this.DebugService_DebuggerStopped(
+                        this,
+                        this.editorSession.DebugService.CurrentDebuggerStoppedEventArgs);
+                }
             }
         }
 
@@ -646,7 +655,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             int startFrameIndex = stackTraceParams.StartFrame ?? 0;
             int maxFrameCount = stackFrames.Length;
 
-            // If the number of requested levels == 0 (or null), that means get all stack frames 
+            // If the number of requested levels == 0 (or null), that means get all stack frames
             // after the specified startFrame index. Otherwise get all the stack frames.
             int requestedFrameCount = (stackTraceParams.Levels ?? 0);
             if (requestedFrameCount > 0)

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -123,14 +123,17 @@ namespace Microsoft.PowerShell.EditorServices
         /// for the ConsoleService.
         /// </summary>
         /// <param name="powerShellContext"></param>
+        /// <param name="hostInput"></param>
         /// <param name="editorOperations">
         /// An IEditorOperations implementation used to interact with the editor.
         /// </param>
         public void StartDebugSession(
             PowerShellContext powerShellContext,
+            IHostInput hostInput,
             IEditorOperations editorOperations)
         {
             this.PowerShellContext = powerShellContext;
+            this.HostInput = hostInput;
 
             // Initialize all services
             this.RemoteFileManager = new RemoteFileManager(this.PowerShellContext, editorOperations, logger);


### PR DESCRIPTION
This change fixes an issue which causes the command prompt to not appear
when you start an interactive debugging session with the
-DebugServiceOnly parameter.  The fix is to invoke the host's command
loop in this specific case.

Resolves PowerShell/vscode-powershell#942