### PR TITLE
replace sort with sort-object

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -419,7 +419,7 @@ function __Expand-Alias {
     [ref]$errors=$null
 
     $tokens = [System.Management.Automation.PsParser]::Tokenize($targetScript, $errors).Where({$_.type -eq 'command'}) |
-                    Sort Start -Descending
+                    Sort-Object Start -Descending
 
     foreach ($token in  $tokens) {
         $definition=(Get-Command ('`'+$token.Content) -CommandType Alias -ErrorAction SilentlyContinue).Definition


### PR DESCRIPTION
For some reason, on macOS `Sort` did not exist.

I switched it to Sort-Object which is universal and not an alias.

It's a shame we can't run PSSA on our script strings in the c# of PSES :) No aliases allowed!

Resolves https://github.com/PowerShell/vscode-powershell/issues/1185