### PR TITLE
In PSCore RemoteSessionStateProxy.InvokeCommand throws PSNotImpemente…

### DIFF
--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -6,7 +6,6 @@
 using Microsoft.PowerShell.EditorServices.Symbols;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -698,6 +697,12 @@ namespace Microsoft.PowerShell.EditorServices
                     }
 
                     this.areAliasesLoaded = true;
+                }
+                catch (PSNotSupportedException e)
+                {
+                    this.logger.Write(
+                        LogLevel.Warning,
+                        $"Caught PSNotSupportedException while attempting to get aliases from remote session:\n\n{e.ToString()}");
                 }
                 catch (TaskCanceledException)
                 {

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -703,6 +703,9 @@ namespace Microsoft.PowerShell.EditorServices
                     this.logger.Write(
                         LogLevel.Warning,
                         $"Caught PSNotSupportedException while attempting to get aliases from remote session:\n\n{e.ToString()}");
+
+                    // Prevent the aliases from being fetched again - no point if the remote doesn't support InvokeCommand.
+                    this.areAliasesLoaded = true;
                 }
                 catch (TaskCanceledException)
                 {


### PR DESCRIPTION
…dException

Fix #1091 - I think.  Well, at least the initial layer of the onion.  Not sure what else we'll run into connecting to PS Core as the remote. I don't have a setup for testing that atm.

Probably don't want to crash the extension if we can't get aliases when the remote is PS Core.

See https://github.com/PowerShell/PowerShell/blob/4bc52d2358222084738157a08907fac32d13bd3a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs#L2982-L2988