### PR TITLE
fix *-Content calls in psedit scripts and set ComputerName default

### DIFF
--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -47,7 +47,17 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     $filePathName = $_.FullName
 
                     # Get file contents
-                    $contentBytes = Get-Content -Path $filePathName -Raw -Encoding Byte
+                    $params = @{ Path=$filePathName; Raw=$true }
+                    if ($PSVersionTable.PSEdition -eq 'Core')
+                    {
+                        $params += @{ AsByteStream=$true }
+                    }
+                    else
+                    {
+                        $params += @{ Encoding='Byte' }
+                    }
+
+                    $contentBytes = Get-Content @params
 
                     # Notify client for file open.
                     New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($filePathName, $contentBytes) > $null
@@ -85,7 +95,18 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 [byte[]] $Content
             )
 
-            Set-Content -Path $RemoteFilePath -Value $Content -Encoding Byte -Force 2>&1
+            # Set file contents
+            $params = @{ Path=$RemoteFilePath; Value=$Content; Force=$true }
+            if ($PSVersionTable.PSEdition -eq 'Core')
+            {
+                $params += @{ AsByteStream=$true }
+            }
+            else
+            {
+                $params += @{ Encoding='Byte' }
+            }
+
+            Set-Content @params 2>&1
         ";
 
         #endregion

--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -50,11 +50,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     $params = @{ Path=$filePathName; Raw=$true }
                     if ($PSVersionTable.PSEdition -eq 'Core')
                     {
-                        $params += @{ AsByteStream=$true }
+                        $params['AsByteStream']=$true
                     }
                     else
                     {
-                        $params += @{ Encoding='Byte' }
+                        $params['Encoding']='Byte'
                     }
 
                     $contentBytes = Get-Content @params
@@ -99,11 +99,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
             $params = @{ Path=$RemoteFilePath; Value=$Content; Force=$true }
             if ($PSVersionTable.PSEdition -eq 'Core')
             {
-                $params += @{ AsByteStream=$true }
+                $params['AsByteStream']=$true
             }
             else
             {
-                $params += @{ Encoding='Byte' }
+                $params['Encoding']='Byte'
             }
 
             Set-Content @params 2>&1

--- a/src/PowerShellEditorServices/Session/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Session/SessionDetails.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         {
             PSCommand infoCommand = new PSCommand();
             infoCommand.AddScript(
-                "@{ 'computerName' = if ($ExecutionContext.Host.Runspace.ConnectionInfo) {$ExecutionContext.Host.Runspace.ConnectionInfo.ComputerName}  else {'localhost'}; 'processId' = $PID; 'instanceId' = $host.InstanceId }");
+                "@{ 'computerName' = if ([Environment]::MachineName) {[Environment]::MachineName}  else {'localhost'}; 'processId' = $PID; 'instanceId' = $host.InstanceId }");
 
             return infoCommand;
         }

--- a/src/PowerShellEditorServices/Session/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Session/SessionDetails.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         {
             PSCommand infoCommand = new PSCommand();
             infoCommand.AddScript(
-                "@{ 'computerName' = $env:ComputerName; 'processId' = $PID; 'instanceId' = $host.InstanceId }");
+                "@{ 'computerName' = if ($ExecutionContext.Host.Runspace.ConnectionInfo) {$ExecutionContext.Host.Runspace.ConnectionInfo.ComputerName}  else {'localhost'}; 'processId' = $PID; 'instanceId' = $host.InstanceId }");
 
             return infoCommand;
         }


### PR DESCRIPTION
`*-Content -Encoding Byte` was changed to `*-Content -AsByteStream` in PSCore. This PR adds a check for the version of PowerShell... and uses the correct param.

Also, since `$env:ComputerName` is not set on Linux or Mac, we get null ref exceptions so we are using `[Environment]::MachineName` instead and defaulting to "localhost" if it does not exist.

This allowed me to remote edit/debug a file on an Ubuntu VM from my Mac 🎉
  
Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/597
Resolves https://github.com/PowerShell/vscode-powershell/issues/789
  