### PR TITLE
Fix exception when remoting from Windows to non-Windows

### DIFF
--- a/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
                     {
                         moduleInfo = powerShell.Invoke().FirstOrDefault();
                     }
-                    catch (CmdletInvocationException e)
+                    catch (RuntimeException e)
                     {
                         logger.WriteException("Could not load the DSC module!", e);
                     }


### PR DESCRIPTION
Checking for DSC capability is currently done by attempting to import a drive qualified path to where we would expect the DSC module. This fails during parameter validation due to an invalid drive.

This change broadens the scope of the catch block to account for this exception.