### PR TITLE
Adds ability to use separate pipes for reading and writing

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -113,7 +113,7 @@ function Start-EditorServicesHost {
     if ($LanguageServiceNamedPipe) {
         $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
         if ($LanguageServiceWriteNamedPipe) {
-            $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe;$LanguageServiceWriteNamedPipe"
+            $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe$([System.IO.Path]::DirectorySeparatorChar)$LanguageServiceWriteNamedPipe"
         }
         else
         {
@@ -124,7 +124,7 @@ function Start-EditorServicesHost {
     if ($DebugServiceNamedPipe) {
         $debugServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
         if ($DebugServiceWriteNamedPipe) {
-            $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe;$DebugServiceWriteNamedPipe"
+            $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe$([System.IO.Path]::DirectorySeparatorChar)$DebugServiceWriteNamedPipe"
         }
         else
         {

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -128,19 +128,20 @@ function Start-EditorServicesHost {
         }
         "NamedPipe" {
             $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-            $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe"
+            $languageServiceConfig.InOutPipeName = "$LanguageServiceNamedPipe"
             if ($DebugServiceNamedPipe) {
                 $debugServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-                $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe"
+                $debugServiceConfig.InOutPipeName = "$DebugServiceNamedPipe"
             }
         }
         "NamedPipeHalfDuplex" {
-            $sep = [System.IO.Path]::DirectorySeparatorChar
             $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-            $languageServiceConfig.Endpoint = "$LanguageServiceInNamedPipe$sep$LanguageServiceOutNamedPipe"
+            $languageServiceConfig.InPipeName = $LanguageServiceInNamedPipe
+            $languageServiceConfig.OutPipeName = $LanguageServiceOutNamedPipe
             if ($DebugServiceInNamedPipe -and $DebugServiceOutNamedPipe) {
                 $debugServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-                $debugServiceConfig.Endpoint = "$DebugServiceInNamedPipe$sep$DebugServiceOutNamedPipe"
+                $debugServiceConfig.InPipeName = $DebugServiceInNamedPipe
+                $debugServiceConfig.OutPipeName = $DebugServiceOutNamedPipe
             }
         }
     }

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -38,7 +38,13 @@ function Start-EditorServicesHost {
         $LanguageServiceNamedPipe,
 
         [string]
+        $LanguageServiceWriteNamedPipe,
+
+        [string]
         $DebugServiceNamedPipe,
+
+        [string]
+        $DebugServiceWriteNamedPipe,
 
         [ValidateNotNullOrEmpty()]
         [string]
@@ -106,12 +112,24 @@ function Start-EditorServicesHost {
 
     if ($LanguageServiceNamedPipe) {
         $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-        $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe"
+        if ($LanguageServiceWriteNamedPipe) {
+            $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe;$LanguageServiceWriteNamedPipe"
+        }
+        else
+        {
+            $languageServiceConfig.Endpoint = "$LanguageServiceNamedPipe"
+        }
     }
 
     if ($DebugServiceNamedPipe) {
         $debugServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
-        $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe"
+        if ($DebugServiceWriteNamedPipe) {
+            $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe;$DebugServiceWriteNamedPipe"
+        }
+        else
+        {
+            $debugServiceConfig.Endpoint = "$DebugServiceNamedPipe"
+        }
     }
 
     if ($DebugServiceOnly.IsPresent) {

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -44,21 +44,21 @@ function Start-EditorServicesHost {
         [string]
         $DebugServiceNamedPipe,
 
-        [Parameter(ParameterSetName="NamedPipeHalfDuplex",Mandatory=$true)]
+        [Parameter(ParameterSetName="NamedPipeSimplex",Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $LanguageServiceInNamedPipe,
 
-        [Parameter(ParameterSetName="NamedPipeHalfDuplex",Mandatory=$true)]
+        [Parameter(ParameterSetName="NamedPipeSimplex",Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $LanguageServiceOutNamedPipe,
 
-        [Parameter(ParameterSetName="NamedPipeHalfDuplex")]
+        [Parameter(ParameterSetName="NamedPipeSimplex")]
         [string]
         $DebugServiceInNamedPipe,
 
-        [Parameter(ParameterSetName="NamedPipeHalfDuplex")]
+        [Parameter(ParameterSetName="NamedPipeSimplex")]
         [string]
         $DebugServiceOutNamedPipe,
 
@@ -125,6 +125,7 @@ function Start-EditorServicesHost {
         "Stdio" {
             $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::Stdio
             $debugServiceConfig.TransportType    = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::Stdio
+            break
         }
         "NamedPipe" {
             $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
@@ -133,8 +134,9 @@ function Start-EditorServicesHost {
                 $debugServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
                 $debugServiceConfig.InOutPipeName = "$DebugServiceNamedPipe"
             }
+            break
         }
-        "NamedPipeHalfDuplex" {
+        "NamedPipeSimplex" {
             $languageServiceConfig.TransportType = [Microsoft.PowerShell.EditorServices.Host.EditorServiceTransportType]::NamedPipe
             $languageServiceConfig.InPipeName = $LanguageServiceInNamedPipe
             $languageServiceConfig.OutPipeName = $LanguageServiceOutNamedPipe
@@ -143,6 +145,7 @@ function Start-EditorServicesHost {
                 $debugServiceConfig.InPipeName = $DebugServiceInNamedPipe
                 $debugServiceConfig.OutPipeName = $DebugServiceOutNamedPipe
             }
+            break
         }
     }
 

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -464,7 +464,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 case EditorServiceTransportType.NamedPipe:
                 {
                     string endpoint = config.Endpoint;
-                    int splitIndex = endpoint.IndexOf(';');
+                    int splitIndex = endpoint.IndexOf(Path.DirectorySeparatorChar);
                     if (splitIndex > 0)
                     {
                         string readPipeName = endpoint.Substring(0, splitIndex);

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -463,7 +463,19 @@ namespace Microsoft.PowerShell.EditorServices.Host
 
                 case EditorServiceTransportType.NamedPipe:
                 {
-                    return new NamedPipeServerListener(protocol, config.Endpoint, this.logger);
+                    string endpoint = config.Endpoint;
+                    int splitIndex = endpoint.IndexOf(';');
+                    if (splitIndex > 0)
+                    {
+                        string readPipeName = endpoint.Substring(0, splitIndex);
+                        string writePipeName = endpoint.Substring(splitIndex + 1);
+                        this.logger.Write(LogLevel.Verbose, $"Creating NamedPipeServerListener for ${protocol} protocol with two pipes: Read: '" + readPipeName + "'. Write: '" + writePipeName + "'");
+                        return new NamedPipeServerListener(protocol, readPipeName, writePipeName, this.logger);
+                    }
+                    else
+                    {
+                        return new NamedPipeServerListener(protocol, endpoint, this.logger);
+                    }
                 }
 
                 default:

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
         public string InOutPipeName { get; set; }
         public string OutPipeName { get; set; }
         public string InPipeName { get; set; }
-        internal string Endpoint => OutPipeName != null && InPipeName!=null ? $"In pipe: {InPipeName} Out pipe: {OutPipeName}" : $" InOut pipe: {InOutPipeName}";
+        internal string Endpoint => OutPipeName != null && InPipeName != null ? $"In pipe: {InPipeName} Out pipe: {OutPipeName}" : $" InOut pipe: {InOutPipeName}";
     }
 
     /// <summary>
@@ -468,7 +468,7 @@ PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (PID {Pr
                 {
                     if (config.OutPipeName !=null && config.InPipeName !=null)
                     {
-                        this.logger.Write(LogLevel.Verbose, $"Creating NamedPipeServerListener for ${protocol} protocol with two pipes: In: '" + config.InPipeName + "'. Out: '" + config.OutPipeName + "'");
+                        this.logger.Write(LogLevel.Verbose, $"Creating NamedPipeServerListener for ${protocol} protocol with two pipes: In: '{config.InPipeName}'. Out: '{config.OutPipeName}'");
                         return new NamedPipeServerListener(protocol, config.InPipeName, config.OutPipeName, this.logger);
                     }
                     else

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -43,7 +43,10 @@ namespace Microsoft.PowerShell.EditorServices.Host
         /// For Stdio it's ignored.
         /// For NamedPipe it's the pipe name.
         /// </summary>
-        public string Endpoint { get; set; }
+        public string InOutPipeName { get; set; }
+        public string OutPipeName { get; set; }
+        public string InPipeName { get; set; }
+        internal string Endpoint => OutPipeName != null && InPipeName!=null ? $"In pipe: {InPipeName} Out pipe: {OutPipeName}" : $" InOut pipe: {InOutPipeName}";
     }
 
     /// <summary>
@@ -463,18 +466,14 @@ namespace Microsoft.PowerShell.EditorServices.Host
 
                 case EditorServiceTransportType.NamedPipe:
                 {
-                    string endpoint = config.Endpoint;
-                    int splitIndex = endpoint.IndexOf(Path.DirectorySeparatorChar);
-                    if (splitIndex > 0)
+                    if (config.OutPipeName !=null && config.InPipeName !=null)
                     {
-                        string readPipeName = endpoint.Substring(0, splitIndex);
-                        string writePipeName = endpoint.Substring(splitIndex + 1);
-                        this.logger.Write(LogLevel.Verbose, $"Creating NamedPipeServerListener for ${protocol} protocol with two pipes: Read: '" + readPipeName + "'. Write: '" + writePipeName + "'");
-                        return new NamedPipeServerListener(protocol, readPipeName, writePipeName, this.logger);
+                        this.logger.Write(LogLevel.Verbose, $"Creating NamedPipeServerListener for ${protocol} protocol with two pipes: In: '" + config.InPipeName + "'. Out: '" + config.OutPipeName + "'");
+                        return new NamedPipeServerListener(protocol, config.InPipeName, config.OutPipeName, this.logger);
                     }
                     else
                     {
-                        return new NamedPipeServerListener(protocol, endpoint, this.logger);
+                        return new NamedPipeServerListener(protocol, config.InOutPipeName, this.logger);
                     }
                 }
 

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
@@ -11,24 +11,24 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
     public class NamedPipeServerChannel : ChannelBase
     {
         private ILogger logger;
-        private NamedPipeServerStream pipeServer;
-        private NamedPipeServerStream writePipeServer;
+        private NamedPipeServerStream inOutPipeServer;
+        private NamedPipeServerStream outPipeServer;
 
         public NamedPipeServerChannel(
-            NamedPipeServerStream pipeServer,
+            NamedPipeServerStream inOutPipeServer,
             ILogger logger)
         {
-            this.pipeServer = pipeServer;
-            this.writePipeServer = null;
+            this.inOutPipeServer = inOutPipeServer;
+            this.outPipeServer = null;
             this.logger = logger;
         }
         public NamedPipeServerChannel(
-            NamedPipeServerStream readPipeServer,
-            NamedPipeServerStream writePipeServer,
+            NamedPipeServerStream inOutPipeServer,
+            NamedPipeServerStream outPipeServer,
             ILogger logger)
         {
-            this.pipeServer = readPipeServer;
-            this.writePipeServer = writePipeServer;
+            this.inOutPipeServer = inOutPipeServer;
+            this.outPipeServer = outPipeServer;
             this.logger = logger;
         }
 
@@ -36,13 +36,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         {
             this.MessageReader =
                 new MessageReader(
-                    this.pipeServer,
+                    this.inOutPipeServer,
                     messageSerializer,
                     this.logger);
 
             this.MessageWriter =
                 new MessageWriter(
-                    this.writePipeServer ?? this.pipeServer,
+                    this.outPipeServer ?? this.inOutPipeServer,
                     messageSerializer,
                     this.logger);
         }
@@ -50,8 +50,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         protected override void Shutdown()
         {
             // The server listener will take care of the pipe server
-            this.pipeServer = null;
-            this.writePipeServer = null;
+            this.inOutPipeServer = null;
+            this.outPipeServer = null;
         }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
@@ -19,7 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             ILogger logger)
         {
             this.inOutPipeServer = inOutPipeServer;
-            this.outPipeServer = null;
             this.logger = logger;
         }
         public NamedPipeServerChannel(

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerChannel.cs
@@ -12,12 +12,23 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
     {
         private ILogger logger;
         private NamedPipeServerStream pipeServer;
+        private NamedPipeServerStream writePipeServer;
 
         public NamedPipeServerChannel(
             NamedPipeServerStream pipeServer,
             ILogger logger)
         {
             this.pipeServer = pipeServer;
+            this.writePipeServer = null;
+            this.logger = logger;
+        }
+        public NamedPipeServerChannel(
+            NamedPipeServerStream readPipeServer,
+            NamedPipeServerStream writePipeServer,
+            ILogger logger)
+        {
+            this.pipeServer = readPipeServer;
+            this.writePipeServer = writePipeServer;
             this.logger = logger;
         }
 
@@ -31,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 
             this.MessageWriter =
                 new MessageWriter(
-                    this.pipeServer,
+                    this.writePipeServer ?? this.pipeServer,
                     messageSerializer,
                     this.logger);
         }
@@ -40,6 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         {
             // The server listener will take care of the pipe server
             this.pipeServer = null;
+            this.writePipeServer = null;
         }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
@@ -32,7 +32,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
         {
             this.logger = logger;
             this.inOutPipeName = inOutPipeName;
-            this.outPipeName = null;
         }
 
         public NamedPipeServerListener(
@@ -138,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
 
         private void ListenForConnection()
         {
-            List<Task> connectionTasks = new List<Task> {WaitForConnectionAsync(this.inOutPipeServer)};
+            var connectionTasks = new List<Task> {WaitForConnectionAsync(this.inOutPipeServer)};
             if (this.outPipeServer != null)
             {
                 connectionTasks.Add(WaitForConnectionAsync(this.outPipeServer));

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
                     {
                         this.writePipeServer = new NamedPipeServerStream(
                             pipeName: writePipeName,
-                            direction: PipeDirection.InOut,
+                            direction: PipeDirection.Out,
                             maxNumberOfServerInstances: 1,
                             transmissionMode: PipeTransmissionMode.Byte,
                             options: PipeOptions.None);

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeServerListener.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
                         "An unhandled exception occurred while listening for a named pipe client connection",
                         e);
 
-                    throw e;
+                    throw;
                 }
             });
         }


### PR DESCRIPTION
Some clients have blocking File I/O API, thus it is not possible for them to use single named pipe for reading and writing asynchronously. 
E.g. this is [needed](https://github.com/ant-druha/PowerShell/issues/6) for my PowerShell plugin for IntelliJ IDEs. 
For communication protocol I'm using [lsp4j](https://github.com/eclipse/lsp4j) library which has no issues with tcp protocol but it [does not support named pipes](https://github.com/eclipse/lsp4j/issues/250). So the proposed solution was to use two separate pipes. 

This request adds the ability to use separate pipes for reading and writing when the client specifies the "-SplitInOutPipes" switch for the startup script.

Tested that two pipes approach with my plugin (on OS X and Win7) works fine. Also tested with VS Code on OS X and Win7 also seems to work fine.