### PR TITLE
Fix PSES crash when you format an empty PS doc

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -263,8 +263,9 @@ namespace Microsoft.PowerShell.EditorServices
             Hashtable settings,
             int[] rangeList)
         {
-            // we cannot use Range type therefore this workaround of using -1 default value
-            if (!_hasScriptAnalyzerModule)
+            // We cannot use Range type therefore this workaround of using -1 default value.
+            // Invoke-Formatter throws a ParameterBinderValidationException if the ScriptDefinition is an empty string.
+            if (!_hasScriptAnalyzerModule || string.IsNullOrEmpty(scriptDefinition))
             {
                 return null;
             }


### PR DESCRIPTION
Invoke-Formatter -ScriptDefinition '' - throws a terminating error:
ParameterBinderValidationException.

I suppose we could have added another catch statement to the InvokePowerShell method
in the AnalysisService but in general, we probably want to know about such bugs.

We could also update the extension to not send a format request for an empty doc
but I'm not sure it's worth the additional code change given this corner case scenario.
But I could be convinced otherwise.

This is a partial fix to vscode issue https://github.com/PowerShell/vscode-powershell/issues/1346#issuecomment-396084932