### PR TITLE
stdio should only launch language service not debug

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -116,6 +116,8 @@ function Start-EditorServicesHost {
 
     if ($DebugServiceOnly.IsPresent) {
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $false);
+    } elseif($Stdio.IsPresent) {
+        $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
     } else {
         $editorServicesHost.StartLanguageService($languageServiceConfig, $profilePaths);
         $editorServicesHost.StartDebugService($debugServiceConfig, $profilePaths, $true);


### PR DESCRIPTION
if both are launched - then the text is split between the language and debug service - aka PSES just doesn't work.

This should be the final PR in "fixing stdio"