### PR TITLE
ignore .idea folder that jetbrains products like to spit out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ module/PowerShellEditorServices/Third\ Party\ Notices.txt
 
 # Visual Studio for Mac generated file
 *.userprefs
+
+# JetBrains generated file (Rider, intelliJ)
+.idea/


### PR DESCRIPTION
ignore .idea folder that jetbrains products like to spit out (Rider, IntelliJ, Resharper)