### PR TITLE
Fix #570 Get-Help -ShowWindow errors in PSIC

### DIFF
--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHost.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHost.cs
@@ -3,10 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Console;
 using Microsoft.PowerShell.EditorServices.Session;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
+using System.Management.Automation;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 
@@ -75,6 +75,16 @@ namespace Microsoft.PowerShell.EditorServices
         public override string Name
         {
             get { return this.hostDetails.Name; }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        public override PSObject PrivateData
+        {
+            // There is no PrivateData yet but by returning an empty object we can get past PowerShell's
+            // check for $host.PrivateData["window"] which errors on the null returned by default.
+            get { return new PSObject(); }
         }
 
         /// <summary>


### PR DESCRIPTION
This fix overrides the built-in PSHost.PrivateData property, which returns null.  The override instead returns an empty PSObject.  This fixes the Get-Help -ShowWindow scenario since Windows PowerShell will no longer get a NullRefEx on access the host PrivateData property without doing a null check.  Since PrivateData["Window"] will still return null, PowerShell will show the dialog with the desktop as the parent window. IOW this PR does not fix the issue with the help window not appearing on top.  It simply fixes the error you get in PSIC.