### PR TITLE
Fix issue where # in path causes the path to resolve incorrectly

### DIFF
--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -505,12 +505,12 @@ namespace Microsoft.PowerShell.EditorServices
             }
 #endif
             // Check here that we have something like "file:///C%3A/" as a prefix (caller must check the file:// part)
-            if (!(fileUri[7] == '/'
-                  && char.IsLetter(fileUri[8])
-                  && fileUri[9] == '%'
-                  && fileUri[10] == '3'
-                  && fileUri[11] == 'A'
-                  && fileUri[12] == '/'))
+            if (!(fileUri[7] == '/' &&
+                  char.IsLetter(fileUri[8]) &&
+                  fileUri[9] == '%' &&
+                  fileUri[10] == '3' &&
+                  fileUri[11] == 'A' &&
+                  fileUri[12] == '/'))
             {
                 return fileUri;
             }

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -11,6 +11,10 @@ using System.IO;
 using System.Security;
 using System.Text;
 
+#if CoreCLR
+using System.Runtime.InteropServices;
+#endif
+
 namespace Microsoft.PowerShell.EditorServices
 {
     /// <summary>

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -355,15 +355,14 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
-        private string ResolveFilePath(string filePath)
+        internal string ResolveFilePath(string filePath)
         {
             if (!IsPathInMemory(filePath))
             {
                 if (filePath.StartsWith(@"file://"))
                 {
                     // Client sent the path in URI format, extract the local path
-                    Uri fileUri = new Uri(Uri.UnescapeDataString(filePath));
-                    filePath = fileUri.LocalPath;
+                    filePath = new Uri(filePath).LocalPath;
                 }
 
                 // Clients could specify paths with escaped space, [ and ] characters which .NET APIs

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -70,5 +70,23 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                     $"Testing path {testCase.Path}");
             }
         }
+
+        [Theory()]
+        [InlineData("file:///C:/banana/", @"C:\banana\")]
+        [InlineData("file:///C:/banana/ex.ps1", @"C:\banana\ex.ps1")]
+        [InlineData("file:///E:/Path/to/awful%23path", @"E:\Path\to\awful#path")]
+        [InlineData("file:///path/with/no/drive", @"C:\path\with\no\drive")]
+        [InlineData("file:///path/wi[th]/squ[are/brackets/", @"C:\path\wi[th]\squ[are\brackets\")]
+        [InlineData("file:///Carrots/A%5Ere/Good/", @"C:\Carrots\A^re\Good\")]
+        [InlineData("file:///Users/barnaby/%E8%84%9A%E6%9C%AC/Reduce-Directory", @"C:\Users\barnaby\脚本\Reduce-Directory")]
+        [InlineData("file:///C:/Program%20Files%20(x86)/PowerShell/6/pwsh.exe", @"C:\Program Files (x86)\PowerShell\6\pwsh.exe")]
+        public void CorrectlyResolvesPaths(string givenPath, string expectedPath)
+        {
+            Workspace workspace = new Workspace(PowerShellVersion, Logging.NullLogger);
+
+            string resolvedPath = workspace.ResolveFilePath(givenPath);
+
+            Assert.Equal(expectedPath, resolvedPath);
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -72,14 +72,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
         }
 
         [Theory()]
-        [InlineData("file:///C:/banana/", @"C:\banana\")]
-        [InlineData("file:///C:/banana/ex.ps1", @"C:\banana\ex.ps1")]
-        [InlineData("file:///E:/Path/to/awful%23path", @"E:\Path\to\awful#path")]
+        [InlineData("file:///C%3A/banana/", @"C:\banana\")]
+        [InlineData("file:///C%3A/banana/ex.ps1", @"C:\banana\ex.ps1")]
+        [InlineData("file:///E%3A/Path/to/awful%23path", @"E:\Path\to\awful#path")]
         [InlineData("file:///path/with/no/drive", @"C:\path\with\no\drive")]
         [InlineData("file:///path/wi[th]/squ[are/brackets/", @"C:\path\wi[th]\squ[are\brackets\")]
         [InlineData("file:///Carrots/A%5Ere/Good/", @"C:\Carrots\A^re\Good\")]
         [InlineData("file:///Users/barnaby/%E8%84%9A%E6%9C%AC/Reduce-Directory", @"C:\Users\barnaby\脚本\Reduce-Directory")]
-        [InlineData("file:///C:/Program%20Files%20(x86)/PowerShell/6/pwsh.exe", @"C:\Program Files (x86)\PowerShell\6\pwsh.exe")]
+        [InlineData("file:///C%3A/Program%20Files%20%28x86%29/PowerShell/6/pwsh.exe", @"C:\Program Files (x86)\PowerShell\6\pwsh.exe")]
+        [InlineData("file:///home/maxim/test%20folder/%D0%9F%D0%B0%D0%BF%D0%BA%D0%B0/helloworld.ps1", @"C:\home\maxim\test folder\Папка\helloworld.ps1")]
         public void CorrectlyResolvesPaths(string givenPath, string expectedPath)
         {
             Workspace workspace = new Workspace(PowerShellVersion, Logging.NullLogger);


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1518 in a second way!

We seemed to be double escaping URIs. I've changed the behaviour and added a battery of tests around `Workspace.ResolveFilePath()` (that we should add to).

Now a URI like `file:///C:/foo/bar#x/baz/` will resolve to `C:\foo\bar#x\baz\` and not `C:\foo\bar`.