### PR TITLE
Change PSES to be buildable as a standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/_site/
 docs/_repo/
 docs/metadata/
 tools/
+*.zip
 
 # quickbuild.exe
 /VersionGeneratingLogs/

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,12 @@
+{
+    "PSScriptAnalyzer":{
+        "MinimumVersion":"1.6",
+        "MaximumVersion":"1.99",
+        "AllowPrerelease":false
+    },
+    "Plaster":{
+        "MinimumVersion":"1.0",
+        "MaximumVersion":"1.99",
+        "AllowPrerelease":false
+    }
+}

--- a/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
+++ b/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 {
     public class ServerTestsBase
     {
-        private static int sessionCounter;        
+        private static int sessionCounter;
         private Process serviceProcess;
         protected IMessageSender messageSender;
         protected IMessageHandlers messageHandlers;
@@ -35,7 +35,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             bool waitForDebugger = false)
         {
             string modulePath = Path.GetFullPath(@"..\..\..\..\..\module");
-            string scriptPath = Path.Combine(modulePath, "Start-EditorServices.ps1");
+            string scriptPath = Path.GetFullPath(Path.Combine(modulePath, @"PowerShellEditorServices\Start-EditorServices.ps1"));
+
+            if (!File.Exists(scriptPath))
+            {
+                throw new IOException(String.Format("Bad start script path: '{0}'", scriptPath));
+            }
 
 #if CoreCLR
             Assembly assembly = this.GetType().GetTypeInfo().Assembly;
@@ -47,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             FileVersionInfo fileVersionInfo =
                 FileVersionInfo.GetVersionInfo(assemblyPath);
 
-            string sessionPath = 
+            string sessionPath =
                 Path.Combine(
                     Path.GetDirectoryName(assemblyPath), $"session-{++sessionCounter}.json");
 
@@ -64,9 +69,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     fileVersionInfo.FileBuildPart);
 
             string scriptArgs =
-                string.Format(
                     "\"" + scriptPath + "\" " +
-                    "-EditorServicesVersion \"{0}\" " +
                     "-HostName \\\"PowerShell Editor Services Test Host\\\" " +
                     "-HostProfileId \"Test.PowerShellEditorServices\" " +
                     "-HostVersion \"1.0.0\" " +
@@ -75,8 +78,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     "-LogPath \"" + logPath + "\" " +
                     "-SessionDetailsPath \"" + sessionPath + "\" " +
                     "-FeatureFlags @() " +
-                    "-AdditionalModules @() ",
-                   editorServicesModuleVersion);
+                    "-AdditionalModules @() ";
 
             if (waitForDebugger)
             {
@@ -117,6 +119,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             var maxRetryAttempts = 10;
             while (maxRetryAttempts-- > 0)
             {
+                if (this.serviceProcess.HasExited)
+                {
+                    throw new Exception(String.Format("Server host process quit unexpectedly: '{0}'", this.serviceProcess.StandardError.ReadToEnd()));
+                }
+
                 try
                 {
                     using (var stream = new FileStream(sessionPath, FileMode.Open, FileAccess.Read, FileShare.None))
@@ -125,9 +132,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                         sessionDetailsText = reader.ReadToEnd();
                         break;
                     }
-                }
-                catch (FileNotFoundException)
-                {
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
When PSES builds, it should be responsible for its own modules. So I've added a build rule that populates its `/module/` directory. This moves the `modules.json` file over from the VSCode extension as well.

So with this, PSES should be generally self contained and ready to run after building.