### PR TITLE
Fix file recursion overflow problems

### DIFF
--- a/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
+++ b/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
@@ -2,8 +2,8 @@ namespace Microsoft.PowerShell.EditorServices.Host
 {
     public static class BuildInfo
     {
-        public const string BuildVersion = "<unset>";
-        public const string BuildOrigin = "<unset>";
-        public static readonly System.DateTime? BuildTime = null;
+        public const string BuildVersion = "<development-build>";
+        public const string BuildOrigin = "<development>";
+        public static readonly System.DateTime? BuildTime = System.DateTime.Parse("2018-11-20T11:49:16");
     }
 }

--- a/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
+++ b/src/PowerShellEditorServices.Host/BuildInfo/BuildInfo.cs
@@ -2,8 +2,8 @@ namespace Microsoft.PowerShell.EditorServices.Host
 {
     public static class BuildInfo
     {
-        public const string BuildVersion = "<development-build>";
-        public const string BuildOrigin = "<development>";
-        public static readonly System.DateTime? BuildTime = System.DateTime.Parse("2018-11-20T11:49:16");
+        public const string BuildVersion = "<unset>";
+        public const string BuildOrigin = "<unset>";
+        public static readonly System.DateTime? BuildTime = null;
     }
 }

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -78,6 +78,21 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerMemberName] string callerName = null,
             [CallerFilePath] string callerSourceFile = null,
             [CallerLineNumber] int callerLineNumber = 0);
+
+        /// <summary>
+        /// Log an exception that has been handled cleanly or is otherwise not expected to cause problems in the logs.
+        /// </summary>
+        /// <param name="errorMessage">The error message of the exception to be logged.</param>
+        /// <param name="exception">The exception itself that has been thrown.</param>
+        /// <param name="callerName">The name of the method in which the ILogger is being called.</param>
+        /// <param name="callerSourceFile">The name of the source file in which the ILogger is being called.</param>
+        /// <param name="callerLineNumber">The line number in the file where the ILogger is being called.</param>
+        void WriteHandledException(
+            string errorMessage,
+            Exception exception,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0);
     }
 
 

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -106,6 +106,14 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 ErrorLevelName, callerSourceFile, callerName, callerLineNumber, errorMessage, indentedException);
         }
 
+        /// <summary>
+        /// Log an exception that has been handled cleanly or is otherwise not expected to cause problems in the logs.
+        /// </summary>
+        /// <param name="errorMessage">The error message of the exception to be logged.</param>
+        /// <param name="exception">The exception itself that has been thrown.</param>
+        /// <param name="callerName">The name of the method in which the ILogger is being called.</param>
+        /// <param name="callerSourceFile">The name of the source file in which the ILogger is being called.</param>
+        /// <param name="callerLineNumber">The line number in the file where the ILogger is being called.</param>
         public void WriteHandledException(
             string errorMessage,
             Exception exception,

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -150,6 +150,13 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 .ToString();
         }
 
+        /// <summary>
+        /// Creates a prettified log message from an exception.
+        /// </summary>
+        /// <param name="messagePrelude">The user-readable tag for this exception entry.</param>
+        /// <param name="errorMessage">The user-readable short description of the error.</param>
+        /// <param name="exception">The exception object itself. Must not be null.</param>
+        /// <returns>An indented, formatted string of the body.</returns>
         private static string IndentExceptionMessage(
             string messagePrelude,
             string errorMessage,

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -63,6 +63,24 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerFilePath] string callerSourceFile = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
+            Write(logLevel, new StringBuilder(logMessage), callerName, callerSourceFile, callerLineNumber);
+        }
+
+        /// <summary>
+        /// Write a message with the given severity to the logs. Takes a StringBuilder to allow for minimal allocation.
+        /// </summary>
+        /// <param name="logLevel">The severity level of the log message.</param>
+        /// <param name="logMessage">The log message itself in StringBuilder form for manipulation.</param>
+        /// <param name="callerName">The name of the calling method.</param>
+        /// <param name="callerSourceFile">The name of the source file of the caller.</param>
+        /// <param name="callerLineNumber">The line number where the log is being called.</param>
+        private void Write(
+            LogLevel logLevel,
+            StringBuilder logMessage,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
             string indentedLogMsg = IndentMsg(logMessage);
             string logLevelName = logLevel.ToString().ToUpper();
 
@@ -103,7 +121,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerFilePath] string callerSourceFile = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            string body = IndentExceptionMessage("Exception", errorMessage, exception);
+            StringBuilder body = FormatExceptionMessage("Exception", errorMessage, exception);
             Write(LogLevel.Error, body, callerName, callerSourceFile, callerLineNumber);
         }
 
@@ -122,18 +140,8 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             [CallerFilePath] string callerSourceFile = null,
             [CallerLineNumber] int callerLineNumber = 0)
         {
-            string body = IndentExceptionMessage("Handled exception", errorMessage, exception);
+            StringBuilder body = FormatExceptionMessage("Handled exception", errorMessage, exception);
             Write(LogLevel.Warning, body, callerName, callerSourceFile, callerLineNumber);
-        }
-
-        /// <summary>
-        /// Utility function to indent a log message by one level.
-        /// </summary>
-        /// <param name="logMessage">The log message to indent.</param>
-        /// <returns>The indented log message string.</returns>
-        private static string IndentMsg(string logMessage)
-        {
-            return IndentMsg(new StringBuilder(logMessage));
         }
 
         /// <summary>
@@ -157,7 +165,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="errorMessage">The user-readable short description of the error.</param>
         /// <param name="exception">The exception object itself. Must not be null.</param>
         /// <returns>An indented, formatted string of the body.</returns>
-        private static string IndentExceptionMessage(
+        private static StringBuilder FormatExceptionMessage(
             string messagePrelude,
             string errorMessage,
             Exception exception)
@@ -167,7 +175,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 .Append(Environment.NewLine)
                 .Append(exception.ToString());
 
-            return IndentMsg(sb);
+            return sb;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -17,6 +17,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         private static readonly string ErrorLevelName = LogLevel.Error.ToString().ToUpper();
 
         /// <summary>
+        /// The name of the WARNING log level.
+        /// </summary>
+        private static readonly string WarningLevelName = LogLevel.Warning.ToString().ToUpper();
+
+        /// <summary>
         /// The internal Serilog logger to log to.
         /// </summary>
         private readonly Logger _logger;
@@ -57,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 
             int threadId = Thread.CurrentThread.ManagedThreadId;
 
-            string messageTemplate = 
+            string messageTemplate =
                 "[{LogLevelName:l}] tid:{threadId} in '{CallerName:l}' {CallerSourceFile:l}:{CallerLineNumber}:{IndentedLogMsg:l}";
 
             switch (logLevel)
@@ -100,6 +105,20 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             _logger.Error("[{ErrorLevelName:l}] {CallerSourceFile:l}: In method '{CallerName:l}', line {CallerLineNumber}: {ErrorMessage:l}{IndentedException:l}",
                 ErrorLevelName, callerSourceFile, callerName, callerLineNumber, errorMessage, indentedException);
         }
+
+        public void WriteHandledException(
+            string errorMessage,
+            Exception exception,
+            [CallerMemberName] string callerName = null,
+            [CallerFilePath] string callerSourceFile = null,
+            [CallerLineNumber] int callerLineNumber = 0)
+        {
+            string indentedException = IndentMsg(exception.ToString());
+
+            _logger.Warning("[{WarningLevelName:l}] {CallerSourceFile:l}: In method '{CallerName:l}', line {CallerLineNumber}: Handled exception {ErrorMessage:l}{IndentedException:l}",
+                WarningLevelName, callerSourceFile, callerName, callerLineNumber, errorMessage, indentedException);
+        }
+
 
         /// <summary>
         /// Utility function to indent a log message by one level.

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -22,6 +22,13 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
+        private static readonly string[] s_psFilePatterns = new []
+        {
+            "*.ps1",
+            "*.psm1",
+            "*.psd1"
+        };
+
         private ILogger logger;
         private Version powerShellVersion;
         private Dictionary<string, ScriptFile> workspaceFiles = new Dictionary<string, ScriptFile>();
@@ -295,7 +302,6 @@ namespace Microsoft.PowerShell.EditorServices
         private IEnumerable<string> RecursivelyEnumerateFiles(string folderPath)
         {
             var foundFiles = Enumerable.Empty<string>();
-            var patterns = new string[] { @"*.ps1", @"*.psm1", @"*.psd1" };
 
             try
             {
@@ -326,7 +332,7 @@ namespace Microsoft.PowerShell.EditorServices
                     e);
             }
 
-            foreach (var pattern in patterns)
+            foreach (var pattern in s_psFilePatterns)
             {
                 try
                 {

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -299,66 +299,106 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Private Methods
 
+        /// <summary>
+        /// Find PowerShell files recursively down from a given directory path.
+        /// Currently returns files in depth-first order.
+        /// Directory.GetFiles(folderPath, pattern, SearchOption.AllDirectories) would provide this,
+        /// but a cycle in the filesystem will cause that to enter an infinite loop.
+        /// </summary>
+        /// <param name="folderPath">The absolute path of the base folder to search.</param>
+        /// <returns>
+        /// All PowerShell files in the recursive directory hierarchy under the given base directory, up to 64 directories deep.
+        /// </returns>
         private IEnumerable<string> RecursivelyEnumerateFiles(string folderPath)
         {
-            var foundFiles = Enumerable.Empty<string>();
+            var foundFiles = new List<string>();
+            var dirStack = new Stack<string>();
 
-            try
+            // Kick the search off with the base directory
+            dirStack.Push(folderPath);
+
+            const int recursionDepthLimit = 64;
+            while (dirStack.Any())
             {
-                IEnumerable<string> subDirs = Directory.GetDirectories(folderPath);
-                foreach (string dir in subDirs)
+                string currDir = dirStack.Pop();
+
+                // Look for any PowerShell files in the current directory
+                foreach (string pattern in s_psFilePatterns)
                 {
-                    foundFiles =
-                        foundFiles.Concat(
-                            RecursivelyEnumerateFiles(dir));
-                }
-            }
-            catch (DirectoryNotFoundException e)
-            {
-                this.logger.WriteException(
-                    $"Could not enumerate files in the path '{folderPath}' due to it being an invalid path",
-                    e);
-            }
-            catch (PathTooLongException e)
-            {
-                this.logger.WriteException(
-                    $"Could not enumerate files in the path '{folderPath}' due to the path being too long",
-                    e);
-            }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
-            {
-                this.logger.WriteException(
-                    $"Could not enumerate files in the path '{folderPath}' due to the path not being accessible",
-                    e);
-            }
+                    string[] psFiles;
+                    try
+                    {
+                        psFiles = Directory.GetFiles(currDir, pattern, SearchOption.TopDirectoryOnly);
+                    }
+                    catch (DirectoryNotFoundException e)
+                    {
+                        this.logger.WriteException(
+                            $"Could not enumerate files in the path '{currDir}' due to it being an invalid path",
+                            e);
 
-            foreach (var pattern in s_psFilePatterns)
-            {
+                        continue;
+                    }
+                    catch (PathTooLongException e)
+                    {
+                        this.logger.WriteException(
+                            $"Could not enumerate files in the path '{currDir}' due to the path being too long",
+                            e);
+
+                        continue;
+                    }
+                    catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+                    {
+                        this.logger.WriteException(
+                            $"Could not enumerate files in the path '{currDir}' due to the path not being accessible",
+                            e);
+
+                        continue;
+                    }
+
+                    foundFiles.AddRange(psFiles);
+                }
+
+                // Prevent unbounded recursion here
+                // If we get too deep, keep processing but go no deeper
+                if (dirStack.Count >= recursionDepthLimit)
+                {
+                    continue;
+                }
+
+                // Add the recursive directories to search next
+                string[] subDirs;
                 try
                 {
-                    foundFiles =
-                        foundFiles.Concat(
-                            Directory.GetFiles(
-                                folderPath,
-                                pattern));
+                    subDirs = Directory.GetFiles(currDir, pattern, SearchOption.TopDirectoryOnly);
                 }
                 catch (DirectoryNotFoundException e)
                 {
                     this.logger.WriteException(
-                        $"Could not enumerate files in the path '{folderPath}' due to a path being an invalid path",
+                        $"Could not enumerate directories in the path '{currDir}' due to it being an invalid path",
                         e);
+
+                    continue;
                 }
                 catch (PathTooLongException e)
                 {
                     this.logger.WriteException(
-                        $"Could not enumerate files in the path '{folderPath}' due to a path being too long",
+                        $"Could not enumerate directories in the path '{currDir}' due to the path being too long",
                         e);
+
+                    continue;
                 }
                 catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
                 {
                     this.logger.WriteException(
-                        $"Could not enumerate files in the path '{folderPath}' due to a path not being accessible",
+                        $"Could not enumerate directories in the path '{currDir}' due to the path not being accessible",
                         e);
+
+                    continue;
+                }
+
+                foreach (string subDir in subDirs)
+                {
+                    dirStack.Push(subDir);
                 }
             }
 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PowerShell.EditorServices
                 string[] subDirs;
                 try
                 {
-                    subDirs = Directory.GetFiles(currDir, pattern, SearchOption.TopDirectoryOnly);
+                    subDirs = Directory.GetDirectories(currDir);
                 }
                 catch (DirectoryNotFoundException e)
                 {

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -362,6 +362,7 @@ namespace Microsoft.PowerShell.EditorServices
                 // If we get too deep, keep processing but go no deeper
                 if (dirStack.Count >= recursionDepthLimit)
                 {
+                    this.logger.Write(LogLevel.Warning, $"Recursion depth limit hit for path {folderPath}");
                     continue;
                 }
 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerShell.EditorServices
                     }
                     catch (DirectoryNotFoundException e)
                     {
-                        this.logger.WriteException(
+                        this.logger.WriteHandledException(
                             $"Could not enumerate files in the path '{currDir}' due to it being an invalid path",
                             e);
 
@@ -340,7 +340,7 @@ namespace Microsoft.PowerShell.EditorServices
                     }
                     catch (PathTooLongException e)
                     {
-                        this.logger.WriteException(
+                        this.logger.WriteHandledException(
                             $"Could not enumerate files in the path '{currDir}' due to the path being too long",
                             e);
 
@@ -348,7 +348,7 @@ namespace Microsoft.PowerShell.EditorServices
                     }
                     catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
                     {
-                        this.logger.WriteException(
+                        this.logger.WriteHandledException(
                             $"Could not enumerate files in the path '{currDir}' due to the path not being accessible",
                             e);
 
@@ -373,7 +373,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
                 catch (DirectoryNotFoundException e)
                 {
-                    this.logger.WriteException(
+                    this.logger.WriteHandledException(
                         $"Could not enumerate directories in the path '{currDir}' due to it being an invalid path",
                         e);
 
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
                 catch (PathTooLongException e)
                 {
-                    this.logger.WriteException(
+                    this.logger.WriteHandledException(
                         $"Could not enumerate directories in the path '{currDir}' due to the path being too long",
                         e);
 
@@ -389,7 +389,7 @@ namespace Microsoft.PowerShell.EditorServices
                 }
                 catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
                 {
-                    this.logger.WriteException(
+                    this.logger.WriteHandledException(
                         $"Could not enumerate directories in the path '{currDir}' due to the path not being accessible",
                         e);
 


### PR DESCRIPTION
Aims to fix https://github.com/PowerShell/vscode-powershell/issues/1613.

Rather than using method recursion to process recursive directories, we now use a while loop and a stack and stop recursing at a depth of 64.

It's a naive solution to the problem, but I didn't want to do any sophisticated expensive checks like building a hashmap of paths or testing for symlinks in case that would cause a performance hit (although it might not be very important).

I also added a new logging method to log exceptions in the log that aren't really fatal.