### PR TITLE
workaround to support inmemory://

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         {
             // If the file isn't untitled, return a URI-style path
             return
-                !filePath.StartsWith("untitled")
+                !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
                     ? new Uri("file://" + filePath).AbsoluteUri
                     : filePath;
         }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1358,7 +1358,7 @@ function __Expand-Alias {
         {
             // If the file isn't untitled, return a URI-style path
             return
-                !filePath.StartsWith("untitled")
+                !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
                     ? new Uri("file://" + filePath).AbsoluteUri
                     : filePath;
         }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 // Test short non-file paths
                 new { IsInMemory = true,  Path = "untitled:untitled-1" },
                 new { IsInMemory = true,  Path = shortUriForm },
+                new { IsInMemory = true, Path = "inmemory://foo.ps1" },
 
                 // Test long non-file path - known to have crashed PSES
                 new { IsInMemory = true,  Path = longUriForm },


### PR DESCRIPTION
This isn't the most elegant solution but it does the trick. I don't think we'll run into many (if not any) more Uri schemes we care about. When we run into another, then we can probably discuss a better solution.

Let me know if you feel differently. 