### PR TITLE
Fix crash where lines appended to end of script file causes out of bounds exception

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -324,7 +324,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="isInsertion">If true, the position to validate is for an applied change.</param>
         public void ValidatePosition(int line, int column, bool isInsertion)
         {
-            // If new content is being added, VSCode sometimes likes to add it a (FileLines.Count + 1),
+            // If new content is being added, VSCode sometimes likes to add it at (FileLines.Count + 1),
             // which used to crash EditorServices. Now we append it on to the end of the file.
             // See https://github.com/PowerShell/vscode-powershell/issues/1283
             int maxLine = isInsertion ? this.FileLines.Count + 1 : this.FileLines.Count;

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -309,8 +309,19 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="line">The 1-based line to be validated.</param>
         /// <param name="column">The 1-based column to be validated.</param>
-        /// <param name="isInsertion">If true, the position to validate is for an applied changnvokee.</param>
-        public void ValidatePosition(int line, int column, bool isInsertion = false)
+        public void ValidatePosition(int line, int column)
+        {
+            ValidatePosition(line, column, isInsertion: false);
+        }
+
+        /// <summary>
+        /// Throws ArgumentOutOfRangeException if the given position is outside
+        /// of the file's buffer extents.
+        /// </summary>
+        /// <param name="line">The 1-based line to be validated.</param>
+        /// <param name="column">The 1-based column to be validated.</param>
+        /// <param name="isInsertion">If true, the position to validate is for an applied change.</param>
+        public void ValidatePosition(int line, int column, bool isInsertion)
         {
             int maxLine = isInsertion ? this.FileLines.Count + 1 : this.FileLines.Count;
             if (line < 1 || line > maxLine)

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -309,6 +309,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="line">The 1-based line to be validated.</param>
         /// <param name="column">The 1-based column to be validated.</param>
+        /// <param name="isInsertion">If true, the position to validate is for an applied change.</param>
         public void ValidatePosition(int line, int column, bool isInsertion = false)
         {
             int maxLine = isInsertion ? this.FileLines.Count + 1 : this.FileLines.Count;

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -309,7 +309,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="line">The 1-based line to be validated.</param>
         /// <param name="column">The 1-based column to be validated.</param>
-        /// <param name="isInsertion">If true, the position to validate is for an applied change.</param>
+        /// <param name="isInsertion">If true, the position to validate is for an applied changnvokee.</param>
         public void ValidatePosition(int line, int column, bool isInsertion = false)
         {
             int maxLine = isInsertion ? this.FileLines.Count + 1 : this.FileLines.Count;
@@ -362,7 +362,7 @@ namespace Microsoft.PowerShell.EditorServices
                 this.ValidatePosition(fileChange.EndLine, fileChange.EndOffset, isInsertion: true);
 
                 // If the change is a pure append to the file, we just need to add the new lines on the end
-                if (fileChange.EndLine == this.FileLines.Count + 1)
+                if (fileChange.Line == this.FileLines.Count + 1)
                 {
                     foreach (string addedLine in changeLines)
                     {

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -13,7 +13,7 @@ namespace PSLanguageService.Test
 {
     public class ScriptFileChangeTests
     {
-        private static readonly Version PowerShellVersion = new Version("5.0"); 
+        private static readonly Version PowerShellVersion = new Version("5.0");
 
         [Fact]
         public void CanApplySingleLineInsert()
@@ -128,6 +128,22 @@ namespace PSLanguageService.Test
         }
 
         [Fact]
+        public void CanApplyEditsToEndOfFile()
+        {
+            this.AssertFileChange(
+                "line1\n\rline2\n\rline3\n\r",
+                "line1\n\rline2\n\rline3\n\r\n\r\n\r",
+                new FileChange
+                {
+                    Line = 5,
+                    EndLine = 5,
+                    Offset = 1,
+                    EndOffset = 1,
+                    InsertString = "\n\r\n\r"
+                });
+        }
+
+        [Fact]
         public void FindsDotSourcedFiles()
         {
             string exampleScriptContents =
@@ -139,7 +155,7 @@ namespace PSLanguageService.Test
 
             using (StringReader stringReader = new StringReader(exampleScriptContents))
             {
-                ScriptFile scriptFile = 
+                ScriptFile scriptFile =
                     new ScriptFile(
                         "DotSourceTestFile.ps1",
                         "DotSourceTestFile.ps1",
@@ -178,7 +194,7 @@ namespace PSLanguageService.Test
             using (StringReader stringReader = new StringReader(initialString))
             {
                 // Create an in-memory file from the StringReader
-                ScriptFile fileToChange = 
+                ScriptFile fileToChange =
                     new ScriptFile(
                         "TestFile.ps1",
                         "TestFile.ps1",

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -131,15 +131,15 @@ namespace PSLanguageService.Test
         public void CanApplyEditsToEndOfFile()
         {
             this.AssertFileChange(
-                "line1\n\rline2\n\rline3\n\r",
-                "line1\n\rline2\n\rline3\n\r\n\r\n\r",
+                "line1\r\nline2\r\nline3\r\n\r\n",
+                "line1\r\nline2\r\nline3\r\n\r\n\r\n\r\n",
                 new FileChange
                 {
                     Line = 5,
                     EndLine = 5,
                     Offset = 1,
                     EndOffset = 1,
-                    InsertString = "\n\r\n\r"
+                    InsertString = "\r\n\r\n"
                 });
         }
 


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1283 and fixes https://github.com/PowerShell/vscode-powershell/issues/1492.

**Note**: I doubt it will affect https://github.com/PowerShell/vscode-powershell/issues/1453; that looks like a separate issue.

It looks like there is a tendency for VSCode to generate a text document change request with an offset that is one beyond the current lines we track under certain conditions. @rkeithhill's repro is the best I've seen.

Anyway, this PR just detects that case and bypasses all the magic insertion logic -- instead we just append the lines to the end.