### PR TITLE
Fix #779: NRE on Dispose in ExecutionTimer

### DIFF
--- a/src/PowerShellEditorServices/Utility/ObjectPool.cs
+++ b/src/PowerShellEditorServices/Utility/ObjectPool.cs
@@ -7,13 +7,23 @@ using System.Collections.Concurrent;
 
 namespace Microsoft.PowerShell.EditorServices.Utility
 {
-    public class ObjectPool<T>
+    /// <summary>
+    /// A basic implementation of the object pool pattern.
+    /// </summary>
+    internal class ObjectPool<T>
         where T : new()
     {
         private ConcurrentBag<T> _pool = new ConcurrentBag<T>();
 
+        /// <summary>
+        /// Get an instance of an object, either new or from the pool depending on availability.
+        /// </summary>
         public T Rent() => _pool.TryTake(out var obj) ? obj : new T();
 
+        /// <summary>
+        /// Return an object to the pool.
+        /// </summary>
+        /// <param name="obj">The object to return to the pool.</param>
         public void Return(T obj) => _pool.Add(obj);
     }
 }

--- a/src/PowerShellEditorServices/Utility/ObjectPool.cs
+++ b/src/PowerShellEditorServices/Utility/ObjectPool.cs
@@ -1,0 +1,19 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Concurrent;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    public class ObjectPool<T>
+        where T : new()
+    {
+        private ConcurrentBag<T> _pool = new ConcurrentBag<T>();
+
+        public T Rent() => _pool.TryTake(out var obj) ? obj : new T();
+
+        public void Return(T obj) => _pool.Add(obj);
+    }
+}

--- a/test/PowerShellEditorServices.Test/Utility/ExecutionTimerTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/ExecutionTimerTests.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Utility
+{
+    public class ExecutionTimerTests
+    {
+        [Fact]
+        public async void DoesNotThrowExceptionWhenDisposedOnAnotherThread()
+        {
+            var timer = ExecutionTimer.Start(Logging.CreateLogger().Build(), "Message");
+            await Task.Run(() => timer.Dispose());
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test/Utility/ObjectPoolTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/ObjectPoolTests.cs
@@ -1,0 +1,23 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Utility
+{
+    public class ObjectPoolTests
+    {
+        [Fact]
+        public void DoesNotCreateNewObjects()
+        {
+            var pool = new ObjectPool<object>();
+            var obj = pool.Rent();
+            pool.Return(obj);
+
+            Assert.Same(obj, pool.Rent());
+        }
+    }
+}


### PR DESCRIPTION
Fix #779: NRE on Dispose in ExecutionTimer

As discussed, `ThreadStatic` implementation replaced by an object pool. My object pool is very basic as I didn't feel like the current usage warranted anything more complex. Let me know if you think I should do anything different!