### PR TITLE
Add more useful PSSA rules that should be enabled by default

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -55,12 +55,9 @@ namespace Microsoft.PowerShell.EditorServices
             "PSAvoidDefaultValueSwitchParameter",
             "PSUseDeclaredVarsMoreThanAssignments",
             "PSPossibleIncorrectComparisonWithNull",
-            "PSAvoidUsingWriteHost",
-            "PSAvoidUsingEmptyCatchBlock",
-            "PSAvoidUsingWMICmdlet",
-            "PSUseSingularNouns",
-            "PSAvoidUsingInvokeExpression",
-            "PSAvoidDefaultValueForMandatoryParameter"
+            "PSAvoidDefaultValueForMandatoryParameter",
+            "PSAvoidTrailingWhitespace",
+            "PossibleIncorrectUsageOfRedirectionOperator"
         };
 
         #endregion // Private Fields

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices
             "PSAvoidUsingWriteHost",
             "PSAvoidUsingEmptyCatchBlock",
             "PSAvoidUsingWMICmdlet",
-            "PSUseSingularNouns"
+            "PSUseSingularNouns",
             "PSAvoidUsingInvokeExpression",
             "PSAvoidDefaultValueForMandatoryParameter"
         };

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices
             "PSPossibleIncorrectComparisonWithNull",
             "PSAvoidDefaultValueForMandatoryParameter",
             "PSAvoidTrailingWhitespace",
-            "PossibleIncorrectUsageOfRedirectionOperator"
+            "PSPossibleIncorrectUsageOfRedirectionOperator"
         };
 
         #endregion // Private Fields

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -53,7 +53,14 @@ namespace Microsoft.PowerShell.EditorServices
             "PSShouldProcess",
             "PSMissingModuleManifestField",
             "PSAvoidDefaultValueSwitchParameter",
-            "PSUseDeclaredVarsMoreThanAssignments"
+            "PSUseDeclaredVarsMoreThanAssignments",
+            "PSPossibleIncorrectComparisonWithNull",
+            "PSAvoidUsingWriteHost",
+            "PSAvoidUsingEmptyCatchBlock",
+            "PSAvoidUsingWMICmdlet",
+            "PSUseSingularNouns"
+            "PSAvoidUsingInvokeExpression",
+            "PSAvoidDefaultValueForMandatoryParameter"
         };
 
         #endregion // Private Fields


### PR DESCRIPTION
Since the majority of people do not customize the PSSA settings inside VSCode and just use the vs code extension how it comes out of the box, therefore enabling more useful PSSA rules by default, especially `PSPossibleIncorrectComparisonWithNull` (this was what drove me to change the defaults because I really expected this to be on by default when I was doing a demo)
The parallel nature of PSSA (that executes all rules in parallel) means that the time to analyse a script will be always bound by the slowest rule.