### PR TITLE
Fix issue with stat format on Linux

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -224,7 +224,7 @@ function Set-NamedPipeMode {
     )
     chmod $DEFAULT_USER_MODE $PipeFile
     if ($IsLinux) {
-        $mode = stat -c "%A" $PipeFile
+        $mode = stat -c "%a" $PipeFile
     }
     else {
         $mode = stat -f "%A" $PipeFile

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -222,13 +222,20 @@ function Set-NamedPipeMode {
         [string]
         $PipeFile
     )
+
+    if ($IsWindows) {
+        return
+    }
+
     chmod $DEFAULT_USER_MODE $PipeFile
+
     if ($IsLinux) {
         $mode = stat -c "%a" $PipeFile
     }
-    else {
+    elseif ($IsMacOS) {
         $mode = stat -f "%A" $PipeFile
     }
+
     if ($mode -ne $DEFAULT_USER_MODE) {
         ExitWithError "Permissions to the pipe file were not set properly. Expected: $DEFAULT_USER_MODE Actual: $mode for file: $PipeFile"
     }


### PR DESCRIPTION
The `stat` usage in the startup script currently does not work on Linux.

This changes the `%A` to `%a` to make it work.