### PR TITLE
increment version for prerelease

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.8.2</VersionPrefix>
+    <VersionPrefix>1.8.3</VersionPrefix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.8.2.{build}'
+version: '1.8.3.{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerShellEditorServices.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.2'
+ModuleVersion = '1.8.3'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'


### PR DESCRIPTION
Bumping the version to 1.8.3 so that if people grab the vsix in vscode-powershell it will not get overwritten by the current release.

addresses https://github.com/PowerShell/vscode-powershell/issues/1445