### PR TITLE
Remove LINQ usage in language service methods

### DIFF
--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -516,11 +516,10 @@ namespace Microsoft.PowerShell.EditorServices
                         foundSymbol,
                         false);
 
-            return
-                new FindOccurrencesResult
-                {
-                    FoundOccurrences = symbolOccurrences
-                };
+            return new FindOccurrencesResult
+            {
+                FoundOccurrences = symbolOccurrences
+            };
         }
 
         /// <summary>
@@ -723,7 +722,7 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     if (!_cmdletToAliasDictionary.ContainsKey(aliasInfo.Definition))
                     {
-                        _cmdletToAliasDictionary.Add(aliasInfo.Definition, new List<String>() { aliasInfo.Name });
+                        _cmdletToAliasDictionary.Add(aliasInfo.Definition, new List<String>{ aliasInfo.Name });
                     }
                     else
                     {
@@ -804,16 +803,15 @@ namespace Microsoft.PowerShell.EditorServices
                     workspace);
 
             SymbolReference foundDefinition = null;
-            for (int i = 0; i < nestedModuleFiles.Length; i++)
+            foreach (ScriptFile nestedModuleFile in nestedModuleFiles)
             {
-                foundDefinition =
-                    AstOperations.FindDefinitionOfSymbol(
-                        nestedModuleFiles[i].ScriptAst,
-                        foundSymbol);
+                foundDefinition = AstOperations.FindDefinitionOfSymbol(
+                    nestedModuleFile.ScriptAst,
+                    foundSymbol);
 
                 if (foundDefinition != null)
                 {
-                    foundDefinition.FilePath = nestedModuleFiles[i].FilePath;
+                    foundDefinition.FilePath = nestedModuleFile.FilePath;
                     break;
                 }
             }

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -824,6 +824,7 @@ namespace Microsoft.PowerShell.EditorServices
                 return ast is StatementAst && ast.Extent.Contains(lineNumber, columnNumber);
             }, true);
 
+            // Find the Ast with the smallest extent
             Ast minAst = scriptFile.ScriptAst;
             foreach (Ast ast in asts)
             {

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices
             PowerShellContext powerShellContext,
             ILogger logger)
         {
-            Validate.IsNotNull("powerShellContext", powerShellContext);
+            Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
             _powerShellContext = powerShellContext;
             _logger = logger;
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.EditorServices
             int lineNumber,
             int columnNumber)
         {
-            Validate.IsNotNull("scriptFile", scriptFile);
+            Validate.IsNotNull(nameof(scriptFile), scriptFile);
 
             // Get the offset at the specified position.  This method
             // will also validate the given position.
@@ -279,7 +279,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns></returns>
         public FindOccurrencesResult FindSymbolsInFile(ScriptFile scriptFile)
         {
-            Validate.IsNotNull("scriptFile", scriptFile);
+            Validate.IsNotNull(nameof(scriptFile), scriptFile);
 
             var foundOccurrences = new List<SymbolReference>();
             foreach (IDocumentSymbolProvider symbolProvider in _documentSymbolProviders)
@@ -406,9 +406,9 @@ namespace Microsoft.PowerShell.EditorServices
             SymbolReference foundSymbol,
             Workspace workspace)
         {
-            Validate.IsNotNull("sourceFile", sourceFile);
-            Validate.IsNotNull("foundSymbol", foundSymbol);
-            Validate.IsNotNull("workspace", workspace);
+            Validate.IsNotNull(nameof(sourceFile), sourceFile);
+            Validate.IsNotNull(nameof(foundSymbol), foundSymbol);
+            Validate.IsNotNull(nameof(workspace), workspace);
 
             ScriptFile[] referencedFiles =
                 workspace.ExpandScriptReferences(

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -439,8 +439,8 @@ namespace Microsoft.PowerShell.EditorServices
             if (foundDefinition == null)
             {
                 // Get a list of all powershell files in the workspace path
-                var allFiles = workspace.EnumeratePSFiles();
-                foreach (var file in allFiles)
+                IEnumerable<string> allFiles = workspace.EnumeratePSFiles();
+                foreach (string file in allFiles)
                 {
                     if (filesSearched.Contains(file))
                     {
@@ -592,7 +592,7 @@ namespace Microsoft.PowerShell.EditorServices
             int lineNumber,
             int columnNumber)
         {
-            var ast = FindSmallestStatementAst(scriptFile, lineNumber, columnNumber);
+            Ast ast = FindSmallestStatementAst(scriptFile, lineNumber, columnNumber);
             if (ast == null)
             {
                 return null;
@@ -611,7 +611,7 @@ namespace Microsoft.PowerShell.EditorServices
             ScriptFile scriptFile,
             int lineNumber)
         {
-            var functionDefinitionAst = scriptFile.ScriptAst.Find(
+            Ast functionDefinitionAst = scriptFile.ScriptAst.Find(
                 ast => ast is FunctionDefinitionAst && ast.Extent.StartLineNumber == lineNumber,
                 true);
 
@@ -631,7 +631,7 @@ namespace Microsoft.PowerShell.EditorServices
             out string helpLocation)
         {
             // check if the next line contains a function definition
-            var funcDefnAst = GetFunctionDefinitionAtLine(scriptFile, lineNumber + 1);
+            FunctionDefinitionAst funcDefnAst = GetFunctionDefinitionAtLine(scriptFile, lineNumber + 1);
             if (funcDefnAst != null)
             {
                 helpLocation = "before";
@@ -639,7 +639,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             // find all the script definitions that contain the line `lineNumber`
-            var foundAsts = scriptFile.ScriptAst.FindAll(
+            IEnumerable<Ast> foundAsts = scriptFile.ScriptAst.FindAll(
                 ast =>
                 {
                     var fdAst = ast as FunctionDefinitionAst;

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -381,8 +381,6 @@ namespace Microsoft.PowerShell.EditorServices
                     reference.FilePath = file.FilePath;
                     symbolReferences.Add(reference);
                 }
-
-                symbolReferences.AddRange(symbolReferences);
             }
 
             return new FindReferencesResult


### PR DESCRIPTION
Removes most LINQ calls in the language service methods.

There are also some style changes. They should be contained to commits marked `[Style]`.