### PR TITLE
Eliminate duplicate dgb prompt

### DIFF
--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -642,8 +642,8 @@ namespace Microsoft.PowerShell.EditorServices
                     .OfType<string>()
                     .FirstOrDefault() ?? "PS> ";
 
-            // Add the [DBG] prefix if we're stopped in the debugger
-            if (this.powerShellContext.IsDebuggerStopped)
+            // Add the [DBG] prefix if we're stopped in the debugger and the prompt doesn't already have [DBG] in it
+            if (this.powerShellContext.IsDebuggerStopped && !promptString.Contains("[DBG]"))
             {
                 promptString =
                     string.Format(


### PR DESCRIPTION
This is to eliminate duplicate `[DBG]` in the prompt string for folks like me that write their prompt function to handle the DBG prompt.  Without this change, my prompt looks like this:

![image](https://user-images.githubusercontent.com/5177512/36465684-7b8b331e-1693-11e8-8985-81c34f20a3bd.png)

And after this change:

![image](https://user-images.githubusercontent.com/5177512/36465774-dc8b6166-1693-11e8-8578-32dca91e8a1f.png)
