### PR TITLE
New-EditorFile works on non-powershell untitled files

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -40,6 +40,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
     {
         public string CurrentFileContent { get; set; }
 
+        public string CurrentFileLanguage { get; set; }
+
         public string CurrentFilePath { get; set; }
 
         public Position CursorPosition { get; set; }

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/EditorCommands.cs
@@ -38,6 +38,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
 
     public class ClientEditorContext
     {
+        public string CurrentFileContent { get; set; }
+
         public string CurrentFilePath { get; set; }
 
         public Position CursorPosition { get; set; }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -499,14 +499,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             if (!ScriptFile.IsUntitledPath(setBreakpointsParams.Source.Path) &&
                 !_editorSession.Workspace.TryGetFile(
                     setBreakpointsParams.Source.Path,
-                    out scriptFile,
-                    out Exception exception))
+                    out scriptFile))
             {
-                Logger.WriteException(
-                    $"Failed to set breakpoint on file: {setBreakpointsParams.Source.Path}",
-                    exception);
-
-                string message = _noDebug ? string.Empty : "Source file could not be accessed, breakpoint not set - " + exception.Message;
+                string message = _noDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
                 var srcBreakpoints = setBreakpointsParams.Breakpoints
                     .Select(srcBkpt => Protocol.DebugAdapter.Breakpoint.Create(
                         srcBkpt, setBreakpointsParams.Source.Path, message, verified: _noDebug));

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -494,31 +494,19 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             ScriptFile scriptFile = null;
 
-            // Fix for issue #195 - user can change name of file outside of VSCode in which case
-            // VSCode sends breakpoint requests with the original filename that doesn't exist anymore.
-            try
-            {
-                // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
-                // the Source.Path comes through as Untitled-X.
-                if (!ScriptFile.IsUntitledPath(setBreakpointsParams.Source.Path))
-                {
-                    scriptFile = _editorSession.Workspace.GetFile(setBreakpointsParams.Source.Path);
-                }
-            }
-            catch (Exception e) when (
-                e is FileNotFoundException ||
-                e is DirectoryNotFoundException ||
-                e is IOException ||
-                e is NotSupportedException ||
-                e is PathTooLongException ||
-                e is SecurityException ||
-                e is UnauthorizedAccessException)
+            // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
+            // the Source.Path comes through as Untitled-X. That's why we check for IsUntitledPath.
+            if (!ScriptFile.IsUntitledPath(setBreakpointsParams.Source.Path) &&
+                !_editorSession.Workspace.TryGetFile(
+                    setBreakpointsParams.Source.Path,
+                    out scriptFile,
+                    out Exception exception))
             {
                 Logger.WriteException(
                     $"Failed to set breakpoint on file: {setBreakpointsParams.Source.Path}",
-                    e);
+                    exception);
 
-                string message = _noDebug ? string.Empty : "Source file could not be accessed, breakpoint not set - " + e.Message;
+                string message = _noDebug ? string.Empty : "Source file could not be accessed, breakpoint not set - " + exception.Message;
                 var srcBreakpoints = setBreakpointsParams.Breakpoints
                     .Select(srcBkpt => Protocol.DebugAdapter.Breakpoint.Create(
                         srcBkpt, setBreakpointsParams.Source.Path, message, verified: _noDebug));

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using Microsoft.PowerShell.EditorServices;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Protocol.LanguageServer;
 using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
@@ -89,10 +90,17 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public EditorContext ConvertClientEditorContext(
             ClientEditorContext clientContext)
         {
+
+            ScriptFile scriptFile = null;
+            if (!this.editorSession.Workspace.TryGetFile(clientContext.CurrentFilePath, out scriptFile))
+            {
+                scriptFile = this.editorSession.Workspace.GetFileBuffer(clientContext.CurrentFilePath, clientContext.CurrentFileContent);
+            }
+
             return
                 new EditorContext(
                     this,
-                    this.editorSession.Workspace.GetFile(clientContext.CurrentFilePath),
+                    scriptFile,
                     new BufferPosition(
                         clientContext.CursorPosition.Line + 1,
                         clientContext.CursorPosition.Character + 1),

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -94,7 +94,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             ScriptFile scriptFile = null;
             if (!this.editorSession.Workspace.TryGetFile(clientContext.CurrentFilePath, out scriptFile))
             {
-                scriptFile = this.editorSession.Workspace.GetFileBuffer(clientContext.CurrentFilePath, clientContext.CurrentFileContent);
+                scriptFile = this.editorSession.Workspace.GetFileBuffer(
+                    clientContext.CurrentFilePath,
+                    clientContext.CurrentFileContent);
             }
 
             return

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -90,14 +90,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public EditorContext ConvertClientEditorContext(
             ClientEditorContext clientContext)
         {
-
-            ScriptFile scriptFile = null;
-            if (!this.editorSession.Workspace.TryGetFile(clientContext.CurrentFilePath, out scriptFile))
-            {
-                scriptFile = this.editorSession.Workspace.GetFileBuffer(
-                    clientContext.CurrentFilePath,
-                    clientContext.CurrentFileContent);
-            }
+            ScriptFile scriptFile = this.editorSession.Workspace.CreateScriptFileFromFileBuffer(
+                clientContext.CurrentFilePath,
+                clientContext.CurrentFileContent);
 
             return
                 new EditorContext(
@@ -110,7 +105,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         clientContext.SelectionRange.Start.Line + 1,
                         clientContext.SelectionRange.Start.Character + 1,
                         clientContext.SelectionRange.End.Line + 1,
-                        clientContext.SelectionRange.End.Character + 1));
+                        clientContext.SelectionRange.End.Character + 1),
+                    clientContext.CurrentFileLanguage);
         }
 
         public Task NewFile()

--- a/src/PowerShellEditorServices/Extensions/EditorContext.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorContext.cs
@@ -52,10 +52,11 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             IEditorOperations editorOperations,
             ScriptFile currentFile,
             BufferPosition cursorPosition,
-            BufferRange selectedRange)
+            BufferRange selectedRange,
+            string language = "Unknown")
         {
             this.editorOperations = editorOperations;
-            this.CurrentFile = new FileContext(currentFile, this, editorOperations);
+            this.CurrentFile = new FileContext(currentFile, this, editorOperations, language);
             this.SelectedRange = selectedRange;
             this.CursorPosition = new FilePosition(currentFile, cursorPosition);
         }

--- a/src/PowerShellEditorServices/Extensions/EditorContext.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorContext.cs
@@ -48,6 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="currentFile">The ScriptFile that is in the active editor buffer.</param>
         /// <param name="cursorPosition">The position of the user's cursor in the active editor buffer.</param>
         /// <param name="selectedRange">The range of the user's selection in the active editor buffer.</param>
+        /// <param name="language">Determines the language of the file.false If it is not specified, then it defaults to "Unknown"</param>
         public EditorContext(
             IEditorOperations editorOperations,
             ScriptFile currentFile,

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -26,11 +26,41 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         #region Properties
 
         /// <summary>
+        /// Gets the parsed abstract syntax tree for the file.
+        /// </summary>
+        public Ast Ast
+        {
+            get { return this.scriptFile.ScriptAst; }
+        }
+
+        /// <summary>
+        /// Gets a BufferRange which represents the entire content
+        /// range of the file.
+        /// </summary>
+        public BufferRange FileRange
+        {
+            get { return this.scriptFile.FileRange; }
+        }
+
+        /// <summary>
+        /// Gets the language of the file.
+        /// </summary>
+        public string Language { get; private set; }
+
+        /// <summary>
         /// Gets the filesystem path of the file.
         /// </summary>
         public string Path
         {
             get { return this.scriptFile.FilePath; }
+        }
+
+        /// <summary>
+        /// Gets the parsed token list for the file.
+        /// </summary>
+        public Token[] Tokens
+        {
+            get { return this.scriptFile.ScriptTokens; }
         }
 
         /// <summary>
@@ -46,31 +76,6 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             }
         }
 
-        /// <summary>
-        /// Gets the parsed abstract syntax tree for the file.
-        /// </summary>
-        public Ast Ast
-        {
-            get { return this.scriptFile.ScriptAst; }
-        }
-
-        /// <summary>
-        /// Gets the parsed token list for the file.
-        /// </summary>
-        public Token[] Tokens
-        {
-            get { return this.scriptFile.ScriptTokens; }
-        }
-
-        /// <summary>
-        /// Gets a BufferRange which represents the entire content
-        /// range of the file.
-        /// </summary>
-        public BufferRange FileRange
-        {
-            get { return this.scriptFile.FileRange; }
-        }
-
         #endregion
 
         #region Constructors
@@ -84,11 +89,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         public FileContext(
             ScriptFile scriptFile,
             EditorContext editorContext,
-            IEditorOperations editorOperations)
+            IEditorOperations editorOperations,
+            string language = "Unknown")
         {
+            if (string.IsNullOrWhiteSpace(language))
+            {
+                language = "Unknown";
+            }
+
             this.scriptFile = scriptFile;
             this.editorContext = editorContext;
             this.editorOperations = editorOperations;
+            this.Language = language;
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -86,6 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="scriptFile">The ScriptFile to which this file refers.</param>
         /// <param name="editorContext">The EditorContext to which this file relates.</param>
         /// <param name="editorOperations">An IEditorOperations implementation which performs operations in the editor.</param>
+        /// <param name="language">Determines the language of the file.false If it is not specified, then it defaults to "Unknown"</param>
         public FileContext(
             ScriptFile scriptFile,
             EditorContext editorContext,

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -342,17 +342,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 if (!fileMap.Contains(file))
                 {
-                    ScriptFile scriptFile;
-                    try
-                    {
-                        scriptFile = workspace.GetFile(file);
-                    }
-                    catch (Exception e) when (e is IOException
-                                           || e is SecurityException
-                                           || e is FileNotFoundException
-                                           || e is DirectoryNotFoundException
-                                           || e is PathTooLongException
-                                           || e is UnauthorizedAccessException)
+                    if (!workspace.TryGetFile(file, out ScriptFile scriptFile))
                     {
                         // If we can't access the file for some reason, just ignore it
                         continue;

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -58,6 +58,35 @@ namespace Microsoft.PowerShell.EditorServices
         #region Public Methods
 
         /// <summary>
+        /// Creates a new ScriptFile instance which is identified by the given file
+        /// path and initially contains the given buffer contents.
+        /// </summary>
+        /// <param name="filePath">The file path for which a buffer will be retrieved.</param>
+        /// <param name="initialBuffer">The initial buffer contents if there is not an existing ScriptFile for this path.</param>
+        /// <returns>A ScriptFile instance for the specified path.</returns>
+        public ScriptFile CreateScriptFileFromFileBuffer(string filePath, string initialBuffer)
+        {
+            Validate.IsNotNullOrEmptyString("filePath", filePath);
+
+            // Resolve the full file path
+            string resolvedFilePath = this.ResolveFilePath(filePath);
+            string keyName = resolvedFilePath.ToLower();
+
+            ScriptFile scriptFile =
+                new ScriptFile(
+                    resolvedFilePath,
+                    filePath,
+                    initialBuffer,
+                    this.powerShellVersion);
+
+            this.workspaceFiles[keyName] = scriptFile;
+
+            this.logger.Write(LogLevel.Verbose, "Opened file as in-memory buffer: " + resolvedFilePath);
+
+            return scriptFile;
+        }
+
+        /// <summary>
         /// Gets an open file in the workspace.  If the file isn't open but
         /// exists on the filesystem, load and return it.
         /// </summary>

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -108,21 +108,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
         public bool TryGetFile(string filePath, out ScriptFile scriptFile)
         {
-            return TryGetFile(filePath, out scriptFile, out Exception e);
-        }
-
-        /// <summary>
-        /// Tries to get an open file in the workspace. Returns true or false if it succeeds.
-        /// </summary>
-        /// <param name="filePath">The file path at which the script resides.</param>
-        /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
-        /// <param name="exception">The out parameter that will contain the underlying exception.</param>
-        public bool TryGetFile(string filePath, out ScriptFile scriptFile, out Exception exception)
-        {
             try
             {
                 scriptFile = GetFile(filePath);
-                exception = null;
                 return true;
             }
             catch (Exception e) when (
@@ -133,8 +121,10 @@ namespace Microsoft.PowerShell.EditorServices
                 e is PathTooLongException ||
                 e is UnauthorizedAccessException)
             {
+                this.logger.WriteException(
+                    $"Failed to set breakpoint on file: {filePath}",
+                    e);
                 scriptFile = null;
-                exception = e;
                 return false;
             }
         }

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -102,6 +102,25 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
+        /// Tries to get an open file in the workspace. Returns true or false if it succeeds.
+        /// </summary>
+        /// <param name="filePath">The file path at which the script resides.</param>
+        /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
+        public bool TryGetFile(string filePath, out ScriptFile scriptFile)
+        {
+            try
+            {
+                scriptFile = GetFile(filePath);
+                return true;
+            }
+            catch (FileNotFoundException)
+            {
+                scriptFile = null;
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Gets a new ScriptFile instance which is identified by the given file path.
         /// </summary>
         /// <param name="filePath">The file path for which a buffer will be retrieved.</param>

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
-        /// Tries to get an open file in the workspace. Returns true or false if it succeeds.
+        /// Tries to get an open file in the workspace. Returns true if it succeeds, false otherwise.
         /// </summary>
         /// <param name="filePath">The file path at which the script resides.</param>
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -108,14 +108,33 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
         public bool TryGetFile(string filePath, out ScriptFile scriptFile)
         {
+            return TryGetFile(filePath, out scriptFile, out Exception e);
+        }
+
+        /// <summary>
+        /// Tries to get an open file in the workspace. Returns true or false if it succeeds.
+        /// </summary>
+        /// <param name="filePath">The file path at which the script resides.</param>
+        /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
+        /// <param name="exception">The out parameter that will contain the underlying exception.</param>
+        public bool TryGetFile(string filePath, out ScriptFile scriptFile, out Exception exception)
+        {
             try
             {
                 scriptFile = GetFile(filePath);
+                exception = null;
                 return true;
             }
-            catch (FileNotFoundException)
+            catch (Exception e) when (
+                e is IOException ||
+                e is SecurityException ||
+                e is FileNotFoundException ||
+                e is DirectoryNotFoundException ||
+                e is PathTooLongException ||
+                e is UnauthorizedAccessException)
             {
                 scriptFile = null;
+                exception = e;
                 return false;
             }
         }


### PR DESCRIPTION
Partnered with: [vscode-powershell issue]

This fixes the problem where `$psEditor.GetEditorContext()` assumed that the file open was a real file on the file system OR a powershell untitled file. Since that isn't always the case, It would throw an exception:

```
Exception calling "GetEditorContext" with "0" argument(s): "One or more errors occurred. (Could not find file '/Users/tyler/Code/PowerShell/vscode/PowerShellEditorServices/untitled:Untitled-1'.)"
At /Users/tyler/.vscode-insiders/extensions/ms-vscode.powershell-1.9.0/modules/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1:152 char:13
+             $psEditor.GetEditorContext().CurrentFile.InsertText(($val ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
+ FullyQualifiedErrorId : AggregateException
```

This also means that `New-EditorFile -Value 'asdf'` actually works when you don't have your default language mode set to PowerShell.

Now we try to get the file and if that throws a FileNotFound, we grab the ScriptFile from the FileBuffer

fixes #434 