### PR TITLE
first build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,14 @@ function needsOpenSsl () {
 }
 
 function needsDotNet451TargetingPack () {
-    # how could we check for this?
+    if($BootstrapBuildEnv -and ($OS -eq "Windows")) {
+        $hasNet451TargetingPack = Get-CimInstance Win32_Product | Where-Object Name -match '\.NET Framework 4\.5\.1 Multi-Targeting Pack'
+        if(-not $hasNet451TargetingPack) {
+            return $true
+        }
+    } elseif($OS -eq "Windows") {
+        Write-Host "[Bootstrap] Did not check if the .NET 4.5.1 Targeting Pack is present. To check, run 'build.ps1 -BootstrapBuildEnv'"
+    }
     return $false
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,6 @@ param(
 
 $NeededTools = @{
     OpenSsl = "openssl for macOS"
-    DotNet451TargetingPack = ".NET 4.5.1 Targeting Pack"
     PowerShellGet = "PowerShellGet latest"
     InvokeBuild = "InvokeBuild latest"
 }
@@ -36,18 +35,6 @@ function needsOpenSsl () {
     return $false
 }
 
-function needsDotNet451TargetingPack () {
-    if($BootstrapBuildEnv -and ($OS -eq "Windows")) {
-        $hasNet451TargetingPack = Get-CimInstance Win32_Product | Where-Object Name -match '\.NET Framework 4\.5\.1 Multi-Targeting Pack'
-        if(-not $hasNet451TargetingPack) {
-            return $true
-        }
-    } elseif($OS -eq "Windows") {
-        Write-Host "[Bootstrap] Did not check if the .NET 4.5.1 Targeting Pack is present. To check, run 'build.ps1 -BootstrapBuildEnv'"
-    }
-    return $false
-}
-
 function needsPowerShellGet () {
     if (Get-Module -ListAvailable -Name PowerShellGet) {
         return $false
@@ -67,9 +54,6 @@ function getMissingTools () {
 
     if (needsOpenSsl) {
         $missingTools += $NeededTools.OpenSsl
-    }
-    if (needsDotNet451TargetingPack) {
-        $missingTools += $NeededTools.DotNet451TargetingPack
     }
     if (needsPowerShellGet) {
         $missingTools += $NeededTools.PowerShellGet

--- a/build.ps1
+++ b/build.ps1
@@ -90,7 +90,15 @@ if ($BootstrapBuildEnv) {
     }
     Write-Host "`n$string`n"
 } elseif ($Clean) {
-    Invoke-Build Clean
+    if(hasMissingTools) {
+        Write-Host "You are missing needed tools. Run './build.ps1 -BootstrapBuildEnv' to see what they are."
+    } else {
+        Invoke-Build Clean
+    }
 } else {
-    Invoke-Build Build
+    if(hasMissingTools) {
+        Write-Host "You are missing needed tools. Run './build.ps1 -BootstrapBuildEnv' to see what they are."
+    } else {
+        Invoke-Build Build
+    }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+param(
+    [Parameter()]
+    [switch]
+    $Clean,
+
+    [Parameter()]
+    [switch]
+    $BootstrapBuildEnv
+)
+
+$NeededTools = @{
+    OpenSsl = "openssl for macOS"
+    DotNet451TargetingPack = ".NET 4.5.1 Targeting Pack"
+    PowerShellGet = "PowerShellGet latest"
+    InvokeBuild = "InvokeBuild latest"
+}
+
+if ((-not $PSVersionTable["OS"]) -or $PSVersionTable["OS"].Contains("Windows")) {
+    $OS = "Windows"
+} elseif ($PSVersionTable["OS"].Contains("Darwin")) {
+    $OS = "macOS"
+} else {
+    $OS = "Linux"
+}
+
+
+function needsOpenSsl () {
+    if ($OS -eq "macOS") {
+        try {
+            $opensslVersion = (openssl version)
+        } catch {
+            return $true
+        }
+    }
+    return $false
+}
+
+function needsDotNet451TargetingPack () {
+    # how could we check for this?
+    return $false
+}
+
+function needsPowerShellGet () {
+    if (Get-Module -ListAvailable -Name PowerShellGet) {
+        return $false
+    }
+    return $true
+}
+
+function needsInvokeBuild () {
+    if (Get-Module -ListAvailable -Name InvokeBuild) {
+        return $false
+    }
+    return $true
+}
+
+function getMissingTools () {
+    $missingTools = @()
+
+    if (needsOpenSsl) {
+        $missingTools += $NeededTools.OpenSsl
+    }
+    if (needsDotNet451TargetingPack) {
+        $missingTools += $NeededTools.DotNet451TargetingPack
+    }
+    if (needsPowerShellGet) {
+        $missingTools += $NeededTools.PowerShellGet
+    }
+    if (needsInvokeBuild) {
+        $missingTools += $NeededTools.InvokeBuild
+    }
+
+    return $missingTools
+}
+
+function hasMissingTools () {
+    return ((getMissingTools).Count -gt 0)
+}
+
+if ($BootstrapBuildEnv) {
+    $string = "Here is what your environment is missing:`n"
+    $missingTools = getMissingTools
+    if (($missingTools).Count -eq 0) {
+        $string += "* nothing!`n`n Run this script without a flag to build or a -Clean to clean."
+    } else {
+        $missingTools | ForEach-Object {$string += "* $_`n"}
+        $string += "`nAll instructions for installing these tools can be found on PowerShell Editor Services' Github:`n" `
+            + "https://github.com/powershell/PowerShellEditorServices#development"
+    }
+    Write-Host "`n$string`n"
+} elseif ($Clean) {
+    Invoke-Build Clean
+} else {
+    Invoke-Build Build
+}

--- a/build.ps1
+++ b/build.ps1
@@ -2,11 +2,15 @@
 param(
     [Parameter()]
     [switch]
+    $Bootstrap,
+
+    [Parameter()]
+    [switch]
     $Clean,
 
     [Parameter()]
     [switch]
-    $BootstrapBuildEnv
+    $Test
 )
 
 $NeededTools = @{
@@ -69,7 +73,7 @@ function hasMissingTools () {
     return ((getMissingTools).Count -gt 0)
 }
 
-if ($BootstrapBuildEnv) {
+if ($Bootstrap) {
     $string = "Here is what your environment is missing:`n"
     $missingTools = getMissingTools
     if (($missingTools).Count -eq 0) {
@@ -80,16 +84,16 @@ if ($BootstrapBuildEnv) {
             + "https://github.com/powershell/PowerShellEditorServices#development"
     }
     Write-Host "`n$string`n"
-} elseif ($Clean) {
-    if(hasMissingTools) {
-        Write-Host "You are missing needed tools. Run './build.ps1 -BootstrapBuildEnv' to see what they are."
-    } else {
+} elseif(hasMissingTools) {
+    Write-Host "You are missing needed tools. Run './build.ps1 -Bootstrap' to see what they are."
+} else {
+    if($Clean) {
         Invoke-Build Clean
     }
-} else {
-    if(hasMissingTools) {
-        Write-Host "You are missing needed tools. Run './build.ps1 -BootstrapBuildEnv' to see what they are."
-    } else {
-        Invoke-Build Build
+
+    Invoke-Build Build
+
+    if($Test) {
+        Invoke-Build Test
     }
 }


### PR DESCRIPTION
## In scope:

* running `build.ps1` checks for missing tools and runs `Invoke-Build Build`
* running `build.ps1 -Clean` checks for missing tools and runs `Invoke-Build Clean` and then `Invoke-Build Build`
* running `build.ps1 -Test` checks for missing tools and runs `Invoke-Build Build` and then `Invoke-Build Test`
* running `build.ps1 -Bootstrap` informs you of what tools you are missing
    - the dependencies it checks for are:
        - openssl for macOS
        - PowerShellGet
        - InvokeBuild

## Out of scope:

* pulling dotnet sdk installation out of current build script

The script is a bit verbose on purpose so that we can easily add additional dependencies.

Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/586