### PR TITLE
Initial CODEOWNERS file to auto assign PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# https://help.github.com/articles/about-codeowners/
+
+# Global reviewers
+* @tylerl0706
+
+# Area: Analysis & Formatting
+src/PowerShellEditorServices/Analysis/                 @rjmholt
+
+# Area: Debugging
+src/PowerShellEditorServices/Debugging/                @rkeithhill
+src/PowerShellEditorServices.Protocol/DebugAdapter/    @rkeithhill
+
+# Area: Integrated Console / Host
+src/PowerShellEditorServices/Console/                  @SeeminglyScience
+src/PowerShellEditorServices/Session/*ReadLine*.cs     @SeeminglyScience
+src/PowerShellEditorServices.Host/                     @SeeminglyScience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 
 # Global reviewers
-* @tylerl0706
+* @tylerl0706 @rjmholt
 
 # Area: Analysis & Formatting
 src/PowerShellEditorServices/Analysis/                 @rjmholt


### PR DESCRIPTION
I'm not entirely sure this is supported:
```
src/PowerShellEditorServices/Session/*ReadLine*.cs 
```
guess we just have to see once this is merged.