### PR TITLE
Get rid of the unneeded exception variable causing a compile warning

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptRegion.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 scriptExtentText = scriptExtent.Text;
             }
-            catch (ArgumentOutOfRangeException e)
+            catch (ArgumentOutOfRangeException)
             {
                 scriptExtentText = string.Empty;
             }


### PR DESCRIPTION
We've been sitting on a compile warning for a while, so I've removed the offending variable.