### PR TITLE
Add New-EditorFile

### DIFF
--- a/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
+++ b/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
@@ -77,7 +77,8 @@ FunctionsToExport = @('Register-EditorCommand',
                       'Out-CurrentFile',
                       'Join-ScriptExtent',
                       'Test-ScriptExtent',
-                      'Open-EditorFile')
+                      'Open-EditorFile',
+                      'New-EditorFile')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -78,10 +78,38 @@ function Unregister-EditorCommand {
 }
 
 function Open-EditorFile {
-    param([Parameter(Mandatory=$true)]$FilePaths)
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        $FilePaths,
 
-    Get-ChildItem $FilePaths -File | ForEach-Object {
-        $psEditor.Workspace.OpenFile($_.FullName)
+        [Parameter(ValueFromPipeline=$true)]
+        $NewValue,
+
+        [Parameter()]
+        [switch]
+        $Force
+    )
+
+    begin {
+        $container = @()
+    }
+
+    process {
+        $container += $NewValue
+    }
+
+    end {
+        $FilePaths | ForEach-Object {
+            if (-not (Test-Path $_) -and $Force) {
+                $container > $_
+            }
+        }
+
+        Get-ChildItem $FilePaths -File | ForEach-Object {
+            $psEditor.Workspace.OpenFile($_.FullName)
+        }
     }
 }
 Set-Alias psedit Open-EditorFile -Scope Global

--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -129,7 +129,14 @@ function New-EditorFile {
             {
                 if (-not (Test-Path $fileName) -or $Force) {
                     New-Item -Path $fileName -ItemType File | Out-Null
-                    $psEditor.Workspace.OpenFile($fileName)
+
+                    if ($Path.Count -gt 1) {
+                        $preview = $false
+                    } else {
+                        $preview = $true
+                    }
+
+                    $psEditor.Workspace.OpenFile($fileName, $preview)
                     $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
                 } else {
                     $PSCmdlet.WriteError( (
@@ -164,8 +171,14 @@ function Open-EditorFile {
     }
 
     end {
+        if ($Paths.Count -gt 1) {
+            $preview = $false
+        } else {
+            $preview = $true
+        }
+
         Get-ChildItem $Paths -File | ForEach-Object {
-            $psEditor.Workspace.OpenFile($_.FullName)
+            $psEditor.Workspace.OpenFile($_.FullName, $preview)
         }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -111,8 +111,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
     public class OpenFileRequest
     {
         public static readonly
-            RequestType<string, EditorCommandResponse, object, object> Type =
-            RequestType<string, EditorCommandResponse, object, object>.Create("editor/openFile");
+        RequestType<OpenFileDetails, EditorCommandResponse, object, object> Type =
+            RequestType<OpenFileDetails, EditorCommandResponse, object, object>.Create("editor/openFile");
+    }
+
+    public class OpenFileDetails
+    {
+        public string FilePath { get; set; }
+
+        public bool Preview { get; set; }
     }
 
     public class CloseFileRequest

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -12,6 +12,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     internal class LanguageServerEditorOperations : IEditorOperations
     {
+        private const bool DefaultPreviewSetting = true;
+
         private EditorSession editorSession;
         private IMessageSender messageSender;
 
@@ -115,7 +117,24 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             return
                 this.messageSender.SendRequest(
                     OpenFileRequest.Type,
-                    filePath,
+                    new OpenFileDetails
+                    {
+                        FilePath = filePath,
+                        Preview = DefaultPreviewSetting
+                    },
+                    true);
+        }
+
+        public Task OpenFile(string filePath, bool preview)
+        {
+            return
+                this.messageSender.SendRequest(
+                    OpenFileRequest.Type,
+                    new OpenFileDetails
+                    {
+                        FilePath = filePath,
+                        Preview = preview
+                    },
                     true);
         }
 

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -58,6 +58,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             this.editorOperations.OpenFile(filePath).Wait();
         }
 
+        /// <summary>
+        /// Opens a file in the workspace.  If the file is already open
+        /// its buffer will be made active.
+        /// You can specify whether the file opens as a preview or as a durable editor.
+        /// </summary>
+        /// <param name="filePath">The path to the file to be opened.</param>
+        /// <param name="preview">Determines wether the file is opened as a preview or as a durable editor.</param>
+        public void OpenFile(string filePath, bool preview)
+        {
+            this.editorOperations.OpenFile(filePath, preview).Wait();
+        }
+
         #endregion
     }
 }

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -48,6 +48,16 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         Task OpenFile(string filePath);
 
         /// <summary>
+        /// Causes a file to be opened in the editor.  If the file is
+        /// already open, the editor must switch to the file.
+        /// You can specify whether the file opens as a preview or as a durable editor.
+        /// </summary>
+        /// <param name="filePath">The path of the file to be opened.</param>
+        /// <param name="preview">Determines wether the file is opened as a preview or as a durable editor.</param>
+        /// <returns>A Task that can be tracked for completion.</returns>
+        Task OpenFile(string filePath, bool preview);
+
+        /// <summary>
         /// Causes a file to be closed in the editor.
         /// </summary>
         /// <param name="filePath">The path of the file to be closed.</param>

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -195,6 +195,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             throw new NotImplementedException();
         }
 
+        public Task OpenFile(string filePath, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task CloseFile(string filePath)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Here's what you can do:

```powershell
Open-EditorFile foo.txt -Force
```

This will create a new file called `foo.txt` if no file exists. It will throw an error if you don't add `-force` and `foo.txt` does not exist.

Also,
```powershell
Get-Process | Open-EditorFile foo.txt -Force
```

This will create a new file called `foo.txt` with the contents of what came in through the pipeline. Another example:

```powershell
irm https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1 | psedit install-powershell.ps1 -Force
```

You can also do:
```powershell
Get-Process | Open-EditorFile
```
This will open an Untitled file in your editor and put the contents in it.

This works in local and remote sessions.

Note, Get-Process has an issue in remote sessions when piping to a file. I originally thought it was my code but it was not:
https://github.com/PowerShell/PowerShell/issues/6115

The vscode-powershell PR is here: https://github.com/PowerShell/vscode-powershell/pull/1197

Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/414
Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/413