### PR TITLE
Fix ConvertTo-ScriptExtent swapping start line and column

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/ConvertTo-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/ConvertTo-ScriptExtent.ps1
@@ -97,8 +97,8 @@ function ConvertTo-ScriptExtent {
             if (-not $StartColumnNumber) { $StartColumnNumber = 1 }
             if (-not $StartLineNumber)   { $StartLineNumber   = 1 }
             $StartBuffer = New-Object Microsoft.PowerShell.EditorServices.BufferPosition @(
-                $StartColumnNumber,
-                $StartLineNumber)
+                $StartLineNumber,
+                $StartColumnNumber)
 
             if ($EndLineNumber -and $EndColumnNumber) {
                 $EndBuffer = New-Object Microsoft.PowerShell.EditorServices.BufferPosition @(


### PR DESCRIPTION
- Fixed an issue where `ConvertTo-ScriptExtent` could reverse starting line and column in some situations.