### PR TITLE
(GH-799) Revive docfx scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ registered_data.ini
 .dotnet/
 module/Plaster
 module/PSScriptAnalyzer
-docs/_site/
-docs/_repo/
-docs/metadata/
 *.zip
 
 # Generated build info file
@@ -74,3 +71,9 @@ module/PowerShellEditorServices/Third\ Party\ Notices.txt
 
 # JetBrains generated file (Rider, intelliJ)
 .idea/
+
+# Docfx generation
+docs/_site/
+docs/_repo/
+docs/metadata/
+tools/docfx

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -114,19 +114,6 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, TestP
             $ENV:MSBuildExtensionsPath = $SDKVersionPath
             $ENV:MSBUILD_EXE_PATH = Join-Path -Path $SDKVersionPath -ChildPath 'MSBuild.dll'
 
-            # # Get currently installed VS Verion
-            # DocFX may require - https://github.com/dotnet/docfx/issues/2491#issuecomment-371722477
-            # $VisualStudioVersion = (Get-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7" |
-            #     Get-Member -MemberType NoteProperty |
-            #     Where-Object { $_.Name -notlike 'PS*'} |
-            #     Sort-Object |
-            #     Select -First 1).Name
-            # # Get Visual Studio install path
-            # $VSINSTALLDIR =  $(Get-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\SxS\VS7").$VisualStudioVersion;
-            # # Add Visual Studio environment variables
-            # $env:VisualStudioVersion = $VisualStudioVersion;
-            # $env:VSINSTALLDIR = $VSINSTALLDIR;
-
             Write-Host "`n### Using dotnet SDK at path $SDKVersionPath" -ForegroundColor Green
         } else {
             throw "Unable to find any SDKs in path $SDKPath"

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,7 +4,27 @@
       "src": [
         {
           "files": [ "*.csproj" ],
-          "cwd": "../src/PowerShellEditorServices",
+          "src": "../src/PowerShellEditorServices",
+          "exclude": [ "**/obj/**", "**/bin/**" ]
+        },
+        {
+          "files": [ "*.csproj" ],
+          "src": "../src/PowerShellEditorServices.Channel.WebSocket",
+          "exclude": [ "**/obj/**", "**/bin/**" ]
+        },
+        {
+          "files": [ "*.csproj" ],
+          "src": "../src/PowerShellEditorServices.Host",
+          "exclude": [ "**/obj/**", "**/bin/**" ]
+        },
+        {
+          "files": [ "*.csproj" ],
+          "src": "../src/PowerShellEditorServices.Protocol",
+          "exclude": [ "**/obj/**", "**/bin/**" ]
+        },
+        {
+          "files": [ "*.csproj" ],
+          "src": "../src/PowerShellEditorServices.VSCode",
           "exclude": [ "**/obj/**", "**/bin/**" ]
         }
       ],
@@ -14,21 +34,21 @@
   "build": {
     "content": [
       {
-        "cwd": "metadata/api",
+        "src": "metadata/api",
         "files": [
           "**/**.yml"
         ],
         "dest": "api"
       },
       {
-        "cwd": "../",
+        "src": "../",
         "files": [
           "CONTRIBUTING.md",
           "CHANGELOG.md"
         ]
       },
       {
-        "cwd":  ".",
+        "src":  ".",
         "files": [
           "toc.yml",
           "index.md",


### PR DESCRIPTION
Previously the document generation scripts for docfx were broken e.g. Unable to
download docfx from github due to TLS.  This commit;
* Updates the BuildDocs script to properly clean and download docfx from Github
* Updates the docfx.json file to use the correct naming (cwd -> src) and to
  use the correct project files
* Updates gitignore to ignore docfx working directory
* Adds two build tasks (BuildDocs and ServeDocs) to build and serve
  autogenerated documentation
* Adds additional configuration switch for Invoke-Build for legacy applications,
  like docfx, which use MSBuild as a library but it needs the dotNet Core
  versions of MSBuild instead of VS 2015/2017