### PR TITLE
Make the 'PSESRemoteSessionOpenFile' a support event

### DIFF
--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -199,14 +199,14 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 [string] $PSEditModule
             )
 
-            Register-EngineEvent -SourceIdentifier PSESRemoteSessionOpenFile -Forward
+            Register-EngineEvent -SourceIdentifier PSESRemoteSessionOpenFile -Forward -SupportEvent
             New-Module -ScriptBlock ([Scriptblock]::Create($PSEditModule)) -Name PSEdit | Import-Module -Global
         ";
 
         private const string RemovePSEditFunctionScript = @"
             Get-Module PSEdit | Remove-Module
 
-            Get-EventSubscriber -SourceIdentifier PSESRemoteSessionOpenFile -EA Ignore | Unregister-Event
+            Unregister-Event -SourceIdentifier PSESRemoteSessionOpenFile -Force -ErrorAction Ignore
         ";
 
         private const string SetRemoteContentsScript = @"


### PR DESCRIPTION
Make the `PSESRemoteSessionOpenFile` a support event, so `Get-EventSubscriber` won't show up that subscriber. `Get-EventSubscriber -Force` can still show the support events. `Unregister-Event -Force` needs to be used to remove a support event.

The event subscriber for `PSInternalRemoteDebuggerStopEvent` and `PSInternalRemoteDebuggerBreakpointUpdatedEvent` are already made support events, see [`ServerRunspacePoolDriver.cs`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs#L2167).