### PR TITLE
Implement better way to test for in-memory file

### DIFF
--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -407,6 +407,10 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     isInMemory = true;
                 }
+                catch (PathTooLongException)
+                {
+                    // If we ever get here, it should be an actual file so, not in memory
+                }
             }
 
             return isInMemory;

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -35,5 +35,35 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             Assert.Equal(@"..\PeerPath\FilePath.ps1", workspace.GetRelativePath(testPathOutside));
             Assert.Equal(testPathAnotherDrive, workspace.GetRelativePath(testPathAnotherDrive));
         }
+
+        [Fact]
+        public void CanDetermineIsPathInMemory()
+        {
+            var tempDir = Environment.GetEnvironmentVariable("TEMP");
+
+            var shortDirPath = Path.Combine(tempDir, "GitHub", "PowerShellEditorServices");
+            var shortFilePath = Path.Combine(shortDirPath, "foo.ps1");
+            var shortDirUriForm = new Uri(shortDirPath).ToString();
+            var shortFileUriForm = new Uri(shortFilePath).ToString();
+
+            // Test short file absolute paths
+            Assert.False(Workspace.IsPathInMemory(shortDirPath));
+            Assert.False(Workspace.IsPathInMemory(shortFilePath));
+            Assert.False(Workspace.IsPathInMemory(shortDirUriForm));
+            Assert.False(Workspace.IsPathInMemory(shortFileUriForm));
+
+            // Test short file relative paths - not sure we'll ever get these but just in case
+            Assert.False(Workspace.IsPathInMemory("foo.ps1"));
+            Assert.False(Workspace.IsPathInMemory(".." + Path.DirectorySeparatorChar + "foo.ps1"));
+
+            // Test short non-file paths
+            Assert.True(Workspace.IsPathInMemory("untitled:untitled-1"));
+            var shortUriForm = "git:/c%3A/Users/Keith/GitHub/dahlbyk/posh-git/src/PoshGitTypes.ps1?%7B%22path%22%3A%22c%3A%5C%5CUsers%5C%5CKeith%5C%5CGitHub%5C%5Cdahlbyk%5C%5Cposh-git%5C%5Csrc%5C%5CPoshGitTypes.ps1%22%2C%22ref%22%3A%22~%22%7D";
+            Assert.True(Workspace.IsPathInMemory(shortUriForm));
+
+            // Test long non-file path - known to have crashed PSES
+            var longUriForm = "gitlens-git:c%3A%5CUsers%5CKeith%5CGitHub%5Cdahlbyk%5Cposh-git%5Csrc%5CPoshGitTypes%3Ae0022701.ps1?%7B%22fileName%22%3A%22src%2FPoshGitTypes.ps1%22%2C%22repoPath%22%3A%22c%3A%2FUsers%2FKeith%2FGitHub%2Fdahlbyk%2Fposh-git%22%2C%22sha%22%3A%22e0022701fa12e0bc22d0458673d6443c942b974a%22%7D";
+            Assert.True(Workspace.IsPathInMemory(longUriForm));
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -3,12 +3,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices;
 using System;
 using System.IO;
-using System.Linq;
-using Xunit;
 using Microsoft.PowerShell.EditorServices.Utility;
+using Xunit;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Session
 {
@@ -40,30 +38,36 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
         public void CanDetermineIsPathInMemory()
         {
             var tempDir = Environment.GetEnvironmentVariable("TEMP");
-
             var shortDirPath = Path.Combine(tempDir, "GitHub", "PowerShellEditorServices");
             var shortFilePath = Path.Combine(shortDirPath, "foo.ps1");
-            var shortDirUriForm = new Uri(shortDirPath).ToString();
-            var shortFileUriForm = new Uri(shortFilePath).ToString();
-
-            // Test short file absolute paths
-            Assert.False(Workspace.IsPathInMemory(shortDirPath));
-            Assert.False(Workspace.IsPathInMemory(shortFilePath));
-            Assert.False(Workspace.IsPathInMemory(shortDirUriForm));
-            Assert.False(Workspace.IsPathInMemory(shortFileUriForm));
-
-            // Test short file relative paths - not sure we'll ever get these but just in case
-            Assert.False(Workspace.IsPathInMemory("foo.ps1"));
-            Assert.False(Workspace.IsPathInMemory(".." + Path.DirectorySeparatorChar + "foo.ps1"));
-
-            // Test short non-file paths
-            Assert.True(Workspace.IsPathInMemory("untitled:untitled-1"));
             var shortUriForm = "git:/c%3A/Users/Keith/GitHub/dahlbyk/posh-git/src/PoshGitTypes.ps1?%7B%22path%22%3A%22c%3A%5C%5CUsers%5C%5CKeith%5C%5CGitHub%5C%5Cdahlbyk%5C%5Cposh-git%5C%5Csrc%5C%5CPoshGitTypes.ps1%22%2C%22ref%22%3A%22~%22%7D";
-            Assert.True(Workspace.IsPathInMemory(shortUriForm));
-
-            // Test long non-file path - known to have crashed PSES
             var longUriForm = "gitlens-git:c%3A%5CUsers%5CKeith%5CGitHub%5Cdahlbyk%5Cposh-git%5Csrc%5CPoshGitTypes%3Ae0022701.ps1?%7B%22fileName%22%3A%22src%2FPoshGitTypes.ps1%22%2C%22repoPath%22%3A%22c%3A%2FUsers%2FKeith%2FGitHub%2Fdahlbyk%2Fposh-git%22%2C%22sha%22%3A%22e0022701fa12e0bc22d0458673d6443c942b974a%22%7D";
-            Assert.True(Workspace.IsPathInMemory(longUriForm));
+
+            var testCases = new[] {
+                // Test short file absolute paths
+                new { IsInMemory = false, Path = shortDirPath },
+                new { IsInMemory = false, Path = shortFilePath },
+                new { IsInMemory = false, Path = new Uri(shortDirPath).ToString() },
+                new { IsInMemory = false, Path = new Uri(shortFilePath).ToString() },
+
+                // Test short file relative paths - not sure we'll ever get these but just in case
+                new { IsInMemory = false, Path = "foo.ps1" },
+                new { IsInMemory = false, Path = ".." + Path.DirectorySeparatorChar + "foo.ps1" },
+
+                // Test short non-file paths
+                new { IsInMemory = true,  Path = "untitled:untitled-1" },
+                new { IsInMemory = false,  Path = shortUriForm },
+
+                // Test long non-file path - known to have crashed PSES
+                new { IsInMemory = true,  Path = longUriForm },
+            };
+
+            foreach (var testCase in testCases)
+            {
+                Assert.True(
+                    Workspace.IsPathInMemory(testCase.Path) == testCase.IsInMemory,
+                    $"Testing path {testCase.Path}");
+            }
         }
     }
 }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
 
                 // Test short non-file paths
                 new { IsInMemory = true,  Path = "untitled:untitled-1" },
-                new { IsInMemory = false,  Path = shortUriForm },
+                new { IsInMemory = true,  Path = shortUriForm },
 
                 // Test long non-file path - known to have crashed PSES
                 new { IsInMemory = true,  Path = longUriForm },


### PR DESCRIPTION
Fix #569

PSES would crash quite often when the user viewed a ps1 file in a diff window
or an earlier version using GitLens.

This approach using the System.Uri class that can detect file vs other schemes.
URI chokes on relative file paths.  In this case, we fall back to the previous
approach of using Path.GetFullPath().