### PR TITLE
Do not enable PSAvoidTrailingWhitespace rule by default as it currently flags whitespace-only lines as well and users don't like it

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -72,7 +72,6 @@ namespace Microsoft.PowerShell.EditorServices
             "PSUseDeclaredVarsMoreThanAssignments",
             "PSPossibleIncorrectComparisonWithNull",
             "PSAvoidDefaultValueForMandatoryParameter",
-            "PSAvoidTrailingWhitespace",
             "PSPossibleIncorrectUsageOfRedirectionOperator"
         };
 


### PR DESCRIPTION
Despite modern editors having the ability to eliminate redundant whitespace when saving the file automatically, people are still upset by PSSA pointing out whitespace for whitespace-only lines by the rule `PSAvoidTrailingWhitespace`. Until the rule is customisable for that with a potential change of the default behaviour, it is probably better to not have this rule enabled by default. This rule got enabled by default in version`1.8.0` of the vscode extension along with other rules.
References:
https://github.com/PowerShell/PSScriptAnalyzer/issues/1033
https://github.com/PowerShell/PSScriptAnalyzer/issues/1036
https://github.com/PowerShell/vscode-powershell/issues/1429
https://github.com/PowerShell/vscode-powershell/issues/1432