### PR TITLE
Fix crash where edits up to the end of the file do not work

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -636,7 +636,6 @@ namespace Microsoft.PowerShell.EditorServices
                 this.FileLines.Insert(currentLineNumber - 1, finalLine);
                 currentLineNumber++;
             }
-
         }
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -223,6 +223,55 @@ namespace PSLanguageService.Test
             );
         }
 
+        [Fact]
+        public void CanEditUpToEndOfFile()
+        {
+            this.AssertFileChange(
+                "line1\r\nline2\r\nline3\r\nline4",
+                "line1\r\nline2\r\nnewline3\r\nnewline4",
+                new FileChange
+                {
+                    Line = 3,
+                    EndLine = 5,
+                    Offset = 1,
+                    EndOffset = 1,
+                    InsertString = "newline3\r\nnewline4"
+                }
+            );
+        }
+
+        [Fact]
+        public void CanEditOffPartOfLineUpToEndOfFile()
+        {
+            this.AssertFileChange(
+                "line1\r\nline2\r\nline3\r\nline4",
+                "line1\r\nline2\r\nline-new-3\r\nline-new-4\r\nline-new-5",
+                new FileChange
+                {
+                    Line = 3,
+                    EndLine = 5,
+                    Offset = 5,
+                    InsertString = "-new-3\r\nline-new-4\r\nline-new-5"
+                }
+            );
+        }
+
+        [Fact]
+        public void CanEditSingleLineAtEndOfFile()
+        {
+            this.AssertFileChange(
+                "line1\r\nline2\r\nline3",
+                "line1\r\nline2\r\nline-new-3",
+                new FileChange
+                {
+                    Line = 3,
+                    EndLine = 4,
+                    Offset = 5,
+                    InsertString = "-new-3"
+                }
+            );
+        }
+
         internal static ScriptFile CreateScriptFile(string initialString)
         {
             using (StringReader stringReader = new StringReader(initialString))


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1561.

We now handle *edit* messages that go up to the end of the file properly.

Previously we would get a message with a non-empty insertion that went up to 1 past the current line in the VSCode buffer. We handled the empty case as a simple deletion, but we now handle the edit case too.

I split out the function handling this so it uses `return` rather than complicated nesting `if`s -- then the caller handles the `ParseFileContents` method after.