### PR TITLE
Fix NRE when trying to start the stopwatch

### DIFF
--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerLineNumber] int callerLineNumber = -1)
         {
             var timer = new ExecutionTimer(logger, message, callerMemberName, callerFilePath, callerLineNumber);
-            t_stopwatch.Start();
+            Stopwatch.Start();
             return timer;
         }
 

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -93,6 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 callerLineNumber: _callerLineNumber);
         }
 
-        private Stopwatch Stopwatch => t_stopwatch ?? (t_stopwatch = new Stopwatch());
+        [ThreadStatic]
+        private static Stopwatch Stopwatch => t_stopwatch ?? (t_stopwatch = new Stopwatch());
     }
 }

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -93,7 +93,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 callerLineNumber: _callerLineNumber);
         }
 
-        [ThreadStatic]
         private static Stopwatch Stopwatch => t_stopwatch ?? (t_stopwatch = new Stopwatch());
     }
 }


### PR DESCRIPTION
Discovered while debugging that the stopwatch in the execution timer wasn't being used properly.