### PR TITLE
Fix local remoting

### DIFF
--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 // Grab the $host.name which will tell us if we're in a PSRP session or not
                 string hostname =
                         PowerShellContext.ExecuteScriptAndGetItem<string>(
-                            "$host.name",
+                            "$Host.Name",
                             runspace,
                             defaultValue: string.Empty);
 

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -218,12 +218,15 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     // ProcessId property isn't on the object, move on.
                 }
 
+                // Grab the $host.name which will tell us if we're in a PSRP session or not
                 string hostname =
                         PowerShellContext.ExecuteScriptAndGetItem<string>(
                             "$host.name",
                             runspace,
                             defaultValue: "");
 
+                // hostname is 'ServerRemoteHost' when the user enters a session.
+                // ex. Enter-PSSession, Enter-PSHostProcess
                 if (hostname == "ServerRemoteHost")
                 {
                     runspaceId =

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -193,7 +193,6 @@ namespace Microsoft.PowerShell.EditorServices.Session
             Validate.IsNotNull(nameof(runspace), runspace);
             Validate.IsNotNull(nameof(sessionDetails), sessionDetails);
 
-            var runspaceId = runspace.InstanceId;
             var runspaceLocation = RunspaceLocation.Local;
             var runspaceContext = RunspaceContext.Original;
             var versionDetails = PowerShellVersionDetails.GetVersionDetails(runspace, logger);
@@ -229,11 +228,6 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 // ex. Enter-PSSession, Enter-PSHostProcess
                 if (hostName.Equals("ServerRemoteHost", StringComparison.Ordinal))
                 {
-                    runspaceId =
-                        PowerShellContext.ExecuteScriptAndGetItem<Guid>(
-                            "$host.Runspace.InstanceId",
-                            runspace);
-
                     runspaceLocation = RunspaceLocation.Remote;
                     connectionString =
                         runspace.ConnectionInfo.ComputerName +

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -218,7 +218,13 @@ namespace Microsoft.PowerShell.EditorServices.Session
                     // ProcessId property isn't on the object, move on.
                 }
 
-                if (runspace.ConnectionInfo.ComputerName != "localhost")
+                string hostname =
+                        PowerShellContext.ExecuteScriptAndGetItem<string>(
+                            "$host.name",
+                            runspace,
+                            defaultValue: "");
+
+                if (hostname == "ServerRemoteHost")
                 {
                     runspaceId =
                         PowerShellContext.ExecuteScriptAndGetItem<Guid>(

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
 
                 // hostname is 'ServerRemoteHost' when the user enters a session.
                 // ex. Enter-PSSession, Enter-PSHostProcess
-                if (hostname == "ServerRemoteHost")
+                if (hostName.Equals("ServerRemoteHost", StringComparison.Ordinal))
                 {
                     runspaceId =
                         PowerShellContext.ExecuteScriptAndGetItem<Guid>(

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                 }
 
                 // Grab the $host.name which will tell us if we're in a PSRP session or not
-                string hostname =
+                string hostName =
                         PowerShellContext.ExecuteScriptAndGetItem<string>(
                             "$Host.Name",
                             runspace,

--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.EditorServices.Session
                         PowerShellContext.ExecuteScriptAndGetItem<string>(
                             "$host.name",
                             runspace,
-                            defaultValue: "");
+                            defaultValue: string.Empty);
 
                 // hostname is 'ServerRemoteHost' when the user enters a session.
                 // ex. Enter-PSSession, Enter-PSHostProcess


### PR DESCRIPTION
Before, if you did:

```powershell
Enter-PSSession .
Enter-PSSession -HostName tyler@localhost:4321
```

or any variation that uses localhost... this would get marked as a "Local" session and psedit would not get registered (other bad things could have been happening too...).

This fix makes all PSRP sessions "Remote" sessions so that psedit registers correctly.

This also allows a user to start ssh server in WSL or a container and use:

```powershell
Enter-PSSession -Hostname tyler@localhost:4321
```

to get remote editing & debugging in PSES