### PR TITLE
Remove unnecessary LINQ calls from LanguageServer

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -812,7 +812,7 @@ function __Expand-Alias {
                         Label = parameterSets.CommandName + " " + sig.SignatureText,
                         Documentation = null,
                         Parameters = parameters.ToArray(),
-                    }
+                    };
                 }
                 signatures = sigs.ToArray();
             }
@@ -995,7 +995,7 @@ function __Expand-Alias {
                 {
                     foreach (SymbolReference foundOccurrence in foundSymbols.FoundOccurrences)
                     {
-                        if (!IsQueryMatch(workspaceSymbolParams.Query, foundOccurrence.SymbolType))
+                        if (!IsQueryMatch(workspaceSymbolParams.Query, foundOccurrence.SymbolName))
                         {
                             continue;
                         }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -30,6 +30,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         private static Location[] s_emptyLocationResult = new Location[0];
 
+        private static CompletionItem[] s_emptyCompletionResult = new CompletionItem[0];
+
         private ILogger Logger;
         private bool profilesLoaded;
         private bool consoleReplStarted;
@@ -730,24 +732,18 @@ function __Expand-Alias {
                     cursorLine,
                     cursorColumn);
 
-            CompletionItem[] completionItems = null;
+            CompletionItem[] completionItems = s_emptyCompletionResult;
 
             if (completionResults != null)
             {
                 int sortIndex = 1;
-                completionItems =
-                    completionResults
-                        .Completions
-                        .Select(
-                            c => CreateCompletionItem(
-                                c,
-                                completionResults.ReplacedRange,
-                                sortIndex++))
-                        .ToArray();
-            }
-            else
-            {
-                completionItems = new CompletionItem[0];
+                var completions = new List<CompletionItem>();
+                foreach (CompletionDetails completion in completionResults.Completions)
+                {
+                    CompletionItem completionItem = CreateCompletionItem(completion, completionResults.ReplacedRange, sortIndex);
+                    sortIndex++;
+                }
+                completionItems = completions.ToArray();
             }
 
             await requestContext.SendResult(completionItems);

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -993,26 +993,27 @@ function __Expand-Alias {
 
                 if (foundSymbols != null)
                 {
-                    var matchedSymbols =
-                        foundSymbols
-                            .FoundOccurrences
-                            .Where(r => IsQueryMatch(workspaceSymbolParams.Query, r.SymbolName))
-                            .Select(r =>
-                                {
-                                    return new SymbolInformation
-                                    {
-                                        ContainerName = containerName,
-                                        Kind = r.SymbolType == SymbolType.Variable ? SymbolKind.Variable : SymbolKind.Function,
-                                        Location = new Location
-                                        {
-                                            Uri = GetFileUri(r.FilePath),
-                                            Range = GetRangeFromScriptRegion(r.ScriptRegion)
-                                        },
-                                        Name = GetDecoratedSymbolName(r)
-                                    };
-                                });
+                    foreach (SymbolReference foundOccurrence in foundSymbols.FoundOccurrences)
+                    {
+                        if (!IsQueryMatch(workspaceSymbolParams.Query, foundOccurrence.SymbolType))
+                        {
+                            continue;
+                        }
 
-                    symbols.AddRange(matchedSymbols);
+                        var location = new Location
+                        {
+                            Uri = GetFileUri(foundOccurrence.FilePath),
+                            Range = GetRangeFromScriptRegion(foundOccurrence.ScriptRegion)
+                        };
+
+                        symbols.Add(new SymbolInformation
+                        {
+                            ContainerName = containerName,
+                            Kind = foundOccurrence.SymbolType == SymbolType.Variable ? SymbolKind.Variable : SymbolKind.Function,
+                            Location = location,
+                            Name = GetDecoratedSymbolName(foundOccurrence)
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
Removes a few LINQ calls from the Language Server, in an effort to chip away at performance issues.

Given how complicated and central the logic here is, I haven't made any style changes, but would be happy to make any :)