### PR TITLE
Use PSRL release and filter out previous betas

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -302,7 +302,7 @@ task RestorePsesModules -After Build {
 
         if ($script:SaveModuleSupportsAllowPrerelease)
         {
-            $splatParameters += @{ AllowPrerelease = $moduleInstallDetails.AllowPrerelease }
+            $splatParameters += @{ AllowPrereleaseVersions = $moduleInstallDetails.AllowPrerelease }
         }
 
         Write-Host "`tInstalling module: ${moduleName}"

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -310,24 +310,6 @@ task RestorePsesModules -After Build {
         Save-Module @splatParameters
     }
 
-    # TODO: Replace this with adding a new module to Save when a new PSReadLine release comes out to the Gallery
-    if (-not (Test-Path $PSScriptRoot/module/PSReadLine))
-    {
-        Write-Host "`tInstalling module: PSReadLine"
-
-        # Download AppVeyor zip
-        $jobId = (Invoke-RestMethod https://ci.appveyor.com/api/projects/lzybkr/PSReadLine).build.jobs[0].jobId
-        Invoke-RestMethod https://ci.appveyor.com/api/buildjobs/$jobId/artifacts/bin%2FRelease%2FPSReadLine.zip -OutFile $PSScriptRoot/module/PSRL.zip
-
-        # Position PSReadLine
-        Expand-Archive $PSScriptRoot/module/PSRL.zip $PSScriptRoot/module/PSRL
-        Move-Item $PSScriptRoot/module/PSRL/PSReadLine $PSScriptRoot/module
-
-        # Clean up
-        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL.zip
-        Remove-Item -Force -Recurse $PSScriptRoot/module/PSRL
-    }
-
     Write-Host "`n"
 }
 

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -302,7 +302,7 @@ task RestorePsesModules -After Build {
 
         if ($script:SaveModuleSupportsAllowPrerelease)
         {
-            $splatParameters += @{ AllowPrereleaseVersions = $moduleInstallDetails.AllowPrerelease }
+            $splatParameters += @{ AllowPrerelease = $moduleInstallDetails.AllowPrerelease }
         }
 
         Write-Host "`tInstalling module: ${moduleName}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,10 @@ environment:
 
 install:
   - ps: |
-      Install-Module -Name PowershellGet,PackageManagement -force -confirm:$false -verbose
+      powershell -Command { Install-Module -Name PowershellGet,PackageManagement -force -confirm:$false -verbose }
       Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
-      Install-Module -Name PowerShellGet -MinimumVersion 1.6 -PassThru -Force
-      Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -PassThru -Force
+      Install-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
+      Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
       Install-PackageProvider -Name NuGet -Force | Out-Null
       Import-PackageProvider NuGet -Force | Out-Null
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,12 @@ environment:
 
 install:
   - ps: |
+      Install-Module -Name PowershellGet,PackageManagement -force -confirm:$false -verbose
+      Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
+      Install-Module -Name PowerShellGet -MinimumVersion 1.6 -PassThru -Force
+      Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -PassThru -Force
       Install-PackageProvider -Name NuGet -Force | Out-Null
       Import-PackageProvider NuGet -Force | Out-Null
-      Install-Module -Name PowerShellGet -Force
-      Import-Module PowerShellGet -Force
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
       Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force | Out-Null
       Install-Module platyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,11 @@ environment:
 
 install:
   - ps: |
-      powershell -Command { Install-Module -Name PowershellGet,PackageManagement -force -confirm:$false -verbose }
       Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
-      Install-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
-      Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
+      powershell -Command { Install-Module -Name PowershellGet -MinimumVersion 1.6 -force -confirm:$false -verbose }
+      powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force -Confirm:$false -Verbose }
+      Import-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
+      Import-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
       Install-PackageProvider -Name NuGet -Force | Out-Null
       Import-PackageProvider NuGet -Force | Out-Null
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 
 install:
   - ps: |
-      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+      Install-PackageProvider -Name NuGet -Force | Out-Null
       Import-PackageProvider NuGet -Force | Out-Null
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
       Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ install:
   - ps: |
       Install-PackageProvider -Name NuGet -Force | Out-Null
       Import-PackageProvider NuGet -Force | Out-Null
+      Install-Module -Name PowerShellGet -Force
+      Import-Module PowerShellGet -Force
       Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
       Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force | Out-Null
       Install-Module platyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force | Out-Null

--- a/modules.json
+++ b/modules.json
@@ -8,5 +8,10 @@
         "MinimumVersion":"1.0",
         "MaximumVersion":"1.99",
         "AllowPrerelease":false
+    },
+    "PSReadLine":{
+        "MinimumVersion":"2.0.0-beta3",
+        "MaximumVersion":"2.1",
+        "AllowPrerelease":true
     }
 }

--- a/scripts/travis.ps1
+++ b/scripts/travis.ps1
@@ -1,4 +1,6 @@
 Install-PackageProvider NuGet -Force
+Install-Module -Name PowerShellGet -Force
+Import-Module PowerShellGet -Force
 
 # Install InvokeBuild
 Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force

--- a/scripts/travis.ps1
+++ b/scripts/travis.ps1
@@ -1,6 +1,6 @@
 Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
-powershell -Command { Install-Module -Name PowershellGet -MinimumVersion 1.6 -force -confirm:$false -verbose }
-powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force -Confirm:$false -Verbose }
+powershell -Command { Install-Module -Name PowershellGet -MinimumVersion 1.6 -Scope CurrentUser -force -confirm:$false -verbose }
+powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Scope CurrentUser -Force -Confirm:$false -Verbose }
 Import-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
 Import-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
 Install-PackageProvider -Name NuGet -Force | Out-Null

--- a/scripts/travis.ps1
+++ b/scripts/travis.ps1
@@ -1,4 +1,4 @@
-
+Install-PackageProvider NuGet -Force
 
 # Install InvokeBuild
 Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force

--- a/scripts/travis.ps1
+++ b/scripts/travis.ps1
@@ -1,6 +1,11 @@
-Install-PackageProvider NuGet -Force
-Install-Module -Name PowerShellGet -Force
-Import-Module PowerShellGet -Force
+Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
+powershell -Command { Install-Module -Name PowershellGet -MinimumVersion 1.6 -force -confirm:$false -verbose }
+powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force -Confirm:$false -Verbose }
+Import-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
+Import-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
+Install-PackageProvider -Name NuGet -Force | Out-Null
+Import-PackageProvider NuGet -Force | Out-Null
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
 
 # Install InvokeBuild
 Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             [System.Diagnostics.DebuggerHidden()]
             [System.Diagnostics.DebuggerStepThrough()]
             param()
-            return [Microsoft.PowerShell.PSConsoleReadLine]::ReadLine(
+            return [Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]::ReadLine(
                 $Host.Runspace,
                 $ExecutionContext,
                 $args[0])";
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             param()
             end {
                 $module = Get-Module -ListAvailable PSReadLine |
-                    Where-Object Version -ge '2.0.0' |
+                    Where-Object Version -eq '2.0.0' |
                     Where-Object { $_.PrivateData.PSData.Prerelease -notin 'beta1','beta2' } |
                     Sort-Object -Descending Version |
                     Select-Object -First 1
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
                 }
 
                 Import-Module -ModuleInfo $module
-                return 'Microsoft.PowerShell.PSConsoleReadLine' -as [type]
+                return [Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]
             }";
 
         private readonly PowerShellContext _powerShellContext;

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -30,11 +30,11 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             [System.Diagnostics.DebuggerStepThrough()]
             param()
             end {
-                $module = Get-Module -ListAvailable PSReadLine `
-                    | Where-Object Version -ge '2.0.0' `
-                    | Where-Object { $psd = Import-PowerShellDataFile $_.Path; $release = $psd.PrivateData.PSData.Prerelease; $release -notin (@('beta1', 'beta2')) } `
-                    | Sort-Object -Descending Version `
-                    | Select-Object -First 1
+                $module = Get-Module -ListAvailable PSReadLine |
+                    Where-Object Version -ge '2.0.0' |
+                    Where-Object { $_.PrivateData.PSData.Prerelease -notin 'beta1','beta2' } |
+                    Sort-Object -Descending Version |
+                    Select-Object -First 1
                 if (-not $module) {
                     return
                 }

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             end {
                 $module = Get-Module -ListAvailable PSReadLine `
                     | Where-Object Version -ge '2.0.0' `
-                    | Where-Object { $psd = Import-PowerShellDataFile $_.Path; $release = $psd.PrivateData.PSData.Prerelease; -not (@('beta1', 'beta2') -contains $release) } `
+                    | Where-Object { $psd = Import-PowerShellDataFile $_.Path; $release = $psd.PrivateData.PSData.Prerelease; $release -notin (@('beta1', 'beta2')) } `
                     | Sort-Object -Descending Version `
                     | Select-Object -First 1
                 if (-not $module) {

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -30,7 +30,11 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             [System.Diagnostics.DebuggerStepThrough()]
             param()
             end {
-                $module = Get-Module -ListAvailable PSReadLine | Where-Object Version -ge '2.0.0' | Sort-Object -Descending Version | Select-Object -First 1
+                $module = Get-Module -ListAvailable PSReadLine `
+                    | Where-Object Version -ge '2.0.0' `
+                    | Where-Object { $psd = Import-PowerShellDataFile $_.Path; $release = $psd.PrivateData.PSData.Prerelease; -not (@('beta1', 'beta2') -contains $release) } `
+                    | Sort-Object -Descending Version `
+                    | Select-Object -First 1
                 if (-not $module) {
                     return
                 }


### PR DESCRIPTION
- Uses the PSReadLine beta3 release from PowerShell gallery instead of downloading the master build from AppVeyor
- Filters out the old beta versions that don't have @SeeminglyScience's private API in it (which effectively break us trying to pull PSRL2 in)

Quick question: is there anything else that needs changing for better PSRL module support here?