### PR TITLE
Fix debugger step through on Unix platforms

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -129,6 +129,10 @@ task TestPowerShellApi -If { !$script:IsUnix } {
 task Build {
     exec { & $script:dotnetExe build -c $Configuration .\src\PowerShellEditorServices.Host\PowerShellEditorServices.Host.csproj $script:TargetFrameworksParam }
     exec { & $script:dotnetExe build -c $Configuration .\src\PowerShellEditorServices.VSCode\PowerShellEditorServices.VSCode.csproj $script:TargetFrameworksParam }
+    exec { & $script:dotnetExe publish -c $Configuration .\src\PowerShellEditorServices\PowerShellEditorServices.csproj -f netstandard1.6 }
+    Copy-Item $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\netstandard1.6\publish\UnixConsoleEcho.dll -Destination $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6
+    Copy-Item $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\netstandard1.6\publish\runtimes\osx-64\native\libdisablekeyecho.dylib -Destination $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6
+    Copy-Item $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\netstandard1.6\publish\runtimes\linux-64\native\libdisablekeyecho.so -Destination $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6
 }
 
 function UploadTestLogs {
@@ -185,9 +189,12 @@ task LayoutModule -After Build {
     New-Item -Force $PSScriptRoot\module\PowerShellEditorServices\bin\Core -Type Directory | Out-Null
 
     Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6\* -Filter Microsoft.PowerShell.EditorServices*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
+    Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6\UnixConsoleEcho.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
+    Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6\libdisablekeyecho.* -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
     if (!$script:IsUnix) {
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\* -Filter Microsoft.PowerShell.EditorServices*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\Newtonsoft.Json.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
+        Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\UnixConsoleEcho.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
     }
 
     # Lay out the PowerShellEditorServices.VSCode module's binaries

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -59,6 +59,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="UnixConsoleEcho" Version="0.1.0" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
This change resolves an issue where the debugger would appear hung until a key was pressed on Unix platforms.

This issue was caused by a quirk with the Unix implementation for `System.Console`.  The way cursor position is retrieved is by writing the cursor position escape sequence query and reading it from stdin. To ensure those escape sequences don't trigger `Console.ReadKey`, the internal stdin buffer is locked while `ReadKey` is running. This means that while `ReadKey` is running, any attempts to query cursor position will block the thread until the pending `ReadKey` finishes.

The pipeline appears to hang on a debugger stop because there is a pending `ReadKey` call in another thread and various methods in both the internal PowerShell engine and in our host implementation obtain the cursor position between command executions to determine prompt location.

The best solution to this problem (credit goes to @rkeithhill) is to create an alternative `ReadKey` implementation that waits for `KeyAvailable` before blocking. However, if `ReadKey` is not currently running then any input is echoed to the console. Aside from being generally annoying, this presents a huge problem while trying to do something like `Read-Host -AsSecureString`.

To get around this, I stripped out the native code from corefx that disables console input echo, created a separate package that this project can consume, and implemented a `WaitForKeyAvailable` method that utilizes it.

This fix should be viewed as a temporary solution until either `ReadKey` acts like this by default or a `ReadKeyAsync` method is implemented into corefx.

@tylerl0706 I've tested on Windows and Linux, but it still needs to be tested on Mac.  Thanks again for your help with building! :)

Resolves PowerShell/vscode-powershell#987
Resolves PowerShell/vscode-powershell#1107
Resolves #554