### PR TITLE
Implement initialized notification handler to get rid of log error

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/InitializedNotification.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/InitializedNotification.cs
@@ -1,0 +1,29 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    /// <summary>
+    /// The initialized notification is sent from the client to the server after the client received the result 
+    /// of the initialize request but before the client is sending any other request or notification to the server. 
+    /// The server can use the initialized notification for example to dynamically register capabilities. 
+    /// The initialized notification may only be sent once.
+    /// </summary>
+    public class InitializedNotification
+    {
+        public static readonly
+            NotificationType<InitializedParams, object> Type =
+            NotificationType<InitializedParams, object>.Create("initialized");
+    }
+
+    /// <summary>
+    /// Currently, the initialized message has no parameters.
+    /// </summary>
+    public class InitializedParams
+    {
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -99,6 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.messageHandlers.SetEventHandler(ExitNotification.Type, this.HandleExitNotification);
 
             this.messageHandlers.SetRequestHandler(InitializeRequest.Type, this.HandleInitializeRequest);
+            this.messageHandlers.SetEventHandler(InitializedNotification.Type, this.HandleInitializedNotification);
 
             this.messageHandlers.SetEventHandler(DidOpenTextDocumentNotification.Type, this.HandleDidOpenTextDocumentNotification);
             this.messageHandlers.SetEventHandler(DidCloseTextDocumentNotification.Type, this.HandleDidCloseTextDocumentNotification);
@@ -176,6 +177,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             // Stop the server channel
             await this.Stop();
+        }
+
+        private Task HandleInitializedNotification(InitializedParams initializedParams,
+            EventContext eventContext)
+        {
+            // Can do dynamic registration of capabilities in this notification handler
+            return Task.FromResult(true);
         }
 
         protected async Task HandleInitializeRequest(


### PR DESCRIPTION
We do nothing in the handler atm but in the future we can do dynamic
registration of capabilities in it.