### PR TITLE
Track tempIntegratedConsole launch param, do not exit when session ends

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -303,6 +303,12 @@ namespace Microsoft.PowerShell.EditorServices.Host
 
                         this.debugServiceListener.Start();
                     }
+                    else if (this.debugAdapter.IsUsingTempIntegratedConsole)
+                    {
+                        this.logger.Write(
+                            LogLevel.Normal,
+                            "Previous temp debug session ended");
+                    }
                     else
                     {
                         // Exit the host process

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
@@ -53,6 +53,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public string Cwd { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean value that determines whether to create a temporary
+        /// integrated console for the debug session. Default is false.
+        /// </summary>
+        public bool CreateTemporaryIntegratedConsole { get; set; }
+
+        /// <summary>
         /// Gets or sets the absolute path to the runtime executable to be used.
         /// Default is the runtime executable on the PATH.
         /// </summary>

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -54,6 +54,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.ownsEditorSession = ownsEditorSession;
         }
 
+        /// <summary>
+        /// Gets a boolean that indicates whether the current debug adapter is 
+        /// using a temporary integrated console.
+        /// </summary>
+        public bool IsUsingTempIntegratedConsole { get; private set; }
+
         public void Start()
         {
             // Register all supported message types
@@ -313,6 +319,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.scriptToLaunch = launchParams.Script ?? launchParams.Program;
 #pragma warning restore 618
             this.arguments = arguments;
+            this.IsUsingTempIntegratedConsole = launchParams.CreateTemporaryIntegratedConsole;
 
             // If the current session is remote, map the script path to the remote
             // machine if necessary


### PR DESCRIPTION
This does not leave a working prompt.  I think that is OK for now.  This is still better than the current situation.