### PR TITLE
Fix crash for finding symbols on bad paths

### DIFF
--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -346,9 +347,13 @@ namespace Microsoft.PowerShell.EditorServices
                     {
                         scriptFile = workspace.GetFile(file);
                     }
-                    catch (IOException)
+                    catch (Exception e) when (e is IOException
+                                           || e is SecurityException
+                                           || e is FileNotFoundException
+                                           || e is DirectoryNotFoundException
+                                           || e is PathTooLongException)
                     {
-                        // If the file has ceased to exist for some reason, we just skip it
+                        // If we can't access the file for some reason, just ignore it
                         continue;
                     }
 

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -351,7 +351,8 @@ namespace Microsoft.PowerShell.EditorServices
                                            || e is SecurityException
                                            || e is FileNotFoundException
                                            || e is DirectoryNotFoundException
-                                           || e is PathTooLongException)
+                                           || e is PathTooLongException
+                                           || e is UnauthorizedAccessException)
                     {
                         // If we can't access the file for some reason, just ignore it
                         continue;


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1518.

Protects against trying to open bad paths from `ScriptFile.GetFile()` in the symbol provider.

This fixes the given issue, but might not be the best way to do so -- perhaps better for `GetFile()` to return null in this case?

But we can change that at some later point perhaps.