### PR TITLE
grab psrl from gallery

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -310,24 +310,6 @@ task RestorePsesModules -After Build {
         Save-Module @splatParameters
     }
 
-    # TODO: Replace this with adding a new module to Save when a new PSReadLine release comes out to the Gallery
-    if (-not (Test-Path $PSScriptRoot/module/PSReadLine))
-    {
-        Write-Host "`tInstalling module: PSReadLine"
-
-        # Download AppVeyor zip
-        $jobId = (Invoke-RestMethod https://ci.appveyor.com/api/projects/lzybkr/PSReadLine).build.jobs[0].jobId
-        Invoke-RestMethod https://ci.appveyor.com/api/buildjobs/$jobId/artifacts/bin%2FRelease%2FPSReadLine.zip -OutFile $PSScriptRoot/module/PSRL.zip
-
-        # Position PSReadLine
-        Expand-Archive $PSScriptRoot/module/PSRL.zip $PSScriptRoot/module/PSRL
-        Move-Item $PSScriptRoot/module/PSRL/PSReadLine $PSScriptRoot/module
-
-        # Clean up
-        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL.zip
-        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL
-    }
-
     Write-Host "`n"
 }
 

--- a/modules.json
+++ b/modules.json
@@ -8,5 +8,10 @@
         "MinimumVersion":"1.0",
         "MaximumVersion":"1.99",
         "AllowPrerelease":false
+    },
+    "PSReadLine":{
+        "MinimumVersion":"2.0.0-beta3",
+        "MaximumVersion":"2.99",
+        "AllowPrerelease":true
     }
 }


### PR DESCRIPTION
Now that beta3 is out and that has @SeeminglyScience's change, we can pull PSRL in from the Gallery directly.

Note: this does not fix the problem that still exists in PSCore where PSCore ships with PSRL 2.0 beta2... which gets picked up over the 2.0 beta 3 because they're are... in PowerShell's mind... the same version (2.0). fun times...

