### PR TITLE
Fix error w/Start-EditorServices transcript logging using temp console

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -80,7 +80,9 @@ $maxPortNumber = 30000
 
 if ($LogLevel -eq "Diagnostic") {
     $VerbosePreference = 'Continue'
-    Start-Transcript (Join-Path (Split-Path $LogPath -Parent) Start-EditorServices.log) -Force
+    $scriptName = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
+    $logFileName = [System.IO.Path]::GetFileName($LogPath)
+    Start-Transcript (Join-Path (Split-Path $LogPath -Parent) "$scriptName-$logFileName") -Force
 }
 
 function LogSection([string]$msg) {


### PR DESCRIPTION
This error happens because when log level is set to Diagnostic, we use
Start-Transcript to log the output of Start-EditorServices.ps1.
But the log filename we we're using was always Start-EditorServices.log.
When we start a temp console debug session, it's using the
Start-EditorServices.ps1 script to start the debug session.
That attempts to log to the original log file which is locked.
This causes an error. The fix is to append the log filename
which will be unique per launch of the Start-ES script.