### PR TITLE
change Enumerate* to Get*

### DIFF
--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             try
             {
-                IEnumerable<string> subDirs = Directory.EnumerateDirectories(folderPath);
+                IEnumerable<string> subDirs = Directory.GetDirectories(folderPath);
                 foreach (string dir in subDirs)
                 {
                     foundFiles =
@@ -274,7 +274,7 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     foundFiles =
                         foundFiles.Concat(
-                            Directory.EnumerateFiles(
+                            Directory.GetFiles(
                                 folderPath,
                                 pattern));
                 }

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -278,10 +278,22 @@ namespace Microsoft.PowerShell.EditorServices
                                 folderPath,
                                 pattern));
                 }
-                catch (UnauthorizedAccessException e)
+                catch (DirectoryNotFoundException e)
                 {
                     this.logger.WriteException(
-                        $"Could not enumerate files in the path '{folderPath}' due to a file not being accessible",
+                        $"Could not enumerate files in the path '{folderPath}' due to a path being an invalid path",
+                        e);
+                }
+                catch (PathTooLongException e)
+                {
+                    this.logger.WriteException(
+                        $"Could not enumerate files in the path '{folderPath}' due to a path being too long",
+                        e);
+                }
+                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+                {
+                    this.logger.WriteException(
+                        $"Could not enumerate files in the path '{folderPath}' due to a path not being accessible",
                         e);
                 }
             }


### PR DESCRIPTION
As @daviwil mentioned in #612, 
> If you change those EnumerateDirectories/Files calls to GetDirectories/Files, it might take care of the problem. There's really no benefit to using the Enumerate variety since we're not streaming the results back anyway, it just seemed to be the right thing to do at the time.

He was correct! Changing the Enumerates to Gets did the trick. Verified this on macOS by opening up a big workspace and finding all references/go to definition.

Resolves #612 
Resolves https://github.com/PowerShell/vscode-powershell/issues/908
Resolves https://github.com/daviwil/ide-powershell/issues/1