### PR TITLE
Attempt to fix issue with stepping in dbgr on Linux

### DIFF
--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -487,6 +487,19 @@ namespace Microsoft.PowerShell.EditorServices.Console
                             }
                             else
                             {
+                                // Check to see if a key is available.
+                                // If not check for cancellation requested.
+                                while (!Console.KeyAvailable)
+                                {
+                                    if (cancellationToken.IsCancellationRequested)
+                                    {
+                                        //this.bufferedKey = keyInfo;
+                                        throw new TaskCanceledException();
+                                    }
+
+                                    Thread.Sleep(100);
+                                }
+
                                 keyInfo = Console.ReadKey(true);
 
                                 if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
Fix #554 

I'm not entirely sure about this fix but what I observed is that you could step once in the debugger on Linux but the second step did nothing until you pressed a key in the interactive session.  That would wake up this code on the blocking ReadKey() and every time the token was set to cancel.  The thought was to not block on ReadKey() but wake up every 100 mSecs and check if a key is available and also if cancellation was requested.  What I don't know is if this would slow down fast typing.  At 100 mSecs I wouldn't think so.
