### PR TITLE
(GH-811) Fix folding with spanning regions

### DIFF
--- a/src/PowerShellEditorServices/Language/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Language/TokenOperations.cs
@@ -16,9 +16,25 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     internal static class TokenOperations
     {
+        // Region kinds to align with VSCode's region kinds
         private const string RegionKindComment = "comment";
         private const string RegionKindRegion = "region";
         private const string RegionKindNone = null;
+
+        // Opening tokens for { } and @{ }
+        private static readonly TokenKind[] s_openingBraces = new []
+        {
+            TokenKind.LCurly,
+            TokenKind.AtCurly
+        };
+
+        // Opening tokens for ( ), @( ), $( )
+        private static readonly TokenKind[] s_openingParens = new []
+        {
+            TokenKind.LParen,
+            TokenKind.AtParen,
+            TokenKind.DollarParen
+        };
 
         /// <summary>
         /// Extracts all of the unique foldable regions in a script given the list tokens
@@ -32,14 +48,14 @@ namespace Microsoft.PowerShell.EditorServices
             // Find matching braces  { -> }
             // Find matching hashes @{ -> }
             foldableRegions.AddRange(
-                MatchTokenElements(tokens, new TokenKind[] { TokenKind.LCurly, TokenKind.AtCurly }, TokenKind.RCurly, RegionKindNone)
+                MatchTokenElements(tokens, s_openingBraces, TokenKind.RCurly, RegionKindNone)
             );
 
             // Find matching parentheses     ( -> )
             // Find matching array literals @( -> )
             // Find matching subexpressions $( -> )
             foldableRegions.AddRange(
-                MatchTokenElements(tokens, new TokenKind[] { TokenKind.LParen, TokenKind.AtParen, TokenKind.DollarParen }, TokenKind.RParen, RegionKindNone)
+                MatchTokenElements(tokens, s_openingParens, TokenKind.RParen, RegionKindNone)
             );
 
             // Find contiguous here strings @' -> '@

--- a/src/PowerShellEditorServices/Language/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Language/TokenOperations.cs
@@ -47,6 +47,11 @@ namespace Microsoft.PowerShell.EditorServices
                 MatchTokenElement(tokens, TokenKind.HereStringLiteral, RegionKindNone)
             );
 
+            // Find unopinionated variable names ${ \n \n }
+            foldableRegions.AddRange(
+                MatchTokenElement(tokens, TokenKind.Variable, RegionKindNone)
+            );
+
             // Find contiguous here strings @" -> "@
             foldableRegions.AddRange(
                 MatchTokenElement(tokens, TokenKind.HereStringExpandable, RegionKindNone)

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -111,7 +111,13 @@ double quoted herestrings should also fold
 # Comment Block 2
 # Comment Block 2
 $something = $true
-#endregion Comment Block 3";
+#endregion Comment Block 3
+
+# What about anonymous variable assignment
+${this
+is
+valid} = 5
+";
         private FoldingReference[] expectedAllInOneScriptFolds = {
             CreateFoldingReference(0,   0,  3, 10, "region"),
             CreateFoldingReference(1,   0,  2,  2, "comment"),
@@ -127,7 +133,8 @@ $something = $true
             CreateFoldingReference(56,  7, 58,  3, null),
             CreateFoldingReference(64,  0, 65,  0, "comment"),
             CreateFoldingReference(67,  0, 71, 26, "region"),
-            CreateFoldingReference(68,  0, 69,  0, "comment")
+            CreateFoldingReference(68,  0, 69,  0, "comment"),
+            CreateFoldingReference(75,  0, 76,  6, null),
         };
 
         /// <summary>
@@ -244,6 +251,5 @@ $y = $(
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
-
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -67,6 +67,9 @@ herestrings should fold
 
 '@
 
+# This won't confuse things
+Get-Command -Param @I
+
 $I = @""
 double quoted herestrings should also fold
 
@@ -122,19 +125,19 @@ valid} = 5
             CreateFoldingReference(0,   0,  3, 10, "region"),
             CreateFoldingReference(1,   0,  2,  2, "comment"),
             CreateFoldingReference(10,  0, 14,  2, "comment"),
-            CreateFoldingReference(16, 30, 59,  1, null),
+            CreateFoldingReference(16, 30, 62,  1, null),
             CreateFoldingReference(17,  0, 21,  2, "comment"),
             CreateFoldingReference(23,  7, 25,  2, null),
-            CreateFoldingReference(28,  5, 30,  2, null),
-            CreateFoldingReference(35,  2, 36,  0, "comment"),
-            CreateFoldingReference(39,  2, 48, 14, "region"),
-            CreateFoldingReference(41,  4, 44, 14, "region"),
-            CreateFoldingReference(51,  7, 52,  3, null),
-            CreateFoldingReference(56,  7, 58,  3, null),
-            CreateFoldingReference(64,  0, 65,  0, "comment"),
-            CreateFoldingReference(67,  0, 71, 26, "region"),
-            CreateFoldingReference(68,  0, 69,  0, "comment"),
-            CreateFoldingReference(75,  0, 76,  6, null),
+            CreateFoldingReference(31,  5, 33,  2, null),
+            CreateFoldingReference(38,  2, 39,  0, "comment"),
+            CreateFoldingReference(42,  2, 51, 14, "region"),
+            CreateFoldingReference(44,  4, 47, 14, "region"),
+            CreateFoldingReference(54,  7, 55,  3, null),
+            CreateFoldingReference(59,  7, 61,  3, null),
+            CreateFoldingReference(67,  0, 68,  0, "comment"),
+            CreateFoldingReference(70,  0, 74, 26, "region"),
+            CreateFoldingReference(71,  0, 72,  0, "comment"),
+            CreateFoldingReference(78,  0, 79,  6, null),
         };
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -217,5 +217,33 @@ $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
             FoldingReference[] result = GetRegions(testString);
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
+
+        // This tests that token matching { -> }, @{ -> } and
+        // ( -> ), @( -> ) and $( -> ) does not confuse the folder
+        [Fact]
+        public void LaguageServiceFindsFoldablRegionsWithSameEndToken() {
+            string testString =
+@"foreach ($1 in $2) {
+
+    $x = @{
+        'abc' = 'def'
+    }
+}
+
+$y = $(
+    $arr = @('1', '2'); Write-Host ($arr)
+)
+";
+            FoldingReference[] expectedFolds = {
+                CreateFoldingReference(0, 19, 4, 1, null),
+                CreateFoldingReference(2,  9, 3, 5, null),
+                CreateFoldingReference(7,  5, 8, 1, null)
+            };
+
+            FoldingReference[] result = GetRegions(testString);
+
+            AssertFoldingReferenceArrays(expectedFolds, result);
+        }
+
     }
 }


### PR DESCRIPTION
From https://github.com/PowerShell/vscode-powershell/issues/1631

Fixes #811

---

In the use case above the following code snippet is confusing the folder;

Bad folder
``` powershell
foreach ($1 in $2) {     <----- STARTS MATCH HERE (1)

    $x = @{  <-----   STARTS MATCH HERE (2)
        'abc' = 'def'
    }        <----- ENDS   MATCH HERE (1) (2)
}
```

Good folder
``` powershell
foreach ($1 in $2) {     <----- STARTS MATCH HERE (1)

    $x = @{  <-----   STARTS MATCH HERE (2)
        'abc' = 'def'
    }        <----- ENDS  MATCH HERE (2)
}        <----- ENDS  MATCH HERE (1)
```

The old grammar based folder knew the difference between a `}` terminating a hash vs a script block.  The PowerShell Tokeniser does not.

Note I found this is also the case for  `@( ... )`, `( ... )`, and `$( ... )`