### PR TITLE
Reduce allocations in the CodeLens providers

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -101,13 +101,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <returns>All generated CodeLenses for the given script file.</returns>
         public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
         {
-            var acc = new List<CodeLens>();
-            foreach (CodeLens[] providerResult in InvokeProviders(provider => provider.ProvideCodeLenses(scriptFile)))
-            {
-                acc.AddRange(providerResult);
-            }
-
-            return acc.ToArray();
+            return InvokeProviders(provider => provider.ProvideCodeLenses(scriptFile))
+                .SelectMany(codeLens => codeLens)
+                .ToArray();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 CodeLensData codeLensData = codeLens.Data.ToObject<CodeLensData>();
 
                 ICodeLensProvider originalProvider =
-                    this.Providers.FirstOrDefault(
+                    Providers.FirstOrDefault(
                         provider => provider.ProviderId.Equals(codeLensData.ProviderId));
 
                 if (originalProvider != null)

--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             RequestContext<LanguageServer.CodeLens[]> requestContext)
         {
             var scriptFile =
-                this._editorSession.Workspace.GetFile(
+                _editorSession.Workspace.GetFile(
                     codeLensParams.TextDocument.Uri);
 
             CodeLens[] codeLensResults = ProvideCodeLenses(scriptFile);
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 if (originalProvider != null)
                 {
                     ScriptFile scriptFile =
-                        this._editorSession.Workspace.GetFile(
+                        _editorSession.Workspace.GetFile(
                             codeLensData.Uri);
 
                     ScriptRegion region = new ScriptRegion
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 
                     await requestContext.SendResult(
                         resolvedCodeLens.ToProtocolCodeLens(
-                            this._jsonSerializer));
+                            _jsonSerializer));
                 }
                 else
                 {

--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -119,9 +119,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             CodeLensRequest codeLensParams,
             RequestContext<LanguageServer.CodeLens[]> requestContext)
         {
-            var scriptFile =
-                _editorSession.Workspace.GetFile(
-                    codeLensParams.TextDocument.Uri);
+            ScriptFile scriptFile = _editorSession.Workspace.GetFile(
+                codeLensParams.TextDocument.Uri);
 
             CodeLens[] codeLensResults = ProvideCodeLenses(scriptFile);
 

--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
         {
             var lenses = new List<CodeLens>();
-            foreach (var symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
+            foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
                 if (symbol is PesterSymbolReference pesterSymbol)
                 {

--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -15,71 +15,90 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
     internal class PesterCodeLensProvider : FeatureProviderBase, ICodeLensProvider
     {
-        private static char[] QuoteChars = new char[] { '\'', '"'};
+        /// <summary>
+        /// The editor session context to provide CodeLenses for.
+        /// </summary>
+        private EditorSession _editorSession;
 
-        private EditorSession editorSession;
-        private IDocumentSymbolProvider symbolProvider;
+        /// <summary>
+        /// The symbol provider to get symbols from to build code lenses with.
+        /// </summary>
+        private IDocumentSymbolProvider _symbolProvider;
 
+        /// <summary>
+        /// Create a new Pester CodeLens provider for a given editor session.
+        /// </summary>
+        /// <param name="editorSession">The editor session context for which to provide Pester CodeLenses.</param>
         public PesterCodeLensProvider(EditorSession editorSession)
         {
-            this.editorSession = editorSession;
-            this.symbolProvider = new PesterDocumentSymbolProvider();
+            _editorSession = editorSession;
+            _symbolProvider = new PesterDocumentSymbolProvider();
         }
 
-        private IEnumerable<CodeLens> GetPesterLens(
+        /// <summary>
+        /// Get the Pester CodeLenses for a given Pester symbol.
+        /// </summary>
+        /// <param name="pesterSymbol">The Pester symbol to get CodeLenses for.</param>
+        /// <param name="scriptFile">The script file the Pester symbol comes from.</param>
+        /// <returns>All CodeLenses for the given Pester symbol.</returns>
+        private CodeLens[] GetPesterLens(
             PesterSymbolReference pesterSymbol,
             ScriptFile scriptFile)
         {
-            var clientCommands = new ClientCommand[]
+            var codeLensResults = new CodeLens[]
             {
-                new ClientCommand(
-                    "PowerShell.RunPesterTests",
-                    "Run tests",
-                    new object[]
-                    {
-                        scriptFile.ClientFilePath,
-                        false, // Don't debug
-                        pesterSymbol.TestName,
-                    }),
+                new CodeLens(
+                    this,
+                    scriptFile,
+                    pesterSymbol.ScriptRegion,
+                    new ClientCommand(
+                        "PowerShell.RunPesterTests",
+                        "Run tests",
+                        new object[] { scriptFile.ClientFilePath, false /* No debug */, pesterSymbol.TestName })),
 
-                new ClientCommand(
-                    "PowerShell.RunPesterTests",
-                    "Debug tests",
-                    new object[]
-                    {
-                        scriptFile.ClientFilePath,
-                        true, // Run in debugger
-                        pesterSymbol.TestName,
-                    }),
+                new CodeLens(
+                    this,
+                    scriptFile,
+                    pesterSymbol.ScriptRegion,
+                    new ClientCommand(
+                        "PowerShell.RunPesterTests",
+                        "Debug tests",
+                        new object[] { scriptFile.ClientFilePath, true /* Run in debugger */, pesterSymbol.TestName })),
             };
 
-            return
-                clientCommands.Select(
-                    command =>
-                        new CodeLens(
-                            this,
-                            scriptFile,
-                            pesterSymbol.ScriptRegion,
-                            command));
+            return codeLensResults;
         }
 
+        /// <summary>
+        /// Get all Pester CodeLenses for a given script file.
+        /// </summary>
+        /// <param name="scriptFile">The script file to get Pester CodeLenses for.</param>
+        /// <returns>All Pester CodeLenses for the given script file.</returns>
         public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
         {
-            var symbols =
-                this.symbolProvider
-                    .ProvideDocumentSymbols(scriptFile);
+            var lenses = new List<CodeLens>();
+            foreach (var symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
+            {
+                if (symbol is PesterSymbolReference pesterSymbol)
+                {
+                    if (pesterSymbol.Command != PesterCommandType.Describe)
+                    {
+                        continue;
+                    }
 
-            var lenses =
-                symbols
-                    .OfType<PesterSymbolReference>()
-                    .Where(s => s.Command == PesterCommandType.Describe)
-                    .SelectMany(s => this.GetPesterLens(s, scriptFile))
-                    .Where(codeLens => codeLens != null)
-                    .ToArray();
+                    lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
+                }
+            }
 
-            return lenses;
+            return lenses.ToArray();
         }
 
+        /// <summary>
+        /// Resolve the CodeLens provision asynchronously -- just wraps the CodeLens argument in a task.
+        /// </summary>
+        /// <param name="codeLens">The code lens to resolve.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The given CodeLens, wrapped in a task.</returns>
         public Task<CodeLens> ResolveCodeLensAsync(
             CodeLens codeLens,
             CancellationToken cancellationToken)

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             ScriptFile[] references = _editorSession.Workspace.ExpandScriptReferences(
                 codeLens.File);
 
-            var foundSymbol = _editorSession.LanguageService.FindFunctionDefinitionAtLocation(
+            SymbolReference foundSymbol = _editorSession.LanguageService.FindFunctionDefinitionAtLocation(
                 codeLens.File,
                 codeLens.ScriptExtent.StartLineNumber,
                 codeLens.ScriptExtent.StartColumnNumber);

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
     /// </summary>
     internal class ReferencesCodeLensProvider : FeatureProviderBase, ICodeLensProvider
     {
+        private static readonly Location[] s_emptyLocationArray = new Location[0];
+
         /// <summary>
         /// The editor session code lenses are being provided from.
         /// </summary>
@@ -88,7 +90,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             Location[] referenceLocations;
             if (referencesResult == null)
             {
-                referenceLocations = Array.Empty<Location>();
+                referenceLocations = s_emptyLocationArray;
             }
             else
             {

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Commands;
@@ -14,87 +15,120 @@ using Microsoft.PowerShell.EditorServices.Symbols;
 
 namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
+    /// <summary>
+    /// Provides the "reference" code lens by extracting document symbols.
+    /// </summary>
     internal class ReferencesCodeLensProvider : FeatureProviderBase, ICodeLensProvider
     {
-        private EditorSession editorSession;
-        private IDocumentSymbolProvider symbolProvider;
+        /// <summary>
+        /// The editor session code lenses are being provided from.
+        /// </summary>
+        private EditorSession _editorSession;
 
+        /// <summary>
+        /// The document symbol provider to supply symbols to generate the code lenses.
+        /// </summary>
+        private IDocumentSymbolProvider _symbolProvider;
+
+        /// <summary>
+        /// Construct a new ReferencesCodeLensProvider for a given EditorSession.
+        /// </summary>
+        /// <param name="editorSession"></param>
         public ReferencesCodeLensProvider(EditorSession editorSession)
         {
-            this.editorSession = editorSession;
+            _editorSession = editorSession;
 
             // TODO: Pull this from components
-            this.symbolProvider =
-                new ScriptDocumentSymbolProvider(
-                    editorSession.PowerShellContext.LocalPowerShellVersion.Version);
+            _symbolProvider = new ScriptDocumentSymbolProvider(
+                editorSession.PowerShellContext.LocalPowerShellVersion.Version);
         }
 
+        /// <summary>
+        /// Get all reference code lenses for a given script file.
+        /// </summary>
+        /// <param name="scriptFile">The PowerShell script file to get code lenses for.</param>
+        /// <returns>An array of CodeLenses describing all functions in the given script file.</returns>
         public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
         {
-            return
-                this.symbolProvider
-                    .ProvideDocumentSymbols(scriptFile)
-                    .Where(symbol => symbol.SymbolType == SymbolType.Function)
-                    .Select(
-                        symbol =>
-                            new CodeLens(
-                                this,
-                                scriptFile,
-                                symbol.ScriptRegion))
-                    .ToArray();
+            var acc = new List<CodeLens>();
+            foreach (SymbolReference sym in _symbolProvider.ProvideDocumentSymbols(scriptFile))
+            {
+                if (sym.SymbolType == SymbolType.Function)
+                {
+                    acc.Add(new CodeLens(this, scriptFile, sym.ScriptRegion));
+                }
+            }
+
+            return acc.ToArray();
         }
 
+        /// <summary>
+        /// Take a codelens and create a new codelens object with updated references.
+        /// </summary>
+        /// <param name="codeLens">The old code lens to get updated references for.</param>
+        /// <param name="cancellationToken">The cancellation token for this request.</param>
+        /// <returns>A new code lens object describing the same data as the old one but with updated references.</returns>
         public async Task<CodeLens> ResolveCodeLensAsync(
             CodeLens codeLens,
             CancellationToken cancellationToken)
         {
-            ScriptFile[] references =
-                editorSession.Workspace.ExpandScriptReferences(
-                    codeLens.File);
+            ScriptFile[] references = _editorSession.Workspace.ExpandScriptReferences(
+                codeLens.File);
 
-            var foundSymbol =
-                this.editorSession.LanguageService.FindFunctionDefinitionAtLocation(
-                    codeLens.File,
-                    codeLens.ScriptExtent.StartLineNumber,
-                    codeLens.ScriptExtent.StartColumnNumber);
+            var foundSymbol = _editorSession.LanguageService.FindFunctionDefinitionAtLocation(
+                codeLens.File,
+                codeLens.ScriptExtent.StartLineNumber,
+                codeLens.ScriptExtent.StartColumnNumber);
 
-            FindReferencesResult referencesResult =
-                await editorSession.LanguageService.FindReferencesOfSymbol(
-                    foundSymbol,
-                    references,
-                    editorSession.Workspace);
+            FindReferencesResult referencesResult = await _editorSession.LanguageService.FindReferencesOfSymbol(
+                foundSymbol,
+                references,
+                _editorSession.Workspace);
 
-            Location[] referenceLocations =
-                referencesResult == null
-                    ? new Location[0]
-                    : referencesResult
-                        .FoundReferences
-                        .Where(r => NotReferenceDefinition(foundSymbol, r))
-                        .Select(
-                            r => new Location
-                            {
-                                Uri = GetFileUri(r.FilePath),
-                                Range = r.ScriptRegion.ToRange()
-                            })
-                        .ToArray();
+            Location[] referenceLocations;
+            if (referencesResult == null)
+            {
+                referenceLocations = Array.Empty<Location>();
+            }
+            else
+            {
+                var acc = new List<Location>();
+                foreach (SymbolReference foundReference in referencesResult.FoundReferences)
+                {
+                    if (!NotReferenceDefinition(foundSymbol, foundReference))
+                    {
+                        continue;
+                    }
 
-            return
-                new CodeLens(
-                    codeLens,
-                    new ClientCommand(
-                        "editor.action.showReferences",
-                        referenceLocations.Length == 1
-                            ? "1 reference"
-                            : $"{referenceLocations.Length} references",
-                        new object[]
-                        {
-                            codeLens.File.ClientFilePath,
-                            codeLens.ScriptExtent.ToRange().Start,
-                            referenceLocations,
-                        }
+                    acc.Add(new Location
+                    {
+                        Uri = GetFileUri(foundReference.FilePath),
+                        Range = foundReference.ScriptRegion.ToRange()
+                    });
+                }
+                referenceLocations = acc.ToArray();
+            }
+
+            return new CodeLens(
+                codeLens,
+                new ClientCommand(
+                    "editor.action.showReferences",
+                    GetReferenceCountHeader(referenceLocations.Length),
+                    new object[]
+                    {
+                        codeLens.File.ClientFilePath,
+                        codeLens.ScriptExtent.ToRange().Start,
+                        referenceLocations,
+                    }
                     ));
         }
 
+        /// <summary>
+        /// Check whether a SymbolReference is not a reference to another defined symbol.
+        /// </summary>
+        /// <param name="definition">The symbol definition that may be referenced.</param>
+        /// <param name="reference">The reference symbol to check.</param>
+        /// <returns>True if the reference is not a reference to the definition, false otherwise.</returns>
         private static bool NotReferenceDefinition(
             SymbolReference definition,
             SymbolReference reference)
@@ -105,6 +139,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 || !string.Equals(definition.SymbolName, reference.SymbolName, StringComparison.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Get a URI for a given file path.
+        /// </summary>
+        /// <param name="filePath">A file path that may be prefixed with URI scheme already.</param>
+        /// <returns>A URI to the file.</returns>
         private static string GetFileUri(string filePath)
         {
             // If the file isn't untitled, return a URI-style path
@@ -112,6 +151,25 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
                     ? new Uri("file://" + filePath).AbsoluteUri
                     : filePath;
+        }
+
+        /// <summary>
+        /// Get the code lens header for the number of references on a definition,
+        /// given the number of references.
+        /// </summary>
+        /// <param name="referenceCount">The number of references found for a given definition.</param>
+        /// <returns>The header string for the reference code lens.</returns>
+        private static string GetReferenceCountHeader(int referenceCount)
+        {
+            if (referenceCount == 1)
+            {
+                return "1 reference";
+            }
+
+            var sb = new StringBuilder(14); // "100 references".Length = 14
+            sb.Append(referenceCount);
+            sb.Append(" references");
+            return sb.ToString();
         }
     }
 }

--- a/src/PowerShellEditorServices/Utility/HashCodeCombiner.cs
+++ b/src/PowerShellEditorServices/Utility/HashCodeCombiner.cs
@@ -1,0 +1,7 @@
+namespace PowerShellEditorServices.Utility
+{
+    public class HashCodeCombiner
+    {
+        
+    }
+}

--- a/src/PowerShellEditorServices/Utility/HashCodeCombiner.cs
+++ b/src/PowerShellEditorServices/Utility/HashCodeCombiner.cs
@@ -1,7 +1,0 @@
-namespace PowerShellEditorServices.Utility
-{
-    public class HashCodeCombiner
-    {
-        
-    }
-}


### PR DESCRIPTION
Went and tackled some easy stuff in the CodeLens provider (since disabling it seems to give the best performance improvement for EditorServices).

There should be no semantic changes from this.

I didn't go after caching, since that's a bit riskier and probably needs some design discussion about where the caches live (i.e. what objects are responsible for them).