### PR TITLE
Log build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ docs/_repo/
 docs/metadata/
 *.zip
 
+# Generated build info file
+src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
+
 # quickbuild.exe
 /VersionGeneratingLogs/
 QLogs

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -153,7 +153,7 @@ task CreateBuildInfo -Before Build {
         $buildVersion = $env:APPVEYOR_BUILD_VERSION
         $buildOrigin = if ($env:CI) { "AppVeyor CI" } else { "AppVeyor" }
     }
-    elseif ($env:VSTS_BUILD)
+    elseif ($env:TF_BUILD)
     {
         $psd1Path = [System.IO.Path]::Combine($PSScriptRoot, "module", "PowerShellEditorServices", "PowerShellEditorServices.psd1")
         $buildVersion = (Import-PowerShellDataFile -LiteralPath $psd1Path).Version
@@ -254,6 +254,7 @@ task LayoutModule -After Build {
     New-Item -Force $PSScriptRoot\module\PowerShellEditorServices\bin\Core -Type Directory | Out-Null
 
     Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\netstandard1.6\publish\Serilog*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
+    Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\netstandard1.6\publish\System.Runtime.InteropServices.RuntimeInformation.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
 
     Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6\* -Filter Microsoft.PowerShell.EditorServices*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
     Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\netstandard1.6\UnixConsoleEcho.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Core\
@@ -262,11 +263,11 @@ task LayoutModule -After Build {
 
     if (!$script:IsUnix) {
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\net451\Serilog*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop
+        Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices\bin\$Configuration\net451\System.Runtime.InteropServices.RuntimeInformation.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
 
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\* -Filter Microsoft.PowerShell.EditorServices*.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\Newtonsoft.Json.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
         Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\UnixConsoleEcho.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
-        Copy-Item -Force -Path $PSScriptRoot\src\PowerShellEditorServices.Host\bin\$Configuration\net451\publish\System.Runtime.InteropServices.RuntimeInformation.dll -Destination $PSScriptRoot\module\PowerShellEditorServices\bin\Desktop\
     }
 
     # Copy Third Party Notices.txt to module folder

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -20,6 +20,7 @@ $script:IsCIBuild = $env:APPVEYOR -ne $null
 $script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
 $script:TargetFrameworksParam = "/p:TargetFrameworks=\`"$(if (!$script:IsUnix) { "net451;" })netstandard1.6\`""
 $script:SaveModuleSupportsAllowPrerelease = (Get-Command Save-Module).Parameters.ContainsKey("AllowPrerelease")
+$script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Host", "BuildInfo", "BuildInfo.cs")
 
 if ($PSVersionTable.PSEdition -ne "Core") {
     Add-Type -Assembly System.IO.Compression.FileSystem
@@ -140,6 +141,51 @@ task TestPowerShellApi -If { !$script:IsUnix } {
 
     # Do a final restore to put everything back to normal
     exec { & $script:dotnetExe restore .\src\PowerShellEditorServices\PowerShellEditorServices.csproj }
+}
+
+task CreateBuildInfo -Before Build {
+    $buildVersion = "<development-build>"
+    $buildOrigin = "<development>"
+
+    # Set build info fields on build platforms
+    if ($env:APPVEYOR)
+    {
+        $buildVersion = $env:APPVEYOR_BUILD_VERSION
+        $buildOrigin = if ($env:CI) { "AppVeyor CI" } else { "AppVeyor" }
+    }
+    elseif ($env:VSTS_BUILD)
+    {
+        $psd1Path = [System.IO.Path]::Combine($PSScriptRoot, "module", "PowerShellEditorServices", "PowerShellEditorServices.psd1")
+        $buildVersion = (Import-PowerShellDataFile -LiteralPath $psd1Path).Version
+        $buildOrigin = "VSTS"
+    }
+
+    # Allow override of build info fields (except date)
+    if ($env:PSES_BUILD_VERSION)
+    {
+        $buildVersion = $env:PSES_BUILD_VERSION
+    }
+
+    if ($env:PSES_BUILD_ORIGIN)
+    {
+        $buildOrigin = $env:PSES_BUILD_ORIGIN
+    }
+
+    [string]$buildTime = [datetime]::Now.ToString("s", [System.Globalization.CultureInfo]::InvariantCulture)
+
+    $buildInfoContents = @"
+namespace Microsoft.PowerShell.EditorServices.Host
+{
+    public static class BuildInfo
+    {
+        public const string BuildVersion = "$buildVersion";
+        public const string BuildOrigin = "$buildOrigin";
+        public static readonly System.DateTime? BuildTime = System.DateTime.Parse("$buildTime");
+    }
+}
+"@
+
+    Set-Content -LiteralPath $script:BuildInfoPath -Value $buildInfoContents -Force
 }
 
 task Build {

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -243,6 +243,9 @@ function Set-NamedPipeMode {
     }
 }
 
+LogSection "Console Encoding"
+Log $OutputEncoding
+
 # Add BundledModulesPath to $env:PSModulePath
 if ($BundledModulesPath) {
     $env:PSModulePath = $env:PSModulePath.TrimEnd([System.IO.Path]::PathSeparator) + [System.IO.Path]::PathSeparator + $BundledModulesPath

--- a/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
+++ b/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
@@ -4,6 +4,6 @@ namespace Microsoft.PowerShell.EditorServices.Host
     {
         public const string BuildVersion = "<unset>";
         public const string BuildOrigin = "<unset>";
-        public static readonly DateTime? BuildTime = null;
+        public static readonly System.DateTime? BuildTime = null;
     }
 }

--- a/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
+++ b/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
@@ -1,0 +1,9 @@
+namespace Microsoft.PowerShell.EditorServices.Host
+{
+    public static class BuildInfo
+    {
+        public const string BuildVersion = "<unset>";
+        public const string BuildOrigin = "<unset>";
+        public static readonly DateTime? BuildTime = null;
+    }
+}

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerShell.EditorServices.Host
 {
@@ -140,39 +141,42 @@ namespace Microsoft.PowerShell.EditorServices.Host
                             .Build();
 
 #if CoreCLR
-            FileVersionInfo fileVersionInfo =
-                FileVersionInfo.GetVersionInfo(this.GetType().GetTypeInfo().Assembly.Location);
-
-            // TODO #278: Need the correct dependency package for this to work correctly
-            //string osVersionString = RuntimeInformation.OSDescription;
-            //string processArchitecture = RuntimeInformation.ProcessArchitecture == Architecture.X64 ? "64-bit" : "32-bit";
-            //string osArchitecture = RuntimeInformation.OSArchitecture == Architecture.X64 ? "64-bit" : "32-bit";
+            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(this.GetType().GetTypeInfo().Assembly.Location);
 #else
-            FileVersionInfo fileVersionInfo =
-                FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
-            string osVersionString = Environment.OSVersion.VersionString;
-            string processArchitecture = Environment.Is64BitProcess ? "64-bit" : "32-bit";
-            string osArchitecture = Environment.Is64BitOperatingSystem ? "64-bit" : "32-bit";
+            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
 #endif
 
-            string newLine = Environment.NewLine;
-
-            this.logger.Write(
-                LogLevel.Normal,
-                string.Format(
-                    $"PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (pid {Process.GetCurrentProcess().Id})..." + newLine + newLine +
-                     "  Host application details:" + newLine + newLine +
-                    $"    Name:      {this.hostDetails.Name}" + newLine +
-                    $"    ProfileId: {this.hostDetails.ProfileId}" + newLine +
-                    $"    Version:   {this.hostDetails.Version}" + newLine +
-#if !CoreCLR
-                    $"    Arch:      {processArchitecture}" + newLine + newLine +
-                     "  Operating system details:" + newLine + newLine +
-                    $"    Version: {osVersionString}" + newLine +
-                    $"    Arch:    {osArchitecture}"));
+#if CoreCLR
+            string osVersion = RuntimeInformation.OSDescription;
 #else
-                    ""));
+            string osVersion = Environment.OSVersion.VersionString;
 #endif
+
+            string buildTime = BuildInfo.BuildTime?.ToString("s", System.Globalization.CultureInfo.InvariantCulture) ?? "<unspecified>";
+
+            string logHeader = $@"
+PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (PID {Process.GetCurrentProcess().Id}
+
+  Host application details:
+
+    Name:      {this.hostDetails.Name}
+    Version:   {this.hostDetails.Version}
+    ProfileId: {this.hostDetails.ProfileId}
+    Arch:      {RuntimeInformation.OSArchitecture}
+
+  Operating system details:
+
+    Version: {osVersion}
+    Arch:    {RuntimeInformation.OSArchitecture}
+
+  Build information:
+
+    Version: {BuildInfo.BuildVersion}
+    Origin:  {BuildInfo.BuildOrigin}
+    Date:    {buildTime}
+";
+
+            this.logger.Write(LogLevel.Normal, logHeader);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -146,11 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(this.GetType().Assembly.Location);
 #endif
 
-#if CoreCLR
             string osVersion = RuntimeInformation.OSDescription;
-#else
-            string osVersion = Environment.OSVersion.VersionString;
-#endif
 
             string buildTime = BuildInfo.BuildTime?.ToString("s", System.Globalization.CultureInfo.InvariantCulture) ?? "<unspecified>";
 

--- a/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
+++ b/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
+++ b/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
@@ -20,8 +20,6 @@
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>
     </PackageReference>
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerShell.EditorServices.Console
         #region Constructors
         static ConsoleReadLine()
         {
-            // Maybe we should just include the RuntimeInformation package for FullCLR?
-            #if CoreCLR
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 s_consoleProxy = new WindowsConsoleOperations();
@@ -38,9 +36,6 @@ namespace Microsoft.PowerShell.EditorServices.Console
             }
 
             s_consoleProxy = new UnixConsoleOperations();
-            #else
-            s_consoleProxy = new WindowsConsoleOperations();
-            #endif
         }
 
         public ConsoleReadLine(PowerShellContext powerShellContext)

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -325,14 +325,10 @@ namespace Microsoft.PowerShell.EditorServices
 
             // We want to look for references first in referenced files, hence we use ordered dictionary
             // TODO: File system case-sensitivity is based on filesystem not OS, but OS is a much cheaper heuristic
-#if CoreCLR
-            // The RuntimeInformation.IsOSPlatform is not supported in .NET Framework
             var fileMap = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
                 ? new OrderedDictionary()
                 : new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
-#else
-            var fileMap = new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
-#endif
+
             foreach (ScriptFile file in referencedFiles)
             {
                 fileMap.Add(file.FilePath, file);

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -65,6 +65,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.2.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -10,10 +10,7 @@ using System.Linq;
 using System.IO;
 using System.Security;
 using System.Text;
-
-#if CoreCLR
 using System.Runtime.InteropServices;
-#endif
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -498,12 +495,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>A file-scheme URI string with the drive colon unescaped.</returns>
         private static string UnescapeDriveColon(string fileUri)
         {
-#if CoreCLR
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return fileUri;
             }
-#endif
+
             // Check here that we have something like "file:///C%3A/" as a prefix (caller must check the file:// part)
             if (!(fileUri[7] == '/' &&
                   char.IsLetter(fileUri[8]) &&


### PR DESCRIPTION
Partially helps https://github.com/PowerShell/vscode-powershell/issues/1393.

This logs the information about where the extension was build in the log file at startup.

I also cleaned up the startup logging a little bit.