### PR TITLE
Add pipeline input to Write-VSCodeHtmlContentView cmdlet

### DIFF
--- a/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Write-VSCodeHtmlContentView.ps1
+++ b/module/PowerShellEditorServices.VSCode/Public/HtmlContentView/Write-VSCodeHtmlContentView.ps1
@@ -33,7 +33,7 @@ function Write-VSCodeHtmlContentView {
         [Microsoft.PowerShell.EditorServices.VSCode.CustomViews.IHtmlContentView]
         $HtmlContentView,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [Alias("Content")]
         [ValidateNotNull()]
         [string]


### PR DESCRIPTION
This change adds the ValueFromPipeline setting to the
AppendedHtmlBodyContent parameter of the Write-VSCodeHtmlContentView
cmdlet so that pipeline output can be written out to an HtmlContentView
with ease.

Resolves PowerShell/vscode-powershell#909.