### PR TITLE
Fix off-by-one on maxlLine calc

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -279,12 +279,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="column">The 1-based column to be validated.</param>
         public void ValidatePosition(int line, int column)
         {
-            if (line < 1 || line > this.FileLines.Count + 1)
+            int maxLine = this.FileLines.Count;
+            if (line < 1 || line > maxLine)
             {
-                throw new ArgumentOutOfRangeException("Position is outside of file line range.");
+                throw new ArgumentOutOfRangeException($"Position {line}:{column} is outside of the line range of 1 to {maxLine}.");
             }
 
-            // The maximum column is either one past the length of the string
+            // The maximum column is either **one past** the length of the string
             // or 1 if the string is empty.
             string lineString = this.FileLines[line - 1];
             int maxColumn = lineString.Length > 0 ? lineString.Length + 1 : 1;
@@ -293,7 +294,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 throw new ArgumentOutOfRangeException(
                     string.Format(
-                        "Position is outside of column range for line {0}.",
+                        "Position {line}:{column} is outside of the column range of 1 to {maxColumn}.",
                         line));
             }
         }

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -292,10 +292,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (column < 1 || column > maxColumn)
             {
-                throw new ArgumentOutOfRangeException(
-                    string.Format(
-                        "Position {line}:{column} is outside of the column range of 1 to {maxColumn}.",
-                        line));
+                throw new ArgumentOutOfRangeException($"Position {line}:{column} is outside of the column range of 1 to {maxColumn}.");
             }
         }
 


### PR DESCRIPTION
The old code allowed the line param to be *equal* to FileLines.Count + 1.
That's not a valid index even after subtracting 1 to get to a 0-based index.
Also added more data to log messages to help in the future.

@daviwil I pretty sure about the off-by-one but not 100% sure.  Can you double check?  At the very least, I'd like to enhance the log messages.

This is related to #567.  I'm not sure if this fixes it (kind of doubt it) but I'm hopeful the enhanced log messages might help if someone repro's this.
