### PR TITLE
Fix bug where bg of -1 causes crash of interactive session.

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Is this an untitled script?
             Task launchTask = null;
 
-            if (this.scriptToLaunch.StartsWith("untitled"))
+            if (this.scriptToLaunch.StartsWith("untitled:"))
             {
                 ScriptFile untitledScript =
                     this.editorSession.Workspace.GetFile(
@@ -252,6 +252,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 #pragma warning disable 618
                 launchParams.Program;
 #pragma warning restore 618
+
+            // We come through here first when debugging an untitled (unsaved) file - there is now working dir.
+            if (workingDir.StartsWith("untitled:"))
+            {
+                workingDir = null;
+            }
 
             if (workingDir != null)
             {

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -413,6 +413,14 @@ namespace Microsoft.PowerShell.EditorServices
         {
             var diagnosticRecords = new PSObject[0];
 
+            // When a new, empty file is created there are by definition no issues.
+            // Furthermore, if you call Invoke-ScriptAnalyzer with an empty ScriptDefinition
+            // it will generate a ParameterBindingValidationException.
+            if (string.IsNullOrEmpty(scriptContent))
+            {
+                return diagnosticRecords;
+            }
+
             if (hasScriptAnalyzerModule
                 && (typeof(TSettings) == typeof(string)
                     || typeof(TSettings) == typeof(Hashtable)))

--- a/src/PowerShellEditorServices/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/TerminalPSHostUserInterface.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices
             ConsoleColor oldBackgroundColor = System.Console.BackgroundColor;
 
             System.Console.ForegroundColor = foregroundColor;
-            System.Console.BackgroundColor = backgroundColor;
+            System.Console.BackgroundColor = ((int)backgroundColor != -1) ? backgroundColor : oldBackgroundColor;
 
             System.Console.Write(outputString + (includeNewLine ? Environment.NewLine : ""));
 


### PR DESCRIPTION
Fix bug where the user can select the bottom most stack frame during interactive session debugging and that generates an error in VSCode when it can't find <No File>.
Fix #555 ParameterBindingValidationException when invoking PSSA on an empty PS1 file.