### PR TITLE
Cache the reflection call done for completions

### DIFF
--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -5,19 +5,18 @@
 
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Management.Automation.Language;
+using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices
 {
-    using System.Diagnostics;
-    using System.Linq.Expressions;
     using System.Management.Automation;
-    using System.Management.Automation.Language;
-    using System.Management.Automation.Runspaces;
 
     /// <summary>
     /// Provides common operations for the syntax tree of a parsed script.

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -23,28 +23,11 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     internal static class AstOperations
     {
-        private static readonly MethodInfo s_extentCloneWithNewOffset;
-
-        static AstOperations()
-        {
-            // TODO: When netstandard is upgraded to 2.0, see if
-            //       Delegate.CreateDelegate can be used here instead
-            s_extentCloneWithNewOffset =
-#if CoreCLR
-                typeof(PSObject).GetTypeInfo().Assembly
-                    .GetType("System.Management.Automation.Language.InternalScriptPosition")
-                    .GetMethod("CloneWithNewOffset", BindingFlags.Instance | BindingFlags.NonPublic);
-#else
-                typeof(PSObject).GetType().Assembly
-                    .GetType("System.Management.Automation.Language.InternalScriptPosition")
-                    .GetMethod(
-                        "CloneWithNewOffset",
-                        BindingFlags.Instance | BindingFlags.NonPublic,
-                        binder: null,
-                        types: new [] { typeof(int) },
-                        modifiers: null);
-#endif
-        }
+        // TODO: When netstandard is upgraded to 2.0, see if
+        //       Delegate.CreateDelegate can be used here instead
+        private static readonly MethodInfo s_extentCloneWithNewOffset = typeof(PSObject).GetTypeInfo().Assembly
+            .GetType("System.Management.Automation.Language.InternalScriptPosition")
+            .GetMethod("CloneWithNewOffset", BindingFlags.Instance | BindingFlags.NonPublic);
 
         /// <summary>
         /// Gets completions for the symbol found in the Ast at


### PR DESCRIPTION
I noticed that completion queries do a reflection call every time. This code caches instead, but it's not terribly elegant. So if you have any suggestions, please let me know.