### PR TITLE
Reduce allocations when parsing files

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1096,6 +1096,7 @@ function __Expand-Alias {
                 triggerLine1b,
                 out helpLocation);
             var result = new CommentHelpRequestResult();
+            IList<string> lines = null;
             if (functionDefinitionAst != null)
             {
                 var funcExtent = functionDefinitionAst.Extent;
@@ -1104,7 +1105,7 @@ function __Expand-Alias {
                 {
                     // check if the previous character is `<` because it invalidates
                     // the param block the follows it.
-                    var lines = ScriptFile.GetLines(funcText).ToArray();
+                    lines = ScriptFile.GetLines(funcText);
                     var relativeTriggerLine0b = triggerLine1b - funcExtent.StartLineNumber;
                     if (relativeTriggerLine0b > 0 && lines[relativeTriggerLine0b].IndexOf("<") > -1)
                     {
@@ -1122,8 +1123,12 @@ function __Expand-Alias {
                         requestParams.BlockComment,
                         true,
                         helpLocation));
+
                 var help = analysisResults?.FirstOrDefault()?.Correction?.Edits[0].Text;
-                result.Content = help == null ? null : ScriptFile.GetLines(help).ToArray();
+                result.Content = help != null 
+                    ? (lines ?? ScriptFile.GetLines(funcText)).ToArray() 
+                    : null;
+
                 if (helpLocation != null &&
                     !helpLocation.Equals("before", StringComparison.OrdinalIgnoreCase))
                 {

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -296,6 +296,35 @@ namespace PSLanguageService.Test
 
             Assert.Equal(expectedLines, lines);
         }
+
+        [Fact]
+        public void CanSplitLines()
+        {
+            Assert.Equal(TestStringLines, scriptFile.FileLines);
+        }
+
+        [Fact]
+        public void CanGetSameLinesWithUnixLineBreaks()
+        {
+            var unixFile = ScriptFileChangeTests.CreateScriptFile(TestString.Replace("\r\n", "\n"));
+            Assert.Equal(scriptFile.FileLines, unixFile.FileLines);
+        }
+
+        [Fact]
+        public void CanGetLineForEmptyString()
+        {
+            var emptyFile = ScriptFileChangeTests.CreateScriptFile(string.Empty);
+            Assert.Equal(1, emptyFile.FileLines.Count);
+            Assert.Equal(string.Empty, emptyFile.FileLines[0]);
+        }
+
+        [Fact]
+        public void CanGetLineForSpace()
+        {
+            var spaceFile = ScriptFileChangeTests.CreateScriptFile(" ");
+            Assert.Equal(1, spaceFile.FileLines.Count);
+            Assert.Equal(" ", spaceFile.FileLines[0]);
+        }
     }
 
     public class ScriptFilePositionTests


### PR DESCRIPTION
The previous implementation used LINQ on a relatively hot path, returned a lazy IEnumerable that was always eagerly converted to a List or Array and allocated two strings per line when Windows linebreaks were used.  Profiling indicates that PSES spends a huge percentage of its time in GC, so switching to a slightly more complex implementation that allocates less than half as much seems justified.

This is some of the "low hanging fruit" I mentioned in https://github.com/PowerShell/vscode-powershell/issues/1342.