### PR TITLE
Use raw console bgcolor by default in IHostOutput.WriteOutput

### DIFF
--- a/src/PowerShellEditorServices/Session/Host/IHostOutput.cs
+++ b/src/PowerShellEditorServices/Session/Host/IHostOutput.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices
                 includeNewLine,
                 outputType,
                 ConsoleColor.Gray,
-                ConsoleColor.Black);
+                (ConsoleColor)(-1)); // -1 indicates the console's raw background color
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace Microsoft.PowerShell.EditorServices
                 includeNewLine,
                 outputType,
                 foregroundColor,
-                ConsoleColor.Black);
+                (ConsoleColor)(-1)); // -1 indicates the console's raw background color
         }
     }
 }


### PR DESCRIPTION
This change resolves PowerShell/vscode-powershell#637 which reports that
on Linux and macOS the input prompt is printed out with a black
background, overriding the console's default background color.  The
fix is to use a System.ConsoleColor of -1 as the default rather than
System.ConsoleColor.Black so that .NET's console library will not
override the console's background color.