### PR TITLE
No need for package sources

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,10 +3,4 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
-  <packageSources>
-    <clear />
-    <add key="CI Builds (dotnet-core)" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
-  </packageSources>
 </configuration>


### PR DESCRIPTION
#### NOTE THIS IS GOING INTO 2.0.0

These sources aren't needed because now that 2.0.0 pulls in PSStandard, it can fetch it from nuget.org which is the default.

And I don't think we need the dotnet-core one.

Also, as a result of this change, I can successfully build PSES offline finally 😄

@rkeithhill do you know if we need the disableSourceControlIntegration at all? We could possibly get rid of this file all together.