### PR TITLE
Fix codelens crash when a file does not exist

### DIFF
--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
@@ -318,12 +319,21 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 if (!fileMap.Contains(file))
                 {
-                    fileMap.Add(
-                        file,
-                        new ScriptFile(
+                    ScriptFile scriptFile;
+                    try
+                    {
+                        scriptFile = new ScriptFile(
                             file,
                             clientFilePath: null,
-                            powerShellVersion: this.powerShellContext.LocalPowerShellVersion.Version));
+                            powerShellVersion: this.powerShellContext.LocalPowerShellVersion.Version);
+                    }
+                    catch (IOException)
+                    {
+                        // If the file has ceased to exist for some reason, we just skip it
+                        continue;
+                    }
+
+                    fileMap.Add(file, scriptFile);
                 }
             }
 
@@ -338,8 +348,7 @@ namespace Microsoft.PowerShell.EditorServices
                         foundSymbol,
                         CmdletToAliasDictionary,
                         AliasToCmdletDictionary)
-                    .Select(
-                        reference =>
+                    .Select(reference =>
                         {
                             try
                             {

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -310,9 +310,14 @@ namespace Microsoft.PowerShell.EditorServices
 
             // We want to look for references first in referenced files, hence we use ordered dictionary
             // TODO: File system case-sensitivity is based on filesystem not OS, but OS is a much cheaper heuristic
+#if CoreCLR
+            // The RuntimeInformation.IsOSPlatform is not supported in .NET Framework
             var fileMap = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                 ? new OrderedDictionary()
                 : new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
+#else
+            var fileMap = new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
+#endif
             foreach (ScriptFile file in referencedFiles)
             {
                 fileMap.Add(file.FilePath, file);


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1471 and fixes https://github.com/PowerShell/PowerShellEditorServices/issues/718.

If a file is removed when the reference symbols are being parsed, it will cause an exception to be thrown. Now if that file does not exist, we just skip it.