### PR TITLE
Improve error logging for exec of pscommands

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -534,11 +534,11 @@ namespace Microsoft.PowerShell.EditorServices
                                 strBld.Append(error.ToString() + "\r\n");
                                 strBld.Append("ScriptStackTrace:\r\n");
                                 strBld.Append((error.ScriptStackTrace ?? "<null>") + "\r\n");
-                                strBld.Append($"Exception {error.Exception?.ToString() ?? "<null>"}");
+                                strBld.Append($"Exception:\r\n   {error.Exception?.ToString() ?? "<null>"}");
                                 Exception innerEx = error.Exception?.InnerException;
                                 while (innerEx != null)
                                 {
-                                    strBld.Append($"InnerException {innerEx.ToString()}");
+                                    strBld.Append($"InnerException:\r\n   {innerEx.ToString()}");
                                     innerEx = innerEx.InnerException;
                                 }
                             }

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -533,8 +533,8 @@ namespace Microsoft.PowerShell.EditorServices
                                 strBld.Append($"Error #{i++}:\r\n");
                                 strBld.Append(error.ToString() + "\r\n");
                                 strBld.Append("ScriptStackTrace:\r\n");
-                                strBld.Append(error.ScriptStackTrace + "\r\n");
-                                strBld.Append($"Exception {error.Exception.ToString()}");
+                                strBld.Append((error.ScriptStackTrace ?? "<null>") + "\r\n");
+                                strBld.Append($"Exception {error.Exception?.ToString() ?? "<null>"}");
                                 Exception innerEx = error.Exception?.InnerException;
                                 while (innerEx != null)
                                 {


### PR DESCRIPTION
This improves the output to the EditorServices.log file from:
```
1/4/2018 6:49:26 PM [ERROR] - Method "ExecuteCommand" at line 575 of C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\src\PowerShellEditorServices\Session\PowerShellContext.cs

    Execution completed with errors:

    You cannot call a method on a null-valued expression.
    You cannot call a method on a null-valued expression.
```
to
```
1/4/2018 6:49:26 PM [ERROR] - Method "ExecuteCommand" at line 575 of C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\src\PowerShellEditorServices\Session\PowerShellContext.cs

    Execution of command 'Import-Module - C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\bin\Desktop\..\..\Commands\PowerShellEditorServices.Commands.psd1;' completed with errors:
    
    Error #1:
    You cannot call a method on a null-valued expression.
    ScriptStackTrace:
    at Register-EditorCommand<Process>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\Public\CmdletInterface.ps1: line 51
    at <ScriptBlock>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\Private\BuiltInCommands.ps1: line 1
    at <ScriptBlock>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\PowerShellEditorServices.Commands.psm1: line 12
    Exception System.Management.Automation.RuntimeException: You cannot call a method on a null-valued expression.
       at CallSite.Target(Closure , CallSite , Object , Object )
       at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
       at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame)
       at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
    
    Error #2:
    You cannot call a method on a null-valued expression.
    ScriptStackTrace:
    at Register-EditorCommand<Process>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\Public\CmdletInterface.ps1: line 51
    at <ScriptBlock>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\Private\BuiltInCommands.ps1: line 11
    at <ScriptBlock>, C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\module\PowerShellEditorServices\Commands\PowerShellEditorServices.Commands.psm1: line 12
    Exception System.Management.Automation.RuntimeException: You cannot call a method on a null-valued expression.
       at CallSite.Target(Closure , CallSite , Object , Object )
       at System.Management.Automation.Interpreter.DynamicInstruction`3.Run(InterpretedFrame frame)
       at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
```
NOTE: While the two errors above "look" identical they actually arise from different lines of `BuiltInCommands.ps1`.