### PR TITLE
Stop Diagnostic logging from logging to stdio when stdio is present

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -78,10 +78,12 @@ param(
 $DEFAULT_USER_MODE = "600"
 
 if ($LogLevel -eq "Diagnostic") {
-    $VerbosePreference = 'Continue'
+    if (!$Stdio.IsPresent) {
+        $VerbosePreference = 'Continue'
+    }
     $scriptName = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
     $logFileName = [System.IO.Path]::GetFileName($LogPath)
-    Start-Transcript (Join-Path (Split-Path $LogPath -Parent) "$scriptName-$logFileName") -Force
+    Start-Transcript (Join-Path (Split-Path $LogPath -Parent) "$scriptName-$logFileName") -Force | Out-Null
 }
 
 function LogSection([string]$msg) {


### PR DESCRIPTION
when Start-EditorServices logs to stdio when PSES is using stdio to communicate, the logs are treated as messages and PSES fails to work.

This allows you to set it to Diagnostic and also use stdio.