### PR TITLE
Enforce Get-Help offline dropback when page or internet is down

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/ShowHelpRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/ShowHelpRequest.cs
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 using System;
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 
 namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
 {
@@ -16,6 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
             RequestType<string, object, object, object> Type =
             RequestType<string, object, object, object>.Create("powerShell/showOnlineHelp");
     }
+
     public class ShowHelpRequest
     {
         public static readonly

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -261,8 +261,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 try {
                     $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online
                 } catch [System.Management.Automation.PSInvalidOperationException] {
-                    Microsoft.PowerShell.Core\Get-Help $CommandName -Full
-                }";
+                    return Microsoft.PowerShell.Core\Get-Help $CommandName -Full | Out-String
+                }
+                ";
 
             if (string.IsNullOrEmpty(helpParams)) { helpParams = "Get-Help"; }
 
@@ -270,6 +271,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 .AddScript(CheckHelpScript, useLocalScope: true)
                 .AddArgument(helpParams);
 
+            // TODO: Rather than print the help in the console, we should send the string back
+            //       to VSCode to display in a help pop-up (or similar)
             await editorSession.PowerShellContext.ExecuteCommand<PSObject>(checkHelpPSCommand, sendOutputToHost: true);
             await requestContext.SendResult(null);
         }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -264,8 +264,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     $oldSslVersion = [System.Net.ServicePointManager]::SecurityProtocol
                     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
-                    # HEAD means we don't need the content itself back :)
-                    $status = (Invoke-WebRequest -Method Head -Uri $helpUri -ErrorAction Stop).StatusCode
+                    # HEAD means we don't need the content itself back, just the response header
+                    $status = (Invoke-WebRequest -Method Head -Uri $helpUri -TimeoutSec 5 -ErrorAction Stop).StatusCode
                     if ($status -lt 400) {
                         $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online
                         return

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -265,7 +265,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
                     # HEAD means we don't need the content itself back, just the response header
-                    $status = (Invoke-WebRequest -Method Head -Uri $helpUri -TimeoutSec 5 -ErrorAction Stop).StatusCode
+                    $status = (Microsoft.PowerShell.Utility\Invoke-WebRequest -Method Head -Uri $helpUri -TimeoutSec 5 -ErrorAction Stop).StatusCode
                     if ($status -lt 400) {
                         $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online
                         return

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -260,22 +260,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
                 try {
                     $helpUri = [Microsoft.PowerShell.Commands.GetHelpCodeMethods]::GetHelpUri($command)
-                    try {
-                        $oldSslVersion = [System.Net.ServicePointManager]::SecurityProtocol
-                        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
-                        # HEAD means we don't need the content itself back :)
-                        $status = (Invoke-WebRequest -Method Head -Uri $helpUri -ErrorAction Stop).StatusCode
-                    } finally {
-                        [System.Net.ServicePointManager]::SecurityProtocol = $oldSslVersion
-                    }
-                    if ($status -lt 400)
-                    {
+
+                    $oldSslVersion = [System.Net.ServicePointManager]::SecurityProtocol
+                    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+                    # HEAD means we don't need the content itself back :)
+                    $status = (Invoke-WebRequest -Method Head -Uri $helpUri -ErrorAction Stop).StatusCode
+                    if ($status -lt 400) {
                         $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online
                         return
                     }
                 } catch {
                     # Ignore - we want to drop out to Get-Help -Full
+                } finally {
+                    [System.Net.ServicePointManager]::SecurityProtocol = $oldSslVersion
                 }
+
                 return Microsoft.PowerShell.Core\Get-Help $CommandName -Full
                 ";
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -260,8 +260,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
                 try {
                     $helpUri = [Microsoft.PowerShell.Commands.GetHelpCodeMethods]::GetHelpUri($command)
-                    # HEAD means we don't need the content itself back :)
-                    $status = (Invoke-WebRequest -Method Head -Uri $helpUri -ErrorAction Stop).StatusCode
+                    try {
+                        $oldSslVersion = [System.Net.ServicePointManager]::SecurityProtocol
+                        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+                        # HEAD means we don't need the content itself back :)
+                        $status = (Invoke-WebRequest -Method Head -Uri $helpUri -ErrorAction Stop).StatusCode
+                    } finally {
+                        [System.Net.ServicePointManager]::SecurityProtocol = $oldSslVersion
+                    }
                     if ($status -lt 400)
                     {
                         $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online


### PR DESCRIPTION
I noticed it was hard to get the offline behaviour in @corbob's awesome addition to fire, so I made a minor edit where we test if the help page is accessible first.

@corbob GitHub won't let me add you as a reviewer, but if you've got time to review please do!