### PR TITLE
Add an easy to use execution timer

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1523,11 +1523,10 @@ function __Expand-Alias {
                 ScriptFileMarker[] semanticMarkers = null;
                 if (isScriptAnalysisEnabled && editorSession.AnalysisService != null)
                 {
-                    Logger.Write(LogLevel.Verbose, "Analyzing script file: " + scriptFile.FilePath);
-
-                    semanticMarkers = await editorSession.AnalysisService.GetSemanticMarkersAsync(scriptFile);
-
-                    Logger.Write(LogLevel.Verbose, "Analysis complete.");
+                    using (Logger.LogExecutionTime($"Script analysis of {scriptFile.FilePath} completed."))
+                    {
+                        semanticMarkers = await editorSession.AnalysisService.GetSemanticMarkersAsync(scriptFile);
+                    }
                 }
                 else
                 {

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     public struct ExecutionTimer : IDisposable
     {
         [ThreadStatic]
-        private static Stopwatch s_stopwatch;
+        private static Stopwatch t_stopwatch;
 
         private readonly ILogger _logger;
 
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerLineNumber] int callerLineNumber = -1)
         {
             var timer = new ExecutionTimer(logger, message, callerMemberName, callerFilePath, callerLineNumber);
-            s_stopwatch.Start();
+            t_stopwatch.Start();
             return timer;
         }
 
@@ -74,16 +74,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         public void Dispose()
         {
-            s_stopwatch.Stop();
+            t_stopwatch.Stop();
 
             string logMessage = new StringBuilder()
                 .Append(_message)
                 .Append(" [")
-                .Append(s_stopwatch.ElapsedMilliseconds)
+                .Append(t_stopwatch.ElapsedMilliseconds)
                 .Append("ms]")
                 .ToString();
 
-            s_stopwatch.Reset();
+            t_stopwatch.Reset();
 
             _logger.Write(
                 LogLevel.Verbose,
@@ -93,16 +93,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 callerLineNumber: _callerLineNumber);
         }
 
-        private Stopwatch Stopwatch
-        {
-            get
-            {
-                if (s_stopwatch == null)
-                {
-                    s_stopwatch = new Stopwatch();
-                }
-                return s_stopwatch;
-            }
-        }
+        private Stopwatch Stopwatch => t_stopwatch ?? (t_stopwatch = new Stopwatch());
     }
 }

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -66,7 +66,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             _callerMemberName = callerMemberName;
             _callerFilePath = callerFilePath;
             _callerLineNumber = callerLineNumber;
-            _stopwatch = new Stopwatch();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     public struct ExecutionTimer : IDisposable
     {
         [ThreadStatic]
-        private static readonly Stopwatch s_stopwatch = new Stopwatch();
+        private static Stopwatch s_stopwatch;
 
         private readonly ILogger _logger;
 
@@ -91,6 +91,18 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 callerName: _callerMemberName,
                 callerSourceFile: _callerFilePath,
                 callerLineNumber: _callerLineNumber);
+        }
+
+        private Stopwatch Stopwatch
+        {
+            get
+            {
+                if (s_stopwatch == null)
+                {
+                    s_stopwatch = new Stopwatch();
+                }
+                return s_stopwatch;
+            }
         }
     }
 }

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -20,11 +20,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     /// </example>
     public struct ExecutionTimer : IDisposable
     {
+        [ThreadStatic]
+        private static readonly Stopwatch s_stopwatch = new Stopwatch();
+
         private readonly ILogger _logger;
 
         private readonly string _message;
-
-        private readonly Stopwatch _stopwatch;
 
         private readonly string _callerMemberName;
 
@@ -49,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerLineNumber] int callerLineNumber = -1)
         {
             var timer = new ExecutionTimer(logger, message, callerMemberName, callerFilePath, callerLineNumber);
-            timer._stopwatch.Start();
+            s_stopwatch.Start();
             return timer;
         }
 
@@ -74,14 +75,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         public void Dispose()
         {
-            _stopwatch.Stop();
+            s_stopwatch.Stop();
 
             string logMessage = new StringBuilder()
                 .Append(_message)
                 .Append(" [")
-                .Append(_stopwatch.ElapsedMilliseconds)
+                .Append(s_stopwatch.ElapsedMilliseconds)
                 .Append("ms]")
                 .ToString();
+
+            s_stopwatch.Reset();
 
             _logger.Write(
                 LogLevel.Verbose,

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -240,11 +240,29 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         }
     }
 
+    /// <summary>
+    /// Extension method class for the ILogger class.
+    /// </summary>
     public static class ILoggerExtensions
     {
-        public static ExecutionTimer LogExecutionTime(this ILogger logger, string message)
+        /// <summary>
+        /// Log the amount of time an execution takes. The intended usage is to call this method in the
+        /// header of a `using` block to time the interior of the block.
+        /// </summary>
+        /// <param name="logger">The ILogger to log the execution time with.</param>
+        /// <param name="message">The message to log about what has been executed.</param>
+        /// <param name="callerMemberName">The name of the member calling this method.</param>
+        /// <param name="callerFilePath">The file where this method has been called.</param>
+        /// <param name="callerLineNumber">The line number where this method has been called.</param>
+        /// <returns></returns>
+        public static ExecutionTimer LogExecutionTime(
+            this ILogger logger,
+            string message,
+            [CallerMemberName] string callerMemberName = null,
+            [CallerFilePath] string callerFilePath = null,
+            [CallerLineNumber] int callerLineNumber = -1)
         {
-            return ExecutionTimer.Start(logger, message);
+            return ExecutionTimer.Start(logger, message, callerMemberName, callerFilePath, callerLineNumber);
         }
     }
 }

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -239,4 +239,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             throw new ArgumentException($"Unknown LogLevel: '{logLevel}')", nameof(logLevel));
         }
     }
+
+    public static class ILoggerExtensions
+    {
+        public static ExecutionTimer LogExecutionTime(this ILogger logger, string message)
+        {
+            return ExecutionTimer.Start(logger, message);
+        }
+    }
 }

--- a/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
+++ b/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.PowerShell.EditorServices.Utility
@@ -25,23 +26,42 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 
         private readonly Stopwatch _stopwatch;
 
+        private readonly string _callerMemberName;
+
+        private readonly string _callerFilePath;
+
+        private readonly int _callerLineNumber;
+
         /// <summary>
         /// Create a new execution timer and start it.
         /// </summary>
         /// <param name="logger">The logger to log the execution timer message in.</param>
         /// <param name="message">The message to prefix the execution time with.</param>
         /// <returns></returns>
-        public static ExecutionTimer Start(ILogger logger, string message)
+        public static ExecutionTimer Start(
+            ILogger logger,
+            string message,
+            [CallerMemberName] string callerMemberName = null,
+            [CallerFilePath] string callerFilePath = null,
+            [CallerLineNumber] int callerLineNumber = -1)
         {
-            var timer = new ExecutionTimer(logger, message);
+            var timer = new ExecutionTimer(logger, message, callerMemberName, callerFilePath, callerLineNumber);
             timer._stopwatch.Start();
             return timer;
         }
 
-        internal ExecutionTimer(ILogger logger, string message)
+        internal ExecutionTimer(
+            ILogger logger,
+            string message,
+            string callerMemberName,
+            string callerFilePath,
+            int callerLineNumber)
         {
             _logger = logger;
             _message = message;
+            _callerMemberName = callerMemberName;
+            _callerFilePath = callerFilePath;
+            _callerLineNumber = callerLineNumber;
             _stopwatch = new Stopwatch();
         }
 
@@ -60,7 +80,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 .Append("ms]")
                 .ToString();
 
-            _logger.Write(LogLevel.Verbose, logMessage);
+            _logger.Write(
+                LogLevel.Verbose,
+                logMessage,
+                callerName: _callerMemberName,
+                callerSourceFile: _callerFilePath,
+                callerLineNumber: _callerLineNumber);
         }
     }
 }

--- a/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
+++ b/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
@@ -37,7 +37,10 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         /// <param name="logger">The logger to log the execution timer message in.</param>
         /// <param name="message">The message to prefix the execution time with.</param>
-        /// <returns></returns>
+        /// <param name="callerMemberName">The name of the calling method or property.</param>
+        /// <param name="callerFilePath">The path to the source file of the caller.</param>
+        /// <param name="callerLineNumber">The line where the timer is called.</param>
+        /// <returns>A new, started execution timer.</returns>
         public static ExecutionTimer Start(
             ILogger logger,
             string message,

--- a/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
+++ b/src/PowerShellEditorServices/Utility/PerformanceTimer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    /// <summary>
+    /// Simple timer to be used with `using` to time executions.
+    /// </summary>
+    /// <example>
+    /// An example showing how ExecutionTimer is intended to be used
+    /// <code>
+    /// using (ExecutionTimer.Start(logger, "Execution of MyMethod completed."))
+    /// {
+    ///     MyMethod(various, arguments);
+    /// }
+    /// </code>
+    /// This will print a message like "Execution of MyMethod completed. [50ms]" to the logs.
+    /// </example>
+    public struct ExecutionTimer : IDisposable
+    {
+        private readonly ILogger _logger;
+
+        private readonly string _message;
+
+        private readonly Stopwatch _stopwatch;
+
+        /// <summary>
+        /// Create a new execution timer and start it.
+        /// </summary>
+        /// <param name="logger">The logger to log the execution timer message in.</param>
+        /// <param name="message">The message to prefix the execution time with.</param>
+        /// <returns></returns>
+        public static ExecutionTimer Start(ILogger logger, string message)
+        {
+            var timer = new ExecutionTimer(logger, message);
+            timer._stopwatch.Start();
+            return timer;
+        }
+
+        internal ExecutionTimer(ILogger logger, string message)
+        {
+            _logger = logger;
+            _message = message;
+            _stopwatch = new Stopwatch();
+        }
+
+        /// <summary>
+        /// Dispose of the execution timer by stopping the stopwatch and then printing
+        /// the elapsed time in the logs.
+        /// </summary>
+        public void Dispose()
+        {
+            _stopwatch.Stop();
+
+            string logMessage = new StringBuilder()
+                .Append(_message)
+                .Append(" [")
+                .Append(_stopwatch.ElapsedMilliseconds)
+                .Append("ms]")
+                .ToString();
+
+            _logger.Write(LogLevel.Verbose, logMessage);
+        }
+    }
+}


### PR DESCRIPTION
Adds a method onto the `ILogger` that can time the execution of a `using` block -- so you can time things like:
```csharp
using (_logger.LogExecutionTime("Executed MyMethod."))
{
    MyMethod(args);
}
```

That prints something to the logs like
```
[VERBOSE] Executed MyMethod. [25ms]
```
