### PR TITLE
Log the version of PSSA we import

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -345,12 +345,19 @@ namespace Microsoft.PowerShell.EditorServices
                     {"Module", "PSScriptAnalyzer"}
                 });
 
-                var commandNames = commands?
+                var cmdletInfos = commands?
                     .Select(c => c.ImmediateBaseObject as CmdletInfo)
-                    .Where(c => c != null)
+                    .Where(c => c != null);
+
+                var moduleVersion = cmdletInfos?
+                    .Select(c => c.Version?.ToString())
+                    .FirstOrDefault();
+
+                var commandNames = cmdletInfos?
                     .Select(c => c.Name) ?? Enumerable.Empty<string>();
 
-                sb.AppendLine("The following cmdlets are available in the imported PSScriptAnalyzer module:");
+                sb.Append("The following cmdlets are available in the imported PSScriptAnalyzer module");
+                sb.AppendLine((moduleVersion != null) ? $" (version {moduleVersion}):" : ":");
                 sb.AppendLine(String.Join(Environment.NewLine, commandNames.Select(s => "    " + s)));
                 this._logger.Write(LogLevel.Verbose, sb.ToString());
             }


### PR DESCRIPTION
Given issues we've seen recently, it would be nice to have this info
in the log.

This will output:
```
2018-06-03 20:48:38.753 [VERBOSE] C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\src\PowerShellEditorServices\Analysis\AnalysisService.cs: In method 'EnumeratePSScriptAnalyzerCmdlets', line 362:
    The following cmdlets are available in the imported PSScriptAnalyzer module (version 1.16.1):
        Get-ScriptAnalyzerRule
        Invoke-Formatter
        Invoke-ScriptAnalyzer
```