### PR TITLE
Add support for a "Show Documentation" quick fix menu entry

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -62,6 +62,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets or sets the marker's message string.
         /// </summary>
         public string Message { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the ruleName associated with this marker.
+        /// </summary>
+        public string RuleName { get; set; }
 
         /// <summary>
         /// Gets or sets the marker's message level.
@@ -130,7 +135,6 @@ namespace Microsoft.PowerShell.EditorServices
             // the diagnostic record's properties directly i.e. <instance>.<propertyName>
             // without having to go through PSObject's Members property.
             var diagnosticRecord = psObject as dynamic;
-            string ruleName = diagnosticRecord.RuleName as string;
 
             if (diagnosticRecord.SuggestedCorrections != null)
             {
@@ -160,7 +164,8 @@ namespace Microsoft.PowerShell.EditorServices
 
             return new ScriptFileMarker
             {
-                Message = $"{diagnosticRecord.Message as string} ({ruleName})",
+                Message = $"{diagnosticRecord.Message as string}",
+                RuleName = $"{diagnosticRecord.RuleName as string}",
                 Level = GetMarkerLevelFromDiagnosticSeverity((diagnosticRecord.Severity as Enum).ToString()),
                 ScriptRegion = ScriptRegion.Create(diagnosticRecord.Extent as IScriptExtent),
                 Correction = correction,


### PR DESCRIPTION
This requires a corresponding PR to VSCode to handle the new command:
PowerShell.ShowCodeActionDocumentation

Changed the use of the Diagnostic.Code field to hold the PSSA rule name.
According to the LSP docs, this field is meant to be displayed and
tslint uses it to display the vioated rule. Update the logic to use a
combination of diagnostic fields to get a unique id in order to
retrieve the stored "correction edits" when the
textDocument/codeAction message is processed with the diagnostic
array returned earlier.

Also, observed a few times during startup that RunScriptDiagnostics was
getting called with an empty filesToAnalyze array.  Modified to return
early in that case.

Remove a private overload of DelayThenInvokeDiagnostics that wasn't
being used.