### PR TITLE
Add Async suffix to async methods

### DIFF
--- a/src/PowerShellEditorServices.Channel.WebSocket/WebsocketClientChannel.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/WebsocketClientChannel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
             this.serverUrl = url;
         }
 
-        public override async Task WaitForConnection()
+        public override async Task WaitForConnectionAsync()
         {
             try
             {
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
                 {
                     Logger.Write(LogLevel.Warning,
                         string.Format("Failed to connect to WebSocket server. Error was '{0}'", wsException.Message));
-                   
+
                 }
 
                 throw;
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
     }
 
     /// <summary>
-    /// Extension of <see cref="MemoryStream"/> that sends data to a WebSocket during FlushAsync 
+    /// Extension of <see cref="MemoryStream"/> that sends data to a WebSocket during FlushAsync
     /// and reads during WriteAsync.
     /// </summary>
     internal class ClientWebSocketStream : MemoryStream
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
         /// Constructor
         /// </summary>
         /// <remarks>
-        /// It is expected that the socket is in an Open state. 
+        /// It is expected that the socket is in an Open state.
         /// </remarks>
         /// <param name="socket"></param>
         public ClientWebSocketStream(ClientWebSocket socket)
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
         }
 
         /// <summary>
-        /// Reads from the WebSocket. 
+        /// Reads from the WebSocket.
         /// </summary>
         /// <param name="buffer"></param>
         /// <param name="offset"></param>
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
             {
                 result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer, offset, count), cancellationToken);
             } while (!result.EndOfMessage);
-          
+
             if (result.MessageType == WebSocketMessageType.Close)
             {
                 await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", cancellationToken);

--- a/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
+++ b/src/PowerShellEditorServices.Channel.WebSocket/WebsocketServerChannel.cs
@@ -17,8 +17,8 @@ using Owin.WebSocket;
 namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
 {
     /// <summary>
-    /// Implementation of <see cref="ChannelBase"/> that implements the streams necessary for 
-    /// communicating via OWIN WebSockets. 
+    /// Implementation of <see cref="ChannelBase"/> that implements the streams necessary for
+    /// communicating via OWIN WebSockets.
     /// </summary>
     public class WebSocketServerChannel : ChannelBase
     {
@@ -42,22 +42,22 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
 
             this.MessageWriter =
                 new MessageWriter(
-                    new WebSocketStream(socketConnection), 
+                    new WebSocketStream(socketConnection),
                     messageSerializer);
         }
 
         /// <summary>
-        /// Dispatches data received during calls to OnMessageReceived in the <see cref="WebSocketConnection"/> class.
+        /// Dispatches data received during calls to OnMessageReceivedAsync in the <see cref="WebSocketConnection"/> class.
         /// </summary>
         /// <remarks>
-        /// This method calls an overriden version of the <see cref="MessageDispatcher"/> that dispatches messages on 
-        /// demand rather than running on a background thread. 
+        /// This method calls an overriden version of the <see cref="MessageDispatcher"/> that dispatches messages on
+        /// demand rather than running on a background thread.
         /// </remarks>
         /// <param name="message"></param>
         /// <returns></returns>
-        public async Task Dispatch(ArraySegment<byte> message)
+        public async Task DispatchAsync(ArraySegment<byte> message)
         {
-            //Clear our stream 
+            //Clear our stream
             inStream.SetLength(0);
 
             //Write data and dispatch to handlers
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
             this.socketConnection.Close(WebSocketCloseStatus.NormalClosure, "Server shutting down");
         }
 
-        public override Task WaitForConnection()
+        public override Task WaitForConnectionAsync()
         {
             // TODO: Need to update behavior here
             return Task.FromResult(true);
@@ -78,11 +78,11 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
     }
 
     /// <summary>
-    /// Overriden <see cref="MemoryStream"/> that sends data through a <see cref="WebSocketConnection"/> during the FlushAsync call. 
+    /// Overriden <see cref="MemoryStream"/> that sends data through a <see cref="WebSocketConnection"/> during the FlushAsync call.
     /// </summary>
     /// <remarks>
     /// FlushAsync will send data via the SendBinary method of the <see cref="WebSocketConnection"/> class. The memory streams length will
-    /// then be set to 0 to reset the stream for additional data to be written. 
+    /// then be set to 0 to reset the stream for additional data to be written.
     /// </remarks>
     internal class WebSocketStream : MemoryStream
     {
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
     /// </summary>
     public abstract class EditorServiceWebSocketConnection : WebSocketConnection
     {
-        protected EditorServiceWebSocketConnection() 
+        protected EditorServiceWebSocketConnection()
         {
             Channel = new WebSocketServerChannel(this);
         }
@@ -120,9 +120,9 @@ namespace Microsoft.PowerShell.EditorServices.Channel.WebSocket
             Server.Start();
         }
 
-        public override async Task OnMessageReceived(ArraySegment<byte> message, WebSocketMessageType type)
+        public override async Task OnMessageReceivedAsync(ArraySegment<byte> message, WebSocketMessageType type)
         {
-            await Channel.Dispatch(message);
+            await Channel.DispatchAsync(message);
         }
 
         public override Task OnCloseAsync(WebSocketCloseStatus? closeStatus, string closeStatusDescription)

--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -49,11 +49,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 
             messageHandlers.SetRequestHandler(
                 CodeLensRequest.Type,
-                codeLenses.HandleCodeLensRequest);
+                codeLenses.HandleCodeLensRequestAsync);
 
             messageHandlers.SetRequestHandler(
                 CodeLensResolveRequest.Type,
-                codeLenses.HandleCodeLensResolveRequest);
+                codeLenses.HandleCodeLensResolveRequestAsync);
 
             codeLenses.Providers.Add(
                 new ReferencesCodeLensProvider(
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         /// <param name="codeLensParams">Parameters on the CodeLens request that was received.</param>
         /// <param name="requestContext"></param>
-        private async Task HandleCodeLensRequest(
+        private async Task HandleCodeLensRequestAsync(
             CodeLensRequest codeLensParams,
             RequestContext<LanguageServer.CodeLens[]> requestContext)
         {
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     _jsonSerializer);
             }
 
-            await requestContext.SendResult(codeLensResponse);
+            await requestContext.SendResultAsync(codeLensResponse);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         /// <param name="codeLens">The CodeLens to be resolved/updated.</param>
         /// <param name="requestContext"></param>
-        private async Task HandleCodeLensResolveRequest(
+        private async Task HandleCodeLensResolveRequestAsync(
             LanguageServer.CodeLens codeLens,
             RequestContext<LanguageServer.CodeLens> requestContext)
         {
@@ -178,13 +178,13 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                             originalCodeLens,
                             CancellationToken.None);
 
-                    await requestContext.SendResult(
+                    await requestContext.SendResultAsync(
                         resolvedCodeLens.ToProtocolCodeLens(
                             _jsonSerializer));
                 }
                 else
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Could not find provider for the original CodeLens: {codeLensData.ProviderId}");
                 }
             }

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 codeLens.ScriptExtent.StartLineNumber,
                 codeLens.ScriptExtent.StartColumnNumber);
 
-            FindReferencesResult referencesResult = await _editorSession.LanguageService.FindReferencesOfSymbol(
+            FindReferencesResult referencesResult = await _editorSession.LanguageService.FindReferencesOfSymbolAsync(
                 foundSymbol,
                 references,
                 _editorSession.Workspace);

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
 
             this.languageServiceListener = CreateServiceListener(MessageProtocolType.LanguageServer, config);
 
-            this.languageServiceListener.ClientConnect += this.OnLanguageServiceClientConnect;
+            this.languageServiceListener.ClientConnect += this.OnLanguageServiceClientConnectAsync;
             this.languageServiceListener.Start();
 
             this.logger.Write(
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     config.TransportType, config.Endpoint));
         }
 
-        private async void OnLanguageServiceClientConnect(
+        private async void OnLanguageServiceClientConnectAsync(
             object sender,
             ChannelBase serverChannel)
         {
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                     this.serverCompletedTask,
                     this.logger);
 
-            await this.editorSession.PowerShellContext.ImportCommandsModule(
+            await this.editorSession.PowerShellContext.ImportCommandsModuleAsync(
                 Path.Combine(
                     Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location),
                     @"..\Commands"));
@@ -225,7 +225,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             // gets initialized when that is done earlier than LanguageServer.Initialize
             foreach (string module in this.additionalModules)
             {
-                await this.editorSession.PowerShellContext.ExecuteCommand<System.Management.Automation.PSObject>(
+                await this.editorSession.PowerShellContext.ExecuteCommandAsync<System.Management.Automation.PSObject>(
                     new System.Management.Automation.PSCommand().AddCommand("Import-Module").AddArgument(module),
                     false,
                     true);

--- a/src/PowerShellEditorServices.Host/PSHost/PromptHandlers.cs
+++ b/src/PowerShellEditorServices.Host/PSHost/PromptHandlers.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             base.ShowPrompt(promptStyle);
 
             messageSender
-                .SendRequest(
+                .SendRequestAsync(
                     ShowChoicePromptRequest.Type,
                     new ShowChoicePromptRequest
                     {
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 .ConfigureAwait(false);
         }
 
-        protected override Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
             this.readLineTask = new TaskCompletionSource<string>();
             return this.readLineTask.Task;
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             base.ShowFieldPrompt(fieldDetails);
 
             messageSender
-                .SendRequest(
+                .SendRequestAsync(
                     ShowInputPromptRequest.Type,
                     new ShowInputPromptRequest
                     {
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
                 .ConfigureAwait(false);
         }
 
-        protected override Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
             this.readLineTask = new TaskCompletionSource<string>();
             return this.readLineTask.Task;
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             this.readLineTask = null;
         }
 
-        protected override Task<SecureString> ReadSecureString(CancellationToken cancellationToken)
+        protected override Task<SecureString> ReadSecureStringAsync(CancellationToken cancellationToken)
         {
             // TODO: Write a message to the console
             throw new NotImplementedException();

--- a/src/PowerShellEditorServices.Host/PSHost/ProtocolPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices.Host/PSHost/ProtocolPSHostUserInterface.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             // Make sure remaining output is flushed before exiting
             if (this.outputDebouncer != null)
             {
-                this.outputDebouncer.Flush().Wait();
+                this.outputDebouncer.FlushAsync().Wait();
                 this.outputDebouncer = null;
             }
         }
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
             ConsoleColor backgroundColor)
         {
             // TODO: This should use a synchronous method!
-            this.outputDebouncer.Invoke(
+            this.outputDebouncer.InvokeAsync(
                 new OutputWrittenEventArgs(
                     outputString,
                     includeNewLine,
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.EditorServices.Host
         {
         }
 
-        protected override Task<string> ReadCommandLine(CancellationToken cancellationToken)
+        protected override Task<string> ReadCommandLineAsync(CancellationToken cancellationToken)
         {
             // This currently does nothing because the "evaluate" request
             // will cancel the current prompt and execute the user's

--- a/src/PowerShellEditorServices.Host/Symbols/DocumentSymbolFeature.cs
+++ b/src/PowerShellEditorServices.Host/Symbols/DocumentSymbolFeature.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
 
             messageHandlers.SetRequestHandler(
                 DocumentSymbolRequest.Type,
-                this.HandleDocumentSymbolRequest);
+                this.HandleDocumentSymbolRequestAsync);
         }
 
         public static DocumentSymbolFeature Create(
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
                     .SelectMany(r => r);
         }
 
-        protected async Task HandleDocumentSymbolRequest(
+        protected async Task HandleDocumentSymbolRequestAsync(
             DocumentSymbolParams documentSymbolParams,
             RequestContext<SymbolInformation[]> requestContext)
         {
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
                 symbols = new SymbolInformation[0];
             }
 
-            await requestContext.SendResult(symbols);
+            await requestContext.SendResultAsync(symbols);
         }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/DebugAdapterClientBase.cs
@@ -28,12 +28,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
                 logger);
         }
 
-        public async Task Start()
+        public async Task StartAsync()
         {
             this.protocolEndpoint.Start();
 
             // Initialize the debug adapter
-            await this.SendRequest(
+            await this.SendRequestAsync(
                 InitializeRequest.Type,
                 new InitializeRequestArguments
                 {
@@ -48,34 +48,34 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
             this.protocolEndpoint.Stop();
         }
 
-        public async Task LaunchScript(string scriptFilePath)
+        public async Task LaunchScriptAsync(string scriptFilePath)
         {
-            await this.SendRequest(
+            await this.SendRequestAsync(
                 LaunchRequest.Type,
                 new LaunchRequestArguments {
                     Script = scriptFilePath
                 },
                 true);
 
-            await this.SendRequest(
+            await this.SendRequestAsync(
                 ConfigurationDoneRequest.Type,
                 null,
                 true);
         }
 
-        public Task SendEvent<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
+        public Task SendEventAsync<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
         {
-            return ((IMessageSender)protocolEndpoint).SendEvent(eventType, eventParams);
+            return ((IMessageSender)protocolEndpoint).SendEventAsync(eventType, eventParams);
         }
 
-        public Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, TParams requestParams, bool waitForResponse)
+        public Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, TParams requestParams, bool waitForResponse)
         {
-            return ((IMessageSender)protocolEndpoint).SendRequest(requestType, requestParams, waitForResponse);
+            return ((IMessageSender)protocolEndpoint).SendRequestAsync(requestType, requestParams, waitForResponse);
         }
 
-        public Task<TResult> SendRequest<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
+        public Task<TResult> SendRequestAsync<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
         {
-            return ((IMessageSender)protocolEndpoint).SendRequest(requestType0);
+            return ((IMessageSender)protocolEndpoint).SendRequestAsync(requestType0);
         }
 
         public void SetRequestHandler<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, Func<TParams, RequestContext<TResult>, Task> requestHandler)

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageClientBase.cs
@@ -41,46 +41,46 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
             this.protocolEndpoint.Start();
 
             // Initialize the implementation class
-            return this.Initialize();
+            return this.InitializeAsync();
         }
 
-        public async Task Stop()
+        public async Task StopAsync()
         {
-            await this.OnStop();
+            await this.OnStopAsync();
 
             // First, notify the language server that we're stopping
             var response =
-                await this.SendRequest<object, object, object>(
+                await this.SendRequestAsync<object, object, object>(
                     ShutdownRequest.Type);
 
-            await this.SendEvent(ExitNotification.Type, new object());
+            await this.SendEventAsync(ExitNotification.Type, new object());
 
             this.protocolEndpoint.Stop();
         }
 
-        protected virtual Task OnStop()
+        protected virtual Task OnStopAsync()
         {
             return Task.FromResult(true);
         }
 
-        protected virtual Task Initialize()
+        protected virtual Task InitializeAsync()
         {
             return Task.FromResult(true);
         }
 
-        public Task SendEvent<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
+        public Task SendEventAsync<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
         {
-            return ((IMessageSender)protocolEndpoint).SendEvent(eventType, eventParams);
+            return ((IMessageSender)protocolEndpoint).SendEventAsync(eventType, eventParams);
         }
 
-        public Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, TParams requestParams, bool waitForResponse)
+        public Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, TParams requestParams, bool waitForResponse)
         {
-            return ((IMessageSender)protocolEndpoint).SendRequest(requestType, requestParams, waitForResponse);
+            return ((IMessageSender)protocolEndpoint).SendRequestAsync(requestType, requestParams, waitForResponse);
         }
 
-        public Task<TResult> SendRequest<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
+        public Task<TResult> SendRequestAsync<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
         {
-            return ((IMessageSender)protocolEndpoint).SendRequest(requestType0);
+            return ((IMessageSender)protocolEndpoint).SendRequestAsync(requestType0);
         }
 
         public void SetRequestHandler<TParams, TResult, TError, TRegistrationOptions>(RequestType<TParams, TResult, TError, TRegistrationOptions> requestType, Func<TParams, RequestContext<TResult>, Task> requestHandler)

--- a/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
+++ b/src/PowerShellEditorServices.Protocol/Client/LanguageServiceClient.cs
@@ -24,10 +24,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
         {
         }
 
-        protected override Task Initialize()
+        protected override Task InitializeAsync()
         {
             // Add handlers for common events
-            this.SetEventHandler(PublishDiagnosticsNotification.Type, HandlePublishDiagnosticsEvent);
+            this.SetEventHandler(PublishDiagnosticsNotification.Type, HandlePublishDiagnosticsEventAsync);
 
             // Send the 'initialize' request and wait for the response
             var initializeParams = new InitializeParams
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
                 Capabilities = new ClientCapabilities()
             };
 
-            return this.SendRequest(
+            return this.SendRequestAsync(
                 InitializeRequest.Type,
                 initializeParams,
                 true);
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Client
 
         #region Private Methods
 
-        private Task HandlePublishDiagnosticsEvent(
+        private Task HandlePublishDiagnosticsEventAsync(
             PublishDiagnosticsNotification diagnostics,
             EventContext eventContext)
         {

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeClientChannel.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/Channel/NamedPipeClientChannel.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol.Channel
             }
         }
 
-        public static async Task<NamedPipeClientChannel> Connect(
+        public static async Task<NamedPipeClientChannel> ConnectAsync(
             string pipeFile,
             MessageProtocolType messageProtocolType,
             ILogger logger)

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/EventContext.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/EventContext.cs
@@ -21,11 +21,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             this.messageWriter = messageWriter;
         }
 
-        public async Task SendEvent<TParams, TRegistrationOptions>(
+        public async Task SendEventAsync<TParams, TRegistrationOptions>(
             NotificationType<TParams, TRegistrationOptions> eventType,
             TParams eventParams)
         {
-            await this.messageWriter.WriteEvent(
+            await this.messageWriter.WriteEventAsync(
                 eventType,
                 eventParams);
         }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/IMessageSender.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/IMessageSender.cs
@@ -9,16 +9,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 {
     public interface IMessageSender
     {
-        Task SendEvent<TParams, TRegistrationOptions>(
+        Task SendEventAsync<TParams, TRegistrationOptions>(
             NotificationType<TParams, TRegistrationOptions> eventType,
             TParams eventParams);
 
-        Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(
+        Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
             TParams requestParams,
             bool waitForResponse);
 
-        Task<TResult> SendRequest<TResult, TError, TRegistrationOptions>(
+        Task<TResult> SendRequestAsync<TResult, TError, TRegistrationOptions>(
             RequestType0<TResult, TError, TRegistrationOptions> requestType0);
     }
 }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageDispatcher.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         #region Private Methods
 
-        public async Task DispatchMessage(
+        public async Task DispatchMessageAsync(
             Message messageToDispatch,
             MessageWriter messageWriter)
         {

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageReader.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageReader.cs
@@ -75,12 +75,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         #region Public Methods
 
-        public async Task<Message> ReadMessage()
+        public async Task<Message> ReadMessageAsync()
         {
             string messageContent = null;
 
             // Do we need to read more data or can we process the existing buffer?
-            while (!this.needsMoreData || await this.ReadNextChunk())
+            while (!this.needsMoreData || await this.ReadNextChunkAsync())
             {
                 // Clear the flag since we should have what we need now
                 this.needsMoreData = false;
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         #region Private Methods
 
-        private async Task<bool> ReadNextChunk()
+        private async Task<bool> ReadNextChunkAsync()
         {
             // Do we need to resize the buffer?  See if less than 1/4 of the space is left.
             if (((double)(this.messageBuffer.Length - this.bufferEndOffset) / this.messageBuffer.Length) < 0.25)

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/MessageWriter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         // TODO: This method should be made protected or private
 
-        public async Task WriteMessage(Message messageToWrite)
+        public async Task WriteMessageAsync(Message messageToWrite)
         {
             Validate.IsNotNull("messageToWrite", messageToWrite);
 
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             }
         }
 
-        public async Task WriteRequest<TParams, TResult, TError, TRegistrationOptions>(
+        public async Task WriteRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
             TParams requestParams,
             int requestId)
@@ -108,14 +108,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     JToken.FromObject(requestParams, contentSerializer) :
                     null;
 
-            await this.WriteMessage(
+            await this.WriteMessageAsync(
                 Message.Request(
                     requestId.ToString(),
                     requestType.Method,
                     contentObject));
         }
 
-        public async Task WriteResponse<TResult>(TResult resultContent, string method, string requestId)
+        public async Task WriteResponseAsync<TResult>(TResult resultContent, string method, string requestId)
         {
             // Allow null content
             JToken contentObject =
@@ -123,14 +123,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     JToken.FromObject(resultContent, contentSerializer) :
                     null;
 
-            await this.WriteMessage(
+            await this.WriteMessageAsync(
                 Message.Response(
                     requestId,
                     method,
                     contentObject));
         }
 
-        public async Task WriteEvent<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
+        public async Task WriteEventAsync<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
         {
             // Allow null content
             JToken contentObject =
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     JToken.FromObject(eventParams, contentSerializer) :
                     null;
 
-            await this.WriteMessage(
+            await this.WriteMessageAsync(
                 Message.Event(
                     eventType.Method,
                     contentObject));

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/ProtocolEndpoint.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/ProtocolEndpoint.cs
@@ -121,10 +121,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         #region Message Sending
 
-        public Task<TResult> SendRequest<TResult, TError, TRegistrationOptions>(
+        public Task<TResult> SendRequestAsync<TResult, TError, TRegistrationOptions>(
             RequestType0<TResult, TError, TRegistrationOptions> requestType0)
         {
-            return this.SendRequest(
+            return this.SendRequestAsync(
                 RequestType<Object, TResult, TError, TRegistrationOptions>.ConvertToRequestType(requestType0),
                  null);
         }
@@ -138,14 +138,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         /// <param name="requestType"></param>
         /// <param name="requestParams"></param>
         /// <returns></returns>
-        public Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(
+        public Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
             TParams requestParams)
         {
-            return this.SendRequest(requestType, requestParams, true);
+            return this.SendRequestAsync(requestType, requestParams, true);
         }
 
-        public async Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(
+        public async Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
             TParams requestParams,
             bool waitForResponse)
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     responseTask);
             }
 
-            await this.protocolChannel.MessageWriter.WriteRequest<TParams, TResult, TError, TRegistrationOptions>(
+            await this.protocolChannel.MessageWriter.WriteRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
                 requestType,
                 requestParams,
                 this.currentMessageId);
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
         /// <param name="eventType">The type of event being sent.</param>
         /// <param name="eventParams">The event parameters being sent.</param>
         /// <returns>A Task that tracks completion of the send operation.</returns>
-        public Task SendEvent<TParams, TRegistrationOptions>(
+        public Task SendEventAsync<TParams, TRegistrationOptions>(
             NotificationType<TParams, TRegistrationOptions> eventType,
             TParams eventParams)
         {
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 this.SynchronizationContext.Post(
                     async (obj) =>
                     {
-                        await this.protocolChannel.MessageWriter.WriteEvent(
+                        await this.protocolChannel.MessageWriter.WriteEventAsync(
                             eventType,
                             eventParams);
 
@@ -232,7 +232,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             }
             else
             {
-                return this.protocolChannel.MessageWriter.WriteEvent(
+                return this.protocolChannel.MessageWriter.WriteEventAsync(
                     eventType,
                     eventParams);
             }
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             this.messageLoopThread = new AsyncContextThread("Message Dispatcher");
             this.messageLoopThread
                 .Run(
-                    () => this.ListenForMessages(this.messageLoopCancellationToken.Token),
+                    () => this.ListenForMessagesAsync(this.messageLoopCancellationToken.Token),
                     this.Logger)
                 .ContinueWith(this.OnListenTaskCompleted);
         }
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
 
         #region Private Methods
 
-        private async Task ListenForMessages(CancellationToken cancellationToken)
+        private async Task ListenForMessagesAsync(CancellationToken cancellationToken)
         {
             this.SynchronizationContext = SynchronizationContext.Current;
 
@@ -324,7 +324,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                 try
                 {
                     // Read a message from the channel
-                    newMessage = await this.protocolChannel.MessageReader.ReadMessage();
+                    newMessage = await this.protocolChannel.MessageReader.ReadMessageAsync();
                 }
                 catch (MessageParseException e)
                 {
@@ -376,7 +376,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
                     else
                     {
                         // Process the message
-                        await this.messageDispatcher.DispatchMessage(
+                        await this.messageDispatcher.DispatchMessageAsync(
                             newMessage,
                             this.protocolChannel.MessageWriter);
                     }

--- a/src/PowerShellEditorServices.Protocol/MessageProtocol/RequestContext.cs
+++ b/src/PowerShellEditorServices.Protocol/MessageProtocol/RequestContext.cs
@@ -19,24 +19,24 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol
             this.messageWriter = messageWriter;
         }
 
-        public async Task SendResult(TResult resultDetails)
+        public async Task SendResultAsync(TResult resultDetails)
         {
-            await this.messageWriter.WriteResponse<TResult>(
+            await this.messageWriter.WriteResponseAsync<TResult>(
                 resultDetails,
                 requestMessage.Method,
                 requestMessage.Id);
         }
 
-        public async Task SendEvent<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
+        public async Task SendEventAsync<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
         {
-            await this.messageWriter.WriteEvent(
+            await this.messageWriter.WriteEventAsync(
                 eventType,
                 eventParams);
         }
 
-        public async Task SendError(object errorDetails)
+        public async Task SendErrorAsync(object errorDetails)
         {
-            await this.messageWriter.WriteMessage(
+            await this.messageWriter.WriteMessageAsync(
                 Message.ResponseError(
                     requestMessage.Id,
                     requestMessage.Method,

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -63,33 +63,33 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public void Start()
         {
             // Register all supported message types
-            _messageHandlers.SetRequestHandler(InitializeRequest.Type, HandleInitializeRequest);
+            _messageHandlers.SetRequestHandler(InitializeRequest.Type, HandleInitializeRequestAsync);
 
-            _messageHandlers.SetRequestHandler(LaunchRequest.Type, HandleLaunchRequest);
-            _messageHandlers.SetRequestHandler(AttachRequest.Type, HandleAttachRequest);
-            _messageHandlers.SetRequestHandler(ConfigurationDoneRequest.Type, HandleConfigurationDoneRequest);
-            _messageHandlers.SetRequestHandler(DisconnectRequest.Type, HandleDisconnectRequest);
+            _messageHandlers.SetRequestHandler(LaunchRequest.Type, HandleLaunchRequestAsync);
+            _messageHandlers.SetRequestHandler(AttachRequest.Type, HandleAttachRequestAsync);
+            _messageHandlers.SetRequestHandler(ConfigurationDoneRequest.Type, HandleConfigurationDoneRequestAsync);
+            _messageHandlers.SetRequestHandler(DisconnectRequest.Type, HandleDisconnectRequestAsync);
 
-            _messageHandlers.SetRequestHandler(SetBreakpointsRequest.Type, HandleSetBreakpointsRequest);
-            _messageHandlers.SetRequestHandler(SetExceptionBreakpointsRequest.Type, HandleSetExceptionBreakpointsRequest);
-            _messageHandlers.SetRequestHandler(SetFunctionBreakpointsRequest.Type, HandleSetFunctionBreakpointsRequest);
+            _messageHandlers.SetRequestHandler(SetBreakpointsRequest.Type, HandleSetBreakpointsRequestAsync);
+            _messageHandlers.SetRequestHandler(SetExceptionBreakpointsRequest.Type, HandleSetExceptionBreakpointsRequestAsync);
+            _messageHandlers.SetRequestHandler(SetFunctionBreakpointsRequest.Type, HandleSetFunctionBreakpointsRequestAsync);
 
-            _messageHandlers.SetRequestHandler(ContinueRequest.Type, HandleContinueRequest);
-            _messageHandlers.SetRequestHandler(NextRequest.Type, HandleNextRequest);
-            _messageHandlers.SetRequestHandler(StepInRequest.Type, HandleStepInRequest);
-            _messageHandlers.SetRequestHandler(StepOutRequest.Type, HandleStepOutRequest);
-            _messageHandlers.SetRequestHandler(PauseRequest.Type, HandlePauseRequest);
+            _messageHandlers.SetRequestHandler(ContinueRequest.Type, HandleContinueRequestAsync);
+            _messageHandlers.SetRequestHandler(NextRequest.Type, HandleNextRequestAsync);
+            _messageHandlers.SetRequestHandler(StepInRequest.Type, HandleStepInRequestAsync);
+            _messageHandlers.SetRequestHandler(StepOutRequest.Type, HandleStepOutRequestAsync);
+            _messageHandlers.SetRequestHandler(PauseRequest.Type, HandlePauseRequestAsync);
 
-            _messageHandlers.SetRequestHandler(ThreadsRequest.Type, HandleThreadsRequest);
-            _messageHandlers.SetRequestHandler(StackTraceRequest.Type, HandleStackTraceRequest);
-            _messageHandlers.SetRequestHandler(ScopesRequest.Type, HandleScopesRequest);
-            _messageHandlers.SetRequestHandler(VariablesRequest.Type, HandleVariablesRequest);
-            _messageHandlers.SetRequestHandler(SetVariableRequest.Type, HandleSetVariablesRequest);
-            _messageHandlers.SetRequestHandler(SourceRequest.Type, HandleSourceRequest);
-            _messageHandlers.SetRequestHandler(EvaluateRequest.Type, HandleEvaluateRequest);
+            _messageHandlers.SetRequestHandler(ThreadsRequest.Type, HandleThreadsRequestAsync);
+            _messageHandlers.SetRequestHandler(StackTraceRequest.Type, HandleStackTraceRequestAsync);
+            _messageHandlers.SetRequestHandler(ScopesRequest.Type, HandleScopesRequestAsync);
+            _messageHandlers.SetRequestHandler(VariablesRequest.Type, HandleVariablesRequestAsync);
+            _messageHandlers.SetRequestHandler(SetVariableRequest.Type, HandleSetVariablesRequestAsync);
+            _messageHandlers.SetRequestHandler(SourceRequest.Type, HandleSourceRequestAsync);
+            _messageHandlers.SetRequestHandler(EvaluateRequest.Type, HandleEvaluateRequestAsync);
         }
 
-        protected Task LaunchScript(RequestContext<object> requestContext, string scriptToLaunch)
+        protected Task LaunchScriptAsync(RequestContext<object> requestContext, string scriptToLaunch)
         {
             // Is this an untitled script?
             Task launchTask = null;
@@ -99,18 +99,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 ScriptFile untitledScript = _editorSession.Workspace.GetFile(scriptToLaunch);
 
                 launchTask = _editorSession.PowerShellContext
-                    .ExecuteScriptString(untitledScript.Contents, true, true);
+                    .ExecuteScriptStringAsync(untitledScript.Contents, true, true);
             }
             else
             {
                 launchTask = _editorSession.PowerShellContext
-                    .ExecuteScriptWithArgs(scriptToLaunch, _arguments, writeInputToHost: true);
+                    .ExecuteScriptWithArgsAsync(scriptToLaunch, _arguments, writeInputToHost: true);
             }
 
-            return launchTask.ContinueWith(OnExecutionCompleted);
+            return launchTask.ContinueWith(OnExecutionCompletedAsync);
         }
 
-        private async Task OnExecutionCompleted(Task executeTask)
+        private async Task OnExecutionCompletedAsync(Task executeTask)
         {
             try
             {
@@ -136,12 +136,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 {
                     try
                     {
-                        await _editorSession.PowerShellContext.ExecuteScriptString("Exit-PSHostProcess");
+                        await _editorSession.PowerShellContext.ExecuteScriptStringAsync("Exit-PSHostProcess");
 
                         if (_isRemoteAttach &&
                             _editorSession.PowerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote)
                         {
-                            await _editorSession.PowerShellContext.ExecuteScriptString("Exit-PSSession");
+                            await _editorSession.PowerShellContext.ExecuteScriptStringAsync("Exit-PSSession");
                         }
                     }
                     catch (Exception e)
@@ -156,12 +156,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             if (_disconnectRequestContext != null)
             {
                 // Respond to the disconnect request and stop the server
-                await _disconnectRequestContext.SendResult(null);
+                await _disconnectRequestContext.SendResultAsync(null);
                 Stop();
             }
             else
             {
-                await _messageSender.SendEvent(
+                await _messageSender.SendEventAsync(
                     TerminatedEvent.Type,
                     new TerminatedEvent());
             }
@@ -173,9 +173,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             if (_editorSession != null)
             {
-                _editorSession.PowerShellContext.RunspaceChanged -= powerShellContext_RunspaceChanged;
-                _editorSession.DebugService.DebuggerStopped -= DebugService_DebuggerStopped;
-                _editorSession.PowerShellContext.DebuggerResumed -= powerShellContext_DebuggerResumed;
+                _editorSession.PowerShellContext.RunspaceChanged -= powerShellContext_RunspaceChangedAsync;
+                _editorSession.DebugService.DebuggerStopped -= DebugService_DebuggerStoppedAsync;
+                _editorSession.PowerShellContext.DebuggerResumed -= powerShellContext_DebuggerResumedAsync;
 
                 if (_ownsEditorSession)
                 {
@@ -190,15 +190,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         #region Built-in Message Handlers
 
-        private async Task HandleInitializeRequest(
+        private async Task HandleInitializeRequestAsync(
             object shutdownParams,
             RequestContext<InitializeResponseBody> requestContext)
         {
             // Clear any existing breakpoints before proceeding
-            await ClearSessionBreakpoints();
+            await ClearSessionBreakpointsAsync();
 
             // Now send the Initialize response to continue setup
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new InitializeResponseBody {
                     SupportsConfigurationDoneRequest = true,
                     SupportsFunctionBreakpoints = true,
@@ -208,7 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleConfigurationDoneRequest(
+        protected async Task HandleConfigurationDoneRequestAsync(
             object args,
             RequestContext<object> requestContext)
         {
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 if (_editorSession.PowerShellContext.SessionState == PowerShellContextState.Ready)
                 {
                     // Configuration is done, launch the script
-                    var nonAwaitedTask = LaunchScript(requestContext, _scriptToLaunch)
+                    var nonAwaitedTask = LaunchScriptAsync(requestContext, _scriptToLaunch)
                         .ConfigureAwait(continueOnCapturedContext: false);
                 }
                 else
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
 
             if (_isInteractiveDebugSession)
             {
@@ -245,14 +245,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 {
                     // If this is an interactive session and there's a pending breakpoint,
                     // send that information along to the debugger client
-                    DebugService_DebuggerStopped(
+                    DebugService_DebuggerStoppedAsync(
                         this,
                         _editorSession.DebugService.CurrentDebuggerStoppedEventArgs);
                 }
             }
         }
 
-        protected async Task HandleLaunchRequest(
+        protected async Task HandleLaunchRequestAsync(
             LaunchRequestArguments launchParams,
             RequestContext<object> requestContext)
         {
@@ -299,7 +299,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // the working dir should not be changed.
                 if (!string.IsNullOrEmpty(workingDir))
                 {
-                    await _editorSession.PowerShellContext.SetWorkingDirectory(workingDir, isPathAlreadyEscaped: false);
+                    await _editorSession.PowerShellContext.SetWorkingDirectoryAsync(workingDir, isPathAlreadyEscaped: false);
                 }
 
                 Logger.Write(LogLevel.Verbose, $"Working dir " + (string.IsNullOrEmpty(workingDir) ? "not set." : $"set to '{workingDir}'"));
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         _editorSession.PowerShellContext.CurrentRunspace);
             }
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
 
             // If no script is being launched, mark this as an interactive
             // debugging session
@@ -338,12 +338,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // Send the InitializedEvent so that the debugger will continue
             // sending configuration requests
-            await _messageSender.SendEvent(
+            await _messageSender.SendEventAsync(
                 InitializedEvent.Type,
                 null);
         }
 
-        protected async Task HandleAttachRequest(
+        protected async Task HandleAttachRequestAsync(
             AttachRequestArguments attachParams,
             RequestContext<object> requestContext)
         {
@@ -361,7 +361,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     LogLevel.Normal,
                     $"Attach request aborted, received {attachParams.ProcessId} for processId.");
 
-                await requestContext.SendError(
+                await requestContext.SendErrorAsync(
                     "User aborted attach to PowerShell host process.");
 
                 return;
@@ -376,26 +376,26 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
                 if (runspaceVersion.Version.Major < 4)
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Remote sessions are only available with PowerShell 4 and higher (current session is {runspaceVersion.Version}).");
 
                     return;
                 }
                 else if (_editorSession.PowerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote)
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Cannot attach to a process in a remote session when already in a remote session.");
 
                     return;
                 }
 
-                await _editorSession.PowerShellContext.ExecuteScriptString(
+                await _editorSession.PowerShellContext.ExecuteScriptStringAsync(
                     $"Enter-PSSession -ComputerName \"{attachParams.ComputerName}\"",
                     errorMessages);
 
                 if (errorMessages.Length > 0)
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Could not establish remote session to computer '{attachParams.ComputerName}'");
 
                     return;
@@ -411,26 +411,26 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
                 if (runspaceVersion.Version.Major < 5)
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Attaching to a process is only available with PowerShell 5 and higher (current session is {runspaceVersion.Version}).");
 
                     return;
                 }
 
-                await _editorSession.PowerShellContext.ExecuteScriptString(
+                await _editorSession.PowerShellContext.ExecuteScriptStringAsync(
                     $"Enter-PSHostProcess -Id {processId}",
                     errorMessages);
 
                 if (errorMessages.Length > 0)
                 {
-                    await requestContext.SendError(
+                    await requestContext.SendErrorAsync(
                         $"Could not attach to process '{processId}'");
 
                     return;
                 }
 
                 // Clear any existing breakpoints before proceeding
-                await ClearSessionBreakpoints();
+                await ClearSessionBreakpointsAsync();
 
                 // Execute the Debug-Runspace command but don't await it because it
                 // will block the debug adapter initialization process.  The
@@ -440,8 +440,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 _waitingForAttach = true;
                 Task nonAwaitedTask =
                     _editorSession.PowerShellContext
-                        .ExecuteScriptString($"\nDebug-Runspace -Id {runspaceId}")
-                        .ContinueWith(OnExecutionCompleted);
+                        .ExecuteScriptStringAsync($"\nDebug-Runspace -Id {runspaceId}")
+                        .ContinueWith(OnExecutionCompletedAsync);
             }
             else
             {
@@ -449,16 +449,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     LogLevel.Error,
                     $"Attach request failed, '{attachParams.ProcessId}' is an invalid value for the processId.");
 
-                await requestContext.SendError(
+                await requestContext.SendErrorAsync(
                     "A positive integer must be specified for the processId field.");
 
                 return;
             }
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected async Task HandleDisconnectRequest(
+        protected async Task HandleDisconnectRequestAsync(
             object disconnectParams,
             RequestContext<object> requestContext)
         {
@@ -473,20 +473,20 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
                     if (_isInteractiveDebugSession)
                     {
-                        await OnExecutionCompleted(null);
+                        await OnExecutionCompletedAsync(null);
                     }
                 }
                 else
                 {
                     UnregisterEventHandlers();
 
-                    await requestContext.SendResult(null);
+                    await requestContext.SendResultAsync(null);
                     Stop();
                 }
             }
         }
 
-        protected async Task HandleSetBreakpointsRequest(
+        protected async Task HandleSetBreakpointsRequestAsync(
             SetBreakpointsRequestArguments setBreakpointsParams,
             RequestContext<SetBreakpointsResponseBody> requestContext)
         {
@@ -522,7 +522,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         srcBkpt, setBreakpointsParams.Source.Path, message, verified: _noDebug));
 
                 // Return non-verified breakpoint message.
-                await requestContext.SendResult(
+                await requestContext.SendResultAsync(
                     new SetBreakpointsResponseBody {
                         Breakpoints = srcBreakpoints.ToArray()
                     });
@@ -545,7 +545,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         srcBkpt, setBreakpointsParams.Source.Path, message, verified: _noDebug));
 
                 // Return non-verified breakpoint message.
-                await requestContext.SendResult(
+                await requestContext.SendResultAsync(
                     new SetBreakpointsResponseBody
                     {
                         Breakpoints = srcBreakpoints.ToArray()
@@ -576,7 +576,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 try
                 {
                     updatedBreakpointDetails =
-                        await _editorSession.DebugService.SetLineBreakpoints(
+                        await _editorSession.DebugService.SetLineBreakpointsAsync(
                             scriptFile,
                             breakpointDetails);
                 }
@@ -591,7 +591,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new SetBreakpointsResponseBody {
                     Breakpoints =
                         updatedBreakpointDetails
@@ -600,7 +600,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleSetFunctionBreakpointsRequest(
+        protected async Task HandleSetFunctionBreakpointsRequestAsync(
             SetFunctionBreakpointsRequestArguments setBreakpointsParams,
             RequestContext<SetBreakpointsResponseBody> requestContext)
         {
@@ -623,7 +623,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 try
                 {
                     updatedBreakpointDetails =
-                        await _editorSession.DebugService.SetCommandBreakpoints(
+                        await _editorSession.DebugService.SetCommandBreakpointsAsync(
                             breakpointDetails);
                 }
                 catch (Exception e)
@@ -637,7 +637,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new SetBreakpointsResponseBody {
                     Breakpoints =
                         updatedBreakpointDetails
@@ -646,7 +646,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleSetExceptionBreakpointsRequest(
+        protected async Task HandleSetExceptionBreakpointsRequestAsync(
             SetExceptionBreakpointsRequestArguments setExceptionBreakpointsParams,
             RequestContext<object> requestContext)
         {
@@ -672,28 +672,28 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             //    }
             //}
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected async Task HandleContinueRequest(
+        protected async Task HandleContinueRequestAsync(
             object continueParams,
             RequestContext<object> requestContext)
         {
             _editorSession.DebugService.Continue();
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected async Task HandleNextRequest(
+        protected async Task HandleNextRequestAsync(
             object nextParams,
             RequestContext<object> requestContext)
         {
             _editorSession.DebugService.StepOver();
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected Task HandlePauseRequest(
+        protected Task HandlePauseRequestAsync(
             object pauseParams,
             RequestContext<object> requestContext)
         {
@@ -703,36 +703,36 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
             catch (NotSupportedException e)
             {
-                return requestContext.SendError(e.Message);
+                return requestContext.SendErrorAsync(e.Message);
             }
 
             // This request is responded to by sending the "stopped" event
             return Task.FromResult(true);
         }
 
-        protected async Task HandleStepInRequest(
+        protected async Task HandleStepInRequestAsync(
             object stepInParams,
             RequestContext<object> requestContext)
         {
             _editorSession.DebugService.StepIn();
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected async Task HandleStepOutRequest(
+        protected async Task HandleStepOutRequestAsync(
             object stepOutParams,
             RequestContext<object> requestContext)
         {
             _editorSession.DebugService.StepOut();
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        protected async Task HandleThreadsRequest(
+        protected async Task HandleThreadsRequestAsync(
             object threadsParams,
             RequestContext<ThreadsResponseBody> requestContext)
         {
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new ThreadsResponseBody
                 {
                     Threads = new Thread[]
@@ -747,7 +747,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleStackTraceRequest(
+        protected async Task HandleStackTraceRequestAsync(
             StackTraceRequestArguments stackTraceParams,
             RequestContext<StackTraceResponseBody> requestContext)
         {
@@ -758,7 +758,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // begun building.
             if (stackFrames == null)
             {
-                await requestContext.SendResult(
+                await requestContext.SendResultAsync(
                     new StackTraceResponseBody
                     {
                         StackFrames = new StackFrame[0],
@@ -791,7 +791,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         i));
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new StackTraceResponseBody
                 {
                     StackFrames = newStackFrames.ToArray(),
@@ -799,7 +799,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleScopesRequest(
+        protected async Task HandleScopesRequestAsync(
             ScopesRequestArguments scopesParams,
             RequestContext<ScopesResponseBody> requestContext)
         {
@@ -807,7 +807,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 _editorSession.DebugService.GetVariableScopes(
                     scopesParams.FrameId);
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new ScopesResponseBody
                 {
                     Scopes =
@@ -817,7 +817,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleVariablesRequest(
+        protected async Task HandleVariablesRequestAsync(
             VariablesRequestArguments variablesParams,
             RequestContext<VariablesResponseBody> requestContext)
         {
@@ -842,17 +842,17 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // TODO: This shouldn't be so broad
             }
 
-            await requestContext.SendResult(variablesResponse);
+            await requestContext.SendResultAsync(variablesResponse);
         }
 
-        protected async Task HandleSetVariablesRequest(
+        protected async Task HandleSetVariablesRequestAsync(
             SetVariableRequestArguments setVariableParams,
             RequestContext<SetVariableResponseBody> requestContext)
         {
             try
             {
                 string updatedValue =
-                    await _editorSession.DebugService.SetVariable(
+                    await _editorSession.DebugService.SetVariableAsync(
                         setVariableParams.VariablesReference,
                         setVariableParams.Name,
                         setVariableParams.Value);
@@ -862,7 +862,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     Value = updatedValue
                 };
 
-                await requestContext.SendResult(setVariableResponse);
+                await requestContext.SendResultAsync(setVariableResponse);
             }
             catch (Exception ex) when (ex is ArgumentTransformationMetadataException ||
                                        ex is InvalidPowerShellExpressionException ||
@@ -870,18 +870,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             {
                 // Catch common, innocuous errors caused by the user supplying a value that can't be converted or the variable is not settable.
                 Logger.Write(LogLevel.Verbose, $"Failed to set variable: {ex.Message}");
-                await requestContext.SendError(ex.Message);
+                await requestContext.SendErrorAsync(ex.Message);
             }
             catch (Exception ex)
             {
                 Logger.Write(LogLevel.Error, $"Unexpected error setting variable: {ex.Message}");
                 string msg =
                     $"Unexpected error: {ex.GetType().Name} - {ex.Message}  Please report this error to the PowerShellEditorServices project on GitHub.";
-                await requestContext.SendError(msg);
+                await requestContext.SendErrorAsync(msg);
             }
         }
 
-        protected Task HandleSourceRequest(
+        protected Task HandleSourceRequestAsync(
             SourceRequestArguments sourceParams,
             RequestContext<SourceResponseBody> requestContext)
         {
@@ -891,7 +891,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             return Task.FromResult(true);
         }
 
-        protected async Task HandleEvaluateRequest(
+        protected async Task HandleEvaluateRequestAsync(
             EvaluateRequestArguments evaluateParams,
             RequestContext<EvaluateResponseBody> requestContext)
         {
@@ -909,7 +909,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 var notAwaited =
                     _editorSession
                         .PowerShellContext
-                        .ExecuteScriptString(evaluateParams.Expression, false, true)
+                        .ExecuteScriptStringAsync(evaluateParams.Expression, false, true)
                         .ConfigureAwait(false);
             }
             else
@@ -928,7 +928,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     if (result == null)
                     {
                         result =
-                            await _editorSession.DebugService.EvaluateExpression(
+                            await _editorSession.DebugService.EvaluateExpressionAsync(
                                 evaluateParams.Expression,
                                 evaluateParams.FrameId,
                                 isFromRepl);
@@ -944,7 +944,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new EvaluateResponseBody
                 {
                     Result = valueString,
@@ -952,9 +952,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        private async Task WriteUseIntegratedConsoleMessage()
+        private async Task WriteUseIntegratedConsoleMessageAsync()
         {
-            await _messageSender.SendEvent(
+            await _messageSender.SendEventAsync(
                 OutputEvent.Type,
                 new OutputEventBody
                 {
@@ -965,25 +965,25 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         private void RegisterEventHandlers()
         {
-            _editorSession.PowerShellContext.RunspaceChanged += powerShellContext_RunspaceChanged;
-            _editorSession.DebugService.BreakpointUpdated += DebugService_BreakpointUpdated;
-            _editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStopped;
-            _editorSession.PowerShellContext.DebuggerResumed += powerShellContext_DebuggerResumed;
+            _editorSession.PowerShellContext.RunspaceChanged += powerShellContext_RunspaceChangedAsync;
+            _editorSession.DebugService.BreakpointUpdated += DebugService_BreakpointUpdatedAsync;
+            _editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStoppedAsync;
+            _editorSession.PowerShellContext.DebuggerResumed += powerShellContext_DebuggerResumedAsync;
         }
 
         private void UnregisterEventHandlers()
         {
-            _editorSession.PowerShellContext.RunspaceChanged -= powerShellContext_RunspaceChanged;
-            _editorSession.DebugService.BreakpointUpdated -= DebugService_BreakpointUpdated;
-            _editorSession.DebugService.DebuggerStopped -= DebugService_DebuggerStopped;
-            _editorSession.PowerShellContext.DebuggerResumed -= powerShellContext_DebuggerResumed;
+            _editorSession.PowerShellContext.RunspaceChanged -= powerShellContext_RunspaceChangedAsync;
+            _editorSession.DebugService.BreakpointUpdated -= DebugService_BreakpointUpdatedAsync;
+            _editorSession.DebugService.DebuggerStopped -= DebugService_DebuggerStoppedAsync;
+            _editorSession.PowerShellContext.DebuggerResumed -= powerShellContext_DebuggerResumedAsync;
         }
 
-        private async Task ClearSessionBreakpoints()
+        private async Task ClearSessionBreakpointsAsync()
         {
             try
             {
-                await _editorSession.DebugService.ClearAllBreakpoints();
+                await _editorSession.DebugService.ClearAllBreakpointsAsync();
             }
             catch (Exception e)
             {
@@ -995,7 +995,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         #region Event Handlers
 
-        async void DebugService_DebuggerStopped(object sender, DebuggerStoppedEventArgs e)
+        async void DebugService_DebuggerStoppedAsync(object sender, DebuggerStoppedEventArgs e)
         {
             // Provide the reason for why the debugger has stopped script execution.
             // See https://github.com/Microsoft/vscode/issues/3648
@@ -1012,7 +1012,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         : "breakpoint";
             }
 
-            await _messageSender.SendEvent(
+            await _messageSender.SendEventAsync(
                 StoppedEvent.Type,
                 new StoppedEventBody
                 {
@@ -1025,7 +1025,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        async void powerShellContext_RunspaceChanged(object sender, RunspaceChangedEventArgs e)
+        async void powerShellContext_RunspaceChangedAsync(object sender, RunspaceChangedEventArgs e)
         {
             if (_waitingForAttach &&
                 e.ChangeAction == RunspaceChangeAction.Enter &&
@@ -1034,7 +1034,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // Send the InitializedEvent so that the debugger will continue
                 // sending configuration requests
                 _waitingForAttach = false;
-                await _messageSender.SendEvent(InitializedEvent.Type, null);
+                await _messageSender.SendEventAsync(InitializedEvent.Type, null);
             }
             else if (
                 e.ChangeAction == RunspaceChangeAction.Exit &&
@@ -1044,7 +1044,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // Exited the session while the debugger is stopped,
                 // send a ContinuedEvent so that the client changes the
                 // UI to appear to be running again
-                await _messageSender.SendEvent<ContinuedEvent, Object>(
+                await _messageSender.SendEventAsync<ContinuedEvent, Object>(
                     ContinuedEvent.Type,
                     new ContinuedEvent
                     {
@@ -1054,9 +1054,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
         }
 
-        private async void powerShellContext_DebuggerResumed(object sender, DebuggerResumeAction e)
+        private async void powerShellContext_DebuggerResumedAsync(object sender, DebuggerResumeAction e)
         {
-            await _messageSender.SendEvent(
+            await _messageSender.SendEventAsync(
                 ContinuedEvent.Type,
                 new ContinuedEvent
                 {
@@ -1065,7 +1065,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        private async void DebugService_BreakpointUpdated(object sender, BreakpointUpdatedEventArgs e)
+        private async void DebugService_BreakpointUpdatedAsync(object sender, BreakpointUpdatedEventArgs e)
         {
             string reason = "changed";
 
@@ -1106,7 +1106,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             breakpoint.Verified = e.UpdateType != BreakpointUpdateType.Disabled;
 
-            await _messageSender.SendEvent(
+            await _messageSender.SendEventAsync(
                 BreakpointEvent.Type,
                 new BreakpointEvent
                 {

--- a/src/PowerShellEditorServices.Protocol/Server/IMessageDispatcher.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/IMessageDispatcher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol
 {
     public interface IMessageDispatcher
     {
-        Task DispatchMessage(
+        Task DispatchMessageAsync(
             Message messageToDispatch,
             MessageWriter messageWriter);
     }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -77,13 +77,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.editorSession = editorSession;
             this.serverCompletedTask = serverCompletedTask;
             // Attach to the underlying PowerShell context to listen for changes in the runspace or execution status
-            this.editorSession.PowerShellContext.RunspaceChanged += PowerShellContext_RunspaceChanged;
-            this.editorSession.PowerShellContext.ExecutionStatusChanged += PowerShellContext_ExecutionStatusChanged;
+            this.editorSession.PowerShellContext.RunspaceChanged += PowerShellContext_RunspaceChangedAsync;
+            this.editorSession.PowerShellContext.ExecutionStatusChanged += PowerShellContext_ExecutionStatusChangedAsync;
 
             // Attach to ExtensionService events
-            this.editorSession.ExtensionService.CommandAdded += ExtensionService_ExtensionAdded;
-            this.editorSession.ExtensionService.CommandUpdated += ExtensionService_ExtensionUpdated;
-            this.editorSession.ExtensionService.CommandRemoved += ExtensionService_ExtensionRemoved;
+            this.editorSession.ExtensionService.CommandAdded += ExtensionService_ExtensionAddedAsync;
+            this.editorSession.ExtensionService.CommandUpdated += ExtensionService_ExtensionUpdatedAsync;
+            this.editorSession.ExtensionService.CommandRemoved += ExtensionService_ExtensionRemovedAsync;
 
             this.messageSender = messageSender;
             this.messageHandlers = messageHandlers;
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     this.messageSender);
 
             this.editorSession.StartDebugService(this.editorOperations);
-            this.editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStopped;
+            this.editorSession.DebugService.DebuggerStopped += DebugService_DebuggerStoppedAsync;
         }
 
         /// <summary>
@@ -106,59 +106,59 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         {
             // Register all supported message types
 
-            this.messageHandlers.SetRequestHandler(ShutdownRequest.Type, this.HandleShutdownRequest);
-            this.messageHandlers.SetEventHandler(ExitNotification.Type, this.HandleExitNotification);
+            this.messageHandlers.SetRequestHandler(ShutdownRequest.Type, this.HandleShutdownRequestAsync);
+            this.messageHandlers.SetEventHandler(ExitNotification.Type, this.HandleExitNotificationAsync);
 
-            this.messageHandlers.SetRequestHandler(InitializeRequest.Type, this.HandleInitializeRequest);
-            this.messageHandlers.SetEventHandler(InitializedNotification.Type, this.HandleInitializedNotification);
+            this.messageHandlers.SetRequestHandler(InitializeRequest.Type, this.HandleInitializeRequestAsync);
+            this.messageHandlers.SetEventHandler(InitializedNotification.Type, this.HandleInitializedNotificationAsync);
 
-            this.messageHandlers.SetEventHandler(DidOpenTextDocumentNotification.Type, this.HandleDidOpenTextDocumentNotification);
-            this.messageHandlers.SetEventHandler(DidCloseTextDocumentNotification.Type, this.HandleDidCloseTextDocumentNotification);
-            this.messageHandlers.SetEventHandler(DidSaveTextDocumentNotification.Type, this.HandleDidSaveTextDocumentNotification);
-            this.messageHandlers.SetEventHandler(DidChangeTextDocumentNotification.Type, this.HandleDidChangeTextDocumentNotification);
-            this.messageHandlers.SetEventHandler(DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type, this.HandleDidChangeConfigurationNotification);
+            this.messageHandlers.SetEventHandler(DidOpenTextDocumentNotification.Type, this.HandleDidOpenTextDocumentNotificationAsync);
+            this.messageHandlers.SetEventHandler(DidCloseTextDocumentNotification.Type, this.HandleDidCloseTextDocumentNotificationAsync);
+            this.messageHandlers.SetEventHandler(DidSaveTextDocumentNotification.Type, this.HandleDidSaveTextDocumentNotificationAsync);
+            this.messageHandlers.SetEventHandler(DidChangeTextDocumentNotification.Type, this.HandleDidChangeTextDocumentNotificationAsync);
+            this.messageHandlers.SetEventHandler(DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type, this.HandleDidChangeConfigurationNotificationAsync);
 
-            this.messageHandlers.SetRequestHandler(DefinitionRequest.Type, this.HandleDefinitionRequest);
-            this.messageHandlers.SetRequestHandler(ReferencesRequest.Type, this.HandleReferencesRequest);
-            this.messageHandlers.SetRequestHandler(CompletionRequest.Type, this.HandleCompletionRequest);
-            this.messageHandlers.SetRequestHandler(CompletionResolveRequest.Type, this.HandleCompletionResolveRequest);
-            this.messageHandlers.SetRequestHandler(SignatureHelpRequest.Type, this.HandleSignatureHelpRequest);
-            this.messageHandlers.SetRequestHandler(DocumentHighlightRequest.Type, this.HandleDocumentHighlightRequest);
-            this.messageHandlers.SetRequestHandler(HoverRequest.Type, this.HandleHoverRequest);
-            this.messageHandlers.SetRequestHandler(WorkspaceSymbolRequest.Type, this.HandleWorkspaceSymbolRequest);
-            this.messageHandlers.SetRequestHandler(CodeActionRequest.Type, this.HandleCodeActionRequest);
-            this.messageHandlers.SetRequestHandler(DocumentFormattingRequest.Type, this.HandleDocumentFormattingRequest);
+            this.messageHandlers.SetRequestHandler(DefinitionRequest.Type, this.HandleDefinitionRequestAsync);
+            this.messageHandlers.SetRequestHandler(ReferencesRequest.Type, this.HandleReferencesRequestAsync);
+            this.messageHandlers.SetRequestHandler(CompletionRequest.Type, this.HandleCompletionRequestAsync);
+            this.messageHandlers.SetRequestHandler(CompletionResolveRequest.Type, this.HandleCompletionResolveRequestAsync);
+            this.messageHandlers.SetRequestHandler(SignatureHelpRequest.Type, this.HandleSignatureHelpRequestAsync);
+            this.messageHandlers.SetRequestHandler(DocumentHighlightRequest.Type, this.HandleDocumentHighlightRequestAsync);
+            this.messageHandlers.SetRequestHandler(HoverRequest.Type, this.HandleHoverRequestAsync);
+            this.messageHandlers.SetRequestHandler(WorkspaceSymbolRequest.Type, this.HandleWorkspaceSymbolRequestAsync);
+            this.messageHandlers.SetRequestHandler(CodeActionRequest.Type, this.HandleCodeActionRequestAsync);
+            this.messageHandlers.SetRequestHandler(DocumentFormattingRequest.Type, this.HandleDocumentFormattingRequestAsync);
             this.messageHandlers.SetRequestHandler(
                 DocumentRangeFormattingRequest.Type,
-                this.HandleDocumentRangeFormattingRequest);
+                this.HandleDocumentRangeFormattingRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(ShowHelpRequest.Type, this.HandleShowHelpRequest);
+            this.messageHandlers.SetRequestHandler(ShowHelpRequest.Type, this.HandleShowHelpRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(ExpandAliasRequest.Type, this.HandleExpandAliasRequest);
+            this.messageHandlers.SetRequestHandler(ExpandAliasRequest.Type, this.HandleExpandAliasRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(FindModuleRequest.Type, this.HandleFindModuleRequest);
-            this.messageHandlers.SetRequestHandler(InstallModuleRequest.Type, this.HandleInstallModuleRequest);
+            this.messageHandlers.SetRequestHandler(FindModuleRequest.Type, this.HandleFindModuleRequestAsync);
+            this.messageHandlers.SetRequestHandler(InstallModuleRequest.Type, this.HandleInstallModuleRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(InvokeExtensionCommandRequest.Type, this.HandleInvokeExtensionCommandRequest);
+            this.messageHandlers.SetRequestHandler(InvokeExtensionCommandRequest.Type, this.HandleInvokeExtensionCommandRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(PowerShellVersionRequest.Type, this.HandlePowerShellVersionRequest);
+            this.messageHandlers.SetRequestHandler(PowerShellVersionRequest.Type, this.HandlePowerShellVersionRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(NewProjectFromTemplateRequest.Type, this.HandleNewProjectFromTemplateRequest);
-            this.messageHandlers.SetRequestHandler(GetProjectTemplatesRequest.Type, this.HandleGetProjectTemplatesRequest);
+            this.messageHandlers.SetRequestHandler(NewProjectFromTemplateRequest.Type, this.HandleNewProjectFromTemplateRequestAsync);
+            this.messageHandlers.SetRequestHandler(GetProjectTemplatesRequest.Type, this.HandleGetProjectTemplatesRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(DebugAdapterMessages.EvaluateRequest.Type, this.HandleEvaluateRequest);
+            this.messageHandlers.SetRequestHandler(DebugAdapterMessages.EvaluateRequest.Type, this.HandleEvaluateRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(GetPSSARulesRequest.Type, this.HandleGetPSSARulesRequest);
-            this.messageHandlers.SetRequestHandler(SetPSSARulesRequest.Type, this.HandleSetPSSARulesRequest);
+            this.messageHandlers.SetRequestHandler(GetPSSARulesRequest.Type, this.HandleGetPSSARulesRequestAsync);
+            this.messageHandlers.SetRequestHandler(SetPSSARulesRequest.Type, this.HandleSetPSSARulesRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(ScriptRegionRequest.Type, this.HandleGetFormatScriptRegionRequest);
+            this.messageHandlers.SetRequestHandler(ScriptRegionRequest.Type, this.HandleGetFormatScriptRegionRequestAsync);
 
-            this.messageHandlers.SetRequestHandler(GetPSHostProcessesRequest.Type, this.HandleGetPSHostProcessesRequest);
-            this.messageHandlers.SetRequestHandler(CommentHelpRequest.Type, this.HandleCommentHelpRequest);
+            this.messageHandlers.SetRequestHandler(GetPSHostProcessesRequest.Type, this.HandleGetPSHostProcessesRequestAsync);
+            this.messageHandlers.SetRequestHandler(CommentHelpRequest.Type, this.HandleCommentHelpRequestAsync);
 
             // Initialize the extension service
             // TODO: This should be made awaited once Initialize is async!
-            this.editorSession.ExtensionService.Initialize(
+            this.editorSession.ExtensionService.InitializeAsync(
                 this.editorOperations,
                 this.editorSession.Components).Wait();
         }
@@ -175,15 +175,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         #region Built-in Message Handlers
 
-        private async Task HandleShutdownRequest(
+        private async Task HandleShutdownRequestAsync(
             RequestContext<object> requestContext)
         {
             // Allow the implementor to shut down gracefully
 
-            await requestContext.SendResult(new object());
+            await requestContext.SendResultAsync(new object());
         }
 
-        private async Task HandleExitNotification(
+        private async Task HandleExitNotificationAsync(
             object exitParams,
             EventContext eventContext)
         {
@@ -191,14 +191,14 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             await this.Stop();
         }
 
-        private Task HandleInitializedNotification(InitializedParams initializedParams,
+        private Task HandleInitializedNotificationAsync(InitializedParams initializedParams,
             EventContext eventContext)
         {
             // Can do dynamic registration of capabilities in this notification handler
             return Task.FromResult(true);
         }
 
-        protected async Task HandleInitializeRequest(
+        protected async Task HandleInitializeRequestAsync(
             InitializeParams initializeParams,
             RequestContext<InitializeResult> requestContext)
         {
@@ -208,12 +208,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // Set the working directory of the PowerShell session to the workspace path
             if (editorSession.Workspace.WorkspacePath != null)
             {
-                await editorSession.PowerShellContext.SetWorkingDirectory(
+                await editorSession.PowerShellContext.SetWorkingDirectoryAsync(
                     editorSession.Workspace.WorkspacePath,
                     isPathAlreadyEscaped: false);
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new InitializeResult
                 {
                     Capabilities = new ServerCapabilities
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 });
         }
 
-        protected async Task HandleShowHelpRequest(
+        protected async Task HandleShowHelpRequestAsync(
             string helpParams,
             RequestContext<object> requestContext)
         {
@@ -286,11 +286,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
             // TODO: Rather than print the help in the console, we should send the string back
             //       to VSCode to display in a help pop-up (or similar)
-            await editorSession.PowerShellContext.ExecuteCommand<PSObject>(checkHelpPSCommand, sendOutputToHost: true);
-            await requestContext.SendResult(null);
+            await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(checkHelpPSCommand, sendOutputToHost: true);
+            await requestContext.SendResultAsync(null);
         }
 
-        private async Task HandleSetPSSARulesRequest(
+        private async Task HandleSetPSSARulesRequestAsync(
             object param,
             RequestContext<object> requestContext)
         {
@@ -310,16 +310,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 editorSession.AnalysisService.ActiveRules = activeRules.ToArray();
             }
 
-            var sendresult = requestContext.SendResult(null);
+            var sendresult = requestContext.SendResultAsync(null);
             var scripFile = editorSession.Workspace.GetFile((string)dynParams.filepath);
-            await RunScriptDiagnostics(
+            await RunScriptDiagnosticsAsync(
                     new ScriptFile[] { scripFile },
                         editorSession,
-                        this.messageSender.SendEvent);
+                        this.messageSender.SendEventAsync);
             await sendresult;
         }
 
-        private async Task HandleGetFormatScriptRegionRequest(
+        private async Task HandleGetFormatScriptRegionRequestAsync(
             ScriptRegionRequestParams requestParams,
             RequestContext<ScriptRegionRequestResult> requestContext)
         {
@@ -355,13 +355,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     break;
             }
 
-            await requestContext.SendResult(new ScriptRegionRequestResult
+            await requestContext.SendResultAsync(new ScriptRegionRequestResult
             {
                 scriptRegion = scriptRegion
             });
         }
 
-        private async Task HandleGetPSSARulesRequest(
+        private async Task HandleGetPSSARulesRequestAsync(
             object param,
             RequestContext<object> requestContext)
         {
@@ -378,10 +378,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 }
             }
 
-            await requestContext.SendResult(rules);
+            await requestContext.SendResultAsync(rules);
         }
 
-        private async Task HandleInstallModuleRequest(
+        private async Task HandleInstallModuleRequestAsync(
             string moduleName,
             RequestContext<object> requestContext
         )
@@ -389,15 +389,15 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             var script = string.Format("Install-Module -Name {0} -Scope CurrentUser", moduleName);
 
             var executeTask =
-               editorSession.PowerShellContext.ExecuteScriptString(
+               editorSession.PowerShellContext.ExecuteScriptStringAsync(
                    script,
                    true,
                    true).ConfigureAwait(false);
 
-            await requestContext.SendResult(null);
+            await requestContext.SendResultAsync(null);
         }
 
-        private Task HandleInvokeExtensionCommandRequest(
+        private Task HandleInvokeExtensionCommandRequestAsync(
             InvokeExtensionCommandRequest commandDetails,
             RequestContext<string> requestContext)
         {
@@ -410,29 +410,29 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     commandDetails.Context);
 
             Task commandTask =
-                this.editorSession.ExtensionService.InvokeCommand(
+                this.editorSession.ExtensionService.InvokeCommandAsync(
                     commandDetails.Name,
                     editorContext);
 
             commandTask.ContinueWith(t =>
             {
-                return requestContext.SendResult(null);
+                return requestContext.SendResultAsync(null);
             });
 
             return Task.FromResult(true);
         }
 
-        private Task HandleNewProjectFromTemplateRequest(
+        private Task HandleNewProjectFromTemplateRequestAsync(
             NewProjectFromTemplateRequest newProjectArgs,
             RequestContext<NewProjectFromTemplateResponse> requestContext)
         {
             // Don't await the Task here so that we don't block the session
             this.editorSession.TemplateService
-                .CreateFromTemplate(newProjectArgs.TemplatePath, newProjectArgs.DestinationPath)
+                .CreateFromTemplateAsync(newProjectArgs.TemplatePath, newProjectArgs.DestinationPath)
                 .ContinueWith(
                     async task =>
                     {
-                        await requestContext.SendResult(
+                        await requestContext.SendResultAsync(
                             new NewProjectFromTemplateResponse
                             {
                                 CreationSuccessful = task.Result
@@ -442,19 +442,19 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             return Task.FromResult(true);
         }
 
-        private async Task HandleGetProjectTemplatesRequest(
+        private async Task HandleGetProjectTemplatesRequestAsync(
             GetProjectTemplatesRequest requestArgs,
             RequestContext<GetProjectTemplatesResponse> requestContext)
         {
-            bool plasterInstalled = await this.editorSession.TemplateService.ImportPlasterIfInstalled();
+            bool plasterInstalled = await this.editorSession.TemplateService.ImportPlasterIfInstalledAsync();
 
             if (plasterInstalled)
             {
                 var availableTemplates =
-                    await this.editorSession.TemplateService.GetAvailableTemplates(
+                    await this.editorSession.TemplateService.GetAvailableTemplatesAsync(
                         requestArgs.IncludeInstalledModules);
 
-                await requestContext.SendResult(
+                await requestContext.SendResultAsync(
                     new GetProjectTemplatesResponse
                     {
                         Templates = availableTemplates
@@ -462,7 +462,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
             else
             {
-                await requestContext.SendResult(
+                await requestContext.SendResultAsync(
                     new GetProjectTemplatesResponse
                     {
                         NeedsModuleInstall = true,
@@ -471,7 +471,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
         }
 
-        private async Task HandleExpandAliasRequest(
+        private async Task HandleExpandAliasRequestAsync(
             string content,
             RequestContext<string> requestContext)
         {
@@ -500,23 +500,23 @@ function __Expand-Alias {
 }";
             var psCommand = new PSCommand();
             psCommand.AddScript(script);
-            await this.editorSession.PowerShellContext.ExecuteCommand<PSObject>(psCommand);
+            await this.editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
 
             psCommand = new PSCommand();
             psCommand.AddCommand("__Expand-Alias").AddArgument(content);
-            var result = await this.editorSession.PowerShellContext.ExecuteCommand<string>(psCommand);
+            var result = await this.editorSession.PowerShellContext.ExecuteCommandAsync<string>(psCommand);
 
-            await requestContext.SendResult(result.First().ToString());
+            await requestContext.SendResultAsync(result.First().ToString());
         }
 
-        private async Task HandleFindModuleRequest(
+        private async Task HandleFindModuleRequestAsync(
             object param,
             RequestContext<object> requestContext)
         {
             var psCommand = new PSCommand();
             psCommand.AddScript("Find-Module | Select Name, Description");
 
-            var modules = await editorSession.PowerShellContext.ExecuteCommand<PSObject>(psCommand);
+            var modules = await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
 
             var moduleList = new List<PSModuleMessage>();
 
@@ -528,10 +528,10 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(moduleList);
+            await requestContext.SendResultAsync(moduleList);
         }
 
-        protected Task HandleDidOpenTextDocumentNotification(
+        protected Task HandleDidOpenTextDocumentNotificationAsync(
             DidOpenTextDocumentParams openParams,
             EventContext eventContext)
         {
@@ -541,7 +541,7 @@ function __Expand-Alias {
                     openParams.TextDocument.Text);
 
             // TODO: Get all recently edited files in the workspace
-            this.RunScriptDiagnostics(
+            this.RunScriptDiagnosticsAsync(
                 new ScriptFile[] { openedFile },
                 editorSession,
                 eventContext);
@@ -551,7 +551,7 @@ function __Expand-Alias {
             return Task.FromResult(true);
         }
 
-        protected async Task HandleDidCloseTextDocumentNotification(
+        protected async Task HandleDidCloseTextDocumentNotificationAsync(
             DidCloseTextDocumentParams closeParams,
             EventContext eventContext)
         {
@@ -561,12 +561,12 @@ function __Expand-Alias {
             if (fileToClose != null)
             {
                 editorSession.Workspace.CloseFile(fileToClose);
-                await ClearMarkers(fileToClose, eventContext);
+                await ClearMarkersAsync(fileToClose, eventContext);
             }
 
             Logger.Write(LogLevel.Verbose, "Finished closing document.");
         }
-        protected async Task HandleDidSaveTextDocumentNotification(
+        protected async Task HandleDidSaveTextDocumentNotificationAsync(
             DidSaveTextDocumentParams saveParams,
             EventContext eventContext)
         {
@@ -578,13 +578,13 @@ function __Expand-Alias {
             {
                 if (this.editorSession.RemoteFileManager.IsUnderRemoteTempPath(savedFile.FilePath))
                 {
-                    await this.editorSession.RemoteFileManager.SaveRemoteFile(
+                    await this.editorSession.RemoteFileManager.SaveRemoteFileAsync(
                         savedFile.FilePath);
                 }
             }
         }
 
-        protected Task HandleDidChangeTextDocumentNotification(
+        protected Task HandleDidChangeTextDocumentNotificationAsync(
             DidChangeTextDocumentParams textChangeParams,
             EventContext eventContext)
         {
@@ -604,7 +604,7 @@ function __Expand-Alias {
             }
 
             // TODO: Get all recently edited files in the workspace
-            this.RunScriptDiagnostics(
+            this.RunScriptDiagnosticsAsync(
                 changedFiles.ToArray(),
                 editorSession,
                 eventContext);
@@ -612,7 +612,7 @@ function __Expand-Alias {
             return Task.FromResult(true);
         }
 
-        protected async Task HandleDidChangeConfigurationNotification(
+        protected async Task HandleDidChangeConfigurationNotificationAsync(
             DidChangeConfigurationParams<LanguageServerSettingsWrapper> configChangeParams,
             EventContext eventContext)
         {
@@ -631,7 +631,7 @@ function __Expand-Alias {
                 this.currentSettings.EnableProfileLoading &&
                 oldLoadProfiles != this.currentSettings.EnableProfileLoading)
             {
-                await this.editorSession.PowerShellContext.LoadHostProfiles();
+                await this.editorSession.PowerShellContext.LoadHostProfilesAsync();
                 this.profilesLoaded = true;
             }
 
@@ -665,18 +665,18 @@ function __Expand-Alias {
                 {
                     foreach (var scriptFile in editorSession.Workspace.GetOpenedFiles())
                     {
-                        await ClearMarkers(scriptFile, eventContext);
+                        await ClearMarkersAsync(scriptFile, eventContext);
                     }
                 }
 
-                await this.RunScriptDiagnostics(
+                await this.RunScriptDiagnosticsAsync(
                     this.editorSession.Workspace.GetOpenedFiles(),
                     this.editorSession,
                     eventContext);
             }
         }
 
-        protected async Task HandleDefinitionRequest(
+        protected async Task HandleDefinitionRequestAsync(
             TextDocumentPositionParams textDocumentPosition,
             RequestContext<Location[]> requestContext)
         {
@@ -696,7 +696,7 @@ function __Expand-Alias {
             if (foundSymbol != null)
             {
                 definition =
-                    await editorSession.LanguageService.GetDefinitionOfSymbol(
+                    await editorSession.LanguageService.GetDefinitionOfSymbolAsync(
                         scriptFile,
                         foundSymbol,
                         editorSession.Workspace);
@@ -712,10 +712,10 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(definitionLocations.ToArray());
+            await requestContext.SendResultAsync(definitionLocations.ToArray());
         }
 
-        protected async Task HandleReferencesRequest(
+        protected async Task HandleReferencesRequestAsync(
             ReferencesParams referencesParams,
             RequestContext<Location[]> requestContext)
         {
@@ -730,7 +730,7 @@ function __Expand-Alias {
                     referencesParams.Position.Character + 1);
 
             FindReferencesResult referencesResult =
-                await editorSession.LanguageService.FindReferencesOfSymbol(
+                await editorSession.LanguageService.FindReferencesOfSymbolAsync(
                     foundSymbol,
                     editorSession.Workspace.ExpandScriptReferences(scriptFile),
                     editorSession.Workspace);
@@ -751,10 +751,10 @@ function __Expand-Alias {
                 referenceLocations = locations.ToArray();
             }
 
-            await requestContext.SendResult(referenceLocations);
+            await requestContext.SendResultAsync(referenceLocations);
         }
 
-        protected async Task HandleCompletionRequest(
+        protected async Task HandleCompletionRequestAsync(
             TextDocumentPositionParams textDocumentPositionParams,
             RequestContext<CompletionItem[]> requestContext)
         {
@@ -766,7 +766,7 @@ function __Expand-Alias {
                     textDocumentPositionParams.TextDocument.Uri);
 
             CompletionResults completionResults =
-                await editorSession.LanguageService.GetCompletionsInFile(
+                await editorSession.LanguageService.GetCompletionsInFileAsync(
                     scriptFile,
                     cursorLine,
                     cursorColumn);
@@ -782,10 +782,10 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(completionItems);
+            await requestContext.SendResultAsync(completionItems);
         }
 
-        protected async Task HandleCompletionResolveRequest(
+        protected async Task HandleCompletionResolveRequestAsync(
             CompletionItem completionItem,
             RequestContext<CompletionItem> requestContext)
         {
@@ -793,24 +793,24 @@ function __Expand-Alias {
             {
                 // Get the documentation for the function
                 CommandInfo commandInfo =
-                    await CommandHelpers.GetCommandInfo(
+                    await CommandHelpers.GetCommandInfoAsync(
                         completionItem.Label,
                         this.editorSession.PowerShellContext);
 
                 if (commandInfo != null)
                 {
                     completionItem.Documentation =
-                        await CommandHelpers.GetCommandSynopsis(
+                        await CommandHelpers.GetCommandSynopsisAsync(
                             commandInfo,
                             this.editorSession.PowerShellContext);
                 }
             }
 
             // Send back the updated CompletionItem
-            await requestContext.SendResult(completionItem);
+            await requestContext.SendResultAsync(completionItem);
         }
 
-        protected async Task HandleSignatureHelpRequest(
+        protected async Task HandleSignatureHelpRequestAsync(
             TextDocumentPositionParams textDocumentPositionParams,
             RequestContext<SignatureHelp> requestContext)
         {
@@ -819,7 +819,7 @@ function __Expand-Alias {
                     textDocumentPositionParams.TextDocument.Uri);
 
             ParameterSetSignatures parameterSets =
-                await editorSession.LanguageService.FindParameterSetsInFile(
+                await editorSession.LanguageService.FindParameterSetsInFileAsync(
                     scriptFile,
                     textDocumentPositionParams.Position.Line + 1,
                     textDocumentPositionParams.Position.Character + 1);
@@ -848,7 +848,7 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new SignatureHelp
                 {
                     Signatures = signatures,
@@ -857,7 +857,7 @@ function __Expand-Alias {
                 });
         }
 
-        protected async Task HandleDocumentHighlightRequest(
+        protected async Task HandleDocumentHighlightRequestAsync(
             TextDocumentPositionParams textDocumentPositionParams,
             RequestContext<DocumentHighlight[]> requestContext)
         {
@@ -887,10 +887,10 @@ function __Expand-Alias {
                 documentHighlights = highlights.ToArray();
             }
 
-            await requestContext.SendResult(documentHighlights);
+            await requestContext.SendResultAsync(documentHighlights);
         }
 
-        protected async Task HandleHoverRequest(
+        protected async Task HandleHoverRequestAsync(
             TextDocumentPositionParams textDocumentPositionParams,
             RequestContext<Hover> requestContext)
         {
@@ -901,7 +901,7 @@ function __Expand-Alias {
             SymbolDetails symbolDetails =
                 await editorSession
                     .LanguageService
-                    .FindSymbolDetailsAtLocation(
+                    .FindSymbolDetailsAtLocationAsync(
                         scriptFile,
                         textDocumentPositionParams.Position.Line + 1,
                         textDocumentPositionParams.Position.Character + 1);
@@ -931,7 +931,7 @@ function __Expand-Alias {
                 symbolRange = GetRangeFromScriptRegion(symbolDetails.SymbolReference.ScriptRegion);
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new Hover
                 {
                     Contents = symbolInfo.ToArray(),
@@ -939,7 +939,7 @@ function __Expand-Alias {
                 });
         }
 
-        protected async Task HandleDocumentSymbolRequest(
+        protected async Task HandleDocumentSymbolRequestAsync(
             DocumentSymbolParams documentSymbolParams,
             RequestContext<SymbolInformation[]> requestContext)
         {
@@ -976,7 +976,7 @@ function __Expand-Alias {
                 symbols = symbolAcc.ToArray();
             }
 
-            await requestContext.SendResult(symbols);
+            await requestContext.SendResultAsync(symbols);
         }
 
         public static SymbolKind GetSymbolKind(SymbolType symbolType)
@@ -1007,7 +1007,7 @@ function __Expand-Alias {
             return name;
         }
 
-        protected async Task HandleWorkspaceSymbolRequest(
+        protected async Task HandleWorkspaceSymbolRequestAsync(
             WorkspaceSymbolParams workspaceSymbolParams,
             RequestContext<SymbolInformation[]> requestContext)
         {
@@ -1048,19 +1048,19 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(symbols.ToArray());
+            await requestContext.SendResultAsync(symbols.ToArray());
         }
 
-        protected async Task HandlePowerShellVersionRequest(
+        protected async Task HandlePowerShellVersionRequestAsync(
             object noParams,
             RequestContext<PowerShellVersion> requestContext)
         {
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new PowerShellVersion(
                     this.editorSession.PowerShellContext.LocalPowerShellVersion));
         }
 
-        protected async Task HandleGetPSHostProcessesRequest(
+        protected async Task HandleGetPSHostProcessesRequestAsync(
             object noParams,
             RequestContext<GetPSHostProcessesResponse[]> requestContext)
         {
@@ -1076,7 +1076,7 @@ function __Expand-Alias {
                     .AddParameter("NE")
                     .AddParameter("Value", processId.ToString());
 
-                var processes = await editorSession.PowerShellContext.ExecuteCommand<PSObject>(psCommand);
+                var processes = await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
                 if (processes != null)
                 {
                     foreach (dynamic p in processes)
@@ -1093,10 +1093,10 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(psHostProcesses.ToArray());
+            await requestContext.SendResultAsync(psHostProcesses.ToArray());
         }
 
-        protected async Task HandleCommentHelpRequest(
+        protected async Task HandleCommentHelpRequestAsync(
            CommentHelpRequestParams requestParams,
            RequestContext<CommentHelpRequestResult> requestContext)
         {
@@ -1113,7 +1113,7 @@ function __Expand-Alias {
 
             if (functionDefinitionAst == null)
             {
-                await requestContext.SendResult(result);
+                await requestContext.SendResultAsync(result);
                 return;
             }
 
@@ -1146,7 +1146,7 @@ function __Expand-Alias {
 
             if (helpText == null)
             {
-                await requestContext.SendResult(result);
+                await requestContext.SendResultAsync(result);
                 return;
             }
 
@@ -1160,7 +1160,7 @@ function __Expand-Alias {
                 result.Content = result.Content.Skip(1).ToArray();
             }
 
-            await requestContext.SendResult(result);
+            await requestContext.SendResultAsync(result);
         }
 
         private bool IsQueryMatch(string query, string symbolName)
@@ -1168,7 +1168,7 @@ function __Expand-Alias {
             return symbolName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        protected async Task HandleCodeActionRequest(
+        protected async Task HandleCodeActionRequestAsync(
             CodeActionParams codeActionParams,
             RequestContext<CodeActionCommand[]> requestContext)
         {
@@ -1194,20 +1194,20 @@ function __Expand-Alias {
                 }
             }
 
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 codeActionCommands.ToArray());
         }
 
-        protected async Task HandleDocumentFormattingRequest(
+        protected async Task HandleDocumentFormattingRequestAsync(
             DocumentFormattingParams formattingParams,
             RequestContext<TextEdit[]> requestContext)
         {
-            var result = await Format(
+            var result = await FormatAsync(
                 formattingParams.TextDocument.Uri,
                 formattingParams.options,
                 null);
 
-            await requestContext.SendResult(new TextEdit[1]
+            await requestContext.SendResultAsync(new TextEdit[1]
             {
                 new TextEdit
                 {
@@ -1217,16 +1217,16 @@ function __Expand-Alias {
             });
         }
 
-        protected async Task HandleDocumentRangeFormattingRequest(
+        protected async Task HandleDocumentRangeFormattingRequestAsync(
             DocumentRangeFormattingParams formattingParams,
             RequestContext<TextEdit[]> requestContext)
         {
-            var result = await Format(
+            var result = await FormatAsync(
                 formattingParams.TextDocument.Uri,
                 formattingParams.Options,
                 formattingParams.Range);
 
-            await requestContext.SendResult(new TextEdit[1]
+            await requestContext.SendResultAsync(new TextEdit[1]
             {
                 new TextEdit
                 {
@@ -1236,7 +1236,7 @@ function __Expand-Alias {
             });
         }
 
-        protected Task HandleEvaluateRequest(
+        protected Task HandleEvaluateRequestAsync(
             DebugAdapterMessages.EvaluateRequestArguments evaluateParams,
             RequestContext<DebugAdapterMessages.EvaluateResponseBody> requestContext)
         {
@@ -1245,7 +1245,7 @@ function __Expand-Alias {
             // is executing.  This important in cases where the pipeline thread
             // gets blocked by something in the script like a prompt to the user.
             var executeTask =
-                this.editorSession.PowerShellContext.ExecuteScriptString(
+                this.editorSession.PowerShellContext.ExecuteScriptStringAsync(
                     evaluateParams.Expression,
                     writeInputToHost: true,
                     writeOutputToHost: true,
@@ -1259,7 +1259,7 @@ function __Expand-Alias {
                     // Return an empty result since the result value is irrelevant
                     // for this request in the LanguageServer
                     return
-                        requestContext.SendResult(
+                        requestContext.SendResultAsync(
                             new DebugAdapterMessages.EvaluateResponseBody
                             {
                                 Result = "",
@@ -1274,7 +1274,7 @@ function __Expand-Alias {
 
         #region Event Handlers
 
-        private async Task<Tuple<string, Range>> Format(
+        private async Task<Tuple<string, Range>> FormatAsync(
             string documentUri,
             FormattingOptions options,
             Range range)
@@ -1309,7 +1309,7 @@ function __Expand-Alias {
                 }
             };
 
-            formattedScript = await editorSession.AnalysisService.Format(
+            formattedScript = await editorSession.AnalysisService.FormatAsync(
                 scriptFile.Contents,
                 pssaSettings,
                 rangeList);
@@ -1317,9 +1317,9 @@ function __Expand-Alias {
             return Tuple.Create(formattedScript, editRange);
         }
 
-        private async void PowerShellContext_RunspaceChanged(object sender, Session.RunspaceChangedEventArgs e)
+        private async void PowerShellContext_RunspaceChangedAsync(object sender, Session.RunspaceChangedEventArgs e)
         {
-            await this.messageSender.SendEvent(
+            await this.messageSender.SendEventAsync(
                 RunspaceChangedEvent.Type,
                 new Protocol.LanguageServer.RunspaceDetails(e.NewRunspace));
         }
@@ -1329,16 +1329,16 @@ function __Expand-Alias {
         /// </summary>
         /// <param name="sender">the PowerShell context sending the execution event</param>
         /// <param name="e">details of the execution status change</param>
-        private async void PowerShellContext_ExecutionStatusChanged(object sender, ExecutionStatusChangedEventArgs e)
+        private async void PowerShellContext_ExecutionStatusChangedAsync(object sender, ExecutionStatusChangedEventArgs e)
         {
-            await this.messageSender.SendEvent(
+            await this.messageSender.SendEventAsync(
                 ExecutionStatusChangedEvent.Type,
                 e);
         }
 
-        private async void ExtensionService_ExtensionAdded(object sender, EditorCommand e)
+        private async void ExtensionService_ExtensionAddedAsync(object sender, EditorCommand e)
         {
-            await this.messageSender.SendEvent(
+            await this.messageSender.SendEventAsync(
                 ExtensionCommandAddedNotification.Type,
                 new ExtensionCommandAddedNotification
                 {
@@ -1347,9 +1347,9 @@ function __Expand-Alias {
                 });
         }
 
-        private async void ExtensionService_ExtensionUpdated(object sender, EditorCommand e)
+        private async void ExtensionService_ExtensionUpdatedAsync(object sender, EditorCommand e)
         {
-            await this.messageSender.SendEvent(
+            await this.messageSender.SendEventAsync(
                 ExtensionCommandUpdatedNotification.Type,
                 new ExtensionCommandUpdatedNotification
                 {
@@ -1357,9 +1357,9 @@ function __Expand-Alias {
                 });
         }
 
-        private async void ExtensionService_ExtensionRemoved(object sender, EditorCommand e)
+        private async void ExtensionService_ExtensionRemovedAsync(object sender, EditorCommand e)
         {
-            await this.messageSender.SendEvent(
+            await this.messageSender.SendEventAsync(
                 ExtensionCommandRemovedNotification.Type,
                 new ExtensionCommandRemovedNotification
                 {
@@ -1367,11 +1367,11 @@ function __Expand-Alias {
                 });
         }
 
-        private async void DebugService_DebuggerStopped(object sender, DebuggerStoppedEventArgs e)
+        private async void DebugService_DebuggerStoppedAsync(object sender, DebuggerStoppedEventArgs e)
         {
             if (!this.editorSession.DebugService.IsClientAttached)
             {
-                await this.messageSender.SendEvent(
+                await this.messageSender.SendEventAsync(
                     StartDebuggerEvent.Type,
                     new StartDebuggerEvent());
             }
@@ -1424,15 +1424,15 @@ function __Expand-Alias {
             };
         }
 
-        private Task RunScriptDiagnostics(
+        private Task RunScriptDiagnosticsAsync(
             ScriptFile[] filesToAnalyze,
             EditorSession editorSession,
             EventContext eventContext)
         {
-            return RunScriptDiagnostics(filesToAnalyze, editorSession, this.messageSender.SendEvent);
+            return RunScriptDiagnosticsAsync(filesToAnalyze, editorSession, this.messageSender.SendEventAsync);
         }
 
-        private Task RunScriptDiagnostics(
+        private Task RunScriptDiagnosticsAsync(
             ScriptFile[] filesToAnalyze,
             EditorSession editorSession,
             Func<NotificationType<PublishDiagnosticsNotification, object>, PublishDiagnosticsNotification, Task> eventSender)
@@ -1472,7 +1472,7 @@ function __Expand-Alias {
             existingRequestCancellation = new CancellationTokenSource();
             Task.Factory.StartNew(
                 () =>
-                    DelayThenInvokeDiagnostics(
+                    DelayThenInvokeDiagnosticsAsync(
                         750,
                         filesToAnalyze,
                         this.currentSettings.ScriptAnalysis?.Enable.Value ?? false,
@@ -1488,7 +1488,7 @@ function __Expand-Alias {
             return Task.FromResult(true);
         }
 
-        private static async Task DelayThenInvokeDiagnostics(
+        private static async Task DelayThenInvokeDiagnosticsAsync(
             int delayMilliseconds,
             ScriptFile[] filesToAnalyze,
             bool isScriptAnalysisEnabled,
@@ -1498,19 +1498,19 @@ function __Expand-Alias {
             ILogger Logger,
             CancellationToken cancellationToken)
         {
-            await DelayThenInvokeDiagnostics(
+            await DelayThenInvokeDiagnosticsAsync(
                 delayMilliseconds,
                 filesToAnalyze,
                 isScriptAnalysisEnabled,
                 correctionIndex,
                 editorSession,
-                eventContext.SendEvent,
+                eventContext.SendEventAsync,
                 Logger,
                 cancellationToken);
         }
 
 
-        private static async Task DelayThenInvokeDiagnostics(
+        private static async Task DelayThenInvokeDiagnosticsAsync(
             int delayMilliseconds,
             ScriptFile[] filesToAnalyze,
             bool isScriptAnalysisEnabled,
@@ -1531,7 +1531,7 @@ function __Expand-Alias {
                 // If the task is cancelled, exit directly
                 foreach (var script in filesToAnalyze)
                 {
-                    await PublishScriptDiagnostics(
+                    await PublishScriptDiagnosticsAsync(
                         script,
                         script.SyntaxMarkers,
                         correctionIndex,
@@ -1566,7 +1566,7 @@ function __Expand-Alias {
                     semanticMarkers = new ScriptFileMarker[0];
                 }
 
-                await PublishScriptDiagnostics(
+                await PublishScriptDiagnosticsAsync(
                     scriptFile,
                     scriptFile.SyntaxMarkers.Concat(semanticMarkers).ToArray(),
                     correctionIndex,
@@ -1574,30 +1574,30 @@ function __Expand-Alias {
             }
         }
 
-        private async Task ClearMarkers(ScriptFile scriptFile, EventContext eventContext)
+        private async Task ClearMarkersAsync(ScriptFile scriptFile, EventContext eventContext)
         {
             // send empty diagnostic markers to clear any markers associated with the given file
-            await PublishScriptDiagnostics(
+            await PublishScriptDiagnosticsAsync(
                     scriptFile,
                     new ScriptFileMarker[0],
                     this.codeActionsPerFile,
                     eventContext);
         }
 
-        private static async Task PublishScriptDiagnostics(
+        private static async Task PublishScriptDiagnosticsAsync(
             ScriptFile scriptFile,
             ScriptFileMarker[] markers,
             Dictionary<string, Dictionary<string, MarkerCorrection>> correctionIndex,
             EventContext eventContext)
         {
-            await PublishScriptDiagnostics(
+            await PublishScriptDiagnosticsAsync(
                 scriptFile,
                 markers,
                 correctionIndex,
-                eventContext.SendEvent);
+                eventContext.SendEventAsync);
         }
 
-        private static async Task PublishScriptDiagnostics(
+        private static async Task PublishScriptDiagnosticsAsync(
             ScriptFile scriptFile,
             ScriptFileMarker[] markers,
             Dictionary<string, Dictionary<string, MarkerCorrection>> correctionIndex,

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerEditorOperations.cs
@@ -25,10 +25,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             this.messageSender = messageSender;
         }
 
-        public async Task<EditorContext> GetEditorContext()
+        public async Task<EditorContext> GetEditorContextAsync()
         {
             ClientEditorContext clientContext =
-                await this.messageSender.SendRequest(
+                await this.messageSender.SendRequestAsync(
                     GetEditorContextRequest.Type,
                     new GetEditorContextRequest(),
                     true);
@@ -36,9 +36,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             return this.ConvertClientEditorContext(clientContext);
         }
 
-        public async Task InsertText(string filePath, string text, BufferRange insertRange)
+        public async Task InsertTextAsync(string filePath, string text, BufferRange insertRange)
         {
-            await this.messageSender.SendRequest(
+            await this.messageSender.SendRequestAsync(
                 InsertTextRequest.Type,
                 new InsertTextRequest
                 {
@@ -63,9 +63,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // TODO: Set the last param back to true!
         }
 
-        public Task SetSelection(BufferRange selectionRange)
+        public Task SetSelectionAsync(BufferRange selectionRange)
         {
-            return this.messageSender.SendRequest(
+            return this.messageSender.SendRequestAsync(
                 SetSelectionRequest.Type,
                 new SetSelectionRequest
                 {
@@ -103,19 +103,19 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         clientContext.SelectionRange.End.Character + 1));
         }
 
-        public Task NewFile()
+        public Task NewFileAsync()
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     NewFileRequest.Type,
                     null,
                     true);
         }
 
-        public Task OpenFile(string filePath)
+        public Task OpenFileAsync(string filePath)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     OpenFileRequest.Type,
                     new OpenFileDetails
                     {
@@ -125,10 +125,10 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     true);
         }
 
-        public Task OpenFile(string filePath, bool preview)
+        public Task OpenFileAsync(string filePath, bool preview)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     OpenFileRequest.Type,
                     new OpenFileDetails
                     {
@@ -138,24 +138,24 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     true);
         }
 
-        public Task CloseFile(string filePath)
+        public Task CloseFileAsync(string filePath)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     CloseFileRequest.Type,
                     filePath,
                     true);
         }
 
-        public Task SaveFile(string filePath)
+        public Task SaveFileAsync(string filePath)
         {
-            return SaveFile(filePath, null);
+            return SaveFileAsync(filePath, null);
         }
 
-        public Task SaveFile(string currentPath, string newSavePath)
+        public Task SaveFileAsync(string currentPath, string newSavePath)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     SaveFileRequest.Type,
                     new SaveFileDetails
                     {
@@ -175,37 +175,37 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             return this.editorSession.Workspace.GetRelativePath(filePath);
         }
 
-        public Task ShowInformationMessage(string message)
+        public Task ShowInformationMessageAsync(string message)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     ShowInformationMessageRequest.Type,
                     message,
                     true);
         }
 
-        public Task ShowErrorMessage(string message)
+        public Task ShowErrorMessageAsync(string message)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     ShowErrorMessageRequest.Type,
                     message,
                     true);
         }
 
-        public Task ShowWarningMessage(string message)
+        public Task ShowWarningMessageAsync(string message)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     ShowWarningMessageRequest.Type,
                     message,
                     true);
         }
 
-        public Task SetStatusBarMessage(string message, int? timeout)
+        public Task SetStatusBarMessageAsync(string message, int? timeout)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     SetStatusBarMessageRequest.Type,
                     new StatusBarMessageDetails
                     {

--- a/src/PowerShellEditorServices.Protocol/Server/OutputDebouncer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/OutputDebouncer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 
         #region Private Methods
 
-        protected override async Task OnInvoke(OutputWrittenEventArgs output)
+        protected override async Task OnInvokeAsync(OutputWrittenEventArgs output)
         {
             bool outputIsError = output.OutputType == OutputType.Error;
 
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 if (this.currentOutputString != null)
                 {
                     // Flush the output
-                    await this.OnFlush();
+                    await this.OnFlushAsync();
                 }
 
                 this.currentOutputString = string.Empty;
@@ -77,13 +77,13 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     string.Empty);
         }
 
-        protected override async Task OnFlush()
+        protected override async Task OnFlushAsync()
         {
             // Only flush output if there is some to flush
             if (this.currentOutputString != null)
             {
                 // Send an event for the current output
-                await this.messageSender.SendEvent(
+                await this.messageSender.SendEventAsync(
                     OutputEvent.Type,
                     new OutputEventBody
                     {

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
@@ -34,10 +34,10 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
             this.logger = logger;
         }
 
-        internal Task Create()
+        internal Task CreateAsync()
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     NewCustomViewRequest.Type,
                     new NewCustomViewRequest
                     {
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         public Task Show(ViewColumn viewColumn)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     ShowCustomViewRequest.Type,
                     new ShowCustomViewRequest
                     {
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         public Task Close()
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     CloseCustomViewRequest.Type,
                     new CloseCustomViewRequest
                     {

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
@@ -26,10 +26,10 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         {
         }
 
-        public Task SetContent(string htmlBodyContent)
+        public Task SetContentAsync(string htmlBodyContent)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     SetHtmlContentViewRequest.Type,
                     new SetHtmlContentViewRequest
                     {
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     }, true);
         }
 
-        public Task SetContent(HtmlContent htmlContent)
+        public Task SetContentAsync(HtmlContent htmlContent)
         {
             HtmlContent validatedContent =
                 new HtmlContent()
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                 };
 
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     SetHtmlContentViewRequest.Type,
                     new SetHtmlContentViewRequest
                     {
@@ -58,10 +58,10 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     }, true);
         }
 
-        public Task AppendContent(string appendedHtmlBodyContent)
+        public Task AppendContentAsync(string appendedHtmlBodyContent)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     AppendHtmlContentViewRequest.Type,
                     new AppendHtmlContentViewRequest
                     {

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         {
         }
 
-        public async Task<IHtmlContentView> CreateHtmlContentView(string viewTitle)
+        public async Task<IHtmlContentView> CreateHtmlContentViewAsync(string viewTitle)
         {
             HtmlContentView htmlView =
                 new HtmlContentView(
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     this.messageSender,
                     this.logger);
 
-            await htmlView.Create();
+            await htmlView.CreateAsync();
             this.AddView(htmlView);
 
             return htmlView;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// The HTML content that is placed inside of the page's body tag.
         /// </param>
         /// <returns>A Task which can be awaited for completion.</returns>
-        Task SetContent(string htmlBodyContent);
+        Task SetContentAsync(string htmlBodyContent);
 
         /// <summary>
         /// Sets the HTML content of the view.
@@ -30,7 +30,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// The HTML content that is placed inside of the page's body tag.
         /// </param>
         /// <returns>A Task which can be awaited for completion.</returns>
-        Task SetContent(HtmlContent htmlContent);
+        Task SetContentAsync(HtmlContent htmlContent);
 
         /// <summary>
         /// Appends HTML body content to the view.
@@ -39,6 +39,6 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// The HTML fragment to be appended to the output stream.
         /// </param>
         /// <returns>A Task which can be awaited for completion.</returns>
-        Task AppendContent(string appendedHtmlBodyContent);
+        Task AppendContentAsync(string appendedHtmlBodyContent);
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
@@ -21,6 +21,6 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// <returns>
         /// A Task to await for completion, returns the IHtmlContentView instance.
         /// </returns>
-        Task<IHtmlContentView> CreateHtmlContentView(string viewTitle);
+        Task<IHtmlContentView> CreateHtmlContentViewAsync(string viewTitle);
     }
 }

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -323,7 +323,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="settings">ScriptAnalyzer settings</param>
         /// <param name="rangeList">The range within which formatting should be applied.</param>
         /// <returns>The formatted script text.</returns>
-        public async Task<string> Format(
+        public async Task<string> FormatAsync(
             string scriptDefinition,
             Hashtable settings,
             int[] rangeList)

--- a/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/ChoicePromptHandler.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's choice.
         /// </returns>
-        public async Task<int> PromptForChoice(
+        public async Task<int> PromptForChoiceAsync(
             string promptCaption,
             string promptMessage,
             ChoiceDetails[] choices,
@@ -132,8 +132,8 @@ namespace Microsoft.PowerShell.EditorServices.Console
             cancellationToken.Register(this.CancelPrompt, true);
 
             // Convert the int[] result to int
-            return await this.WaitForTask(
-                this.StartPromptLoop(this.promptCancellationTokenSource.Token)
+            return await this.WaitForTaskAsync(
+                this.StartPromptLoopAsync(this.promptCancellationTokenSource.Token)
                     .ContinueWith(
                         task =>
                         {
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's choices.
         /// </returns>
-        public async Task<int[]> PromptForChoice(
+        public async Task<int[]> PromptForChoiceAsync(
             string promptCaption,
             string promptMessage,
             ChoiceDetails[] choices,
@@ -191,12 +191,12 @@ namespace Microsoft.PowerShell.EditorServices.Console
             // Cancel the TaskCompletionSource if the caller cancels the task
             cancellationToken.Register(this.CancelPrompt, true);
 
-            return await this.WaitForTask(
-                this.StartPromptLoop(
+            return await this.WaitForTaskAsync(
+                this.StartPromptLoopAsync(
                     this.promptCancellationTokenSource.Token));
         }
 
-        private async Task<T> WaitForTask<T>(Task<T> taskToWait)
+        private async Task<T> WaitForTaskAsync<T>(Task<T> taskToWait)
         {
             Task finishedTask =
                 await Task.WhenAny(
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             return taskToWait.Result;
         }
 
-        private async Task<int[]> StartPromptLoop(
+        private async Task<int[]> StartPromptLoopAsync(
             CancellationToken cancellationToken)
         {
             int[] choiceIndexes = null;
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                string responseString = await this.ReadInputString(cancellationToken);
+                string responseString = await this.ReadInputStringAsync(cancellationToken);
                 if (responseString == null)
                 {
                     // If the response string is null, the prompt has been cancelled
@@ -334,7 +334,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        protected abstract Task<string> ReadInputString(CancellationToken cancellationToken);
+        protected abstract Task<string> ReadInputStringAsync(CancellationToken cancellationToken);
 
         #endregion
 

--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -37,17 +37,17 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
         #region Public Methods
 
-        public Task<string> ReadCommandLine(CancellationToken cancellationToken)
+        public Task<string> ReadCommandLineAsync(CancellationToken cancellationToken)
         {
             return this.ReadLineAsync(true, cancellationToken);
         }
 
-        public Task<string> ReadSimpleLine(CancellationToken cancellationToken)
+        public Task<string> ReadSimpleLineAsync(CancellationToken cancellationToken)
         {
             return this.ReadLineAsync(false, cancellationToken);
         }
 
-        public async Task<SecureString> ReadSecureLine(CancellationToken cancellationToken)
+        public async Task<SecureString> ReadSecureLineAsync(CancellationToken cancellationToken)
         {
             SecureString secureString = new SecureString();
 
@@ -211,13 +211,13 @@ namespace Microsoft.PowerShell.EditorServices.Console
                                 command.AddParameter("Options", null);
 
                                 var results =
-                                    await this.powerShellContext.ExecuteCommand<CommandCompletion>(command, false, false);
+                                    await this.powerShellContext.ExecuteCommandAsync<CommandCompletion>(command, false, false);
 
                                 currentCompletion = results.FirstOrDefault();
                             }
                             else
                             {
-                                using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandle())
+                                using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandleAsync())
                                 using (PowerShell powerShell = PowerShell.Create())
                                 {
                                     powerShell.Runspace = runspaceHandle.Runspace;
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
                             command.AddCommand("Get-History");
 
                             currentHistory =
-                                await this.powerShellContext.ExecuteCommand<PSObject>(
+                                await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                                     command,
                                     false,
                                     false) as Collection<PSObject>;

--- a/src/PowerShellEditorServices/Console/InputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/InputPromptHandler.cs
@@ -58,11 +58,11 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        public Task<string> PromptForInput(
+        public Task<string> PromptForInputAsync(
             CancellationToken cancellationToken)
         {
             Task<Dictionary<string, object>> innerTask =
-                this.PromptForInput(
+                this.PromptForInputAsync(
                     null,
                     null,
                     new FieldDetails[] { new FieldDetails("", "", typeof(string), false, "") },
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        public async Task<Dictionary<string, object>> PromptForInput(
+        public async Task<Dictionary<string, object>> PromptForInputAsync(
             string promptCaption,
             string promptMessage,
             FieldDetails[] fields,
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             this.ShowPromptMessage(promptCaption, promptMessage);
 
             Task<Dictionary<string, object>> promptTask =
-                this.StartPromptLoop(this.promptCancellationTokenSource.Token);
+                this.StartPromptLoopAsync(this.promptCancellationTokenSource.Token);
 
             Task finishedTask =
                 await Task.WhenAny(
@@ -142,11 +142,11 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        public Task<SecureString> PromptForSecureInput(
+        public Task<SecureString> PromptForSecureInputAsync(
             CancellationToken cancellationToken)
         {
             Task<Dictionary<string, object>> innerTask =
-                this.PromptForInput(
+                this.PromptForInputAsync(
                     null,
                     null,
                     new FieldDetails[] { new FieldDetails("", "", typeof(SecureString), false, "") },
@@ -209,7 +209,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        protected abstract Task<string> ReadInputString(CancellationToken cancellationToken);
+        protected abstract Task<string> ReadInputStringAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Reads a SecureString asynchronously from the console.
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// A Task instance that can be monitored for completion to get
         /// the user's input.
         /// </returns>
-        protected abstract Task<SecureString> ReadSecureString(CancellationToken cancellationToken);
+        protected abstract Task<SecureString> ReadSecureStringAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Called when an error should be displayed, such as when the
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
         #region Private Methods
 
-        private async Task<Dictionary<string, object>> StartPromptLoop(
+        private async Task<Dictionary<string, object>> StartPromptLoopAsync(
             CancellationToken cancellationToken)
         {
             this.GetNextField();
@@ -255,13 +255,13 @@ namespace Microsoft.PowerShell.EditorServices.Console
                 // Read input depending on field type
                 if (this.currentField.FieldType == typeof(SecureString))
                 {
-                    SecureString secureString = await this.ReadSecureString(cancellationToken);
+                    SecureString secureString = await this.ReadSecureStringAsync(cancellationToken);
                     responseValue = secureString;
                     enteredValue = secureString != null;
                 }
                 else
                 {
-                    responseString = await this.ReadInputString(cancellationToken);
+                    responseString = await this.ReadInputStringAsync(cancellationToken);
                     responseValue = responseString;
                     enteredValue = responseString != null && responseString.Length > 0;
 

--- a/src/PowerShellEditorServices/Console/TerminalChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/TerminalChoicePromptHandler.cs
@@ -52,9 +52,9 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// </summary>
         /// <param name="cancellationToken">A CancellationToken that can be used to cancel the prompt.</param>
         /// <returns>A Task that can be awaited to get the user's response.</returns>
-        protected override async Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override async Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
-            string inputString = await this.consoleReadLine.ReadSimpleLine(cancellationToken);
+            string inputString = await this.consoleReadLine.ReadSimpleLineAsync(cancellationToken);
             this.hostOutput.WriteOutput(string.Empty);
 
             return inputString;

--- a/src/PowerShellEditorServices/Console/TerminalInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Console/TerminalInputPromptHandler.cs
@@ -54,9 +54,9 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// </summary>
         /// <param name="cancellationToken">A CancellationToken that can be used to cancel the prompt.</param>
         /// <returns>A Task that can be awaited to get the user's response.</returns>
-        protected override async Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override async Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
-            string inputString = await this.consoleReadLine.ReadSimpleLine(cancellationToken);
+            string inputString = await this.consoleReadLine.ReadSimpleLineAsync(cancellationToken);
             this.hostOutput.WriteOutput(string.Empty);
 
             return inputString;
@@ -67,9 +67,9 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// </summary>
         /// <param name="cancellationToken">A CancellationToken that can be used to cancel the prompt.</param>
         /// <returns>A Task that can be awaited to get the user's response.</returns>
-        protected override async Task<SecureString> ReadSecureString(CancellationToken cancellationToken)
+        protected override async Task<SecureString> ReadSecureStringAsync(CancellationToken cancellationToken)
         {
-            SecureString secureString = await this.consoleReadLine.ReadSecureLine(cancellationToken);
+            SecureString secureString = await this.consoleReadLine.ReadSecureLineAsync(cancellationToken);
             this.hostOutput.WriteOutput(string.Empty);
 
             return secureString;

--- a/src/PowerShellEditorServices/Debugging/DebugService.cs
+++ b/src/PowerShellEditorServices/Debugging/DebugService.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             this.logger = logger;
             this.powerShellContext = powerShellContext;
-            this.powerShellContext.DebuggerStop += this.OnDebuggerStop;
+            this.powerShellContext.DebuggerStop += this.OnDebuggerStopAsync;
             this.powerShellContext.DebuggerResumed += this.OnDebuggerResumed;
 
             this.powerShellContext.BreakpointUpdated += this.OnBreakpointUpdated;
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<BreakpointDetails[]> SetLineBreakpoints(
+        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
             ScriptFile scriptFile,
             BreakpointDetails[] breakpoints,
             bool clearExisting = true)
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 if (clearExisting)
                 {
-                    await this.ClearBreakpointsInFile(scriptFile);
+                    await this.ClearBreakpointsInFileAsync(scriptFile);
                 }
 
                 foreach (BreakpointDetails breakpoint in breakpoints)
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices
                     }
 
                     IEnumerable<Breakpoint> configuredBreakpoints =
-                        await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
+                        await this.powerShellContext.ExecuteCommandAsync<Breakpoint>(psCommand);
 
                     // The order in which the breakpoints are returned is significant to the
                     // VSCode client and should match the order in which they are passed in.
@@ -235,7 +235,7 @@ namespace Microsoft.PowerShell.EditorServices
             else
             {
                 resultBreakpointDetails =
-                    await dscBreakpoints.SetLineBreakpoints(
+                    await dscBreakpoints.SetLineBreakpointsAsync(
                         this.powerShellContext,
                         escapedScriptPath,
                         breakpoints);
@@ -250,7 +250,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="breakpoints">CommandBreakpointDetails for each command breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing function breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<CommandBreakpointDetails[]> SetCommandBreakpoints(
+        public async Task<CommandBreakpointDetails[]> SetCommandBreakpointsAsync(
             CommandBreakpointDetails[] breakpoints,
             bool clearExisting = true)
         {
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (clearExisting)
             {
-                await this.ClearCommandBreakpoints();
+                await this.ClearCommandBreakpointsAsync();
             }
 
             if (breakpoints.Length > 0)
@@ -287,7 +287,7 @@ namespace Microsoft.PowerShell.EditorServices
                     }
 
                     IEnumerable<Breakpoint> configuredBreakpoints =
-                        await this.powerShellContext.ExecuteCommand<Breakpoint>(psCommand);
+                        await this.powerShellContext.ExecuteCommandAsync<Breakpoint>(psCommand);
 
                     // The order in which the breakpoints are returned is significant to the
                     // VSCode client and should match the order in which they are passed in.
@@ -470,7 +470,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="value">The new string value.  This value must not be null.  If you want to set the variable to $null
         /// pass in the string "$null".</param>
         /// <returns>The string representation of the value the variable was set to.</returns>
-        public async Task<string> SetVariable(int variableContainerReferenceId, string name, string value)
+        public async Task<string> SetVariableAsync(int variableContainerReferenceId, string name, string value)
         {
             Validate.IsNotNull(nameof(name), name);
             Validate.IsNotNull(nameof(value), value);
@@ -488,7 +488,7 @@ namespace Microsoft.PowerShell.EditorServices
             psCommand.AddScript(value);
             var errorMessages = new StringBuilder();
             var results =
-                await this.powerShellContext.ExecuteCommand<object>(
+                await this.powerShellContext.ExecuteCommandAsync<object>(
                     psCommand,
                     errorMessages,
                     false,
@@ -561,7 +561,7 @@ namespace Microsoft.PowerShell.EditorServices
             psCommand.AddParameter("Name", name.TrimStart('$'));
             psCommand.AddParameter("Scope", scope);
 
-            IEnumerable<PSVariable> result = await this.powerShellContext.ExecuteCommand<PSVariable>(psCommand, sendErrorToHost: false);
+            IEnumerable<PSVariable> result = await this.powerShellContext.ExecuteCommandAsync<PSVariable>(psCommand, sendErrorToHost: false);
             PSVariable psVariable = result.FirstOrDefault();
             if (psVariable == null)
             {
@@ -590,7 +590,7 @@ namespace Microsoft.PowerShell.EditorServices
                 errorMessages.Clear();
 
                 var getExecContextResults =
-                    await this.powerShellContext.ExecuteCommand<object>(
+                    await this.powerShellContext.ExecuteCommandAsync<object>(
                         psCommand,
                         errorMessages,
                         sendErrorToHost: false);
@@ -628,13 +628,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// If true, writes the expression result as host output rather than returning the results.
         /// In this case, the return value of this function will be null.</param>
         /// <returns>A VariableDetails object containing the result.</returns>
-        public async Task<VariableDetails> EvaluateExpression(
+        public async Task<VariableDetails> EvaluateExpressionAsync(
             string expressionString,
             int stackFrameId,
             bool writeResultAsOutput)
         {
             var results =
-                await this.powerShellContext.ExecuteScriptString(
+                await this.powerShellContext.ExecuteScriptStringAsync(
                     expressionString,
                     false,
                     writeResultAsOutput);
@@ -741,20 +741,20 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Clears all breakpoints in the current session.
         /// </summary>
-        public async Task ClearAllBreakpoints()
+        public async Task ClearAllBreakpointsAsync()
         {
             PSCommand psCommand = new PSCommand();
             psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
             psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
 
-            await this.powerShellContext.ExecuteCommand<object>(psCommand);
+            await this.powerShellContext.ExecuteCommandAsync<object>(psCommand);
         }
 
         #endregion
 
         #region Private Methods
 
-        private async Task ClearBreakpointsInFile(ScriptFile scriptFile)
+        private async Task ClearBreakpointsInFileAsync(ScriptFile scriptFile)
         {
             List<Breakpoint> breakpoints = null;
 
@@ -767,7 +767,7 @@ namespace Microsoft.PowerShell.EditorServices
                     psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
                     psCommand.AddParameter("Id", breakpoints.Select(b => b.Id).ToArray());
 
-                    await this.powerShellContext.ExecuteCommand<object>(psCommand);
+                    await this.powerShellContext.ExecuteCommandAsync<object>(psCommand);
 
                     // Clear the existing breakpoints list for the file
                     breakpoints.Clear();
@@ -775,17 +775,17 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
-        private async Task ClearCommandBreakpoints()
+        private async Task ClearCommandBreakpointsAsync()
         {
             PSCommand psCommand = new PSCommand();
             psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
             psCommand.AddParameter("Type", "Command");
             psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
 
-            await this.powerShellContext.ExecuteCommand<object>(psCommand);
+            await this.powerShellContext.ExecuteCommandAsync<object>(psCommand);
         }
 
-        private async Task FetchStackFramesAndVariables(string scriptNameOverride)
+        private async Task FetchStackFramesAndVariablesAsync(string scriptNameOverride)
         {
             await this.debugInfoHandle.WaitAsync();
             try
@@ -798,8 +798,8 @@ namespace Microsoft.PowerShell.EditorServices
 
                 // Must retrieve global/script variales before stack frame variables
                 // as we check stack frame variables against globals.
-                await FetchGlobalAndScriptVariables();
-                await FetchStackFrames(scriptNameOverride);
+                await FetchGlobalAndScriptVariablesAsync();
+                await FetchStackFramesAsync(scriptNameOverride);
             }
             finally
             {
@@ -807,17 +807,17 @@ namespace Microsoft.PowerShell.EditorServices
             }
         }
 
-        private async Task FetchGlobalAndScriptVariables()
+        private async Task FetchGlobalAndScriptVariablesAsync()
         {
             // Retrieve globals first as script variable retrieval needs to search globals.
             this.globalScopeVariables =
-                await FetchVariableContainer(VariableContainerDetails.GlobalScopeName, null);
+                await FetchVariableContainerAsync(VariableContainerDetails.GlobalScopeName, null);
 
             this.scriptScopeVariables =
-                await FetchVariableContainer(VariableContainerDetails.ScriptScopeName, null);
+                await FetchVariableContainerAsync(VariableContainerDetails.ScriptScopeName, null);
         }
 
-        private async Task<VariableContainerDetails> FetchVariableContainer(
+        private async Task<VariableContainerDetails> FetchVariableContainerAsync(
             string scope,
             VariableContainerDetails autoVariables)
         {
@@ -829,7 +829,7 @@ namespace Microsoft.PowerShell.EditorServices
                 new VariableContainerDetails(this.nextVariableId++, "Scope: " + scope);
             this.variables.Add(scopeVariableContainer);
 
-            var results = await this.powerShellContext.ExecuteCommand<PSObject>(psCommand, sendErrorToHost: false);
+            var results = await this.powerShellContext.ExecuteCommandAsync<PSObject>(psCommand, sendErrorToHost: false);
             if (results != null)
             {
                 foreach (PSObject psVariableObject in results)
@@ -923,7 +923,7 @@ namespace Microsoft.PowerShell.EditorServices
             return true;
         }
 
-        private async Task FetchStackFrames(string scriptNameOverride)
+        private async Task FetchStackFramesAsync(string scriptNameOverride)
         {
             PSCommand psCommand = new PSCommand();
 
@@ -934,7 +934,7 @@ namespace Microsoft.PowerShell.EditorServices
             var callStackVarName = $"$global:{PsesGlobalVariableNamePrefix}CallStack";
             psCommand.AddScript($"{callStackVarName} = Get-PSCallStack; {callStackVarName}");
 
-            var results = await this.powerShellContext.ExecuteCommand<PSObject>(psCommand);
+            var results = await this.powerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
 
             var callStackFrames = results.ToArray();
 
@@ -950,7 +950,7 @@ namespace Microsoft.PowerShell.EditorServices
                 this.variables.Add(autoVariables);
 
                 VariableContainerDetails localVariables =
-                    await FetchVariableContainer(i.ToString(), autoVariables);
+                    await FetchVariableContainerAsync(i.ToString(), autoVariables);
 
                 // When debugging, this is the best way I can find to get what is likely the workspace root.
                 // This is controlled by the "cwd:" setting in the launch config.
@@ -1190,7 +1190,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public event EventHandler<DebuggerStoppedEventArgs> DebuggerStopped;
 
-        private async void OnDebuggerStop(object sender, DebuggerStopEventArgs e)
+        private async void OnDebuggerStopAsync(object sender, DebuggerStopEventArgs e)
         {
             bool noScriptName = false;
             string localScriptPath = e.InvocationInfo.ScriptName;
@@ -1203,7 +1203,7 @@ namespace Microsoft.PowerShell.EditorServices
                 command.AddScript($"list 1 {int.MaxValue}");
 
                 IEnumerable<PSObject> scriptListingLines =
-                    await this.powerShellContext.ExecuteCommand<PSObject>(
+                    await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                         command, false, false);
 
                 if (scriptListingLines != null)
@@ -1238,7 +1238,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             // Get call stack and variables.
-            await this.FetchStackFramesAndVariables(
+            await this.FetchStackFramesAndVariablesAsync(
                 noScriptName ? localScriptPath : null);
 
             // If this is a remote connection and the debugger stopped at a line
@@ -1248,7 +1248,7 @@ namespace Microsoft.PowerShell.EditorServices
                 !noScriptName)
             {
                 localScriptPath =
-                    await this.remoteFileManager.FetchRemoteFile(
+                    await this.remoteFileManager.FetchRemoteFileAsync(
                         e.InvocationInfo.ScriptName,
                         this.powerShellContext.CurrentRunspace);
             }

--- a/src/PowerShellEditorServices/Extensions/EditorContext.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorContext.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         public void SetSelection(BufferRange selectionRange)
         {
             this.editorOperations
-                .SetSelection(selectionRange)
+                .SetSelectionAsync(selectionRange)
                 .Wait();
         }
 

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <returns>A instance of the EditorContext class.</returns>
         public EditorContext GetEditorContext()
         {
-            return this.editorOperations.GetEditorContext().Result;
+            return this.editorOperations.GetEditorContextAsync().Result;
         }
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorWindow.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWindow.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             this.editorOperations = editorOperations;
         }
 
-        #endregion 
+        #endregion
 
         #region Public Methods
 
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="message">The message to be shown.</param>
         public void ShowInformationMessage(string message)
         {
-            this.editorOperations.ShowInformationMessage(message).Wait();
+            this.editorOperations.ShowInformationMessageAsync(message).Wait();
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="message">The message to be shown.</param>
         public void ShowErrorMessage(string message)
         {
-            this.editorOperations.ShowErrorMessage(message).Wait();
+            this.editorOperations.ShowErrorMessageAsync(message).Wait();
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="message">The message to be shown.</param>
         public void ShowWarningMessage(string message)
         {
-            this.editorOperations.ShowWarningMessage(message).Wait();
+            this.editorOperations.ShowWarningMessageAsync(message).Wait();
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="message">The message to be shown.</param>
         public void SetStatusBarMessage(string message)
         {
-            this.editorOperations.SetStatusBarMessage(message, null).Wait();
+            this.editorOperations.SetStatusBarMessageAsync(message, null).Wait();
         }
 
         /// <summary>
@@ -75,9 +75,9 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="timeout">A timeout in milliseconds for how long the message should remain visible.</param>
         public void SetStatusBarMessage(string message, int timeout)
         {
-            this.editorOperations.SetStatusBarMessage(message, timeout).Wait();
+            this.editorOperations.SetStatusBarMessageAsync(message, timeout).Wait();
         }
 
-        #endregion 
+        #endregion
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         public void NewFile()
         {
-            this.editorOperations.NewFile().Wait();
+            this.editorOperations.NewFileAsync().Wait();
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="filePath">The path to the file to be opened.</param>
         public void OpenFile(string filePath)
         {
-            this.editorOperations.OpenFile(filePath).Wait();
+            this.editorOperations.OpenFileAsync(filePath).Wait();
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="preview">Determines wether the file is opened as a preview or as a durable editor.</param>
         public void OpenFile(string filePath, bool preview)
         {
-            this.editorOperations.OpenFile(filePath, preview).Wait();
+            this.editorOperations.OpenFileAsync(filePath, preview).Wait();
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Extensions/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Extensions/ExtensionService.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="editorOperations">An IEditorOperations implementation.</param>
         /// <param name="componentRegistry">An IComponentRegistry instance which provides components in the session.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task Initialize(
+        public async Task InitializeAsync(
             IEditorOperations editorOperations,
             IComponentRegistry componentRegistry)
         {
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
 
             // Register the editor object in the runspace
             PSCommand variableCommand = new PSCommand();
-            using (RunspaceHandle handle = await this.PowerShellContext.GetRunspaceHandle())
+            using (RunspaceHandle handle = await this.PowerShellContext.GetRunspaceHandleAsync())
             {
                 handle.Runspace.SessionStateProxy.PSVariable.Set(
                     "psEditor",
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="commandName">The unique name of the command to be invoked.</param>
         /// <param name="editorContext">The context in which the command is being invoked.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task InvokeCommand(string commandName, EditorContext editorContext)
+        public async Task InvokeCommandAsync(string commandName, EditorContext editorContext)
         {
             EditorCommand editorCommand;
 
@@ -108,7 +108,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
                 executeCommand.AddParameter("ScriptBlock", editorCommand.ScriptBlock);
                 executeCommand.AddParameter("ArgumentList", new object[] { editorContext });
 
-                await this.PowerShellContext.ExecuteCommand<object>(
+                await this.PowerShellContext.ExecuteCommandAsync<object>(
                     executeCommand,
                     !editorCommand.SuppressOutput,
                     true);

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         public void InsertText(string textToInsert, BufferRange insertRange)
         {
             this.editorOperations
-                .InsertText(this.scriptFile.ClientFilePath, textToInsert, insertRange)
+                .InsertTextAsync(this.scriptFile.ClientFilePath, textToInsert, insertRange)
                 .Wait();
         }
 
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         public void Save()
         {
-            this.editorOperations.SaveFile(this.scriptFile.FilePath);
+            this.editorOperations.SaveFileAsync(this.scriptFile.FilePath);
         }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
                 throw new IOException(String.Format("The file '{0}' already exists", absolutePath));
             }
 
-            this.editorOperations.SaveFile(this.scriptFile.FilePath, newFilePath);
+            this.editorOperations.SaveFileAsync(this.scriptFile.FilePath, newFilePath);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// Gets the EditorContext for the editor's current state.
         /// </summary>
         /// <returns>A new EditorContext object.</returns>
-        Task<EditorContext> GetEditorContext();
+        Task<EditorContext> GetEditorContextAsync();
 
         /// <summary>
         /// Gets the path to the editor's active workspace.
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// Causes a new untitled file to be created in the editor.
         /// </summary>
         /// <returns>A task that can be awaited for completion.</returns>
-        Task NewFile();
+        Task NewFileAsync();
 
         /// <summary>
         /// Causes a file to be opened in the editor.  If the file is
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         /// <param name="filePath">The path of the file to be opened.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task OpenFile(string filePath);
+        Task OpenFileAsync(string filePath);
 
         /// <summary>
         /// Causes a file to be opened in the editor.  If the file is
@@ -55,21 +55,21 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="filePath">The path of the file to be opened.</param>
         /// <param name="preview">Determines wether the file is opened as a preview or as a durable editor.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task OpenFile(string filePath, bool preview);
+        Task OpenFileAsync(string filePath, bool preview);
 
         /// <summary>
         /// Causes a file to be closed in the editor.
         /// </summary>
         /// <param name="filePath">The path of the file to be closed.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task CloseFile(string filePath);
+        Task CloseFileAsync(string filePath);
 
         /// <summary>
         /// Causes a file to be saved in the editor.
         /// </summary>
         /// <param name="filePath">The path of the file to be saved.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task SaveFile(string filePath);
+        Task SaveFileAsync(string filePath);
 
         /// <summary>
         /// Causes a file to be saved as a new file in a new editor window.
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="oldFilePath">the path of the current file being saved</param>
         /// <param name="newFilePath">the path of the new file where the current window content will be saved</param>
         /// <returns></returns>
-        Task SaveFile(string oldFilePath, string newFilePath);
+        Task SaveFileAsync(string oldFilePath, string newFilePath);
 
         /// <summary>
         /// Inserts text into the specified range for the file at the specified path.
@@ -86,35 +86,35 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="insertText">The text to insert into the file.</param>
         /// <param name="insertRange">The range in the file to be replaced.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task InsertText(string filePath, string insertText, BufferRange insertRange);
+        Task InsertTextAsync(string filePath, string insertText, BufferRange insertRange);
 
         /// <summary>
         /// Causes the selection to be changed in the editor's active file buffer.
         /// </summary>
         /// <param name="selectionRange">The range over which the selection will be made.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task SetSelection(BufferRange selectionRange);
+        Task SetSelectionAsync(BufferRange selectionRange);
 
         /// <summary>
         /// Shows an informational message to the user.
         /// </summary>
         /// <param name="message">The message to be shown.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task ShowInformationMessage(string message);
+        Task ShowInformationMessageAsync(string message);
 
         /// <summary>
         /// Shows an error message to the user.
         /// </summary>
         /// <param name="message">The message to be shown.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task ShowErrorMessage(string message);
+        Task ShowErrorMessageAsync(string message);
 
         /// <summary>
         /// Shows a warning message to the user.
         /// </summary>
         /// <param name="message">The message to be shown.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task ShowWarningMessage(string message);
+        Task ShowWarningMessageAsync(string message);
 
         /// <summary>
         /// Sets the status bar message in the editor UI (if applicable).
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="message">The message to be shown.</param>
         /// <param name="timeout">If non-null, a timeout in milliseconds for how long the message should remain visible.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
-        Task SetStatusBarMessage(string message, int? timeout);
+        Task SetStatusBarMessageAsync(string message, int? timeout);
     }
 }
 

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// A CommandCompletion instance that contains completions for the
         /// symbol at the given offset.
         /// </returns>
-        static public async Task<CommandCompletion> GetCompletions(
+        static public async Task<CommandCompletion> GetCompletionsAsync(
             Ast scriptAst,
             Token[] currentTokens,
             int fileOffset,
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.EditorServices
                 // main runspace.
                 if (powerShellContext.IsCurrentRunspaceOutOfProcess())
                 {
-                    using (RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandle(cancellationToken))
+                    using (RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandleAsync(cancellationToken))
                     using (PowerShell powerShell = PowerShell.Create())
                     {
                         powerShell.Runspace = runspaceHandle.Runspace;
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
 
                 CommandCompletion commandCompletion = null;
-                await powerShellContext.InvokeOnPipelineThread(
+                await powerShellContext.InvokeOnPipelineThreadAsync(
                     pwsh =>
                     {
                         stopwatch.Start();

--- a/src/PowerShellEditorServices/Language/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Language/CommandHelpers.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="commandName">The name of the command.</param>
         /// <param name="powerShellContext">The PowerShellContext to use for running Get-Command.</param>
         /// <returns>A CommandInfo object with details about the specified command.</returns>
-        public static async Task<CommandInfo> GetCommandInfo(
+        public static async Task<CommandInfo> GetCommandInfoAsync(
             string commandName,
             PowerShellContext powerShellContext)
         {
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             return
                 (await powerShellContext
-                    .ExecuteCommand<PSObject>(command, false, false))
+                    .ExecuteCommandAsync<PSObject>(command, false, false))
                     .Select(o => o.BaseObject)
                     .OfType<CommandInfo>()
                     .FirstOrDefault();
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="commandInfo">The CommandInfo instance for the command.</param>
         /// <param name="powerShellContext">The PowerShellContext to use for getting command documentation.</param>
         /// <returns></returns>
-        public static async Task<string> GetCommandSynopsis(
+        public static async Task<string> GetCommandSynopsisAsync(
             CommandInfo commandInfo,
             PowerShellContext powerShellContext)
         {
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices
                 command.AddArgument(commandInfo);
                 command.AddParameter("ErrorAction", "Ignore");
 
-                var results = await powerShellContext.ExecuteCommand<PSObject>(command, false, false);
+                var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, false, false);
                 helpObject = results.FirstOrDefault();
 
                 if (helpObject != null)

--- a/src/PowerShellEditorServices/Language/LanguageService.cs
+++ b/src/PowerShellEditorServices/Language/LanguageService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <returns>
         /// A CommandCompletion instance completions for the identified statement.
         /// </returns>
-        public async Task<CompletionResults> GetCompletionsInFile(
+        public async Task<CompletionResults> GetCompletionsInFileAsync(
             ScriptFile scriptFile,
             int lineNumber,
             int columnNumber)
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices
                     columnNumber);
 
             CommandCompletion commandCompletion =
-                await AstOperations.GetCompletions(
+                await AstOperations.GetCompletionsAsync(
                     scriptFile.ScriptAst,
                     scriptFile.ScriptTokens,
                     fileOffset,
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="lineNumber">The line number at which the symbol can be located.</param>
         /// <param name="columnNumber">The column number at which the symbol can be located.</param>
         /// <returns></returns>
-        public async Task<SymbolDetails> FindSymbolDetailsAtLocation(
+        public async Task<SymbolDetails> FindSymbolDetailsAtLocationAsync(
             ScriptFile scriptFile,
             int lineNumber,
             int columnNumber)
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             symbolReference.FilePath = scriptFile.FilePath;
             symbolDetails =
-                await SymbolDetails.Create(
+                await SymbolDetails.CreateAsync(
                     symbolReference,
                     _powerShellContext);
 
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="referencedFiles">An array of scriptFiles too search for references in</param>
         /// <param name="workspace">The workspace that will be searched for symbols</param>
         /// <returns>FindReferencesResult</returns>
-        public async Task<FindReferencesResult> FindReferencesOfSymbol(
+        public async Task<FindReferencesResult> FindReferencesOfSymbolAsync(
             SymbolReference foundSymbol,
             ScriptFile[] referencedFiles,
             Workspace workspace)
@@ -323,7 +323,7 @@ namespace Microsoft.PowerShell.EditorServices
                 foundSymbol.ScriptRegion.StartColumnNumber);
 
             // Make sure aliases have been loaded
-            await GetAliases();
+            await GetAliasesAsync();
 
             // We want to look for references first in referenced files, hence we use ordered dictionary
             // TODO: File system case-sensitivity is based on filesystem not OS, but OS is a much cheaper heuristic
@@ -415,7 +415,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="foundSymbol">The symbol for which a definition will be found.</param>
         /// <param name="workspace">The Workspace to which the ScriptFile belongs.</param>
         /// <returns>The resulting GetDefinitionResult for the symbol's definition.</returns>
-        public async Task<GetDefinitionResult> GetDefinitionOfSymbol(
+        public async Task<GetDefinitionResult> GetDefinitionOfSymbolAsync(
             ScriptFile sourceFile,
             SymbolReference foundSymbol,
             Workspace workspace)
@@ -483,7 +483,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (foundDefinition == null)
             {
                 CommandInfo cmdInfo =
-                    await CommandHelpers.GetCommandInfo(
+                    await CommandHelpers.GetCommandInfoAsync(
                         foundSymbol.SymbolName,
                         _powerShellContext);
 
@@ -543,7 +543,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="lineNumber">The line number of the cursor for the given script</param>
         /// <param name="columnNumber">The coulumn number of the cursor for the given script</param>
         /// <returns>ParameterSetSignatures</returns>
-        public async Task<ParameterSetSignatures> FindParameterSetsInFile(
+        public async Task<ParameterSetSignatures> FindParameterSetsInFileAsync(
             ScriptFile file,
             int lineNumber,
             int columnNumber)
@@ -560,7 +560,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             CommandInfo commandInfo =
-                await CommandHelpers.GetCommandInfo(
+                await CommandHelpers.GetCommandInfoAsync(
                     foundSymbol.SymbolName,
                     _powerShellContext);
 
@@ -714,7 +714,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Gets all aliases found in the runspace
         /// </summary>
-        private async Task GetAliases()
+        private async Task GetAliasesAsync()
         {
             if (_areAliasesLoaded)
             {
@@ -730,7 +730,7 @@ namespace Microsoft.PowerShell.EditorServices
                     return;
                 }
 
-                var aliases = await _powerShellContext.ExecuteCommand<AliasInfo>(
+                var aliases = await _powerShellContext.ExecuteCommandAsync<AliasInfo>(
                     new PSCommand()
                         .AddCommand("Microsoft.PowerShell.Core\\Get-Command")
                         .AddParameter("CommandType", CommandTypes.Alias),

--- a/src/PowerShellEditorServices/Language/SymbolDetails.cs
+++ b/src/PowerShellEditorServices/Language/SymbolDetails.cs
@@ -38,8 +38,8 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Constructors
 
-        static internal async Task<SymbolDetails> Create(
-            SymbolReference symbolReference, 
+        static internal async Task<SymbolDetails> CreateAsync(
+            SymbolReference symbolReference,
             PowerShellContext powerShellContext)
         {
             SymbolDetails symbolDetails = new SymbolDetails();
@@ -49,14 +49,14 @@ namespace Microsoft.PowerShell.EditorServices
             if (symbolReference.SymbolType == SymbolType.Function)
             {
                 CommandInfo commandInfo =
-                    await CommandHelpers.GetCommandInfo(
+                    await CommandHelpers.GetCommandInfoAsync(
                         symbolReference.SymbolName,
                         powerShellContext);
 
                 if (commandInfo != null)
                 {
                     symbolDetails.Documentation =
-                        await CommandHelpers.GetCommandSynopsis(
+                        await CommandHelpers.GetCommandSynopsisAsync(
                             commandInfo,
                             powerShellContext);
 

--- a/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Session/Capabilities/DscBreakpointCapability.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
         private Dictionary<string, int[]> breakpointsPerFile =
             new Dictionary<string, int[]>();
 
-        public async Task<List<BreakpointDetails>> SetLineBreakpoints(
+        public async Task<List<BreakpointDetails>> SetLineBreakpointsAsync(
             PowerShellContext powerShellContext,
             string scriptPath,
             BreakpointDetails[] breakpoints)
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Session.Capabilities
             // Run Enable-DscDebug as a script because running it as a PSCommand
             // causes an error which states that the Breakpoint parameter has not
             // been passed.
-            await powerShellContext.ExecuteScriptString(
+            await powerShellContext.ExecuteScriptStringAsync(
                 hashtableString.Length > 0
                     ? $"Enable-DscDebug -Breakpoint {hashtableString}"
                     : "Disable-DscDebug",

--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices
                     Task.Factory.StartNew(
                         async () =>
                         {
-                            await this.StartReplLoop(this.commandLoopCancellationToken.Token);
+                            await this.StartReplLoopAsync(this.commandLoopCancellationToken.Token);
                         });
             }
             else
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// A CancellationToken used to cancel the command line request.
         /// </param>
         /// <returns>A Task that can be awaited for the resulting input string.</returns>
-        protected abstract Task<string> ReadCommandLine(CancellationToken cancellationToken);
+        protected abstract Task<string> ReadCommandLineAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates an InputPrompt handle to use for displaying input
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.EditorServices
             CancellationTokenSource cancellationToken = new CancellationTokenSource();
             Task<Dictionary<string, object>> promptTask =
                 this.CreateInputPromptHandler()
-                    .PromptForInput(
+                    .PromptForInputAsync(
                         promptCaption,
                         promptMessage,
                         fields,
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell.EditorServices
             CancellationTokenSource cancellationToken = new CancellationTokenSource();
             Task<int> promptTask =
                 this.CreateChoicePromptHandler()
-                    .PromptForChoice(
+                    .PromptForChoiceAsync(
                         promptCaption,
                         promptMessage,
                         choices,
@@ -372,7 +372,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             Task<Dictionary<string, object>> promptTask =
                 this.CreateInputPromptHandler()
-                    .PromptForInput(
+                    .PromptForInputAsync(
                         promptCaption,
                         promptMessage,
                         new FieldDetails[] { new CredentialFieldDetails("Credential", "Credential", userName) },
@@ -446,7 +446,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             Task<string> promptTask =
                 this.CreateInputPromptHandler()
-                    .PromptForInput(cancellationToken.Token);
+                    .PromptForInputAsync(cancellationToken.Token);
 
             // Run the prompt task and wait for it to return
             this.WaitForPromptCompletion(
@@ -467,7 +467,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             Task<SecureString> promptTask =
                 this.CreateInputPromptHandler()
-                    .PromptForSecureInput(cancellationToken.Token);
+                    .PromptForSecureInputAsync(cancellationToken.Token);
 
             // Run the prompt task and wait for it to return
             this.WaitForPromptCompletion(
@@ -621,7 +621,7 @@ namespace Microsoft.PowerShell.EditorServices
             CancellationTokenSource cancellationToken = new CancellationTokenSource();
             Task<int[]> promptTask =
                 this.CreateChoicePromptHandler()
-                    .PromptForChoice(
+                    .PromptForChoiceAsync(
                         promptCaption,
                         promptMessage,
                         choices,
@@ -644,7 +644,7 @@ namespace Microsoft.PowerShell.EditorServices
 
         private Coordinates lastPromptLocation;
 
-        private async Task WritePromptStringToHost(CancellationToken cancellationToken)
+        private async Task WritePromptStringToHostAsync(CancellationToken cancellationToken)
         {
             try
             {
@@ -665,7 +665,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             cancellationToken.ThrowIfCancellationRequested();
             string promptString =
-                (await this.powerShellContext.ExecuteCommand<PSObject>(promptCommand, false, false))
+                (await this.powerShellContext.ExecuteCommandAsync<PSObject>(promptCommand, false, false))
                     .Select(pso => pso.BaseObject)
                     .OfType<string>()
                     .FirstOrDefault() ?? "PS> ";
@@ -734,7 +734,7 @@ namespace Microsoft.PowerShell.EditorServices
         internal ConsoleColor ProgressForegroundColor { get; set; } = ConsoleColor.Yellow;
         internal ConsoleColor ProgressBackgroundColor { get; set; } = ConsoleColor.DarkCyan;
 
-        private async Task StartReplLoop(CancellationToken cancellationToken)
+        private async Task StartReplLoopAsync(CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -743,7 +743,7 @@ namespace Microsoft.PowerShell.EditorServices
 
                 try
                 {
-                    await this.WritePromptStringToHost(cancellationToken);
+                    await this.WritePromptStringToHostAsync(cancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -753,7 +753,7 @@ namespace Microsoft.PowerShell.EditorServices
                 try
                 {
                     originalCursorTop = await ConsoleProxy.GetCursorTopAsync(cancellationToken);
-                    commandString = await this.ReadCommandLine(cancellationToken);
+                    commandString = await this.ReadCommandLineAsync(cancellationToken);
                 }
                 catch (PipelineStoppedException)
                 {
@@ -790,7 +790,7 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     var unusedTask =
                         this.powerShellContext
-                            .ExecuteScriptString(
+                            .ExecuteScriptStringAsync(
                                 commandString,
                                 writeInputToHost: false,
                                 writeOutputToHost: true,
@@ -949,7 +949,7 @@ namespace Microsoft.PowerShell.EditorServices
                     eventArgs.HadErrors))
             {
                 this.WriteOutput(string.Empty, true);
-                var unusedTask = this.WritePromptStringToHost(CancellationToken.None);
+                var unusedTask = this.WritePromptStringToHostAsync(CancellationToken.None);
             }
         }
 

--- a/src/PowerShellEditorServices/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/TerminalPSHostUserInterface.cs
@@ -69,9 +69,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// A CancellationToken used to cancel the command line request.
         /// </param>
         /// <returns>A Task that can be awaited for the resulting input string.</returns>
-        protected override Task<string> ReadCommandLine(CancellationToken cancellationToken)
+        protected override Task<string> ReadCommandLineAsync(CancellationToken cancellationToken)
         {
-            return this.consoleReadLine.ReadCommandLine(cancellationToken);
+            return this.consoleReadLine.ReadCommandLineAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Session/InvocationEventQueue.cs
+++ b/src/PowerShellEditorServices/Session/InvocationEventQueue.cs
@@ -57,11 +57,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// Executes a command on the main pipeline thread through
         /// eventing. A <see cref="PSEngineEvent.OnIdle" /> event subscriber will
         /// be created that creates a nested PowerShell instance for
-        /// <see cref="PowerShellContext.ExecuteCommand" /> to utilize.
+        /// <see cref="PowerShellContext.ExecuteCommandAsync" /> to utilize.
         /// </summary>
         /// <remarks>
         /// Avoid using this method directly if possible.
-        /// <see cref="PowerShellContext.ExecuteCommand" /> will route commands
+        /// <see cref="PowerShellContext.ExecuteCommandAsync" /> will route commands
         /// through this method if required.
         /// </remarks>
         /// <typeparam name="TResult">The expected result type.</typeparam>
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// An awaitable <see cref="Task" /> which will provide results once the command
         /// execution completes.
         /// </returns>
-        internal async Task<IEnumerable<TResult>> ExecuteCommandOnIdle<TResult>(
+        internal async Task<IEnumerable<TResult>> ExecuteCommandOnIdleAsync<TResult>(
             PSCommand psCommand,
             StringBuilder errorMessages,
             ExecutionOptions executionOptions)
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
 
             await SetInvocationRequestAsync(
                 new InvocationRequest(
-                    pwsh => request.Execute().GetAwaiter().GetResult()));
+                    pwsh => request.ExecuteAsync().GetAwaiter().GetResult()));
 
             try
             {
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// <returns>
         /// An awaitable <see cref="Task" /> that the caller can use to know when execution completes.
         /// </returns>
-        internal async Task InvokeOnPipelineThread(Action<PowerShell> invocationAction)
+        internal async Task InvokeOnPipelineThreadAsync(Action<PowerShell> invocationAction)
         {
             var request = new InvocationRequest(pwsh =>
             {

--- a/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Session/PSReadLinePromptContext.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
                         _readLineCancellationSource.Token);
                 }
 
-                var result = (await _powerShellContext.ExecuteCommand<string>(
+                var result = (await _powerShellContext.ExecuteCommandAsync<string>(
                     new PSCommand()
                         .AddScript(ReadLineScript)
                         .AddArgument(_readLineCancellationSource.Token),
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.Session {
             { }
         }
 
-        public async Task WaitForReadLineExitAsync () {
+        public async Task WaitForReadLineExitAsync() {
             using (await _promptNest.GetRunspaceHandleAsync(CancellationToken.None, isReadLine: true))
             { }
         }

--- a/src/PowerShellEditorServices/Session/PipelineExecutionRequest.cs
+++ b/src/PowerShellEditorServices/Session/PipelineExecutionRequest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
 {
     internal interface IPipelineExecutionRequest
     {
-        Task Execute();
+        Task ExecuteAsync();
 
         Task WaitTask { get; }
     }
@@ -66,10 +66,10 @@ namespace Microsoft.PowerShell.EditorServices.Session
             _resultsTask = new TaskCompletionSource<IEnumerable<TResult>>();
         }
 
-        public async Task Execute()
+        public async Task ExecuteAsync()
         {
             var results =
-                await _powerShellContext.ExecuteCommand<TResult>(
+                await _powerShellContext.ExecuteCommandAsync<TResult>(
                     _psCommand,
                     _errorMessages,
                     _executionOptions);

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -350,7 +350,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="moduleBasePath"></param>
         /// <returns></returns>
-        public Task ImportCommandsModule(string moduleBasePath)
+        public Task ImportCommandsModuleAsync(string moduleBasePath)
         {
             PSCommand importCommand = new PSCommand();
             importCommand
@@ -360,7 +360,7 @@ namespace Microsoft.PowerShell.EditorServices
                         moduleBasePath,
                         "PowerShellEditorServices.Commands.psd1"));
 
-            return this.ExecuteCommand<PSObject>(importCommand, false, false);
+            return this.ExecuteCommandAsync<PSObject>(importCommand, false, false);
         }
 
         private static bool CheckIfRunspaceNeedsEventHandlers(RunspaceDetails runspaceDetails)
@@ -408,9 +408,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// so that commands can be executed against it directly.
         /// </summary>
         /// <returns>A RunspaceHandle instance that gives access to the session's runspace.</returns>
-        public Task<RunspaceHandle> GetRunspaceHandle()
+        public Task<RunspaceHandle> GetRunspaceHandleAsync()
         {
-            return this.GetRunspaceHandleImpl(CancellationToken.None, isReadLine: false);
+            return this.GetRunspaceHandleImplAsync(CancellationToken.None, isReadLine: false);
         }
 
         /// <summary>
@@ -420,9 +420,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="cancellationToken">A CancellationToken that can be used to cancel the request.</param>
         /// <returns>A RunspaceHandle instance that gives access to the session's runspace.</returns>
-        public Task<RunspaceHandle> GetRunspaceHandle(CancellationToken cancellationToken)
+        public Task<RunspaceHandle> GetRunspaceHandleAsync(CancellationToken cancellationToken)
         {
-            return this.GetRunspaceHandleImpl(cancellationToken, isReadLine: false);
+            return this.GetRunspaceHandleImplAsync(cancellationToken, isReadLine: false);
         }
 
         /// <summary>
@@ -441,12 +441,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// An awaitable Task which will provide results once the command
         /// execution completes.
         /// </returns>
-        public async Task<IEnumerable<TResult>> ExecuteCommand<TResult>(
+        public async Task<IEnumerable<TResult>> ExecuteCommandAsync<TResult>(
             PSCommand psCommand,
             bool sendOutputToHost = false,
             bool sendErrorToHost = true)
         {
-            return await ExecuteCommand<TResult>(psCommand, null, sendOutputToHost, sendErrorToHost);
+            return await ExecuteCommandAsync<TResult>(psCommand, null, sendOutputToHost, sendErrorToHost);
         }
 
         /// <summary>
@@ -469,7 +469,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// An awaitable Task which will provide results once the command
         /// execution completes.
         /// </returns>
-        public Task<IEnumerable<TResult>> ExecuteCommand<TResult>(
+        public Task<IEnumerable<TResult>> ExecuteCommandAsync<TResult>(
             PSCommand psCommand,
             StringBuilder errorMessages,
             bool sendOutputToHost = false,
@@ -477,7 +477,7 @@ namespace Microsoft.PowerShell.EditorServices
             bool addToHistory = false)
         {
             return
-                this.ExecuteCommand<TResult>(
+                this.ExecuteCommandAsync<TResult>(
                     psCommand,
                     errorMessages,
                     new ExecutionOptions
@@ -500,7 +500,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// An awaitable Task which will provide results once the command
         /// execution completes.
         /// </returns>
-        public async Task<IEnumerable<TResult>> ExecuteCommand<TResult>(
+        public async Task<IEnumerable<TResult>> ExecuteCommandAsync<TResult>(
             PSCommand psCommand,
             StringBuilder errorMessages,
             ExecutionOptions executionOptions)
@@ -549,7 +549,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
 
                 // Send the pipeline execution request to the pipeline thread
-                return await threadController.RequestPipelineExecution(
+                return await threadController.RequestPipelineExecutionAsync(
                     new PipelineExecutionRequest<TResult>(
                         this,
                         psCommand,
@@ -578,7 +578,7 @@ namespace Microsoft.PowerShell.EditorServices
                     // don't write output (e.g. command completion)
                     if (executionTarget == ExecutionTarget.InvocationEvent)
                     {
-                        return (await this.InvocationEventQueue.ExecuteCommandOnIdle<TResult>(
+                        return (await this.InvocationEventQueue.ExecuteCommandOnIdleAsync<TResult>(
                             psCommand,
                             errorMessages,
                             executionOptions));
@@ -594,7 +594,7 @@ namespace Microsoft.PowerShell.EditorServices
                             false);
                     }
 
-                    runspaceHandle = await this.GetRunspaceHandle(executionOptions.IsReadLine);
+                    runspaceHandle = await this.GetRunspaceHandleAsync(executionOptions.IsReadLine);
                     if (executionOptions.WriteInputToHost)
                     {
                         this.WriteOutput(psCommand.Commands[0].CommandText, true);
@@ -785,7 +785,7 @@ namespace Microsoft.PowerShell.EditorServices
                             // will exist already so we need to create one and then use it
                             if (runspaceHandle == null)
                             {
-                                runspaceHandle = await this.GetRunspaceHandle();
+                                runspaceHandle = await this.GetRunspaceHandleAsync();
                             }
 
                             sessionDetails = this.GetSessionDetailsInRunspace(runspaceHandle.Runspace);
@@ -824,9 +824,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// An awaitable Task that the caller can use to know when
         /// execution completes.
         /// </returns>
-        public Task ExecuteCommand(PSCommand psCommand)
+        public Task ExecuteCommandAsync(PSCommand psCommand)
         {
-            return this.ExecuteCommand<object>(psCommand);
+            return this.ExecuteCommandAsync<object>(psCommand);
         }
 
         /// <summary>
@@ -834,10 +834,10 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="scriptString">The script string to execute.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
-        public Task<IEnumerable<object>> ExecuteScriptString(
+        public Task<IEnumerable<object>> ExecuteScriptStringAsync(
             string scriptString)
         {
-            return this.ExecuteScriptString(scriptString, false, true);
+            return this.ExecuteScriptStringAsync(scriptString, false, true);
         }
 
         /// <summary>
@@ -846,11 +846,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="scriptString">The script string to execute.</param>
         /// <param name="errorMessages">Error messages from PowerShell will be written to the StringBuilder.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
-        public Task<IEnumerable<object>> ExecuteScriptString(
+        public Task<IEnumerable<object>> ExecuteScriptStringAsync(
             string scriptString,
             StringBuilder errorMessages)
         {
-            return this.ExecuteScriptString(scriptString, errorMessages, false, true, false);
+            return this.ExecuteScriptStringAsync(scriptString, errorMessages, false, true, false);
         }
 
         /// <summary>
@@ -860,12 +860,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="writeInputToHost">If true, causes the script string to be written to the host.</param>
         /// <param name="writeOutputToHost">If true, causes the script output to be written to the host.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
-        public Task<IEnumerable<object>> ExecuteScriptString(
+        public Task<IEnumerable<object>> ExecuteScriptStringAsync(
             string scriptString,
             bool writeInputToHost,
             bool writeOutputToHost)
         {
-            return this.ExecuteScriptString(scriptString, null, writeInputToHost, writeOutputToHost, false);
+            return this.ExecuteScriptStringAsync(scriptString, null, writeInputToHost, writeOutputToHost, false);
         }
 
         /// <summary>
@@ -876,13 +876,13 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="writeOutputToHost">If true, causes the script output to be written to the host.</param>
         /// <param name="addToHistory">If true, adds the command to the user's command history.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
-        public Task<IEnumerable<object>> ExecuteScriptString(
+        public Task<IEnumerable<object>> ExecuteScriptStringAsync(
             string scriptString,
             bool writeInputToHost,
             bool writeOutputToHost,
             bool addToHistory)
         {
-            return this.ExecuteScriptString(scriptString, null, writeInputToHost, writeOutputToHost, addToHistory);
+            return this.ExecuteScriptStringAsync(scriptString, null, writeInputToHost, writeOutputToHost, addToHistory);
         }
 
         /// <summary>
@@ -894,14 +894,14 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="writeOutputToHost">If true, causes the script output to be written to the host.</param>
         /// <param name="addToHistory">If true, adds the command to the user's command history.</param>
         /// <returns>A Task that can be awaited for the script completion.</returns>
-        public async Task<IEnumerable<object>> ExecuteScriptString(
+        public async Task<IEnumerable<object>> ExecuteScriptStringAsync(
             string scriptString,
             StringBuilder errorMessages,
             bool writeInputToHost,
             bool writeOutputToHost,
             bool addToHistory)
         {
-            return await this.ExecuteCommand<object>(
+            return await this.ExecuteCommandAsync<object>(
                 new PSCommand().AddScript(scriptString.Trim()),
                 errorMessages,
                 new ExecutionOptions()
@@ -919,7 +919,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// <param name="arguments">Arguments to pass to the script.</param>
         /// <param name="writeInputToHost">Writes the executed script path and arguments to the host.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task ExecuteScriptWithArgs(string script, string arguments = null, bool writeInputToHost = false)
+        public async Task ExecuteScriptWithArgsAsync(string script, string arguments = null, bool writeInputToHost = false)
         {
             string launchedScript = script;
             PSCommand command = new PSCommand();
@@ -931,7 +931,7 @@ namespace Microsoft.PowerShell.EditorServices
                 try
                 {
                     // Assume we can only debug scripts from the FileSystem provider
-                    string workingDir = (await ExecuteCommand<PathInfo>(
+                    string workingDir = (await ExecuteCommandAsync<PathInfo>(
                         new PSCommand()
                             .AddCommand("Microsoft.PowerShell.Management\\Get-Location")
                             .AddParameter("PSProvider", "FileSystem"),
@@ -974,7 +974,7 @@ namespace Microsoft.PowerShell.EditorServices
                     true);
             }
 
-            await this.ExecuteCommand<object>(
+            await this.ExecuteCommandAsync<object>(
                 command,
                 null,
                 sendOutputToHost: true,
@@ -986,8 +986,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// reliquishing control of the pipeline thread during event processing.
         /// </summary>
         /// <remarks>
-        /// This method is called automatically by <see cref="InvokeOnPipelineThread" /> and
-        /// <see cref="ExecuteCommand" />. Consider using them instead of this method directly when
+        /// This method is called automatically by <see cref="InvokeOnPipelineThreadAsync" /> and
+        /// <see cref="ExecuteCommandAsync" />. Consider using them instead of this method directly when
         /// possible.
         /// </remarks>
         internal void ForcePSEventHandling()
@@ -1008,14 +1008,14 @@ namespace Microsoft.PowerShell.EditorServices
         /// An awaitable <see cref="Task" /> that the caller can use to know when execution completes.
         /// </returns>
         /// <remarks>
-        /// This method is called automatically by <see cref="ExecuteCommand" />. Consider using
+        /// This method is called automatically by <see cref="ExecuteCommandAsync" />. Consider using
         /// that method instead of calling this directly when possible.
         /// </remarks>
-        internal async Task InvokeOnPipelineThread(Action<PowerShell> invocationAction)
+        internal async Task InvokeOnPipelineThreadAsync(Action<PowerShell> invocationAction)
         {
             if (this.PromptNest.IsReadLineBusy())
             {
-                await this.InvocationEventQueue.InvokeOnPipelineThread(invocationAction);
+                await this.InvocationEventQueue.InvokeOnPipelineThreadAsync(invocationAction);
                 return;
             }
 
@@ -1048,7 +1048,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// loaded.
         /// </summary>
         /// <returns>A Task that can be awaited for completion.</returns>
-        public async Task LoadHostProfiles()
+        public async Task LoadHostProfilesAsync()
         {
             if (this.profilePaths != null)
             {
@@ -1058,12 +1058,12 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     command = new PSCommand();
                     command.AddCommand(profilePath, false);
-                    await this.ExecuteCommand<object>(command, true, true);
+                    await this.ExecuteCommandAsync<object>(command, true, true);
                 }
 
                 // Gather the session details (particularly the prompt) after
                 // loading the user's profiles.
-                await this.GetSessionDetailsInRunspace();
+                await this.GetSessionDetailsInRunspaceAsync();
             }
         }
 
@@ -1262,12 +1262,12 @@ namespace Microsoft.PowerShell.EditorServices
             this.initialRunspace = null;
         }
 
-        private async Task<RunspaceHandle> GetRunspaceHandle(bool isReadLine)
+        private async Task<RunspaceHandle> GetRunspaceHandleAsync(bool isReadLine)
         {
-            return await this.GetRunspaceHandleImpl(CancellationToken.None, isReadLine);
+            return await this.GetRunspaceHandleImplAsync(CancellationToken.None, isReadLine);
         }
 
-        private async Task<RunspaceHandle> GetRunspaceHandleImpl(CancellationToken cancellationToken, bool isReadLine)
+        private async Task<RunspaceHandle> GetRunspaceHandleImplAsync(CancellationToken cancellationToken, bool isReadLine)
         {
             return await this.PromptNest.GetRunspaceHandleAsync(cancellationToken, isReadLine);
         }
@@ -1429,7 +1429,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.ConsoleReader?.StopCommandLoop();
             this.ConsoleReader?.StartCommandLoop();
 
-            var localPipelineExecutionTask = localThreadController.TakeExecutionRequest();
+            var localPipelineExecutionTask = localThreadController.TakeExecutionRequestAsync();
             var localDebuggerStoppedTask = localThreadController.Exit();
 
             // Wait for off-thread pipeline requests and/or ExitNestedPrompt
@@ -1442,8 +1442,8 @@ namespace Microsoft.PowerShell.EditorServices
                 if (taskIndex == 0)
                 {
                     var localExecutionTask = localPipelineExecutionTask.GetAwaiter().GetResult();
-                    localPipelineExecutionTask = localThreadController.TakeExecutionRequest();
-                    localExecutionTask.Execute().GetAwaiter().GetResult();
+                    localPipelineExecutionTask = localThreadController.TakeExecutionRequestAsync();
+                    localExecutionTask.ExecuteAsync().GetAwaiter().GetResult();
                     continue;
                 }
 
@@ -1477,9 +1477,9 @@ namespace Microsoft.PowerShell.EditorServices
         /// unescaped before calling this method.
         /// </summary>
         /// <param name="path"></param>
-        public async Task SetWorkingDirectory(string path)
+        public async Task SetWorkingDirectoryAsync(string path)
         {
-            await this.SetWorkingDirectory(path, true);
+            await this.SetWorkingDirectoryAsync(path, true);
         }
 
         /// <summary>
@@ -1487,7 +1487,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         /// <param name="path"></param>
         /// <param name="isPathAlreadyEscaped">Specify false to have the path escaped, otherwise specify true if the path has already been escaped.</param>
-        public async Task SetWorkingDirectory(string path, bool isPathAlreadyEscaped)
+        public async Task SetWorkingDirectoryAsync(string path, bool isPathAlreadyEscaped)
         {
             this.InitialWorkingDirectory = path;
 
@@ -1496,7 +1496,7 @@ namespace Microsoft.PowerShell.EditorServices
                 path = EscapePath(path, false);
             }
 
-            await ExecuteCommand<PSObject>(
+            await ExecuteCommandAsync<PSObject>(
                 new PSCommand().AddCommand("Set-Location").AddParameter("Path", path),
                 null,
                 sendOutputToHost: false,
@@ -1910,9 +1910,9 @@ namespace Microsoft.PowerShell.EditorServices
             return this.mostRecentSessionDetails;
         }
 
-        private async Task<SessionDetails> GetSessionDetailsInRunspace()
+        private async Task<SessionDetails> GetSessionDetailsInRunspaceAsync()
         {
-            using (RunspaceHandle runspaceHandle = await this.GetRunspaceHandle())
+            using (RunspaceHandle runspaceHandle = await this.GetRunspaceHandleAsync())
             {
                 return this.GetSessionDetailsInRunspace(runspaceHandle.Runspace);
             }
@@ -2117,7 +2117,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.logger.Write(LogLevel.Verbose, "Starting pipeline thread message loop...");
 
             Task<IPipelineExecutionRequest> localPipelineExecutionTask =
-                localThreadController.TakeExecutionRequest();
+                localThreadController.TakeExecutionRequestAsync();
             Task<DebuggerResumeAction> localDebuggerStoppedTask =
                 localThreadController.Exit();
             while (true)
@@ -2163,8 +2163,8 @@ namespace Microsoft.PowerShell.EditorServices
                     this.logger.Write(LogLevel.Verbose, "Received pipeline thread execution request.");
 
                     IPipelineExecutionRequest executionRequest = localPipelineExecutionTask.Result;
-                    localPipelineExecutionTask = localThreadController.TakeExecutionRequest();
-                    executionRequest.Execute().GetAwaiter().GetResult();
+                    localPipelineExecutionTask = localThreadController.TakeExecutionRequestAsync();
+                    executionRequest.ExecuteAsync().GetAwaiter().GetResult();
 
                     this.logger.Write(LogLevel.Verbose, "Pipeline thread execution completed.");
 

--- a/src/PowerShellEditorServices/Session/ThreadController.cs
+++ b/src/PowerShellEditorServices/Session/ThreadController.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// A task object representing the asynchronous operation. The Result property will return
         /// the output of the command invocation.
         /// </returns>
-        internal async Task<IEnumerable<TResult>> RequestPipelineExecution<TResult>(
+        internal async Task<IEnumerable<TResult>> RequestPipelineExecutionAsync<TResult>(
             PipelineExecutionRequest<TResult> executionRequest)
         {
             await PipelineRequestQueue.EnqueueAsync(executionRequest);
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
         /// A task object representing the asynchronous operation. The Result property will return
         /// the retrieved pipeline execution request.
         /// </returns>
-        internal async Task<IPipelineExecutionRequest> TakeExecutionRequest()
+        internal async Task<IPipelineExecutionRequest> TakeExecutionRequestAsync()
         {
             return await PipelineRequestQueue.DequeueAsync();
         }

--- a/src/PowerShellEditorServices/Templates/TemplateService.cs
+++ b/src/PowerShellEditorServices/Templates/TemplateService.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
         /// Checks if Plaster is installed on the user's machine.
         /// </summary>
         /// <returns>A Task that can be awaited until the check is complete.  The result will be true if Plaster is installed.</returns>
-        public async Task<bool> ImportPlasterIfInstalled()
+        public async Task<bool> ImportPlasterIfInstalledAsync()
         {
             if (!this.isPlasterInstalled.HasValue)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
                 this.logger.Write(LogLevel.Verbose, "Checking if Plaster is installed...");
 
                 var getResult =
-                    await this.powerShellContext.ExecuteCommand<PSObject>(
+                    await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                         psCommand, false, false);
 
                 PSObject moduleObject = getResult.First();
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
                         .AddParameter("PassThru");
 
                     var importResult =
-                        await this.powerShellContext.ExecuteCommand<object>(
+                        await this.powerShellContext.ExecuteCommandAsync<object>(
                             psCommand, false, false);
 
                     this.isPlasterLoaded = importResult.Any();
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
         /// included templates.
         /// </param>
         /// <returns>A Task which can be awaited for the TemplateDetails list to be returned.</returns>
-        public async Task<TemplateDetails[]> GetAvailableTemplates(
+        public async Task<TemplateDetails[]> GetAvailableTemplatesAsync(
             bool includeInstalledModules)
         {
             if (!this.isPlasterLoaded)
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
             }
 
             var templateObjects =
-                await this.powerShellContext.ExecuteCommand<PSObject>(
+                await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                     psCommand, false, false);
 
             this.logger.Write(
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
         /// <param name="templatePath">The folder path containing the template.</param>
         /// <param name="destinationPath">The folder path where the files will be created.</param>
         /// <returns>A boolean-returning Task which communicates success or failure.</returns>
-        public async Task<bool> CreateFromTemplate(
+        public async Task<bool> CreateFromTemplateAsync(
             string templatePath,
             string destinationPath)
         {
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.EditorServices.Templates
             command.AddParameter("DestinationPath", destinationPath);
 
             var errorString = new System.Text.StringBuilder();
-            await this.powerShellContext.ExecuteCommand<PSObject>(
+            await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                 command,
                 errorString,
                 new ExecutionOptions

--- a/src/PowerShellEditorServices/Utility/AsyncDebouncer.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncDebouncer.cs
@@ -59,12 +59,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// The argument for this implementation's Invoke method.
         /// </param>
         /// <returns>A Task to be awaited until the Invoke is queued.</returns>
-        public async Task Invoke(TInvokeArgs invokeArgument)
+        public async Task InvokeAsync(TInvokeArgs invokeArgument)
         {
             using (await this.asyncLock.LockAsync())
             {
                 // Invoke the implementor
-                await this.OnInvoke(invokeArgument);
+                await this.OnInvokeAsync(invokeArgument);
 
                 // If there's no timer, start one
                 if (this.currentTimerTask == null)
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// deadlocks could occur.
         /// </summary>
         /// <returns>A Task to be awaited until Flush completes.</returns>
-        public async Task Flush()
+        public async Task FlushAsync()
         {
             using (await this.asyncLock.LockAsync())
             {
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 this.CancelTimer();
 
                 // Flush the current output
-                await this.OnFlush();
+                await this.OnFlushAsync();
             }
         }
 
@@ -112,13 +112,13 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// The argument for this implementation's OnInvoke method.
         /// </param>
         /// <returns>A Task to be awaited for the invoke to complete.</returns>
-        protected abstract Task OnInvoke(TInvokeArgs invokeArgument);
+        protected abstract Task OnInvokeAsync(TInvokeArgs invokeArgument);
 
         /// <summary>
         /// Implemented by the subclass to complete the current operation.
         /// </summary>
         /// <returns>A Task to be awaited for the operation to complete.</returns>
-        protected abstract Task OnFlush();
+        protected abstract Task OnFlushAsync();
 
         #endregion
 
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                         {
                             if (!t.IsCanceled)
                             {
-                                return this.Flush();
+                                return this.FlushAsync();
                             }
                             else
                             {
@@ -153,8 +153,8 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             }
 
             // Was the task cancelled?
-            bool wasCancelled = 
-                this.currentTimerTask == null || 
+            bool wasCancelled =
+                this.currentTimerTask == null ||
                 this.currentTimerTask.IsCanceled;
 
             // Clear the current task so that another may be created

--- a/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/DebugAdapterTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 
             this.debugAdapterClient =
                 new DebugAdapterClient(
-                    await NamedPipeClientChannel.Connect(
+                    await NamedPipeClientChannel.ConnectAsync(
                         pipeNames.Item2,
                         MessageProtocolType.DebugAdapter,
                         this.logger),
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             this.messageSender = this.debugAdapterClient;
             this.messageHandlers = this.debugAdapterClient;
 
-            await this.debugAdapterClient.Start();
+            await this.debugAdapterClient.StartAsync();
         }
 
         public Task DisposeAsync()
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 
         private async Task LaunchScript(string scriptPath)
         {
-            await this.debugAdapterClient.LaunchScript(scriptPath);
+            await this.debugAdapterClient.LaunchScriptAsync(scriptPath);
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 
             this.languageServiceClient =
                 new LanguageServiceClient(
-                    await NamedPipeClientChannel.Connect(
+                    await NamedPipeClientChannel.ConnectAsync(
                         pipeNames.Item1,
                         MessageProtocolType.LanguageServer,
                         this.logger),
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
 
         public async Task DisposeAsync()
         {
-            await this.languageServiceClient.Stop();
+            await this.languageServiceClient.StopAsync();
 
             this.KillService();
         }
@@ -644,7 +644,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Assert.Equal(1, showChoicePromptRequest.DefaultChoices[0]);
 
             // Respond to the prompt request
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new ShowChoicePromptResponse
                 {
                     ResponseText = "a"
@@ -695,7 +695,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             Assert.Equal("Name", showInputPromptRequest.Name);
 
             // Respond to the prompt request
-            await requestContext.SendResult(
+            await requestContext.SendResultAsync(
                 new ShowInputPromptResponse
                 {
                     ResponseText = "John"
@@ -865,7 +865,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             bool enableProfileLoading = false)
         {
             // Send the configuration change to cause profiles to be loaded
-            await this.languageServiceClient.SendEvent(
+            await this.languageServiceClient.SendEventAsync(
                 DidChangeConfigurationNotification<LanguageServerSettingsWrapper>.Type,
                 new DidChangeConfigurationParams<LanguageServerSettingsWrapper>
                 {

--- a/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
+++ b/test/PowerShellEditorServices.Test.Host/ServerTestsBase.cs
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
             TParams requestParams)
         {
             return
-                this.messageSender.SendRequest(
+                this.messageSender.SendRequestAsync(
                     requestType,
                     requestParams,
                     true);
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
         protected Task SendEvent<TParams, TRegistrationOptions>(NotificationType<TParams, TRegistrationOptions> eventType, TParams eventParams)
         {
             return
-                this.messageSender.SendEvent(
+                this.messageSender.SendEventAsync(
                     eventType,
                     eventParams);
         }

--- a/test/PowerShellEditorServices.Test.Protocol/Message/MessageReaderWriterTests.cs
+++ b/test/PowerShellEditorServices.Test.Protocol/Message/MessageReaderWriterTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.MessageProtocol
 
             // Write the message and then roll back the stream to be read
             // TODO: This will need to be redone!
-            await messageWriter.WriteMessage(Message.Event("testEvent", null));
+            await messageWriter.WriteMessageAsync(Message.Event("testEvent", null));
             outputStream.Seek(0, SeekOrigin.Begin);
 
             string expectedHeaderString =
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.MessageProtocol
             inputStream.Flush();
             inputStream.Seek(0, SeekOrigin.Begin);
 
-            Message messageResult = messageReader.ReadMessage().Result;
+            Message messageResult = messageReader.ReadMessageAsync().Result;
             Assert.Equal("testEvent", messageResult.Method);
 
             inputStream.Dispose();
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.MessageProtocol
             // Read the written messages from the stream
             for (int i = 0; i < overflowMessageCount; i++)
             {
-                Message messageResult = messageReader.ReadMessage().Result;
+                Message messageResult = messageReader.ReadMessageAsync().Result;
                 Assert.Equal("testEvent", messageResult.Method);
             }
 
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.MessageProtocol
             inputStream.Flush();
             inputStream.Seek(0, SeekOrigin.Begin);
 
-            Message messageResult = messageReader.ReadMessage().Result;
+            Message messageResult = messageReader.ReadMessageAsync().Result;
             Assert.Equal("testEvent", messageResult.Method);
 
             inputStream.Dispose();

--- a/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
+++ b/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
             string outputText,
             bool includeNewLine = false)
         {
-            return debouncer.Invoke(
+            return debouncer.InvokeAsync(
                 new OutputWrittenEventArgs(
                     outputText,
                     includeNewLine,
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
     {
         public List<OutputEventBody> OutputEvents { get; } = new List<OutputEventBody>();
 
-        public Task SendEvent<TParams, TRegistrationOptions>(
+        public Task SendEventAsync<TParams, TRegistrationOptions>(
             NotificationType<TParams, TRegistrationOptions> eventType,
             TParams eventParams)
         {
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
             return Task.FromResult(true);
         }
 
-        public Task<TResult> SendRequest<TParams, TResult, TError, TRegistrationOptions>(
+        public Task<TResult> SendRequestAsync<TParams, TResult, TError, TRegistrationOptions>(
             RequestType<TParams, TResult, TError, TRegistrationOptions> requestType,
             TParams requestParams, bool waitForResponse)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
             throw new NotImplementedException();
         }
 
-        public Task<TResult> SendRequest<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
+        public Task<TResult> SendRequestAsync<TResult, TError, TRegistrationOptions>(RequestType0<TResult, TError, TRegistrationOptions> requestType0)
         {
             // Legitimately not implemented for these tests.
             throw new NotImplementedException();

--- a/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             TestChoicePromptHandler choicePromptHandler = new TestChoicePromptHandler();
             Task<int> promptTask =
-                choicePromptHandler.PromptForChoice(
+                choicePromptHandler.PromptForChoiceAsync(
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             TestChoicePromptHandler choicePromptHandler = new TestChoicePromptHandler();
             Task<int> promptTask =
-                choicePromptHandler.PromptForChoice(
+                choicePromptHandler.PromptForChoiceAsync(
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 new TestChoicePromptHandler();
 
             Task<int> promptTask =
-                choicePromptHandler.PromptForChoice(
+                choicePromptHandler.PromptForChoiceAsync(
                     "Test prompt",
                     "Message is irrelevant",
                     Choices,
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
             this.linePromptTask.SetResult(inputString);
         }
 
-        protected override Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
             this.linePromptTask = new TaskCompletionSource<string>();
             return this.linePromptTask.Task;

--- a/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             TestInputPromptHandler inputPromptHandler = new TestInputPromptHandler();
             Task<Dictionary<string, object>> promptTask =
-                inputPromptHandler.PromptForInput(
+                inputPromptHandler.PromptForInputAsync(
                     "Test Prompt",
                     "Message is irrelevant",
                     Fields,
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             TestInputPromptHandler inputPromptHandler = new TestInputPromptHandler();
             Task<Dictionary<string, object>> promptTask =
-                inputPromptHandler.PromptForInput(
+                inputPromptHandler.PromptForInputAsync(
                     "Test Prompt",
                     "Message is irrelevant",
                     new FieldDetails[]
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         {
             TestInputPromptHandler inputPromptHandler = new TestInputPromptHandler();
             Task<Dictionary<string, object>> promptTask =
-                inputPromptHandler.PromptForInput(
+                inputPromptHandler.PromptForInputAsync(
                     "Test Prompt",
                     "Message is irrelevant",
                     Fields,
@@ -146,13 +146,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
             this.securePromptTask.SetResult(secureString);
         }
 
-        protected override Task<string> ReadInputString(CancellationToken cancellationToken)
+        protected override Task<string> ReadInputStringAsync(CancellationToken cancellationToken)
         {
             this.linePromptTask = new TaskCompletionSource<string>();
             return this.linePromptTask.Task;
         }
 
-        protected override Task<SecureString> ReadSecureString(CancellationToken cancellationToken)
+        protected override Task<SecureString> ReadSecureStringAsync(CancellationToken cancellationToken)
         {
             this.securePromptTask = new TaskCompletionSource<SecureString>();
             return this.securePromptTask.Task;

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 this.workspace.GetFile(
                     TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Debugging/Debug` With Params `[Test].ps1"));
 
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 debugWithParamsFile,
                 new[] { BreakpointDetails.Create("", 3) });
 
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     debugWithParamsFile.FilePath, arguments);
 
             await this.AssertDebuggerStopped(debugWithParamsFile.FilePath);
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerSetsAndClearsFunctionBreakpoints()
         {
             CommandBreakpointDetails[] breakpoints =
-                await this.debugService.SetCommandBreakpoints(
+                await this.debugService.SetCommandBreakpointsAsync(
                     new[] {
                         CommandBreakpointDetails.Create("Write-Host"),
                         CommandBreakpointDetails.Create("Get-Date")
@@ -175,14 +175,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal("Get-Date", breakpoints[1].Name);
 
             breakpoints =
-                await this.debugService.SetCommandBreakpoints(
+                await this.debugService.SetCommandBreakpointsAsync(
                     new[] { CommandBreakpointDetails.Create("Get-Host") });
 
             Assert.Equal(1, breakpoints.Length);
             Assert.Equal("Get-Host", breakpoints[0].Name);
 
             breakpoints =
-                await this.debugService.SetCommandBreakpoints(
+                await this.debugService.SetCommandBreakpointsAsync(
                     new CommandBreakpointDetails[] {});
 
             Assert.Equal(0, breakpoints.Length);
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerStopsOnFunctionBreakpoints()
         {
             CommandBreakpointDetails[] breakpoints =
-                await this.debugService.SetCommandBreakpoints(
+                await this.debugService.SetCommandBreakpointsAsync(
                     new[] {
                         CommandBreakpointDetails.Create("Write-Host")
                     });
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     this.debugScriptFile.FilePath);
 
             // Wait for function breakpoint to hit
@@ -238,7 +238,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerSetsAndClearsLineBreakpoints()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 5),
@@ -252,7 +252,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal(10, breakpoints[1].LineNumber);
 
             breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] { BreakpointDetails.Create("", 2) });
 
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal(1, confirmedBreakpoints.Count());
             Assert.Equal(2, breakpoints[0].LineNumber);
 
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.debugScriptFile,
                 new[] { BreakpointDetails.Create("", 0) });
 
@@ -276,7 +276,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerStopsOnLineBreakpoints()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 5),
@@ -286,7 +286,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     this.debugScriptFile.FilePath);
 
             // Wait for a couple breakpoints
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             const int breakpointValue2 = 20;
 
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 7, null, $"$i -eq {breakpointValue1} -or $i -eq {breakpointValue2}"),
@@ -316,7 +316,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -357,7 +357,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             const int hitCount = 5;
 
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 6, null, null, $"{hitCount}"),
@@ -366,7 +366,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             const int hitCount = 5;
 
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 6, null, $"$i % 2 -eq 0", $"{hitCount}"),
@@ -402,7 +402,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await this.AssertStateChange(PowerShellContextState.Ready);
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptWithArgs(
+                this.powerShellContext.ExecuteScriptWithArgsAsync(
                     this.debugScriptFile.FilePath);
 
             // Wait for conditional breakpoint to hit
@@ -428,7 +428,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerProvidesMessageForInvalidConditionalBreakpoint()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 5),
@@ -450,7 +450,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerFindsParseableButInvalidSimpleBreakpointConditions()
         {
             BreakpointDetails[] breakpoints =
-                await this.debugService.SetLineBreakpoints(
+                await this.debugService.SetLineBreakpointsAsync(
                     this.debugScriptFile,
                     new[] {
                         BreakpointDetails.Create("", 5, column: null, condition: "$i == 100"),
@@ -482,7 +482,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 "Unexpected breakpoint found in script file");
 
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.debugScriptFile.FilePath);
 
             // Break execution and wait for the debugger to stop
@@ -505,7 +505,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         public async Task DebuggerRunsCommandsWhileStopped()
         {
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.debugScriptFile.FilePath);
 
             // Break execution and wait for the debugger to stop
@@ -515,7 +515,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 PowerShellExecutionResult.Stopped);
 
             // Try running a command from outside the pipeline thread
-            await this.powerShellContext.ExecuteScriptString("Get-Command Get-Process");
+            await this.powerShellContext.ExecuteScriptStringAsync("Get-Command Get-Process");
 
             // Abort execution and wait for the debugger to exit
             this.debugService.Abort();
@@ -528,13 +528,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableStringDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -556,13 +556,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerGetsVariables()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 14) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -606,13 +606,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsVariablesNoConversion()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 14) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -624,7 +624,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             // Test set of a local string variable (not strongly typed)
             string newStrValue = "\"Goodbye\"";
-            string setStrValue = await debugService.SetVariable(stackFrames[0].LocalVariables.Id, "$strVar", newStrValue);
+            string setStrValue = await debugService.SetVariableAsync(stackFrames[0].LocalVariables.Id, "$strVar", newStrValue);
             Assert.Equal(newStrValue, setStrValue);
 
             VariableScope[] scopes = this.debugService.GetVariableScopes(0);
@@ -633,13 +633,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             VariableScope scriptScope = scopes.FirstOrDefault(s => s.Name == VariableContainerDetails.ScriptScopeName);
             string newIntValue = "49";
             string newIntExpr = "7 * 7";
-            string setIntValue = await debugService.SetVariable(scriptScope.Id, "$scriptInt", newIntExpr);
+            string setIntValue = await debugService.SetVariableAsync(scriptScope.Id, "$scriptInt", newIntExpr);
             Assert.Equal(newIntValue, setIntValue);
 
             // Test set of global scope int variable (not strongly typed)
             VariableScope globalScope = scopes.FirstOrDefault(s => s.Name == VariableContainerDetails.GlobalScopeName);
             string newGlobalIntValue = "4242";
-            string setGlobalIntValue = await debugService.SetVariable(globalScope.Id, "$MaximumHistoryCount", newGlobalIntValue);
+            string setGlobalIntValue = await debugService.SetVariableAsync(globalScope.Id, "$MaximumHistoryCount", newGlobalIntValue);
             Assert.Equal(newGlobalIntValue, setGlobalIntValue);
 
             // The above just tests that the debug service returns the correct new value string.
@@ -675,13 +675,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsVariablesWithConversion()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 14) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             // Test set of a local string variable (not strongly typed but force conversion)
             string newStrValue = "\"False\"";
             string newStrExpr = "$false";
-            string setStrValue = await debugService.SetVariable(stackFrames[0].LocalVariables.Id, "$strVar2", newStrExpr);
+            string setStrValue = await debugService.SetVariableAsync(stackFrames[0].LocalVariables.Id, "$strVar2", newStrExpr);
             Assert.Equal(newStrValue, setStrValue);
 
             VariableScope[] scopes = this.debugService.GetVariableScopes(0);
@@ -703,14 +703,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             VariableScope scriptScope = scopes.FirstOrDefault(s => s.Name == VariableContainerDetails.ScriptScopeName);
             string newBoolValue = "$true";
             string newBoolExpr = "1";
-            string setBoolValue = await debugService.SetVariable(scriptScope.Id, "$scriptBool", newBoolExpr);
+            string setBoolValue = await debugService.SetVariableAsync(scriptScope.Id, "$scriptBool", newBoolExpr);
             Assert.Equal(newBoolValue, setBoolValue);
 
             // Test set of global scope ActionPreference variable (strongly typed)
             VariableScope globalScope = scopes.FirstOrDefault(s => s.Name == VariableContainerDetails.GlobalScopeName);
             string newGlobalValue = "Continue";
             string newGlobalExpr = "'Continue'";
-            string setGlobalValue = await debugService.SetVariable(globalScope.Id, "$VerbosePreference", newGlobalExpr);
+            string setGlobalValue = await debugService.SetVariableAsync(globalScope.Id, "$VerbosePreference", newGlobalExpr);
             Assert.Equal(newGlobalValue, setGlobalValue);
 
             // The above just tests that the debug service returns the correct new value string.
@@ -746,13 +746,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableEnumDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -774,13 +774,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariableHashtableDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -818,13 +818,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariablePSObjectDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -853,13 +853,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerVariablePSCustomObjectDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -896,13 +896,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 #endif
         public async Task DebuggerVariableProcessObjDisplaysCorrectly()
         {
-            await this.debugService.SetLineBreakpoints(
+            await this.debugService.SetLineBreakpointsAsync(
                 this.variableScriptFile,
                 new[] { BreakpointDetails.Create("", 18) });
 
             // Execute the script and wait for the breakpoint to be hit
             Task executeTask =
-                this.powerShellContext.ExecuteScriptString(
+                this.powerShellContext.ExecuteScriptStringAsync(
                     this.variableScriptFile.FilePath);
 
             await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
@@ -966,7 +966,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         private async Task<IEnumerable<LineBreakpoint>> GetConfirmedBreakpoints(ScriptFile scriptFile)
         {
             return
-                await this.powerShellContext.ExecuteCommand<LineBreakpoint>(
+                await this.powerShellContext.ExecuteCommandAsync<LineBreakpoint>(
                     new PSCommand()
                         .AddCommand("Get-PSBreakpoint")
                         .AddParameter("Script", scriptFile.FilePath));

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         {
             var logger = Logging.NullLogger;
             this.powerShellContext = PowerShellContextFactory.Create(logger);
-            await this.powerShellContext.ImportCommandsModule(
+            await this.powerShellContext.ImportCommandsModuleAsync(
                 TestUtilities.NormalizePath("../../../../../module/PowerShellEditorServices/Commands"));
 
             this.extensionService = new ExtensionService(this.powerShellContext);
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             this.extensionService.CommandUpdated += ExtensionService_ExtensionUpdated;
             this.extensionService.CommandRemoved += ExtensionService_ExtensionRemoved;
 
-            await this.extensionService.Initialize(
+            await this.extensionService.InitializeAsync(
                 this.editorOperations,
                 new ComponentRegistry());
 
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         [Fact]
         public async Task CanRegisterAndInvokeCommandWithCmdletName()
         {
-            await extensionService.PowerShellContext.ExecuteScriptString(
+            await extensionService.PowerShellContext.ExecuteScriptStringAsync(
                 TestUtilities.NormalizeNewlines("function Invoke-Extension { $global:extensionValue = 5 }\n") +
                 "Register-EditorCommand -Name \"test.function\" -DisplayName \"Function extension\" -Function \"Invoke-Extension\"");
 
@@ -80,31 +80,31 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             EditorCommand command = await this.AssertExtensionEvent(EventType.Add, "test.function");
 
             // Invoke the command
-            await extensionService.InvokeCommand("test.function", this.commandContext);
+            await extensionService.InvokeCommandAsync("test.function", this.commandContext);
 
             // Assert the expected value
             PSCommand psCommand = new PSCommand();
             psCommand.AddScript("$global:extensionValue");
-            var results = await powerShellContext.ExecuteCommand<int>(psCommand);
+            var results = await powerShellContext.ExecuteCommandAsync<int>(psCommand);
             Assert.Equal(5, results.FirstOrDefault());
         }
 
         [Fact]
         public async Task CanRegisterAndInvokeCommandWithScriptBlock()
         {
-            await extensionService.PowerShellContext.ExecuteScriptString(
+            await extensionService.PowerShellContext.ExecuteScriptStringAsync(
                 "Register-EditorCommand -Name \"test.scriptblock\" -DisplayName \"ScriptBlock extension\" -ScriptBlock { $global:extensionValue = 10 }");
 
             // Wait for the add event
             EditorCommand command = await this.AssertExtensionEvent(EventType.Add, "test.scriptblock");
 
             // Invoke the command
-            await extensionService.InvokeCommand("test.scriptblock", this.commandContext);
+            await extensionService.InvokeCommandAsync("test.scriptblock", this.commandContext);
 
             // Assert the expected value
             PSCommand psCommand = new PSCommand();
             psCommand.AddScript("$global:extensionValue");
-            var results = await powerShellContext.ExecuteCommand<int>(psCommand);
+            var results = await powerShellContext.ExecuteCommandAsync<int>(psCommand);
             Assert.Equal(10, results.FirstOrDefault());
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         public async Task CanUpdateRegisteredCommand()
         {
             // Register a command and then update it
-            await extensionService.PowerShellContext.ExecuteScriptString(TestUtilities.NormalizeNewlines(
+            await extensionService.PowerShellContext.ExecuteScriptStringAsync(TestUtilities.NormalizeNewlines(
                 "function Invoke-Extension { Write-Output \"Extension output!\" }\n" +
                 "Register-EditorCommand -Name \"test.function\" -DisplayName \"Function extension\" -Function \"Invoke-Extension\"\n" +
                 "Register-EditorCommand -Name \"test.function\" -DisplayName \"Updated Function extension\" -Function \"Invoke-Extension\""));
@@ -128,19 +128,19 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         public async Task CanUnregisterCommand()
         {
             // Add the command and wait for the add event
-            await extensionService.PowerShellContext.ExecuteScriptString(
+            await extensionService.PowerShellContext.ExecuteScriptStringAsync(
                 "Register-EditorCommand -Name \"test.scriptblock\" -DisplayName \"ScriptBlock extension\" -ScriptBlock { Write-Output \"Extension output!\" }");
             await this.AssertExtensionEvent(EventType.Add, "test.scriptblock");
 
             // Remove the command and wait for the remove event
-            await extensionService.PowerShellContext.ExecuteScriptString(
+            await extensionService.PowerShellContext.ExecuteScriptStringAsync(
                 "Unregister-EditorCommand -Name \"test.scriptblock\"");
             await this.AssertExtensionEvent(EventType.Remove, "test.scriptblock");
 
             // Ensure that the command has been unregistered
             await Assert.ThrowsAsync(
                 typeof(KeyNotFoundException),
-                () => extensionService.InvokeCommand("test.scriptblock", this.commandContext));
+                () => extensionService.InvokeCommandAsync("test.scriptblock", this.commandContext));
         }
 
         private async Task<EditorCommand> AssertExtensionEvent(EventType expectedEventType, string expectedExtensionName)
@@ -187,67 +187,67 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             throw new NotImplementedException();
         }
 
-        public Task NewFile()
+        public Task NewFileAsync()
         {
             throw new NotImplementedException();
         }
 
-        public Task OpenFile(string filePath)
+        public Task OpenFileAsync(string filePath)
         {
             throw new NotImplementedException();
         }
 
-        public Task OpenFile(string filePath, bool preview)
+        public Task OpenFileAsync(string filePath, bool preview)
         {
             throw new NotImplementedException();
         }
 
-        public Task CloseFile(string filePath)
+        public Task CloseFileAsync(string filePath)
         {
             throw new NotImplementedException();
         }
 
-        public Task SaveFile(string filePath)
+        public Task SaveFileAsync(string filePath)
         {
-            return SaveFile(filePath, null);
+            return SaveFileAsync(filePath, null);
         }
 
-        public Task SaveFile(string filePath, string newSavePath)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task InsertText(string filePath, string text, BufferRange insertRange)
+        public Task SaveFileAsync(string filePath, string newSavePath)
         {
             throw new NotImplementedException();
         }
 
-        public Task SetSelection(BufferRange selectionRange)
+        public Task InsertTextAsync(string filePath, string text, BufferRange insertRange)
         {
             throw new NotImplementedException();
         }
 
-        public Task<EditorContext> GetEditorContext()
+        public Task SetSelectionAsync(BufferRange selectionRange)
         {
             throw new NotImplementedException();
         }
 
-        public Task ShowInformationMessage(string message)
+        public Task<EditorContext> GetEditorContextAsync()
         {
             throw new NotImplementedException();
         }
 
-        public Task ShowErrorMessage(string message)
+        public Task ShowInformationMessageAsync(string message)
         {
             throw new NotImplementedException();
         }
 
-        public Task ShowWarningMessage(string message)
+        public Task ShowErrorMessageAsync(string message)
         {
             throw new NotImplementedException();
         }
 
-        public Task SetStatusBarMessage(string message, int? timeout)
+        public Task ShowWarningMessageAsync(string message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetStatusBarMessageAsync(string message, int? timeout)
         {
             throw new NotImplementedException();
         }

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         public async Task LanguageServiceFindsDetailsForBuiltInCommand()
         {
             SymbolDetails symbolDetails =
-                await this.languageService.FindSymbolDetailsAtLocation(
+                await this.languageService.FindSymbolDetailsAtLocationAsync(
                     this.GetScriptFile(FindsDetailsForBuiltInCommand.SourceDetails),
                     FindsDetailsForBuiltInCommand.SourceDetails.StartLineNumber,
                     FindsDetailsForBuiltInCommand.SourceDetails.StartColumnNumber);
@@ -349,7 +349,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             // Run the completions request
             return
-                await this.languageService.GetCompletionsInFile(
+                await this.languageService.GetCompletionsInFileAsync(
                     GetScriptFile(scriptRegion),
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber);
@@ -358,7 +358,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         private async Task<ParameterSetSignatures> GetParamSetSignatures(ScriptRegion scriptRegion)
         {
             return
-                await this.languageService.FindParameterSetsInFile(
+                await this.languageService.FindParameterSetsInFileAsync(
                     GetScriptFile(scriptRegion),
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber);
@@ -377,7 +377,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.NotNull(symbolReference);
 
             return
-                await this.languageService.GetDefinitionOfSymbol(
+                await this.languageService.GetDefinitionOfSymbolAsync(
                     scriptFile,
                     symbolReference,
                     workspace);
@@ -401,7 +401,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.NotNull(symbolReference);
 
             return
-                await this.languageService.FindReferencesOfSymbol(
+                await this.languageService.FindReferencesOfSymbolAsync(
                     symbolReference,
                     this.workspace.ExpandScriptReferences(scriptFile),
                     this.workspace);

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
             throw new NotImplementedException();
         }
 
-        protected override Task<string> ReadCommandLine(CancellationToken cancellationToken)
+        protected override Task<string> ReadCommandLineAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult("USER COMMAND");
         }

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
             psCommand.AddScript("$a = \"foo\"; $a");
 
             var executeTask =
-                this.powerShellContext.ExecuteCommand<string>(psCommand);
+                this.powerShellContext.ExecuteCommandAsync<string>(psCommand);
 
             await this.AssertStateChange(PowerShellContextState.Running);
             await this.AssertStateChange(PowerShellContextState.Ready);
@@ -74,14 +74,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         public async Task CanQueueParallelRunspaceRequests()
         {
             // Concurrently initiate 4 requests in the session
-            Task taskOne = this.powerShellContext.ExecuteScriptString("$x = 100");
-            Task<RunspaceHandle> handleTask = this.powerShellContext.GetRunspaceHandle();
-            Task taskTwo = this.powerShellContext.ExecuteScriptString("$x += 200");
-            Task taskThree = this.powerShellContext.ExecuteScriptString("$x = $x / 100");
+            Task taskOne = this.powerShellContext.ExecuteScriptStringAsync("$x = 100");
+            Task<RunspaceHandle> handleTask = this.powerShellContext.GetRunspaceHandleAsync();
+            Task taskTwo = this.powerShellContext.ExecuteScriptStringAsync("$x += 200");
+            Task taskThree = this.powerShellContext.ExecuteScriptStringAsync("$x = $x / 100");
 
             PSCommand psCommand = new PSCommand();
             psCommand.AddScript("$x");
-            Task<IEnumerable<int>> resultTask = this.powerShellContext.ExecuteCommand<int>(psCommand);
+            Task<IEnumerable<int>> resultTask = this.powerShellContext.ExecuteCommandAsync<int>(psCommand);
 
             // Wait for the requested runspace handle and then dispose it
             RunspaceHandle handle = await handleTask;
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 Task.Run(
                     async () =>
                     {
-                        var unusedTask = this.powerShellContext.ExecuteScriptWithArgs(s_debugTestFilePath);
+                        var unusedTask = this.powerShellContext.ExecuteScriptWithArgsAsync(s_debugTestFilePath);
                         await Task.Delay(50);
                         this.powerShellContext.AbortExecution();
                     });
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 };
 
             // Load the profiles for the test host name
-            await this.powerShellContext.LoadHostProfiles();
+            await this.powerShellContext.LoadHostProfilesAsync();
 
             // Ensure that all the paths are set in the correct variables
             // and that the current user's host profile got loaded
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                 "$(Assert-ProfileLoaded)\"");
 
             var result =
-                await this.powerShellContext.ExecuteCommand<string>(
+                await this.powerShellContext.ExecuteCommandAsync<string>(
                     psCommand);
 
             string expectedString =

--- a/test/PowerShellEditorServices.Test/Utility/AsyncDebouncerTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncDebouncerTests.cs
@@ -19,15 +19,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         {
             TestAsyncDebouncer debouncer = new TestAsyncDebouncer();
 
-            await debouncer.Invoke(1);
-            await debouncer.Invoke(2);
-            await debouncer.Invoke(3);
+            await debouncer.InvokeAsync(1);
+            await debouncer.InvokeAsync(2);
+            await debouncer.InvokeAsync(3);
             await Task.Delay(TestAsyncDebouncer.Interval + 100);
 
             // Add a few more items to ensure they are added after the initial interval
-            await debouncer.Invoke(4);
-            await debouncer.Invoke(5);
-            await debouncer.Invoke(6);
+            await debouncer.InvokeAsync(4);
+            await debouncer.InvokeAsync(5);
+            await debouncer.InvokeAsync(6);
 
             Assert.Equal(new List<int> { 1, 2, 3 }, debouncer.FlushedBuffer);
             Assert.True(
@@ -41,18 +41,18 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         }
 
         [Fact]
-        public async Task AsyncDebouncerRestartsAfterInvoke()
+        public async Task AsyncDebouncerRestartsAfterInvokeAsync()
         {
             TestAsyncRestartDebouncer debouncer = new TestAsyncRestartDebouncer();
 
             // Invoke the debouncer and wait a bit between each
             // invoke to make sure the debouncer isn't flushed
             // until after the last invoke.
-            await debouncer.Invoke(1);
+            await debouncer.InvokeAsync(1);
             await Task.Delay(TestAsyncRestartDebouncer.Interval - 100);
-            await debouncer.Invoke(2);
+            await debouncer.InvokeAsync(2);
             await Task.Delay(TestAsyncRestartDebouncer.Interval - 100);
-            await debouncer.Invoke(3);
+            await debouncer.InvokeAsync(3);
             await Task.Delay(TestAsyncRestartDebouncer.Interval + 100);
 
             // The only item flushed should be 3 since its interval has lapsed
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         {
         }
 
-        protected override Task OnInvoke(int args)
+        protected override Task OnInvokeAsync(int args)
         {
             if (!this.firstInvoke.HasValue)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             return Task.FromResult(true);
         }
 
-        protected override Task OnFlush()
+        protected override Task OnFlushAsync()
         {
             // Mark the flush time
             this.TimeToFlush = DateTime.Now - this.firstInvoke.Value;
@@ -118,13 +118,13 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         {
         }
 
-        protected override Task OnInvoke(int args)
+        protected override Task OnInvokeAsync(int args)
         {
             this.lastInvokeInt = args;
             return Task.FromResult(true);
         }
 
-        protected override Task OnFlush()
+        protected override Task OnFlushAsync()
         {
             this.FlushedBuffer.Add(this.lastInvokeInt);
 

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -26,11 +26,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             {
                 // Start 5 consumers
                 await Task.WhenAll(
-                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
-                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
-                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
-                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
-                    Task.Run(() => ConsumeItems(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItemsAsync(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItemsAsync(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItemsAsync(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItemsAsync(inputQueue, outputItems, cancellationTokenSource.Token)),
+                    Task.Run(() => ConsumeItemsAsync(inputQueue, outputItems, cancellationTokenSource.Token)),
                     Task.Run(
                         async () =>
                         {
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             Assert.Equal(1, taskTwo.Result);
         }
 
-        private async Task ConsumeItems(
+        private async Task ConsumeItemsAsync(
             AsyncQueue<int> inputQueue,
             ConcurrentBag<int> outputItems,
             CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #177 in the 2.0.0 branch.

Rename all (hopefully!) async methods with an -`Async` suffix