### PR TITLE
Make AnalysisService use the latest version of PSScriptAnalyzer

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -575,7 +575,7 @@ function __Expand-Alias {
             bool oldScriptAnalysisEnabled =
                 this.currentSettings.ScriptAnalysis.Enable.HasValue ? this.currentSettings.ScriptAnalysis.Enable.Value : false;
             string oldScriptAnalysisSettingsPath =
-                this.currentSettings.ScriptAnalysis.SettingsPath;
+                this.currentSettings.ScriptAnalysis?.SettingsPath;
 
             this.currentSettings.Update(
                 configChangeParams.Settings.Powershell,
@@ -604,12 +604,15 @@ function __Expand-Alias {
             string newSettingsPath = this.currentSettings.ScriptAnalysis.SettingsPath;
             if (!string.Equals(oldScriptAnalysisSettingsPath, newSettingsPath, StringComparison.OrdinalIgnoreCase))
             {
-                this.editorSession.AnalysisService.SettingsPath = newSettingsPath;
-                settingsPathChanged = true;
+                if (this.editorSession.AnalysisService != null)
+                {
+                    this.editorSession.AnalysisService.SettingsPath = newSettingsPath;
+                    settingsPathChanged = true;
+                }
             }
 
             // If script analysis settings have changed we need to clear & possibly update the current diagnostic records.
-            if ((oldScriptAnalysisEnabled != this.currentSettings.ScriptAnalysis.Enable) || settingsPathChanged)
+            if ((oldScriptAnalysisEnabled != this.currentSettings.ScriptAnalysis?.Enable) || settingsPathChanged)
             {
                 // If the user just turned off script analysis or changed the settings path, send a diagnostics
                 // event to clear the analysis markers that they already have.
@@ -1443,7 +1446,7 @@ function __Expand-Alias {
                     DelayThenInvokeDiagnostics(
                         750,
                         filesToAnalyze,
-                        this.currentSettings.ScriptAnalysis.Enable.Value,
+                        this.currentSettings.ScriptAnalysis?.Enable.Value ?? false,
                         this.codeActionsPerFile,
                         editorSession,
                         eventSender,

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -486,8 +486,13 @@ namespace Microsoft.PowerShell.EditorServices
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.AddCommand("Get-Module")
-                    .AddParameter("ListAvailable")
-                    .AddParameter("Name", PSSA_MODULE_NAME);
+                        .AddParameter("ListAvailable")
+                        .AddParameter("Name", PSSA_MODULE_NAME)
+                    .AddCommand("Where-Object")
+                        .AddParameter("Property", "Version")
+                        .AddParameter("ge")
+                        .AddParameter("Value", s_pssaMinimumVersion);
+
 
                 PSModuleInfo pssaModuleInfo;
                 try

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -555,6 +555,10 @@ namespace Microsoft.PowerShell.EditorServices
 
         private bool disposedValue = false; // To detect redundant calls
 
+        /// <summary>
+        /// Dispose of this object.
+        /// </summary>
+        /// <param name="disposing">True if the method is called by the Dispose method, false if called by the finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!disposedValue)

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -98,6 +98,22 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Constructors
 
+        /// <summary>
+        /// Construct a new AnalysisService object.
+        /// </summary>
+        /// <param name="analysisRunspacePool">
+        /// The runspace pool with PSScriptAnalyzer module loaded that will handle
+        /// analysis tasks.
+        /// </param>
+        /// <param name="pssaSettingsPath">
+        /// The path to the PSScriptAnalyzer settings file to handle analysis settings.
+        /// </param>
+        /// <param name="activeRules">An array of rules to be used for analysis.</param>
+        /// <param name="logger">Maintains logs for the analysis service.</param>
+        /// <param name="pssaModuleInfo">
+        /// Optional module info of the loaded PSScriptAnalyzer module. If not provided,
+        /// the analysis service will populate it, but it can be given here to save time.
+        /// </param>
         private AnalysisService(
             RunspacePool analysisRunspacePool,
             string pssaSettingsPath,
@@ -506,6 +522,8 @@ namespace Microsoft.PowerShell.EditorServices
         {
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
+                // Encode an equivalent of the PowerShell pipeline:
+                //   Get-Module -ListAvailable -Name "PSScriptAnalyzer" | Where-Object -Property "Version" -ge "1.16"
                 ps.AddCommand("Get-Module")
                         .AddParameter("ListAvailable")
                         .AddParameter("Name", PSSA_MODULE_NAME)

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -544,7 +544,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region IDisposable Support
 
-        private bool disposedValue = false; // To detect redundant calls
+        private bool _disposedValue = false; // To detect redundant calls
 
         /// <summary>
         /// Dispose of this object.
@@ -552,7 +552,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="disposing">True if the method is called by the Dispose method, false if called by the finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!_disposedValue)
             {
                 if (disposing)
                 {
@@ -561,7 +561,7 @@ namespace Microsoft.PowerShell.EditorServices
                     _analysisRunspacePool = null;
                 }
 
-                disposedValue = true;
+                _disposedValue = true;
             }
         }
 

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Constructors
 
-        public AnalysisService(RunspacePool analysisRunspacePool, string pssaSettingsPath, IEnumerable<string> activeRules, ILogger logger)
+        private AnalysisService(RunspacePool analysisRunspacePool, string pssaSettingsPath, IEnumerable<string> activeRules, ILogger logger)
         {
             _analysisRunspacePool = analysisRunspacePool;
             SettingsPath = pssaSettingsPath;

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -311,19 +311,6 @@ namespace Microsoft.PowerShell.EditorServices
             return result?.Select(r => r?.ImmediateBaseObject as string).FirstOrDefault();
         }
 
-        /// <summary>
-        /// Disposes the runspace being used by the analysis service.
-        /// </summary>
-        public void Dispose()
-        {
-            if (_analysisRunspacePool != null)
-            {
-                _analysisRunspacePool.Close();
-                _analysisRunspacePool.Dispose();
-                _analysisRunspacePool = null;
-            }
-        }
-
         #endregion // public methods
 
         #region Private Methods
@@ -400,20 +387,23 @@ namespace Microsoft.PowerShell.EditorServices
             sb.AppendLine("PSScriptAnalyzer successfully imported:");
 
             // Log version
-            sb.AppendLine($"    Version: {_pssaModuleInfo.Version}");
+            sb.Append("    Version: ");
+            sb.AppendLine(_pssaModuleInfo.Version.ToString());
 
             // Log exported cmdlets
             sb.AppendLine("    Exported Cmdlets:");
             foreach (string cmdletName in _pssaModuleInfo.ExportedCmdlets.Keys.OrderBy(name => name))
             {
-                sb.AppendLine("        " + cmdletName);
+                sb.Append("    ");
+                sb.AppendLine(cmdletName);
             }
 
             // Log available rules
             sb.AppendLine("    Available Rules:");
             foreach (string ruleName in GetPSScriptAnalyzerRules())
             {
-                sb.AppendLine("        " + ruleName);
+                sb.Append("        ");
+                sb.AppendLine(ruleName);
             }
 
             _logger.Write(featureLogLevel, sb.ToString());
@@ -560,5 +550,35 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         #endregion //private methods
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _analysisRunspacePool.Close();
+                    _analysisRunspacePool.Dispose();
+                    _analysisRunspacePool = null;
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Clean up all internal resources and dispose of the analysis service.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+
+        #endregion
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Returns all registered EditorCommands.
         /// </summary>
-        /// <returns>An Array of all registered EditorCommands.</return>
+        /// <returns>An Array of all registered EditorCommands.</returns>
         public EditorCommand[] GetCommands()
         {
             return this.extensionService.GetCommands();

--- a/src/PowerShellEditorServices/Extensions/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Extensions/ExtensionService.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Returns all registered EditorCommands.
         /// </summary>
-        /// <returns>An Array of all registered EditorCommands.</return>
+        /// <returns>An Array of all registered EditorCommands.</returns>
         public EditorCommand[] GetCommands()
         {
             EditorCommand[] commands = new EditorCommand[this.editorCommands.Count];

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -160,18 +160,8 @@ namespace Microsoft.PowerShell.EditorServices
 
         internal void InstantiateAnalysisService(string settingsPath = null)
         {
-            // AnalysisService will throw FileNotFoundException if
-            // Script Analyzer binaries are not included.
-            try
-            {
-                this.AnalysisService = AnalysisService.Create(settingsPath, this.logger);
-            }
-            catch (FileNotFoundException)
-            {
-                this.logger.Write(
-                    LogLevel.Warning,
-                    "Script Analyzer binaries not found, AnalysisService will be disabled.");
-            }
+            // Create the analysis service. If this fails, the result will be null -- any exceptions are caught and logged
+            this.AnalysisService = AnalysisService.Create(settingsPath, this.logger);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Session/EditorSession.cs
+++ b/src/PowerShellEditorServices/Session/EditorSession.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices
             // Script Analyzer binaries are not included.
             try
             {
-                this.AnalysisService = new AnalysisService(settingsPath, this.logger);
+                this.AnalysisService = AnalysisService.Create(settingsPath, this.logger);
             }
             catch (FileNotFoundException)
             {

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -215,7 +215,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// Convert an EditorServices log level to a Serilog log level.
         /// </summary>
         /// <param name="logLevel">The EditorServices log level.</param>
-        /// <returns>The Serilog LogEventLevel corresponding to the EditorServices log level.<returns>
+        /// <returns>The Serilog LogEventLevel corresponding to the EditorServices log level.</returns>
         private static LogEventLevel ConvertLogLevel(LogLevel logLevel)
         {
             switch (logLevel)

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -45,6 +45,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     public interface ILogger : IDisposable
     {
         /// <summary>
+        /// The minimum log level that this logger instance is configured to log at.
+        /// </summary>
+        LogLevel MinimumConfiguredLogLevel { get; }
+
+        /// <summary>
         /// Write a message with the given severity to the logs.
         /// </summary>
         /// <param name="logLevel">The severity level of the log message.</param>
@@ -180,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                     );
                 }
 
-                return new PsesLogger(configuration.CreateLogger());
+                return new PsesLogger(configuration.CreateLogger(), _logLevel);
             }
         }
 

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -24,10 +24,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// Construct a new logger around a Serilog ILogger.
         /// </summary>
         /// <param name="logger">The Serilog logger to use internally.</param>
-        internal PsesLogger(Logger logger)
+        internal PsesLogger(Logger logger, LogLevel minimumLogLevel)
         {
             _logger = logger;
+            MinimumConfiguredLogLevel = minimumLogLevel;
         }
+
+        /// <summary>
+        /// The minimum log level that this logger is configured to log at.
+        /// </summary>
+        public LogLevel MinimumConfiguredLogLevel { get; }
 
         /// <summary>
         /// Write a message with the given severity to the logs.

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// Construct a new logger around a Serilog ILogger.
         /// </summary>
         /// <param name="logger">The Serilog logger to use internally.</param>
+        /// <param name="minimumLogLevel">The minimum severity level the logger is configured to log messages at.</param>
         internal PsesLogger(Logger logger, LogLevel minimumLogLevel)
         {
             _logger = logger;


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1298 and https://github.com/PowerShell/PowerShellEditorServices/issues/657.

## Changes are:
* Load the latest version of PSScriptAnalyzer we can find on the path.
* Eliminate the `VerifyPSScriptAnalyzerAvailable`, since `ImportPSModule()` executes the same code internally.
* Do all the runspace manipulation in a factory method rather than in a constructor...
* Get rid of a bunch of needless private variables that just backed public ones.
* Get rid of `_hasScriptAnalyzerModule`, since it only got checked after the object was constructed (meaning it was always true...).
* Added some null checks on `AnalysisService` usage, since it can definitely be null.

<!--
### Note on the `ImportPSModule` API:
The PowerShell module "API"s are not brilliant, but it is indeed possible to create an `InitialSessionState` with modules with version requirements:
* The [`ImportModulesFromPath`](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L1919) we used to use actually calls the [`ImportPSModule`](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L1875) method using the paths as module names.
* This in turn creates a [`ModuleSpecification` with all the fields except name set to null](https://github.com/PowerShell/PowerShell/blob/c1c5344a8897262433141ecbc13bb06ac2c4bbef/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs#L44), which is fed to the [`ImportPSModule` overload that takes `ModuleSpecification`s](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L1900).
* `ImportPSModule` actually just adds modules to a list to be imported when the runspace is instantiated, [here](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L2419).
* [`ProcessImportModule`](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L2842), if the name is the only thing provided, runs the evil overload [`ProcessImportModule`](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/InitialSessionState.cs#L3011). And if other parameters are given in the `ModuleSpecification`, it uses [`ModuleCmdletBase.GetModuleIfAvailable`](https://github.com/PowerShell/PowerShell/blob/ebc7cdf847ef39c8d71fd0f69849bf59f498111b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs#L3953) to **internally run `Get-Module -Name <name> -ListAvailable`** and filter it. And `ProcessImportModule` just takes the first in the list...

And the fun part is that `ModuleSpecification` has two constructors, one taking a `string` (name) and one taking a `Hashtable` (of parameters). Truly odd. So the import looks like:
```csharp
new ModuleSpecification(new Hashtable()
{
    { "ModuleName", "PSScriptAnalyzer" },
    { "ModuleVersion", "1.16" }
});
```
And it does it this way so the arguments can be coerced to the relevant types by `LanguagePrimitives` (the internal PowerShell type coercion system). Good times!
-->