### PR TITLE
Close stray processes on exit

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -124,8 +124,6 @@ function Start-EditorServicesHost {
 
     if ($DebugServiceOnly.IsPresent) {
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $false);
-    } elseif ($Stdio.IsPresent) {
-        $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
     } else {
         $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $true);

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -124,6 +124,8 @@ function Start-EditorServicesHost {
 
     if ($DebugServiceOnly.IsPresent) {
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $false);
+    } elseif ($Stdio.IsPresent) {
+        $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
     } else {
         $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $true);

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
         private IServerListener languageServiceListener;
         private IServerListener debugServiceListener;
 
-        private TaskCompletionSource<bool> serverCompletedTask;
+        private TaskCompletionSource<bool> serverCompletedTask = new TaskCompletionSource<bool>();
 
         #endregion
 
@@ -226,6 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     this.editorSession,
                     messageDispatcher,
                     protocolEndpoint,
+                    this.serverCompletedTask,
                     this.logger);
 
             await this.editorSession.PowerShellContext.ImportCommandsModule(
@@ -348,7 +349,6 @@ namespace Microsoft.PowerShell.EditorServices.Host
         public void WaitForCompletion()
         {
             // TODO: We need a way to know when to complete this task!
-            this.serverCompletedTask = new TaskCompletionSource<bool>();
             this.serverCompletedTask.Task.Wait();
         }
 

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -56,31 +56,30 @@ namespace Microsoft.PowerShell.EditorServices.Host
     {
         #region Private Fields
 
-        private ILogger logger;
-        private bool enableConsoleRepl;
-        private HostDetails hostDetails;
-        private ProfilePaths profilePaths;
+        private string[] additionalModules;
         private string bundledModulesPath;
         private DebugAdapter debugAdapter;
-        private string[] additionalModules;
         private EditorSession editorSession;
+        private bool enableConsoleRepl;
         private HashSet<string> featureFlags;
+        private HostDetails hostDetails;
         private LanguageServer languageServer;
+        private ILogger logger;
+        private ProfilePaths profilePaths;
+        private TaskCompletionSource<bool> serverCompletedTask;
 
         private IServerListener languageServiceListener;
         private IServerListener debugServiceListener;
-
-        private TaskCompletionSource<bool> serverCompletedTask = new TaskCompletionSource<bool>();
 
         #endregion
 
         #region Properties
 
-        public EditorServicesHostStatus Status { get; private set; }
+        public int DebugServicePort { get; private set; }
 
         public int LanguageServicePort { get; private set; }
 
-        public int DebugServicePort { get; private set; }
+        public EditorServicesHostStatus Status { get; private set; }
 
         #endregion
 
@@ -108,6 +107,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             this.bundledModulesPath = bundledModulesPath;
             this.additionalModules = additionalModules ?? new string[0];
             this.featureFlags = new HashSet<string>(featureFlags ?? new string[0]);
+            this.serverCompletedTask = new TaskCompletionSource<bool>();
 
 #if DEBUG
             if (waitForDebugger)

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         }
 
         /// <summary>
-        /// Initializes a new language server that is used for handing language server protocol messages 
+        /// Initializes a new language server that is used for handing language server protocol messages
         /// </summary>
         /// <param name="editorSession">The editor session that handles the PowerShell runspace</param>
         /// <param name="messageHandlers">An object that manages all of the message handlers</param>
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             Logger.Write(LogLevel.Normal, "Language service is shutting down...");
 
-            // TODO: Raise an event so that the host knows to shut down
+            // complete the task so that the host knows to shut down
             this.serverCompletedTask.SetResult(true);
 
             return Task.FromResult(true);

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -47,15 +47,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             get { return this.editorOperations; }
         }
 
-        /// <param name="editorSession"></param>
-        /// <param name="messageHandlers"></param>
-        /// <param name="messageSender"></param>
-        /// <param name="serverCompletedTask"></param>
-        /// <param name="logger"></param>
-        /// <param name="hostDetails">
-        /// Provides details about the host application.
-        /// </param>
-        public LanguageServer(EditorSession editorSession,
+        /// <summary>
+        /// Initializes a new language server that is used for handing language server protocol messages 
+        /// </summary>
+        /// <param name="editorSession">The editor session that handles the PowerShell runspace</param>
+        /// <param name="messageHandlers">An object that manages all of the message handlers</param>
+        /// <param name="messageSender">The message sender</param>
+        /// <param name="serverCompletedTask">A TaskCompletionSource<bool> that will be completed to stop the running process</param>
+        /// <param name="logger">The logger</param>
+        public LanguageServer(
+            EditorSession editorSession,
             IMessageHandlers messageHandlers,
             IMessageSender messageSender,
             TaskCompletionSource<bool> serverCompletedTask,


### PR DESCRIPTION
Fixes #655 

This shuts down PSES when it receives the `exit` message [following the language server protocol](https://microsoft.github.io/language-server-protocol/specification#exit).

This also makes the `shutdown` message NOT kill the server which also [follows the language server protocol](https://microsoft.github.io/language-server-protocol/specification#shutdown).

I've tested this using the [NeoVim Language Client](https://github.com/autozimu/LanguageClient-neovim)