### PR TITLE
add Save to FileContext API

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -122,6 +122,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
             RequestType<string, EditorCommandResponse, object, object>.Create("editor/closeFile");
     }
 
+    public class SaveFileRequest
+    {
+        public static readonly
+            RequestType<string, EditorCommandResponse, object, object> Type =
+            RequestType<string, EditorCommandResponse, object, object>.Create("editor/saveFile");
+    }
+
     public class ShowInformationMessageRequest
     {
         public static readonly

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -128,6 +128,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     true);
         }
 
+        public Task SaveFile(string filePath)
+        {
+            return
+                this.messageSender.SendRequest(
+                    SaveFileRequest.Type,
+                    filePath,
+                    true);
+        }
+
         public string GetWorkspacePath()
         {
             return this.editorSession.Workspace.WorkspacePath;

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -228,6 +228,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         }
 
         #endregion
+
+        #region File Manipulation
+
+        /// <summary>
+        /// Saves this file.
+        /// </summary>
+        public void Save()
+        {
+            this.editorOperations.SaveFile(this.scriptFile.FilePath);
+        }
+
+        #endregion
     }
 }
 

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -55,6 +55,13 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         Task CloseFile(string filePath);
 
         /// <summary>
+        /// Causes a file to be saved in the editor.
+        /// </summary>
+        /// <param name="filePath">The path of the file to be saved.</param>
+        /// <returns>A Task that can be tracked for completion.</returns>
+        Task SaveFile(string filePath);
+
+        /// <summary>
         /// Inserts text into the specified range for the file at the specified path.
         /// </summary>
         /// <param name="filePath">The path of the file which will have text inserted.</param>

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -200,6 +200,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             throw new NotImplementedException();
         }
 
+        public Task SaveFile(string filePath)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task InsertText(string filePath, string text, BufferRange insertRange)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
This is the PSES portion of this change. See the PSES portion here: https://github.com/PowerShell/vscode-powershell/pull/1139

Please let me know if I'm missing something.

To test this, you can use:
```powershell
$psEditor.GetEditorContext().CurrentFile.Save()
```
in the Integrated Console.