### PR TITLE
Add tests ensuring tagged pester tests still register as pester symbols

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -37,8 +37,17 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
     }
 
     # Make sure the dotnet we found is the right version
-    if ($dotnetExePath -and [version](& $dotnetExePath --version) -ge [version]$requiredSdkVersion) {
-        $script:dotnetExe = $dotnetExePath
+    if ($dotnetExePath) {
+        # dotnet --version can return a semver that System.Version can't handle
+        # e.g.: 2.1.300-preview-01. The replace operator is used to remove any build suffix.
+        $version = (& $dotnetExePath --version) -replace '[+-].*$',''
+        if ([version]$version -ge [version]$requiredSdkVersion) {
+            $script:dotnetExe = $dotnetExePath
+        }
+        else {
+            # Clear the path so that we invoke installation
+            $script:dotnetExe = $null
+        }
     }
     else {
         # Clear the path so that we invoke installation

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -37,7 +37,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
     }
 
     # Make sure the dotnet we found is the right version
-    if ($dotnetExePath -and (& $dotnetExePath --version) -eq $requiredSdkVersion) {
+    if ($dotnetExePath -and [version](& $dotnetExePath --version) -ge [version]$requiredSdkVersion) {
         $script:dotnetExe = $dotnetExePath
     }
     else {
@@ -78,7 +78,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
         $env:DOTNET_INSTALL_DIR = $dotnetExeDir
     }
 
-    Write-Host "`n### Using dotnet v$requiredSDKVersion at path $script:dotnetExe`n" -ForegroundColor Green
+    Write-Host "`n### Using dotnet v$(& $script:dotnetExe --version) at path $script:dotnetExe`n" -ForegroundColor Green
 }
 
 task Clean {

--- a/module/Start-EditorServices.ps1
+++ b/module/Start-EditorServices.ps1
@@ -44,8 +44,25 @@ param(
     [ValidateNotNullOrEmpty()]
     $LogPath,
 
-    [ValidateSet("Normal", "Verbose", "Error","Diagnostic")]
+    [ValidateSet("Diagnostic", "Normal", "Verbose", "Error", "Diagnostic")]
     $LogLevel,
+
+	[Parameter(Mandatory=$true)]
+	[ValidateNotNullOrEmpty()]
+	[string]
+	$SessionDetailsPath,
+
+    [switch]
+    $EnableConsoleRepl,
+
+    [switch]
+    $DebugServiceOnly,
+
+    [string[]]
+    $AdditionalModules,
+
+    [string[]]
+    $FeatureFlags,
 
     [switch]
     $WaitForDebugger,
@@ -54,89 +71,186 @@ param(
     $ConfirmInstall
 )
 
+$minPortNumber = 10000
+$maxPortNumber = 30000
+
+if ($LogLevel -eq "Diagnostic") {
+    $VerbosePreference = 'Continue'
+    Start-Transcript (Join-Path (Split-Path $LogPath -Parent) Start-EditorServices.log) -Force
+}
+
+function LogSection([string]$msg) {
+    Write-Verbose "`n#-- $msg $('-' * ([Math]::Max(0, 73 - $msg.Length)))"
+}
+
+function Log([string[]]$msg) {
+    $msg | Write-Verbose
+}
+
+function ExitWithError($errorString) {
+    Write-Host -ForegroundColor Red "`n`n$errorString"
+
+    # Sleep for a while to make sure the user has time to see and copy the
+    # error message
+    Start-Sleep -Seconds 300
+
+    exit 1;
+}
+
+# Are we running in PowerShell 2 or earlier?
+if ($PSVersionTable.PSVersion.Major -le 2) {
+    # No ConvertTo-Json on PSv2 and below, so write out the JSON manually
+    "{`"status`": `"failed`", `"reason`": `"unsupported`", `"powerShellVersion`": `"$($PSVersionTable.PSVersion.ToString())`"}" |
+        Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
+
+    ExitWithError "Unsupported PowerShell version $($PSVersionTable.PSVersion), language features are disabled."
+}
+
+function WriteSessionFile($sessionInfo) {
+    $sessionInfoJson = ConvertTo-Json -InputObject $sessionInfo -Compress
+    Log "Writing session file with contents:"
+    Log $sessionInfoJson
+    $sessionInfoJson | Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
+}
+
+if ($host.Runspace.LanguageMode -eq 'ConstrainedLanguage') {
+    WriteSessionFile @{
+        "status" = "failed"
+        "reason" = "languageMode"
+        "detail" = $host.Runspace.LanguageMode.ToString()
+    }
+
+    ExitWithError "PowerShell is configured with an unsupported LanguageMode (ConstrainedLanguage), language features are disabled."
+}
+
+# Are we running in PowerShell 5 or later?
+$isPS5orLater = $PSVersionTable.PSVersion.Major -ge 5
+
+# If PSReadline is present in the session, remove it so that runspace
+# management is easier
+if ((Get-Module PSReadline).Count -gt 0) {
+    LogSection "Removing PSReadLine module"
+    Remove-Module PSReadline -ErrorAction SilentlyContinue
+}
+
 # This variable will be assigned later to contain information about
 # what happened while attempting to launch the PowerShell Editor
 # Services host
 $resultDetails = $null;
 
 function Test-ModuleAvailable($ModuleName, $ModuleVersion) {
+    Log "Testing module availability $ModuleName $ModuleVersion"
+
     $modules = Get-Module -ListAvailable $moduleName
     if ($modules -ne $null) {
         if ($ModuleVersion -ne $null) {
             foreach ($module in $modules) {
                 if ($module.Version.Equals($moduleVersion)) {
+                    Log "$ModuleName $ModuleVersion found"
                     return $true;
                 }
             }
         }
         else {
+            Log "$ModuleName $ModuleVersion found"
             return $true;
         }
     }
 
+    Log "$ModuleName $ModuleVersion NOT found"
     return $false;
 }
 
-function Test-PortAvailability($PortNumber) {
-    $portAvailable = $true;
+function Test-PortAvailability {
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]
+        $PortNumber
+    )
+
+    $portAvailable = $true
 
     try {
-        $ipAddress = [System.Net.Dns]::GetHostEntryAsync("localhost").Result.AddressList[0];
-        $tcpListener = [System.Net.Sockets.TcpListener]::new($ipAddress, $portNumber);
-        $tcpListener.Start();
-        $tcpListener.Stop();
-
-    }
-    catch [System.Net.Sockets.SocketException] {
-        # Check the SocketErrorCode to see if it's the expected exception
-        if ($error[0].Exception.InnerException.SocketErrorCode -eq [System.Net.Sockets.SocketError]::AddressAlreadyInUse) {
-            $portAvailable = $false;
+        if ($isPS5orLater) {
+            $ipAddresses = [System.Net.Dns]::GetHostEntryAsync("localhost").Result.AddressList
         }
         else {
-            Write-Output ("Error code: " + $error[0].SocketErrorCode)
+            $ipAddresses = [System.Net.Dns]::GetHostEntry("localhost").AddressList
+        }
+
+        foreach ($ipAddress in $ipAddresses)
+        {
+            Log "Testing availability of port ${PortNumber} at address ${ipAddress} / $($ipAddress.AddressFamily)"
+
+            $tcpListener = New-Object System.Net.Sockets.TcpListener @($ipAddress, $PortNumber)
+            $tcpListener.Start()
+            $tcpListener.Stop()
+        }
+    }
+    catch [System.Net.Sockets.SocketException] {
+        $portAvailable = $false
+
+        # Check the SocketErrorCode to see if it's the expected exception
+        if ($_.Exception.SocketErrorCode -eq [System.Net.Sockets.SocketError]::AddressAlreadyInUse) {
+            Log "Port $PortNumber is in use."
+        }
+        else {
+            Log "SocketException on port ${PortNumber}: $($_.Exception)"
         }
     }
 
-    return $portAvailable;
+    $portAvailable
 }
 
-$rand = [System.Random]::new()
-function Get-AvailablePort {
+$portsInUse = @{}
+$rand = New-Object System.Random
+function Get-AvailablePort() {
     $triesRemaining = 10;
 
     while ($triesRemaining -gt 0) {
-        $port = $rand.Next(10000, 30000)
-        if ((Test-PortAvailability -PortAvailability $port) -eq $true) {
+        do {
+            $port = $rand.Next($minPortNumber, $maxPortNumber)
+        }
+        while ($portsInUse.ContainsKey($port))
+
+        # Whether we succeed or fail, don't try this port again
+        $portsInUse[$port] = 1
+
+        Log "Checking port: $port, attempts remaining $triesRemaining --------------------"
+        if ((Test-PortAvailability -PortNumber $port) -eq $true) {
+            Log "Port: $port is available"
             return $port
         }
 
+        Log "Port: $port is NOT available"
         $triesRemaining--;
     }
 
+    Log "Did not find any available ports!!"
     return $null
 }
 
-# OUTPUT PROTOCOL
-# - "started 29981 39898" - Server(s) are started, language and debug server ports (respectively)
-# - "failed Error message describing the failure" - General failure while starting, show error message to user (?)
-# - "needs_install" - User should be prompted to install PowerShell Editor Services via the PowerShell Gallery
-
 # Add BundledModulesPath to $env:PSModulePath
 if ($BundledModulesPath) {
-    $env:PSMODULEPATH = $BundledModulesPath + [System.IO.Path]::PathSeparator + $env:PSMODULEPATH
+    $env:PSModulePath = $env:PSModulePath.TrimEnd([System.IO.Path]::PathSeparator) + [System.IO.Path]::PathSeparator + $BundledModulesPath
+    LogSection "Updated PSModulePath to:"
+    Log ($env:PSModulePath -split [System.IO.Path]::PathSeparator)
 }
 
+LogSection "Check required modules available"
 # Check if PowerShellGet module is available
 if ((Test-ModuleAvailable "PowerShellGet") -eq $false) {
+    Log "Failed to find PowerShellGet module"
     # TODO: WRITE ERROR
 }
 
 # Check if the expected version of the PowerShell Editor Services
 # module is installed
-$parsedVersion = [System.Version]::new($EditorServicesVersion)
-if ((Test-ModuleAvailable "PowerShellEditorServices" -RequiredVersion $parsedVersion) -eq $false) {
-    if ($ConfirmInstall) {
+$parsedVersion = New-Object System.Version @($EditorServicesVersion)
+if ((Test-ModuleAvailable "PowerShellEditorServices" $parsedVersion) -eq $false) {
+    if ($ConfirmInstall -and $isPS5orLater) {
         # TODO: Check for error and return failure if necessary
+        LogSection "Install PowerShellEditorServices"
         Install-Module "PowerShellEditorServices" -RequiredVersion $parsedVersion -Confirm
     }
     else {
@@ -146,49 +260,94 @@ if ((Test-ModuleAvailable "PowerShellEditorServices" -RequiredVersion $parsedVer
     }
 }
 
-Import-Module PowerShellEditorServices -RequiredVersion $parsedVersion -ErrorAction Stop
-
-# Locate available port numbers for services
-$languageServicePort = Get-AvailablePort
-$debugServicePort = Get-AvailablePort
-
-$editorServicesHost =
-    Start-EditorServicesHost `
-        -HostName $HostName `
-        -HostProfileId $HostProfileId `
-        -HostVersion $HostVersion `
-        -LogPath $LogPath `
-        -LogLevel $LogLevel `
-        -AdditionalModules @() `
-        -LanguageServicePort $languageServicePort `
-        -DebugServicePort $debugServicePort `
-        -BundledModulesPath $BundledModulesPath `
-        -WaitForDebugger:$WaitForDebugger.IsPresent
-
-# TODO: Verify that the service is started
-
-$resultDetails = @{
-    "status" = "started";
-    "channel" = "tcp";
-    "languageServicePort" = $languageServicePort;
-    "debugServicePort" = $debugServicePort;
-};
-
-# Notify the client that the services have started
-Write-Output (ConvertTo-Json -InputObject $resultDetails -Compress)
-
 try {
-    # Wait for the host to complete execution before exiting
-    $editorServicesHost.WaitForCompletion()
+    LogSection "Start up PowerShellEditorServices"
+    Log "Importing PowerShellEditorServices"
+
+    if ($isPS5orLater) {
+        Import-Module PowerShellEditorServices -RequiredVersion $parsedVersion -ErrorAction Stop
+    }
+    else {
+        Import-Module PowerShellEditorServices -Version $parsedVersion -ErrorAction Stop
+    }
+
+    # Locate available port numbers for services
+    Log "Searching for available socket port for the language service"
+    $languageServicePort = Get-AvailablePort
+
+    Log "Searching for available socket port for the debug service"
+    $debugServicePort = Get-AvailablePort
+
+    if (!$languageServicePort -or !$debugServicePort) {
+        ExitWithError "Failed to find an open socket port for either the language or debug service."
+    }
+
+    if ($EnableConsoleRepl) {
+        Write-Host "PowerShell Integrated Console`n"
+    }
+
+    # Create the Editor Services host
+    Log "Invoking Start-EditorServicesHost"
+    $editorServicesHost =
+        Start-EditorServicesHost `
+            -HostName $HostName `
+            -HostProfileId $HostProfileId `
+            -HostVersion $HostVersion `
+            -LogPath $LogPath `
+            -LogLevel $LogLevel `
+            -AdditionalModules $AdditionalModules `
+            -LanguageServicePort $languageServicePort `
+            -DebugServicePort $debugServicePort `
+            -BundledModulesPath $BundledModulesPath `
+            -EnableConsoleRepl:$EnableConsoleRepl.IsPresent `
+            -DebugServiceOnly:$DebugServiceOnly.IsPresent `
+            -WaitForDebugger:$WaitForDebugger.IsPresent
+
+    # TODO: Verify that the service is started
+    Log "Start-EditorServicesHost returned $editorServicesHost"
+
+    $resultDetails = @{
+        "status" = "started";
+        "channel" = "tcp";
+        "languageServicePort" = $languageServicePort;
+        "debugServicePort" = $debugServicePort;
+    }
+
+    # Notify the client that the services have started
+    WriteSessionFile $resultDetails
+
+    Log "Wrote out session file"
 }
 catch [System.Exception] {
-    $e = $_.Exception; #.InnerException;
+    $e = $_.Exception;
     $errorString = ""
+
+    Log "ERRORS caught starting up EditorServicesHost"
 
     while ($e -ne $null) {
         $errorString = $errorString + ($e.Message + "`r`n" + $e.StackTrace + "`r`n")
         $e = $e.InnerException;
+        Log $errorString
     }
 
-    Write-Error ("`r`nCaught error while waiting for EditorServicesHost to complete:`r`n" + $errorString)
+    ExitWithError ("An error occurred while starting PowerShell Editor Services:`r`n`r`n" + $errorString)
+}
+
+try {
+    # Wait for the host to complete execution before exiting
+    LogSection "Waiting for EditorServicesHost to complete execution"
+    $editorServicesHost.WaitForCompletion()
+    Log "EditorServicesHost has completed execution"
+}
+catch [System.Exception] {
+    $e = $_.Exception;
+    $errorString = ""
+
+    Log "ERRORS caught while waiting for EditorServicesHost to complete execution"
+
+    while ($e -ne $null) {
+        $errorString = $errorString + ($e.Message + "`r`n" + $e.StackTrace + "`r`n")
+        $e = $e.InnerException;
+        Log $errorString
+    }
 }

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -390,22 +390,30 @@ namespace Microsoft.PowerShell.EditorServices
             // view of the current file or an untitled file.
             try
             {
-                // NotSupportedException or ArgumentException gets thrown when
-                // given an invalid path.  Since any non-standard path will
-                // trigger this, assume that it means it's an in-memory file
-                // unless the path starts with file:
-                Path.GetFullPath(filePath);
+                // File system absoulute paths will have a URI scheme of file:.
+                // Other schemes like "untitled:" and "gitlens-git:" will return false for IsFile.
+                var uri = new Uri(filePath);
+                isInMemory = !uri.IsFile;
             }
-            catch (ArgumentException)
+            catch (UriFormatException)
             {
-                isInMemory = true;
-            }
-            catch (NotSupportedException)
-            {
-                isInMemory = true;
+                // Relative file paths cause a UriFormatException.
+                // In this case, fallback to using Path.GetFullPath().
+                try
+                {
+                    Path.GetFullPath(filePath);
+                }
+                catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException)
+                {
+                    isInMemory = true;
+                }
+                catch (PathTooLongException)
+                {
+                    // If we ever get here, it should be an actual file so, not in memory
+                }
             }
 
-            return !filePath.ToLower().StartsWith("file:") && isInMemory;
+            return isInMemory;
         }
 
         private string GetBaseFilePath(string filePath)

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -825,7 +825,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Assert.StartsWith("5.", versionDetails.Version);
             Assert.StartsWith("5.", versionDetails.DisplayVersion);
             Assert.Equal("Desktop", versionDetails.Edition);
-            Assert.Equal("x86", versionDetails.Architecture);
+
+            string expectedArchitecture = (IntPtr.Size == 8) ? "x64" : "x86";
+            Assert.Equal(expectedArchitecture, versionDetails.Architecture);
         }
 
         private async Task SendOpenFileEvent(string filePath, bool waitForDiagnostics = true)

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
   </ItemGroup>

--- a/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
+++ b/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.tests.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.tests.ps1
@@ -13,3 +13,15 @@
         }
     }
 }
+
+Describe -Tags "Tag1", "Tag2" "Another dummy test" {
+    It "Works as expected"
+}
+
+Describe "A third test" -Tag "Tag3" {
+    Context "Given pester tags" {
+        It "Should still detect Pester symbols" {
+            $true | Should -BeExactly $true
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         public void LanguageServiceFindsSymbolsInPesterFile()
         {
             var symbolsResult = this.FindSymbolsInFile(FindSymbolsInPesterFile.SourceDetails);
-            Assert.Equal(5, symbolsResult.FoundOccurrences.Count());
+            Assert.Equal(10, symbolsResult.FoundOccurrences.Count());
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
   </ItemGroup>

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -3,12 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices;
 using System;
 using System.IO;
-using System.Linq;
-using Xunit;
 using Microsoft.PowerShell.EditorServices.Utility;
+using Xunit;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Session
 {
@@ -34,6 +32,42 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             Assert.Equal(@"SubFolder\FilePath.ps1", workspace.GetRelativePath(testPathInside));
             Assert.Equal(@"..\PeerPath\FilePath.ps1", workspace.GetRelativePath(testPathOutside));
             Assert.Equal(testPathAnotherDrive, workspace.GetRelativePath(testPathAnotherDrive));
+        }
+
+        [Fact]
+        public void CanDetermineIsPathInMemory()
+        {
+            var tempDir = Environment.GetEnvironmentVariable("TEMP");
+            var shortDirPath = Path.Combine(tempDir, "GitHub", "PowerShellEditorServices");
+            var shortFilePath = Path.Combine(shortDirPath, "foo.ps1");
+            var shortUriForm = "git:/c%3A/Users/Keith/GitHub/dahlbyk/posh-git/src/PoshGitTypes.ps1?%7B%22path%22%3A%22c%3A%5C%5CUsers%5C%5CKeith%5C%5CGitHub%5C%5Cdahlbyk%5C%5Cposh-git%5C%5Csrc%5C%5CPoshGitTypes.ps1%22%2C%22ref%22%3A%22~%22%7D";
+            var longUriForm = "gitlens-git:c%3A%5CUsers%5CKeith%5CGitHub%5Cdahlbyk%5Cposh-git%5Csrc%5CPoshGitTypes%3Ae0022701.ps1?%7B%22fileName%22%3A%22src%2FPoshGitTypes.ps1%22%2C%22repoPath%22%3A%22c%3A%2FUsers%2FKeith%2FGitHub%2Fdahlbyk%2Fposh-git%22%2C%22sha%22%3A%22e0022701fa12e0bc22d0458673d6443c942b974a%22%7D";
+
+            var testCases = new[] {
+                // Test short file absolute paths
+                new { IsInMemory = false, Path = shortDirPath },
+                new { IsInMemory = false, Path = shortFilePath },
+                new { IsInMemory = false, Path = new Uri(shortDirPath).ToString() },
+                new { IsInMemory = false, Path = new Uri(shortFilePath).ToString() },
+
+                // Test short file relative paths - not sure we'll ever get these but just in case
+                new { IsInMemory = false, Path = "foo.ps1" },
+                new { IsInMemory = false, Path = ".." + Path.DirectorySeparatorChar + "foo.ps1" },
+
+                // Test short non-file paths
+                new { IsInMemory = true,  Path = "untitled:untitled-1" },
+                new { IsInMemory = true,  Path = shortUriForm },
+
+                // Test long non-file path - known to have crashed PSES
+                new { IsInMemory = true,  Path = longUriForm },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.True(
+                    Workspace.IsPathInMemory(testCase.Path) == testCase.IsInMemory,
+                    $"Testing path {testCase.Path}");
+            }
         }
     }
 }


### PR DESCRIPTION
PSES currently only tests untagged Pester tests. This adds tests for recognising tagged Pester tests as Pester symbols.

This build should succeed with #638.