### PR TITLE
Fix a null dereference when an invalid cast exception has no inner exception

### DIFF
--- a/src/PowerShellEditorServices/Console/InputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/InputPromptHandler.cs
@@ -275,8 +275,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                     }
                     catch (PSInvalidCastException e)
                     {
-                        this.ShowErrorMessage(e.InnerException);
-
+                        this.ShowErrorMessage(e.InnerException ?? e);
                         continue;
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1450.

When a parameter causes an invalid cast exception in the console, we assumed the inner exception wasn't null. Now if it is, we pass through the outer exception.