### PR TITLE
Do not set breakpoint on non-PowerShell files

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Is this an untitled script?
             Task launchTask = null;
 
-            if (this.scriptToLaunch.StartsWith("untitled:"))
+            if (ScriptFile.IsUntitledPath(this.scriptToLaunch))
             {
                 ScriptFile untitledScript =
                     this.editorSession.Workspace.GetFile(
@@ -259,7 +259,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // When debugging an "untitled" (unsaved) file - the working dir can't be derived
             // from the Script path.  OTOH, if the launch params specifies a Cwd, use it.
-            if (workingDir.StartsWith("untitled:") && string.IsNullOrEmpty(launchParams.Cwd))
+            if (ScriptFile.IsUntitledPath(workingDir) && string.IsNullOrEmpty(launchParams.Cwd))
             {
                 workingDir = null;
             }
@@ -492,7 +492,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             {
                 // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
                 // the Source.Path comes through as Untitled-X.
-                if (!setBreakpointsParams.Source.Path.StartsWith("untitled:"))
+                if (!ScriptFile.IsUntitledPath(setBreakpointsParams.Source.Path))
                 {
                     scriptFile = editorSession.Workspace.GetFile(setBreakpointsParams.Source.Path);
                 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -264,7 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 workingDir = null;
             }
 
-            if (workingDir != null)
+            if (!string.IsNullOrEmpty(workingDir))
             {
                 workingDir = PowerShellContext.UnescapePath(workingDir);
                 try
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            if (workingDir == null)
+            if (string.IsNullOrEmpty(workingDir))
             {
 #if CoreCLR
                 workingDir = AppContext.BaseDirectory;
@@ -490,7 +490,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // VSCode sends breakpoint requests with the original filename that doesn't exist anymore.
             try
             {
-                scriptFile = editorSession.Workspace.GetFile(setBreakpointsParams.Source.Path);
+                // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
+                // the Source.Path comes through as Untitled-X.
+                if (!setBreakpointsParams.Source.Path.StartsWith("untitled:"))
+                {
+                    scriptFile = editorSession.Workspace.GetFile(setBreakpointsParams.Source.Path);
+                }
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
             {
@@ -519,7 +524,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             {
                 Logger.Write(
                     LogLevel.Warning,
-                    $"Attempted to set breakpoints on a non-PoweShell file: {setBreakpointsParams.Source.Path}");
+                    $"Attempted to set breakpoints on a non-PowerShell file: {setBreakpointsParams.Source.Path}");
 
                 string message = this.noDebug ? string.Empty : "Source is not a PowerShell script, breakpoint not set.";
 

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -208,6 +208,19 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
+        /// Deterines whether the supplied path indicates the file is an "untitled:Unitled-X" 
+        /// which has not been saved to file.
+        /// </summary>
+        /// <param name="path">The path to check.</param>
+        /// <returns>True if the path is an untitled file, false otherwise.</returns>
+        public static bool IsUntitledPath(string path)
+        {
+            Validate.IsNotNull(nameof(path), path);
+
+            return path.ToLower().StartsWith("untitled:");
+        }
+
+        /// <summary>
         /// Gets a line from the file's contents.
         /// </summary>
         /// <param name="lineNumber">The 1-based line number in the file.</param>


### PR DESCRIPTION
Fix #574 

There's still an associated but separate bug when a user is attempting to start debug on the current file when the active window is a Git diff window.  I opened an issue on vscode-debugadpter-node project: https://github.com/Microsoft/vscode-debugadapter-node/issues/134