### PR TITLE
Go To Definition works with different Ast types

### DIFF
--- a/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             // We want to check VariableExpressionAsts from within this AssignmentStatementAst so we visit it.
             FindDeclarationVariableExpressionVisitor visitor = new FindDeclarationVariableExpressionVisitor(symbolRef);
-            assignmentStatementAst.Visit(visitor);
+            assignmentStatementAst.Left.Visit(visitor);
 
             if (visitor.FoundDeclaration != null)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// or a decision to continue if it wasn't found</returns>
             public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
             {
-                if(variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+                if (variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))
                 {
                     // TODO also find instances of set-variable
                     FoundDeclaration = new SymbolReference(SymbolType.Variable, variableExpressionAst.Extent);
@@ -132,21 +132,15 @@ namespace Microsoft.PowerShell.EditorServices
                 return AstVisitAction.Continue;
             }
 
-            public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
+            public override AstVisitAction VisitMemberExpression(MemberExpressionAst functionDefinitionAst)
             {
-                // We don't want to discover any variables in nested functions - they get their own scope.
+                // We don't want to discover any variables in member expressisons (`$something.Foo`)
                 return AstVisitAction.SkipChildren;
             }
 
-            public override AstVisitAction VisitScriptBlockExpression(ScriptBlockExpressionAst scriptBlockExpressionAst)
+            public override AstVisitAction VisitIndexExpression(IndexExpressionAst functionDefinitionAst)
             {
-                // We don't want to discover any variables in script block expressions - they get their own scope.
-                return AstVisitAction.SkipChildren;
-            }
-
-            public override AstVisitAction VisitTrap(TrapStatementAst trapStatementAst)
-            {
-                // We don't want to discover any variables in traps - they get their own scope.
+                // We don't want to discover any variables in index expressions (`$something[0]`)
                 return AstVisitAction.SkipChildren;
             }
         }

--- a/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices
             };
 
             if (symbolRef.SymbolType.Equals(SymbolType.Function) &&
-                 nameExtent.Text.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase))
+                nameExtent.Text.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase))
             {
                 this.FoundDeclaration =
                     new SymbolReference(
@@ -83,10 +83,7 @@ namespace Microsoft.PowerShell.EditorServices
                 return AstVisitAction.Continue;
             }
 
-            // The AssignmentStatementAst could contain either of the following Ast types:
-            // VariableExpressionAst, ArrayLiteralAst, ConvertExpressionAst, AttributedExpressionAst
-            // We might need to recurse down the tree to find the VariableExpressionAst we're looking for
-            //                    if (variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+            // We want to check VariableExpressionAsts from within this AssignmentStatementAst so we visit it.
             FindDeclarationVariableExpressionVisitor visitor = new FindDeclarationVariableExpressionVisitor(symbolRef);
             assignmentStatementAst.Visit(visitor);
 
@@ -133,6 +130,24 @@ namespace Microsoft.PowerShell.EditorServices
                     return AstVisitAction.StopVisit;
                 }
                 return AstVisitAction.Continue;
+            }
+
+            public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
+            {
+                // We don't want to discover any variables in nested functions - they get their own scope.
+                return AstVisitAction.SkipChildren;
+            }
+
+            public override AstVisitAction VisitScriptBlockExpression(ScriptBlockExpressionAst scriptBlockExpressionAst)
+            {
+                // We don't want to discover any variables in script block expressions - they get their own scope.
+                return AstVisitAction.SkipChildren;
+            }
+
+            public override AstVisitAction VisitTrap(TrapStatementAst trapStatementAst)
+            {
+                // We don't want to discover any variables in traps - they get their own scope.
+                return AstVisitAction.SkipChildren;
             }
         }
     }

--- a/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindDeclarationVisitor.cs
@@ -115,12 +115,12 @@ namespace Microsoft.PowerShell.EditorServices
                 }
             }
 
-        /// <summary>
-        /// Check if the VariableExpressionAst has the same name as that of symbolRef.
-        /// </summary>
-        /// <param name="variableExpressionAst">A VariableExpressionAst</param>
-        /// <returns>A decision to stop searching if the right VariableExpressionAst was found,
-        /// or a decision to continue if it wasn't found</returns>
+            /// <summary>
+            /// Check if the VariableExpressionAst has the same name as that of symbolRef.
+            /// </summary>
+            /// <param name="variableExpressionAst">A VariableExpressionAst</param>
+            /// <returns>A decision to stop searching if the right VariableExpressionAst was found,
+            /// or a decision to continue if it wasn't found</returns>
             public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
             {
                 if (variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/1439

The issue was that when you hit F12 (aka go to definition) on any of the following scenarios except for the first one, they would fail to find the definition.

```powershell
$var1 = "string"
$var1

[string] $var2 = "string"
$var2

[NJsonSchema.Annotations.NotNull()] $var3 = "string"
$var3

$a, $var4 = "string", "sss"
$var4

$a, [string] $var5 = "string", "sss"
$var5
```
All these scenarios now work with this PR.

We needed to recurse the AST to find the VariableExpressionAst because it could be nested in another Ast type.