### PR TITLE
Fix load order of PSSA modules

### DIFF
--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -534,7 +534,7 @@ namespace Microsoft.PowerShell.EditorServices
                     pssaModuleInfo = ps.Invoke()?
                         .Select(psObj => psObj.BaseObject)
                         .OfType<PSModuleInfo>()
-                        .OrderBy(moduleInfo => moduleInfo.Version)
+                        .OrderByDescending(moduleInfo => moduleInfo.Version)
                         .FirstOrDefault();
                 }
                 catch (Exception e)


### PR DESCRIPTION
Current bug means we always load the oldest version of PSSA.

Now we will load the newest.