### PR TITLE
Fix Pester CodeLens run/debug by not quoting params/already quoted args

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -305,12 +305,22 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 var sb = new StringBuilder();
                 for (int i = 0; i < launchParams.Args.Length; i++)
                 {
-                    sb.Append(PowerShellContext.QuoteEscapeString(launchParams.Args[i]));
-                    if (i < launchParams.Args.Length - 1)
+                    string arg = launchParams.Args[i];
+                    if (arg.StartsWith("-") || arg.StartsWith("'") || arg.StartsWith("\""))
+                    {
+                        sb.Append(arg);
+                    }
+                    else
+                    {
+                        sb.Append(PowerShellContext.QuoteEscapeString(arg));
+                    }
+
+                    if (i < (launchParams.Args.Length - 1))
                     {
                         sb.Append(' ');
                     }
                 }
+
                 arguments = sb.ToString();
                 Logger.Write(LogLevel.Verbose, "Script arguments are: " + arguments);
             }


### PR DESCRIPTION
Requires a corresponding PR in vscode-powershell.

We should look this one over good as it has potential to break folks.

I think the odds are low.  Essentially we added the QuoteEscapString
method because we get raw paths from VSCode when debugging
the current file.  Those paths are quoted because they may contain
spaces and because we use single quotes, existing single quotes
have to be doubled e.g C:\Don'tUseQuotesInPaths to
'C:\Don''tUseQuotesInPaths'.

This unfortunately was always being invoked on args. Now we
check if the arg is a parameter (starts with '-') or is already quoted.  The thinking is if the users is specifying a quoted arg, it's on them
to handle any necessary escaping.

BTW is there another char that can act as the start of a parameter -
like the longer dash - whatever that is called.

Longer term, we need a better solution for how to handle paths
from VSCode.  Maybe we handle them there and eliminate the
escaping logic in PSES?