### PR TITLE
[Ignore] Fix recursion count bug

### DIFF
--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -303,14 +303,13 @@ namespace Microsoft.PowerShell.EditorServices
 
         /// <summary>
         /// Find PowerShell files recursively down from a given directory path.
-        /// Currently returns files in depth-first order.
+        /// Currently collects files in depth-first order.
         /// Directory.GetFiles(folderPath, pattern, SearchOption.AllDirectories) would provide this,
         /// but a cycle in the filesystem will cause that to enter an infinite loop.
         /// </summary>
-        /// <param name="folderPath">The absolute path of the base folder to search.</param>
-        /// <returns>
-        /// All PowerShell files in the recursive directory hierarchy under the given base directory, up to 64 directories deep.
-        /// </returns>
+        /// <param name="folderPath">The path of the current directory to find files in</param>
+        /// <param name="foundFiles">The accumulator for files found so far.</param>
+        /// <param name="currDepth">The current depth of the recursion from the original base directory.</param>
         private void RecursivelyEnumerateFiles(string folderPath, ref List<string> foundFiles, int currDepth = 0)
         {
             const int recursionDepthLimit = 64;

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -390,7 +390,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             foreach (string subDir in subDirs)
             {
-                RecursivelyEnumerateFiles(subDir, ref foundFiles, currDepth + 1);
+                RecursivelyEnumerateFiles(subDir, ref foundFiles, currDepth: currDepth + 1);
             }
         }
 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -351,7 +351,6 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             // Prevent unbounded recursion here
-            // If we get too deep, keep processing but go no deeper
             if (currDepth >= recursionDepthLimit)
             {
                 this.logger.Write(LogLevel.Warning, $"Recursion depth limit hit for path {folderPath}");


### PR DESCRIPTION
@rkeithhill Saw that I'd implemented the recursion depth checking incorrectly (I was checking the stack size, which included all the files in parent directories).

I've rewritten this in the simpler recursive function form, which should actually be more efficient (in some ways), although there are pros and cons.

The other thing I noticed tracing this is that we create files for everything in the `.git` directory. We should really implement a file-ignore config and make it default to all files beginning with `.` or something.