### PR TITLE
Stop before we restart

### DIFF
--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                         this.logger.Write(
                             LogLevel.Normal,
                             "Previous debug session ended, restarting debug service listener...");
-
+                        this.debugServiceListener.Stop();
                         this.debugServiceListener.Start();
                     }
                     else if (this.debugAdapter.IsUsingTempIntegratedConsole)


### PR DESCRIPTION
PSES's debug adapter wasn't properly shutting down between debug sessions (some things were shut down, some things weren't). This might have been the cause of other debug issues we have seen when/if folks have been unable to restart the debugger.

This change is needed to get NamedPipes working because when running Start without fully Stopping before it, the debug adapter would crash with:

> All pipe instances are busy