### PR TITLE
Fix issue where MS Dynamics CRM

### DIFF
--- a/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psm1
+++ b/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psm1
@@ -4,10 +4,10 @@
 #
 
 if (!$PSVersionTable.PSEdition -or $PSVersionTable.PSEdition -eq "Desktop") {
-    Add-Type -Path "$PSScriptRoot/bin/Desktop/Microsoft.PowerShell.EditorServices.VSCode.dll"
+    Microsoft.PowerShell.Utility\Add-Type -Path "$PSScriptRoot/bin/Desktop/Microsoft.PowerShell.EditorServices.VSCode.dll"
 }
 else {
-    Add-Type -Path "$PSScriptRoot/bin/Core/Microsoft.PowerShell.EditorServices.VSCode.dll"
+    Microsoft.PowerShell.Utility\Add-Type -Path "$PSScriptRoot/bin/Core/Microsoft.PowerShell.EditorServices.VSCode.dll"
 }
 
 if ($psEditor -is [Microsoft.PowerShell.EditorServices.Extensions.EditorObject]) {
@@ -17,6 +17,6 @@ else {
     Write-Verbose '$psEditor object not found in the session, components will not be registered.'
 }
 
-Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse | ForEach-Object {
+Microsoft.PowerShell.Management\Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -Recurse | ForEach-Object {
     . $PSItem.FullName
 }

--- a/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psm1
+++ b/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psm1
@@ -3,10 +3,10 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-Import-LocalizedData -BindingVariable Strings -FileName Strings -ErrorAction Ignore
+Microsoft.PowerShell.Utility\Import-LocalizedData -BindingVariable Strings -FileName Strings -ErrorAction Ignore
 
-Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 | ForEach-Object {
+Microsoft.PowerShell.Management\Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 | ForEach-Object {
     . $PSItem.FullName
 }
 
-Export-ModuleMember -Function *-*
+Microsoft.PowerShell.Core\Export-ModuleMember -Function *-*

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -102,17 +102,17 @@ function ExitWithError($errorString) {
 }
 
 function WriteSessionFile($sessionInfo) {
-    $sessionInfoJson = ConvertTo-Json -InputObject $sessionInfo -Compress
+    $sessionInfoJson = Microsoft.PowerShell.Utility\ConvertTo-Json -InputObject $sessionInfo -Compress
     Log "Writing session file with contents:"
     Log $sessionInfoJson
-    $sessionInfoJson | Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
+    $sessionInfoJson | Microsoft.PowerShell.Management\Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
 }
 
 # Are we running in PowerShell 2 or earlier?
 if ($PSVersionTable.PSVersion.Major -le 2) {
     # No ConvertTo-Json on PSv2 and below, so write out the JSON manually
     "{`"status`": `"failed`", `"reason`": `"unsupported`", `"powerShellVersion`": `"$($PSVersionTable.PSVersion.ToString())`"}" |
-        Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
+        Microsoft.PowerShell.Management\Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
 
     ExitWithError "Unsupported PowerShell version $($PSVersionTable.PSVersion), language features are disabled."
 }
@@ -133,9 +133,9 @@ $isPS5orLater = $PSVersionTable.PSVersion.Major -ge 5
 
 # If PSReadline is present in the session, remove it so that runspace
 # management is easier
-if ((Get-Module PSReadline).Count -gt 0) {
+if ((Microsoft.PowerShell.Core\Get-Module PSReadline).Count -gt 0) {
     LogSection "Removing PSReadLine module"
-    Remove-Module PSReadline -ErrorAction SilentlyContinue
+    Microsoft.PowerShell.Core\Remove-Module PSReadline -ErrorAction SilentlyContinue
 }
 
 # This variable will be assigned later to contain information about
@@ -146,7 +146,7 @@ $resultDetails = $null;
 function Test-ModuleAvailable($ModuleName, $ModuleVersion) {
     Log "Testing module availability $ModuleName $ModuleVersion"
 
-    $modules = Get-Module -ListAvailable $moduleName
+    $modules = Microsoft.PowerShell.Core\Get-Module -ListAvailable $moduleName
     if ($modules -ne $null) {
         if ($ModuleVersion -ne $null) {
             foreach ($module in $modules) {
@@ -182,7 +182,7 @@ function Test-PortAvailability {
         $ipAddress = [System.Net.IPAddress]::Loopback
         Log "Testing availability of port ${PortNumber} at address ${ipAddress} / $($ipAddress.AddressFamily)"
 
-        $tcpListener = New-Object System.Net.Sockets.TcpListener @($ipAddress, $PortNumber)
+        $tcpListener = Microsoft.PowerShell.Utility\New-Object System.Net.Sockets.TcpListener @($ipAddress, $PortNumber)
         $tcpListener.Start()
         $tcpListener.Stop()
     }
@@ -202,7 +202,7 @@ function Test-PortAvailability {
 }
 
 $portsInUse = @{}
-$rand = New-Object System.Random
+$rand = Microsoft.PowerShell.Utility\New-Object System.Random
 function Get-AvailablePort() {
     $triesRemaining = 10;
 
@@ -247,7 +247,7 @@ try {
     LogSection "Start up PowerShellEditorServices"
     Log "Importing PowerShellEditorServices"
 
-    Import-Module PowerShellEditorServices -ErrorAction Stop
+    Microsoft.PowerShell.Core\Import-Module PowerShellEditorServices -ErrorAction Stop
 
 	# Locate available port numbers for services
 	# There could be only one service on Stdio channel

--- a/src/PowerShellEditorServices/Session/RemoteFileManager.cs
+++ b/src/PowerShellEditorServices/Session/RemoteFileManager.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
 
                     foreach ($fileName in $Paths)
                     {
-                        dir $fileName | where { ! $_.PSIsContainer } | foreach {
+                        Microsoft.PowerShell.Management\Get-ChildItem $fileName | Where-Object { ! $_.PSIsContainer } | Foreach-Object {
                             $filePathName = $_.FullName
 
                             # Get file contents
@@ -89,10 +89,10 @@ namespace Microsoft.PowerShell.EditorServices.Session
                                 $params['Encoding']='Byte'
                             }
 
-                            $contentBytes = Get-Content @params
+                            $contentBytes = Microsoft.PowerShell.Management\Get-Content @params
 
                             # Notify client for file open.
-                            New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($filePathName, $contentBytes, $preview) > $null
+                            Microsoft.PowerShell.Utility\New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($filePathName, $contentBytes, $preview) > $null
                         }
                     }
                 }
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     if ($Path) {
                         foreach ($fileName in $Path)
                         {
-                            if (-not (Test-Path $fileName) -or $Force) {
+                            if (-not (Microsoft.PowerShell.Management\Test-Path $fileName) -or $Force) {
                                 $valueList > $fileName
 
                                 # Get file contents
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                                     $params['Encoding']='Byte'
                                 }
 
-                                $contentBytes = Get-Content @params
+                                $contentBytes = Microsoft.PowerShell.Management\Get-Content @params
 
                                 if ($Path.Count -gt 1) {
                                     $preview = $false
@@ -171,10 +171,10 @@ namespace Microsoft.PowerShell.EditorServices.Session
                                 }
 
                                 # Notify client for file open.
-                                New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($fileName, $contentBytes, $preview) > $null
+                                Microsoft.PowerShell.Utility\New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($fileName, $contentBytes, $preview) > $null
                             } else {
                                 $PSCmdlet.WriteError( (
-                                    New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                                    Microsoft.PowerShell.Utility\New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
                                         [System.Exception]'File already exists.'
                                         $Null
                                         [System.Management.Automation.ErrorCategory]::ResourceExists
@@ -182,14 +182,14 @@ namespace Microsoft.PowerShell.EditorServices.Session
                             }
                         }
                     } else {
-                        $bytes = [System.Text.Encoding]::UTF8.GetBytes(($valueList | Out-String))
-                        New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($null, $bytes) > $null
+                        $bytes = [System.Text.Encoding]::UTF8.GetBytes(($valueList | Microsoft.PowerShell.Utility\Out-String))
+                        Microsoft.PowerShell.Utility\New-Event -SourceIdentifier PSESRemoteSessionOpenFile -EventArguments @($null, $bytes) > $null
                     }
                 }
             }
 
-            Set-Alias psedit Open-EditorFile -Scope Global
-            Export-ModuleMember -Function Open-EditorFile, New-EditorFile
+            Microsoft.PowerShell.Utility\Set-Alias psedit Open-EditorFile -Scope Global
+            Microsoft.PowerShell.Core\Export-ModuleMember -Function Open-EditorFile, New-EditorFile
         ";
 
         // This script is templated so that the '-Forward' parameter can be added
@@ -199,14 +199,15 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 [string] $PSEditModule
             )
 
-            Register-EngineEvent -SourceIdentifier PSESRemoteSessionOpenFile -Forward -SupportEvent
-            New-Module -ScriptBlock ([Scriptblock]::Create($PSEditModule)) -Name PSEdit | Import-Module -Global
+            Microsoft.PowerShell.Utility\Register-EngineEvent -SourceIdentifier PSESRemoteSessionOpenFile -Forward -SupportEvent
+            Microsoft.PowerShell.Core\New-Module -ScriptBlock ([Scriptblock]::Create($PSEditModule)) -Name PSEdit |
+                Microsoft.PowerShell.Core\Import-Module -Global
         ";
 
         private const string RemovePSEditFunctionScript = @"
-            Get-Module PSEdit | Remove-Module
+            Microsoft.PowerShell.Core\Get-Module PSEdit | Microsoft.PowerShell.Core\Remove-Module
 
-            Unregister-Event -SourceIdentifier PSESRemoteSessionOpenFile -Force -ErrorAction Ignore
+            Microsoft.PowerShell.Utility\Unregister-Event -SourceIdentifier PSESRemoteSessionOpenFile -Force -ErrorAction Ignore
         ";
 
         private const string SetRemoteContentsScript = @"
@@ -226,7 +227,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 $params['Encoding']='Byte'
             }
 
-            Set-Content @params 2>&1
+            Microsoft.PowerShell.Management\Set-Content @params 2>&1
         ";
 
         #endregion


### PR DESCRIPTION
redefines set-content, breaks Start-PSES

Fixes https://github.com/PowerShell/vscode-powershell/issues/1331

I wish we didn't have to module qualify command names like this but
we've been bitten several times now by overridden commands.

One concern I have is testing this due to it needing to be signed.
