### PR TITLE
Add support for running xUnit tests in VS Test Explorer

### DIFF
--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -825,7 +825,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Assert.StartsWith("5.", versionDetails.Version);
             Assert.StartsWith("5.", versionDetails.DisplayVersion);
             Assert.Equal("Desktop", versionDetails.Edition);
-            Assert.Equal("x86", versionDetails.Architecture);
+
+            string expectedArchitecture = (IntPtr.Size == 8) ? "x64" : "x86";
+            Assert.Equal(expectedArchitecture, versionDetails.Architecture);
         }
 
         private async Task SendOpenFileEvent(string filePath, bool waitForDiagnostics = true)

--- a/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
+++ b/test/PowerShellEditorServices.Test.Host/PowerShellEditorServices.Test.Host.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
   </ItemGroup>

--- a/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
+++ b/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
+    <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
   </ItemGroup>


### PR DESCRIPTION
Fix issue with running xUnit tests over and over.  Have a better
way to detect when the session details file has been written.

Fix issue with ServiceReturnsPowerShellVersionDetails test,
where it only worked when you ran the tests using x86 arch.
It now runs correctly using x64.