### PR TITLE
fix GetVersionDetails error

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -845,8 +845,12 @@ namespace Microsoft.PowerShell.EditorServices
 
                 if (typeof(TResult) != typeof(PSObject))
                 {
-                    return
-                       results
+                    return (results.FirstOrDefault() == null)
+                        // Evaluates to null but couldn't put just null (needs to be a TResult) and also couldn't cast null to TResult
+                        ? results
+                            .OfType<TResult>()
+                            .FirstOrDefault()
+                        : results
                             .Select(pso => pso.BaseObject)
                             .OfType<TResult>()
                             .FirstOrDefault();

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -535,7 +535,7 @@ namespace Microsoft.PowerShell.EditorServices
                         if (this.powerShell.HadErrors)
                         {
                             var strBld = new StringBuilder(1024);
-                            strBld.AppendFormat("Execution of the following command(s) completed with errors:\r\n\r\n{0}\r\n", 
+                            strBld.AppendFormat("Execution of the following command(s) completed with errors:\r\n\r\n{0}\r\n",
                                 GetStringForPSCommand(psCommand));
 
                             int i = 1;
@@ -838,19 +838,14 @@ namespace Microsoft.PowerShell.EditorServices
 
                 Collection<PSObject> results = pipeline.Invoke();
 
-                if (results.Count == 0)
+                if (results.Count == 0 || results.FirstOrDefault() == null)
                 {
                     return defaultValue;
                 }
 
                 if (typeof(TResult) != typeof(PSObject))
                 {
-                    return (results.FirstOrDefault() == null)
-                        // Evaluates to null but couldn't put just null (needs to be a TResult) and also couldn't cast null to TResult
-                        ? results
-                            .OfType<TResult>()
-                            .FirstOrDefault()
-                        : results
+                    return results
                             .Select(pso => pso.BaseObject)
                             .OfType<TResult>()
                             .FirstOrDefault();


### PR DESCRIPTION
We were seeing this exception every time on macOS.
```
2018-02-23 20:23:14 [WARNING] - Method "GetVersionDetails" at line 153 of C:\projects\powershelleditorservices\src\PowerShellEditorServices\Session\PowerShellVersionDetails.cs

    Failed to look up PowerShell version, defaulting to version 5.
    
    System.NullReferenceException: Object reference not set to an instance of an object.
       at Microsoft.PowerShell.EditorServices.PowerShellContext.<>c__56`1.<ExecuteScriptAndGetItem>b__56_0(PSObject pso)
       at System.Linq.Enumerable.SelectIListIterator`2.MoveNext()
       at System.Linq.Enumerable.<OfTypeIterator>d__32`1.MoveNext()
       at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Boolean& found)
       at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source)
       at Microsoft.PowerShell.EditorServices.PowerShellContext.ExecuteScriptAndGetItem[TResult](String scriptToExecute, Runspace runspace, TResult defaultValue)
       at Microsoft.PowerShell.EditorServices.Session.PowerShellVersionDetails.GetVersionDetails(Runspace runspace, ILogger logger)
```
 It's because `$env:PROCESSOR_ARCHITECTURE` does not exist on macOS and the result of [this line](https://github.com/PowerShell/PowerShellEditorServices/blob/80755157599b620c8e24517e4d36166bd2943922/src/PowerShellEditorServices/Session/PowerShellVersionDetails.cs#L137) returned a _collection_ that had one value... null - rather than returning just null.

This fix returns just null if the contents of the execution contains just an null item.

Resolves https://github.com/PowerShell/vscode-powershell/issues/1211
Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/636
