### PR TITLE
Rkeithhill/fix breakpoint on nonexisting file

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -504,7 +504,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 e is IOException ||
                 e is NotSupportedException ||
                 e is PathTooLongException ||
-                e is SecurityException)
+                e is SecurityException ||
+                e is UnauthorizedAccessException)
             {
                 Logger.WriteException(
                     $"Failed to set breakpoint on file: {setBreakpointsParams.Source.Path}",

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -512,7 +512,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     e);
 
                 string message = this.noDebug ? string.Empty : "Source file could not be accessed, breakpoint not set - " + e.Message;
-
                 var srcBreakpoints = setBreakpointsParams.Breakpoints
                     .Select(srcBkpt => Protocol.DebugAdapter.Breakpoint.Create(
                         srcBkpt, setBreakpointsParams.Source.Path, message, verified: this.noDebug));


### PR DESCRIPTION
This fixes https://github.com/PowerShell/vscode-powershell/issues/1114

Apparently there are other ways a source file with a breakpoint set on it, cannot be accessed.  In this case, it is when the network location where the file exists goes away.  With this PR I'm adding handling for all other exceptions except Argument*Exceptions in the set breakpoint code.