### PR TITLE
Make pipeline runtime exceptions warnings in log

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -584,7 +584,7 @@ namespace Microsoft.PowerShell.EditorServices
                 catch (RuntimeException e)
                 {
                     this.logger.Write(
-                        LogLevel.Error,
+                        LogLevel.Warning,
                         "Runtime exception occurred while executing command:\r\n\r\n" + e.ToString());
 
                     hadErrors = true;


### PR DESCRIPTION
Resolves https://github.com/PowerShell/vscode-powershell/issues/1573.

Marks runtime executions from `PowerShellContext.Invoke()` as `WARNING`s not `ERROR`s, since they don't crash the extension and often cause distraction in the log.