### PR TITLE
Fix command history while debugging

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -303,10 +303,11 @@ namespace Microsoft.PowerShell.EditorServices.Console
                             command.AddCommand("Get-History");
 
                             currentHistory =
-                                await this.powerShellContext.ExecuteCommand<PSObject>(
-                                    command,
-                                    false,
-                                    false) as Collection<PSObject>;
+                                new Collection<PSObject>(
+                                    (await this.powerShellContext.ExecuteCommand<PSObject>(
+                                        command,
+                                        false,
+                                        false)).ToList());
 
                             if (currentHistory != null)
                             {

--- a/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
@@ -33,8 +33,10 @@ namespace Microsoft.PowerShell.EditorServices.Session
         {
             IEnumerable<TResult> executionResult = null;
 
-            using (var nestedPipeline = currentRunspace.CreateNestedPipeline())
+            string historyString = psCommand.Commands[0].CommandText;
+            using (var nestedPipeline = currentRunspace.CreateNestedPipeline(historyString, sendOutputToHost))
             {
+                nestedPipeline.Commands.Clear();
                 foreach (var command in psCommand.Commands)
                 {
                     nestedPipeline.Commands.Add(command);

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -1490,10 +1490,12 @@ namespace Microsoft.PowerShell.EditorServices
                         {
                             powerShell.Runspace = runspace;
                             powerShell.Commands = command;
+                            var invocationSettings = new PSInvocationSettings();
+                            invocationSettings.AddToHistory = false;
 
                             return
                                 powerShell
-                                    .Invoke()
+                                    .Invoke(null, invocationSettings)
                                     .FirstOrDefault();
                         }
                     });


### PR DESCRIPTION
This change fixes command history while debugging.

- Fixed internal commands being added to command history.
- Fixed `ConsoleReadLine` not retrieving history correctly.