### PR TITLE
Add .gitattributes, .editorconfig and extensions.json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+
+[*.{cs}]
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{json}]
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{ps1xml,props,xml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+CHANGELOG.md merge=union
+* text=auto
+*.png binary

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "ms-vscode.csharp",
+        "ms-vscode.PowerShell",
+        "EditorConfig.EditorConfig",
+        "DavidAnson.vscode-markdownlint"
+    ]
+}


### PR DESCRIPTION
Address #665 

This should help address differences in behavior between editing in VS and in VSCode.  
Although at first, we'll probably get a lot of whitespace changes (due to trimming trailing
whitespace in C# files).