### PR TITLE
Fix PSES crash on debug start when function breakpoint defined

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -645,7 +645,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             SetExceptionBreakpointsRequestArguments setExceptionBreakpointsParams,
             RequestContext<object> requestContext)
         {
-            // TODO: Handle this appropriately
+            // TODO: When support for exception breakpoints (unhandled and/or first chance)
+            //       are added to the PowerShell engine, wire up the VSCode exception 
+            //       breakpoints here using the pattern below to prevent bug regressions.
             //if (!this.noDebug)
             //{
             //    this.setBreakpointInProgress = true;


### PR DESCRIPTION
Fixex https://github.com/PowerShell/vscode-powershell/issues/1159

When VSCode passes us a breakpoint to set, we normally set
a flag to indicate "setBreakpointInProgress" so that when
the DebugService_BreakpointUpdated event is fired, we can
tell that we initiated it instead of the user using Set-PSBreakpoint
to set a breakpoint.   Well, the code that handled function
breakpoints msgs sent by VSCode was not setting that flag.

Also, when the user does use Set-PSBreakpoint -Command
there is no debug protocol event for function breakpoints
so we need to ignore this type of breakpoint set by the user
until the debug protocol support it.  
See https://github.com/Microsoft/vscode-debugadapter-node/issues/157