### PR TITLE
Fix bad pssa settings path crashes PSES

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -91,6 +91,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                             settingsPath = Path.GetFullPath(Path.Combine(workspaceRootPath, settingsPath));
                         }
                     }
+
+                    this.SettingsPath = settingsPath;
+                    logger.Write(LogLevel.Verbose, $"Using Script Analyzer settings path - '{settingsPath ?? ""}'.");
                 }
                 catch (Exception ex) when (ex is NotSupportedException)
                 {
@@ -98,10 +101,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     logger.WriteException(
                         $"Invalid Script Analyzer settings path - '{settingsPath}'.",
                         ex);
-                }
 
-                this.SettingsPath = settingsPath;
-                logger.Write(LogLevel.Verbose, $"Using Script Analyzer settings path - '{settingsPath ?? ""}'.");
+                    this.SettingsPath = null;
+                }
             }
         }
     }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -3,13 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.IO;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
-using System.Reflection;
 using System.Collections;
-using System.Linq;
-using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Security;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
@@ -95,7 +94,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     this.SettingsPath = settingsPath;
                     logger.Write(LogLevel.Verbose, $"Using Script Analyzer settings path - '{settingsPath ?? ""}'.");
                 }
-                catch (Exception ex) when (ex is NotSupportedException)
+                catch (Exception ex) when (
+                    ex is NotSupportedException || 
+                    ex is PathTooLongException ||
+                    ex is SecurityException)
                 {
                     // Invalid chars in path like ${env:HOME} can cause Path.GetFullPath() to throw, catch such errors here
                     logger.WriteException(

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -101,6 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
 
                 this.SettingsPath = settingsPath;
+                logger.Write(LogLevel.Verbose, $"Using Script Analyzer settings path - '{settingsPath ?? ""}'.");
             }
         }
     }


### PR DESCRIPTION
Crash happens if user tries to set path to something like `${env:HOME}\pssettings.psd1` which looks like it might be valid but isn't because the variable doesn't get expanded.

It seems the GH diff view has gotten dumber or something. This is the diff I see in VS:

![image](https://user-images.githubusercontent.com/5177512/34395365-d5659d90-eb1c-11e7-9d79-650ed638baef.png)
