### PR TITLE
Switch to w3c log file timestamp format

### DIFF
--- a/src/PowerShellEditorServices/Utility/FileLogger.cs
+++ b/src/PowerShellEditorServices/Utility/FileLogger.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 // Print the timestamp and log level
                 this.textWriter.WriteLine(
                     "{0} [{1}] - Method \"{2}\" at line {3} of {4}\r\n",
-                    DateTime.Now,
+                    DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
                     logLevel.ToString().ToUpper(),
                     callerName,
                     callerLineNumber,


### PR DESCRIPTION
This is minor but since VSCode is now colorizing log files, this format looks better when viewing PSES log files in VSCode.

Old format:
![image](https://user-images.githubusercontent.com/5177512/36463827-9010e34c-1689-11e8-85ba-3f3b2cdf8105.png)

New format:
![image](https://user-images.githubusercontent.com/5177512/36463887-edb32690-1689-11e8-9a2e-491249ebaa5f.png)
