### PR TITLE
Removed ShowOnlineHelp Message

### DIFF
--- a/src/PowerShellEditorServices.Protocol/LanguageServer/ShowHelpRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/ShowHelpRequest.cs
@@ -9,14 +9,6 @@ using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
 namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
 {
 
-    [Obsolete("This class is deprecated. Use ShowHelpRequest instead.")]
-    public class ShowOnlineHelpRequest
-    {
-        public static readonly
-            RequestType<string, object, object, object> Type =
-            RequestType<string, object, object, object>.Create("powerShell/showOnlineHelp");
-    }
-
     public class ShowHelpRequest
     {
         public static readonly

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -132,7 +132,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 DocumentRangeFormattingRequest.Type,
                 this.HandleDocumentRangeFormattingRequest);
 
-            this.messageHandlers.SetRequestHandler(ShowOnlineHelpRequest.Type, this.HandleShowOnlineHelpRequest);
             this.messageHandlers.SetRequestHandler(ShowHelpRequest.Type, this.HandleShowHelpRequest);
 
             this.messageHandlers.SetRequestHandler(ExpandAliasRequest.Type, this.HandleExpandAliasRequest);
@@ -289,19 +288,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             //       to VSCode to display in a help pop-up (or similar)
             await editorSession.PowerShellContext.ExecuteCommand<PSObject>(checkHelpPSCommand, sendOutputToHost: true);
             await requestContext.SendResult(null);
-        }
-
-        protected async Task HandleShowOnlineHelpRequest(
-            string helpParams,
-            RequestContext<object> requestContext
-        )
-        {
-            PSCommand commandDeprecated = new PSCommand()
-                .AddCommand("Microsoft.PowerShell.Utility\\Write-Verbose")
-                .AddParameter("Message", "'powerShell/showOnlineHelp' has been deprecated. Use 'powerShell/showHelp' instead.");
-
-            await editorSession.PowerShellContext.ExecuteCommand<PSObject>(commandDeprecated, sendOutputToHost: true);
-            await this.HandleShowHelpRequest(helpParams, requestContext);
         }
 
         private async Task HandleSetPSSARulesRequest(


### PR DESCRIPTION
The ShowOnlineHelp message was deprecated in v1.9.0. This is to fully remove the message.

Opened PR against 2.0.0 branch because it shouldn't be removed until 2.0.0 at the earliest.