### PR TITLE
Allow newer dotnet cli

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -78,7 +78,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
         $env:DOTNET_INSTALL_DIR = $dotnetExeDir
     }
 
-    Write-Host "`n### Using dotnet v$(& $dotnetExePath --version) at path $script:dotnetExe`n" -ForegroundColor Green
+    Write-Host "`n### Using dotnet v$(& $script:dotnetExe --version) at path $script:dotnetExe`n" -ForegroundColor Green
 }
 
 task Clean {

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -78,7 +78,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
         $env:DOTNET_INSTALL_DIR = $dotnetExeDir
     }
 
-    Write-Host "`n### Using dotnet v$requiredSDKVersion at path $script:dotnetExe`n" -ForegroundColor Green
+    Write-Host "`n### Using dotnet v$(& $dotnetExePath --version) at path $script:dotnetExe`n" -ForegroundColor Green
 }
 
 task Clean {

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -37,7 +37,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
     }
 
     # Make sure the dotnet we found is the right version
-    if ($dotnetExePath -and (& $dotnetExePath --version) -eq $requiredSdkVersion) {
+    if ($dotnetExePath -and [version](& $dotnetExePath --version) -ge [version]$requiredSdkVersion) {
         $script:dotnetExe = $dotnetExePath
     }
     else {


### PR DESCRIPTION
our build script required 2.0.0. Now the cli is up to 2.1.4. This small change allows newer versions to be used.

We may want to eventually put an upper bound on this... but I don't think the dotnet cli will change much at least how we're using it.