### PR TITLE
Fix incompatible New-Guid usage in start script

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -172,7 +172,7 @@ function New-NamedPipeName {
     # We try 10 times to find a valid pipe name
     for ($i = 0; $i -lt 10; $i++) {
         # add a guid to make the pipe unique
-        $PipeName = "PSES_$((New-Guid).Guid)"
+        $PipeName = "PSES_$([guid]::NewGuid())"
 
         if ((Test-NamedPipeName -PipeName $PipeName)) {
             return $PipeName


### PR DESCRIPTION
Start-EditorServices.ps1 currently uses `New-Guid`, which is a v5+ cmdlet.

This replaces it with `[guid]::NewGuid()` for v3/4 compatibility.