### PR TITLE
Change debug launch handler to treat null/empty cwd to not change dir

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/LaunchRequest.cs
@@ -19,12 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
     public class LaunchRequestArguments
     {
         /// <summary>
-        /// Gets or sets the absolute path to the program to debug.
-        /// </summary>
-        [Obsolete("This property has been deprecated in favor of the Script property.")]
-        public string Program { get; set; }
-
-        /// <summary>
         /// Gets or sets the absolute path to the script to debug.
         /// </summary>
         public string Script { get; set; }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -316,9 +316,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // Store the launch parameters so that they can be used later
             this.noDebug = launchParams.NoDebug;
-#pragma warning disable 618
             this.scriptToLaunch = launchParams.Script;
-#pragma warning restore 618
             this.arguments = arguments;
             this.IsUsingTempIntegratedConsole = launchParams.CreateTemporaryIntegratedConsole;
 


### PR DESCRIPTION
Fix for PowerShell/vscode-powershell#1330

Removes deprecated "Program" field from LaunchRequest class.
Simplifies working dir logic in HandleLaunchRequest.  Basically if the
launch request happens in the regular integrated console, a null/empty
cwd means "do not change the working dir".  If the request is using the
temp integrated console, there is no "existing" workng dir, so we use
the original logic to set the working dir.