### PR TITLE
Catch ArgumentOutOfRange exception

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
             catch (ArgumentOutOfRangeException e)
             {
-                scriptExtentText = "";
+                scriptExtentText = string.Empty;
             }
 
             return new ScriptRegion

--- a/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
@@ -83,10 +83,21 @@ namespace Microsoft.PowerShell.EditorServices
         /// </returns>
         public static ScriptRegion Create(IScriptExtent scriptExtent)
         {
+            // IScriptExtent throws an ArgumentOutOfRange exception if Text is null
+            string scriptExtentText;
+            try
+            {
+                scriptExtentText = scriptExtent.Text;
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                scriptExtentText = "";
+            }
+
             return new ScriptRegion
             {
                 File = scriptExtent.File,
-                Text = scriptExtent.Text,
+                Text = scriptExtentText,
                 StartLineNumber = scriptExtent.StartLineNumber,
                 StartColumnNumber = scriptExtent.StartColumnNumber,
                 StartOffset = scriptExtent.StartOffset,


### PR DESCRIPTION
fixes #582 

`IScriptExtent` throws an `ArgumentOutOfRangeException`. When accessing the `Text` property.

This PR catches that error and sets it to a default value of empty string.