### PR TITLE
remove all references to the Pipeline class

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -9,6 +9,5 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PowerShell/PowerShellEditorServices</RepositoryUrl>
     <DebugType>portable</DebugType>
-    <RuntimeFrameworkVersion>1.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
@@ -37,19 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
             {
                 pwsh.Runspace = currentRunspace;
                 pwsh.Commands = psCommand;
-                var results = pwsh.Invoke();
-
-                if (typeof(TResult) != typeof(PSObject))
-                {
-                    executionResult =
-                        results
-                            .Select(pso => pso.BaseObject)
-                            .Cast<TResult>();
-                }
-                else
-                {
-                    executionResult = results.Cast<TResult>();
-                }
+                executionResult = pwsh.Invoke<TResult>();
             }
 
             // Write the output to the host if necessary

--- a/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell3Operations.cs
@@ -6,11 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices.Session
 {
+    using System.Management.Automation;
+
     internal class PowerShell3Operations : IVersionSpecificOperations
     {
         public void ConfigureDebugger(Runspace runspace)
@@ -32,15 +33,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
             out DebuggerResumeAction? debuggerResumeAction)
         {
             IEnumerable<TResult> executionResult = null;
-
-            using (var nestedPipeline = currentRunspace.CreateNestedPipeline())
+            using (var pwsh = PowerShell.Create())
             {
-                foreach (var command in psCommand.Commands)
-                {
-                    nestedPipeline.Commands.Add(command);
-                }
-
-                var results = nestedPipeline.Invoke();
+                pwsh.Runspace = currentRunspace;
+                pwsh.Commands = psCommand;
+                var results = pwsh.Invoke();
 
                 if (typeof(TResult) != typeof(PSObject))
                 {

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -826,28 +826,13 @@ namespace Microsoft.PowerShell.EditorServices
             using (var pwsh = PowerShell.Create())
             {
                 pwsh.Runspace = runspace;
-                Collection<PSObject> results = pwsh.AddScript(scriptToExecute)
-                    .Invoke(null, new PSInvocationSettings() { AddToHistory = false });
+                Collection<TResult> results = pwsh.AddScript(scriptToExecute).Invoke<TResult>();
 
                 if (results.Count == 0 || results.FirstOrDefault() == null)
                 {
                     return defaultValue;
                 }
-
-                if (typeof(TResult) != typeof(PSObject))
-                {
-                    return results
-                            .Select(pso => pso.BaseObject)
-                            .OfType<TResult>()
-                            .FirstOrDefault();
-                }
-                else
-                {
-                    return
-                        results
-                            .OfType<TResult>()
-                            .FirstOrDefault();
-                }
+                return results.FirstOrDefault();
             }
         }
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -823,20 +823,11 @@ namespace Microsoft.PowerShell.EditorServices
 
         internal static TResult ExecuteScriptAndGetItem<TResult>(string scriptToExecute, Runspace runspace, TResult defaultValue = default(TResult))
         {
-            Pipeline pipeline = null;
-
-            try
+            using (var pwsh = PowerShell.Create())
             {
-                if (runspace.RunspaceAvailability == RunspaceAvailability.AvailableForNestedCommand)
-                {
-                    pipeline = runspace.CreateNestedPipeline(scriptToExecute, false);
-                }
-                else
-                {
-                    pipeline = runspace.CreatePipeline(scriptToExecute, false);
-                }
-
-                Collection<PSObject> results = pipeline.Invoke();
+                pwsh.Runspace = runspace;
+                Collection<PSObject> results = pwsh.AddScript(scriptToExecute)
+                    .Invoke(null, new PSInvocationSettings() { AddToHistory = false });
 
                 if (results.Count == 0 || results.FirstOrDefault() == null)
                 {
@@ -857,10 +848,6 @@ namespace Microsoft.PowerShell.EditorServices
                             .OfType<TResult>()
                             .FirstOrDefault();
                 }
-            }
-            finally
-            {
-                pipeline.Dispose();
             }
         }
 
@@ -1526,6 +1513,12 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
+        private SessionDetails GetSessionDetailsInNestedPipeline()
+        {
+
+            return GetSessionDetailsInRunspace(this.CurrentRunspace.Runspace);
+        }
+
         private SessionDetails GetSessionDetailsInRunspace(Runspace runspace)
         {
             SessionDetails sessionDetails =
@@ -1559,24 +1552,6 @@ namespace Microsoft.PowerShell.EditorServices
                         this.ExecuteCommandInDebugger<PSObject>(command, false)
                             .LastOrDefault();
                 });
-        }
-
-        private SessionDetails GetSessionDetailsInNestedPipeline()
-        {
-            using (var pipeline = this.CurrentRunspace.Runspace.CreateNestedPipeline())
-            {
-                return this.GetSessionDetails(
-                    command =>
-                    {
-                        pipeline.Commands.Clear();
-                        pipeline.Commands.Add(command.Commands[0]);
-
-                        return
-                            pipeline
-                                .Invoke()
-                                .FirstOrDefault();
-                    });
-            }
         }
 
         private void SetProfileVariableInCurrentRunspace(ProfilePaths profilePaths)


### PR DESCRIPTION
I think I'll need to try this on a v3 VM... sadly.

But this removes all the Pipeline references so that we can easily transition to PowerShellStandard.