### PR TITLE
Add $psEditor.GetEditorContext().CurrentFile.SaveAs("Name") support

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -132,8 +132,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
     public class SaveFileRequest
     {
         public static readonly
-            RequestType<string, EditorCommandResponse, object, object> Type =
-            RequestType<string, EditorCommandResponse, object, object>.Create("editor/saveFile");
+            RequestType<SaveFileDetails, EditorCommandResponse, object, object> Type =
+            RequestType<SaveFileDetails, EditorCommandResponse, object, object>.Create("editor/saveFile");
+    }
+
+    public class SaveFileDetails
+    {
+        public string FilePath { get; set; }
+
+        public string NewPath { get; set; }
     }
 
     public class ShowInformationMessageRequest

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -149,10 +149,19 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         public Task SaveFile(string filePath)
         {
+            return SaveFile(filePath, null);
+        }
+
+        public Task SaveFile(string currentPath, string newSavePath)
+        {
             return
                 this.messageSender.SendRequest(
                     SaveFileRequest.Type,
-                    filePath,
+                    new SaveFileDetails
+                    {
+                        FilePath = currentPath,
+                        NewPath = newSavePath
+                    },
                     true);
         }
 

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
 
@@ -237,6 +238,28 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         public void Save()
         {
             this.editorOperations.SaveFile(this.scriptFile.FilePath);
+        }
+
+        /// <summary>
+        /// Save this file under a new path and open a new editor window on that file.
+        /// </summary>
+        /// <param name="newFilePath">
+        /// the path where the file should be saved,
+        /// including the file name with extension as the leaf
+        /// </param>
+        public void SaveAs(string newFilePath)
+        {
+            // Do some validation here so that we can provide a helpful error if the path won't work
+            string absolutePath = System.IO.Path.IsPathRooted(newFilePath) ?
+                newFilePath :
+                System.IO.Path.GetFullPath(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(this.scriptFile.FilePath), newFilePath));
+
+            if (File.Exists(absolutePath))
+            {
+                throw new IOException(String.Format("The file '{0}' already exists", absolutePath));
+            }
+
+            this.editorOperations.SaveFile(this.scriptFile.FilePath, newFilePath);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -72,6 +72,14 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         Task SaveFile(string filePath);
 
         /// <summary>
+        /// Causes a file to be saved as a new file in a new editor window.
+        /// </summary>
+        /// <param name="oldFilePath">the path of the current file being saved</param>
+        /// <param name="newFilePath">the path of the new file where the current window content will be saved</param>
+        /// <returns></returns>
+        Task SaveFile(string oldFilePath, string newFilePath);
+
+        /// <summary>
         /// Inserts text into the specified range for the file at the specified path.
         /// </summary>
         /// <param name="filePath">The path of the file which will have text inserted.</param>

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
 
     public class TestEditorOperations : IEditorOperations
     {
-        
+
         public string GetWorkspacePath()
         {
             throw new NotImplementedException();
@@ -206,6 +206,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         }
 
         public Task SaveFile(string filePath)
+        {
+            return SaveFile(filePath, null);
+        }
+
+        public Task SaveFile(string filePath, string newSavePath)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Adds a `SaveAs()` method to the `FileContext` object, which sends a message to language client to save the current file as something else, at a path relative to the current file.

One note: there's a small amount of validation, just to not let you overwrite a file (since VSCode won't). The question is: should we do more validation, or none and instead get VSCode to send us back a success/failure message?

See [vscode-powershell #1261](https://github.com/PowerShell/vscode-powershell/pull/1261) for the client side of this feature.