### PR TITLE
Add @rkeithhill's IPv6 socket fix to PSES startup script

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -176,21 +176,15 @@ function Test-PortAvailability {
     $portAvailable = $true
 
     try {
-        if ($isPS5orLater) {
-            $ipAddresses = [System.Net.Dns]::GetHostEntryAsync("localhost").Result.AddressList
-        }
-        else {
-            $ipAddresses = [System.Net.Dns]::GetHostEntry("localhost").AddressList
-        }
+        # After some research, I don't believe we should run into problems using an IPv4 port
+        # that happens to be in use via an IPv6 address.  That is based on this info:
+        # https://www.ibm.com/support/knowledgecenter/ssw_i5_54/rzai2/rzai2compipv4ipv6.htm#rzai2compipv4ipv6__compports
+        $ipAddress = [System.Net.IPAddress]::Loopback
+        Log "Testing availability of port ${PortNumber} at address ${ipAddress} / $($ipAddress.AddressFamily)"
 
-        foreach ($ipAddress in $ipAddresses)
-        {
-            Log "Testing availability of port ${PortNumber} at address ${ipAddress} / $($ipAddress.AddressFamily)"
-
-            $tcpListener = New-Object System.Net.Sockets.TcpListener @($ipAddress, $PortNumber)
-            $tcpListener.Start()
-            $tcpListener.Stop()
-        }
+        $tcpListener = New-Object System.Net.Sockets.TcpListener @($ipAddress, $PortNumber)
+        $tcpListener.Start()
+        $tcpListener.Stop()
     }
     catch [System.Net.Sockets.SocketException] {
         $portAvailable = $false


### PR DESCRIPTION
@rkeithhill fixed an issue with starting PSES on machines that don't support IPv6 sockets in https://github.com/PowerShell/vscode-powershell/pull/1281.

But I migrated the startup script to PSES and left out that fix.

This puts it back in.