### PR TITLE
Set Runspaces to use STA when running in Windows PowerShell

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -193,6 +193,7 @@ namespace Microsoft.PowerShell.EditorServices
             Runspace runspace = RunspaceFactory.CreateRunspace(psHost, initialSessionState);
 
             // Windows PowerShell must be hosted in STA mode
+            // This must be set on the runspace *before* it is opened
             if (RuntimeInformation.FrameworkDescription.Equals(DotNetFrameworkDescription))
             {
                 s_runspaceApartmentStateSetter(runspace, ApartmentState.STA);

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Linq;
 using System.Management.Automation.Host;
 using System.Management.Automation.Remoting;
@@ -24,7 +25,6 @@ using Microsoft.PowerShell.EditorServices.Utility;
 namespace Microsoft.PowerShell.EditorServices
 {
     using System.Management.Automation;
-    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Manages the lifetime and usage of a PowerShell session.
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (RuntimeInformation.FrameworkDescription == DotNetFrameworkDescription)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
-                var setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), target: null, method: setterInfo);
+                var setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
                 s_runspaceApartmentStateSetter = (Action<Runspace, ApartmentState>)setter;
             }
         }

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (RuntimeInformation.FrameworkDescription == DotNetFrameworkDescription)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
-                var setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
+                Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
                 s_runspaceApartmentStateSetter = (Action<Runspace, ApartmentState>)setter;
             }
         }

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices
         static PowerShellContext()
         {
             // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection
-            if (RuntimeInformation.FrameworkDescription == DotNetFrameworkDescription)
+            if (RuntimeInformation.FrameworkDescription.Equals(DotNetFrameworkDescription))
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
@@ -193,7 +193,7 @@ namespace Microsoft.PowerShell.EditorServices
             Runspace runspace = RunspaceFactory.CreateRunspace(psHost, initialSessionState);
 
             // Windows PowerShell must be hosted in STA mode
-            if (RuntimeInformation.FrameworkDescription == DotNetFrameworkDescription)
+            if (RuntimeInformation.FrameworkDescription.Equals(DotNetFrameworkDescription))
             {
                 s_runspaceApartmentStateSetter(runspace, ApartmentState.STA);
             }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1571.

I carelessly took out the `runspace.ApartmentState = ApartmentState.STA` line of PSES v1.x without thinking and forgot to reinstate it.

This PR puts it back in.