### PR TITLE
Add events for PowerShell execution status (running, completed, etc).

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/ExecutionStatusChangedEvent.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/ExecutionStatusChangedEvent.cs
@@ -1,0 +1,18 @@
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    /// <summary>
+    /// Defines an event type for PowerShell context execution status changes (e.g. execution has completed)
+    /// </summary>
+    public class ExecutionStatusChangedEvent
+    {
+        /// <summary>
+        /// The notification type for execution status change events in the message protocol
+        /// </summary>
+        /// <returns></returns>
+        public static readonly
+            NotificationType<object, object> Type =
+            NotificationType<object, object>.Create("powerShell/executionStatusChanged");
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/ExecutionStatusChangedEvent.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/ExecutionStatusChangedEvent.cs
@@ -10,7 +10,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
         /// <summary>
         /// The notification type for execution status change events in the message protocol
         /// </summary>
-        /// <returns></returns>
         public static readonly
             NotificationType<object, object> Type =
             NotificationType<object, object>.Create("powerShell/executionStatusChanged");

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1280,7 +1280,6 @@ function __Expand-Alias {
         /// </summary>
         /// <param name="sender">the PowerShell context sending the execution event</param>
         /// <param name="e">details of the execution status change</param>
-        /// <returns></returns>
         private async void PowerShellContext_ExecutionStatusChanged(object sender, ExecutionStatusChangedEventArgs e)
         {
             await this.messageSender.SendEvent(

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -56,7 +56,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             this.Logger = logger;
             this.editorSession = editorSession;
+            // Attach to the underlying PowerShell context to listen for changes in the runspace or execution status
             this.editorSession.PowerShellContext.RunspaceChanged += PowerShellContext_RunspaceChanged;
+            this.editorSession.PowerShellContext.ExecutionStatusChanged += PowerShellContext_ExecutionStatusChanged;
 
             // Attach to ExtensionService events
             this.editorSession.ExtensionService.CommandAdded += ExtensionService_ExtensionAdded;
@@ -1271,6 +1273,19 @@ function __Expand-Alias {
             await this.messageSender.SendEvent(
                 RunspaceChangedEvent.Type,
                 new Protocol.LanguageServer.RunspaceDetails(e.NewRunspace));
+        }
+
+        /// <summary>
+        /// Event hook on the PowerShell context to listen for changes in script execution status
+        /// </summary>
+        /// <param name="sender">the PowerShell context sending the execution event</param>
+        /// <param name="e">details of the execution status change</param>
+        /// <returns></returns>
+        private async void PowerShellContext_ExecutionStatusChanged(object sender, ExecutionStatusChangedEventArgs e)
+        {
+            await this.messageSender.SendEvent(
+                ExecutionStatusChangedEvent.Type,
+                e);
         }
 
         private async void ExtensionService_ExtensionAdded(object sender, EditorCommand e)


### PR DESCRIPTION
Create notification events for when the Language Server runs PowerShell
scripts, so the client is informed about the status of the running
script.

This can be used by the client to alert the user when a script is running.

Solves [vscode-powershell #154](https://github.com/PowerShell/vscode-powershell/issues/154).