### PR TITLE
add userprefs for VS for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ PowerShellEditorServices.sln.ide/storage.ide
 
 # Don't include PlatyPS generated MAML
 module/PowerShellEditorServices/Commands/en-US/*-help.xml
+
+# Visual Studio for Mac generated file
+*.userprefs


### PR DESCRIPTION
On Mac, I have to use Visual Studio for Mac to get the "Go To Def" and such because of this bug:
https://github.com/OmniSharp/omnisharp-vscode/issues/1937

It creates one of these files that doesn't need to be checked in.