### PR TITLE
{WIP} (GH-813) Use AST for Syntax Folder

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -535,7 +535,7 @@ function __Expand-Alias {
         {
             PSCommand psCommand = new PSCommand();
             if (!string.IsNullOrEmpty(param))
-            {    
+            {
                 psCommand.AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddArgument(param);
             }
             else
@@ -1267,7 +1267,7 @@ function __Expand-Alias {
                 }
             }
 
-            // Add "show documentation" commands last so they appear at the bottom of the client UI. 
+            // Add "show documentation" commands last so they appear at the bottom of the client UI.
             // These commands do not require code fixes. Sometimes we get a batch of diagnostics
             // to create commands for. No need to create multiple show doc commands for the same rule.
             var ruleNamesProcessed = new HashSet<string>();
@@ -1382,13 +1382,16 @@ function __Expand-Alias {
             // TODO Should be using dynamic registrations
             if (!this.currentSettings.CodeFolding.Enable) { return null; }
             var result = new List<FoldingRange>();
-            foreach (FoldingReference fold in TokenOperations.FoldableRegions(
-                editorSession.Workspace.GetFile(documentUri).ScriptTokens,
-                this.currentSettings.CodeFolding.ShowLastLine))
+            ScriptFile script = editorSession.Workspace.GetFile(documentUri);
+            // If we're showing the last line, decrement the Endline of all regions by one.
+            int endLineOffset = this.currentSettings.CodeFolding.ShowLastLine ? -1 : 0;
+            foreach (FoldingReference fold in FoldingOperations.FoldableRegions(
+                script.ScriptTokens,
+                script.ScriptAst))
             {
                 result.Add(new FoldingRange {
                     EndCharacter   = fold.EndCharacter,
-                    EndLine        = fold.EndLine,
+                    EndLine        = fold.EndLine + endLineOffset,
                     Kind           = fold.Kind,
                     StartCharacter = fold.StartCharacter,
                     StartLine      = fold.StartLine
@@ -1734,7 +1737,7 @@ function __Expand-Alias {
                 });
         }
 
-        // Generate a unique id that is used as a key to look up the associated code action (code fix) when 
+        // Generate a unique id that is used as a key to look up the associated code action (code fix) when
         // we receive and process the textDocument/codeAction message.
         private static string GetUniqueIdFromDiagnostic(Diagnostic diagnostic)
         {

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1387,7 +1387,7 @@ function __Expand-Alias {
             int endLineOffset = this.currentSettings.CodeFolding.ShowLastLine ? -1 : 0;
             foreach (FoldingReference fold in FoldingOperations.FoldableRegions(
                 script.ScriptTokens,
-                script.ScriptAst))
+                script.ScriptAst).ToArray())
             {
                 result.Add(new FoldingRange {
                     EndCharacter   = fold.EndCharacter,

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -335,13 +335,12 @@ namespace Microsoft.PowerShell.EditorServices
         /// Finds all foldable regions in a script based on AST
         /// </summary>
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
+        /// <param name="refList">The FoldingReferenceList object to add the folds to</param>
         /// <returns>A collection of FoldingReference objects</returns>
-        public static IEnumerable<FoldingReference> FindFoldsInDocument(Ast scriptAst)
+        public static void FindFoldsInDocument(Ast scriptAst, ref FoldingReferenceList refList)
         {
-            FindFoldsVisitor findFoldsVisitor = new FindFoldsVisitor();
+            FindFoldsVisitor findFoldsVisitor = new FindFoldsVisitor(ref refList);
             scriptAst.Visit(findFoldsVisitor);
-
-            return findFoldsVisitor.FoldableRegions;
         }
 
     }

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -330,5 +330,19 @@ namespace Microsoft.PowerShell.EditorServices
 
             return dotSourcedVisitor.DotSourcedFiles.ToArray();
         }
+
+        /// <summary>
+        /// Finds all foldable regions in a script based on AST
+        /// </summary>
+        /// <param name="scriptAst">The abstract syntax tree of the given script</param>
+        /// <returns>A collection of FoldingReference objects</returns>
+        public static IEnumerable<FoldingReference> FindFoldsInDocument(Ast scriptAst)
+        {
+            FindFoldsVisitor findFoldsVisitor = new FindFoldsVisitor();
+            scriptAst.Visit(findFoldsVisitor);
+
+            return findFoldsVisitor.FoldableRegions;
+        }
+
     }
 }

--- a/src/PowerShellEditorServices/Language/FindFoldsVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindFoldsVisitor.cs
@@ -1,0 +1,152 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// The visitor used to find the all folding regions in an AST
+    /// </summary>
+    internal class FindFoldsVisitor : AstVisitor2
+    {
+        private const string RegionKindNone = null;
+
+        public List<FoldingReference> FoldableRegions { get; }
+
+        public FindFoldsVisitor()
+        {
+            FoldableRegions = new List<FoldingReference>();
+        }
+
+        /// <summary>
+        /// Returns whether an Extent could be used as a valid folding region
+        /// </summary>
+        private bool IsValidFoldingExtent(
+            IScriptExtent extent)
+        {
+            // The extent must span at least one line
+            return extent.EndLineNumber > extent.StartLineNumber;
+        }
+
+        /// <summary>
+        /// Creates an instance of a FoldingReference object from a script extent
+        /// </summary>
+        private FoldingReference CreateFoldingReference(
+            IScriptExtent extent,
+            string matchKind)
+        {
+            // Extents are base 1, but LSP is base 0, so minus 1 off all lines and character positions
+            return new FoldingReference
+            {
+                StartLine      = extent.StartLineNumber - 1,
+                StartCharacter = extent.StartColumnNumber - 1,
+                EndLine        = extent.EndLineNumber - 1,
+                EndCharacter   = extent.EndColumnNumber - 1,
+                Kind           = matchKind
+            };
+        }
+
+        // AST object visitor methods
+        public override AstVisitAction VisitArrayExpression(ArrayExpressionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitHashtable(HashtableAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitStatementBlock(StatementBlockAst objAst)
+        {
+            // These parent visitors will get this AST Object.  No need to process it
+            if (objAst.Parent == null) { return AstVisitAction.Continue; }
+            if (objAst.Parent is ArrayExpressionAst) { return AstVisitAction.Continue; }
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitScriptBlock(ScriptBlockAst objAst)
+        {
+            // If the Parent object is null then this represents the entire script.  We don't want to fold that
+            if (objAst.Parent == null) { return AstVisitAction.Continue; }
+            // The ScriptBlockExpressionAst visitor will get this AST Object.  No need to process it
+            if (objAst.Parent is ScriptBlockExpressionAst) { return AstVisitAction.Continue; }
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitScriptBlockExpression(ScriptBlockExpressionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent)) {
+                FoldingReference foldRef = CreateFoldingReference(objAst.ScriptBlock.Extent, RegionKindNone);
+                if (objAst.Parent == null) { return AstVisitAction.Continue; }
+                if (objAst.Parent is InvokeMemberExpressionAst) {
+                    // This is a bit naive.  The ScriptBlockExpressionAst Extent does not include the actual { and }
+                    // characters so the StartCharacter and EndCharacter indexes are out by one.  This could be a bug in
+                    // PowerShell Parser. This is just a workaround
+                    foldRef.StartCharacter--;
+                    foldRef.EndCharacter++;
+                }
+                FoldableRegions.Add(foldRef);
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitStringConstantExpression(StringConstantExpressionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitSubExpression(SubExpressionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitTypeDefinition(TypeDefinitionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitVariableExpression(VariableExpressionAst objAst)
+        {
+            if (IsValidFoldingExtent(objAst.Extent))
+            {
+                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+            }
+            return AstVisitAction.Continue;
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Language/FindFoldsVisitor.cs
+++ b/src/PowerShellEditorServices/Language/FindFoldsVisitor.cs
@@ -16,11 +16,11 @@ namespace Microsoft.PowerShell.EditorServices
     {
         private const string RegionKindNone = null;
 
-        public List<FoldingReference> FoldableRegions { get; }
+        private FoldingReferenceList _refList;
 
-        public FindFoldsVisitor()
+        public FindFoldsVisitor(ref FoldingReferenceList refList)
         {
-            FoldableRegions = new List<FoldingReference>();
+            _refList = refList;
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (objAst.Parent is ArrayExpressionAst) { return AstVisitAction.Continue; }
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (objAst.Parent is ScriptBlockExpressionAst) { return AstVisitAction.Continue; }
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.EditorServices
                     foldRef.StartCharacter--;
                     foldRef.EndCharacter++;
                 }
-                FoldableRegions.Add(foldRef);
+                _refList.SafeAdd(foldRef);
             }
             return AstVisitAction.Continue;
         }
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
 
             return AstVisitAction.Continue;
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             if (IsValidFoldingExtent(objAst.Extent))
             {
-                FoldableRegions.Add(CreateFoldingReference(objAst.Extent, RegionKindNone));
+                _refList.SafeAdd(CreateFoldingReference(objAst.Extent, RegionKindNone));
             }
             return AstVisitAction.Continue;
         }

--- a/src/PowerShellEditorServices/Language/FoldingOperations.cs
+++ b/src/PowerShellEditorServices/Language/FoldingOperations.cs
@@ -18,38 +18,19 @@ namespace Microsoft.PowerShell.EditorServices
         /// Extracts all of the unique foldable regions in a script given a script AST and the list tokens
         /// used to generate the AST
         /// </summary>
-        internal static FoldingReference[] FoldableRegions(
+        internal static FoldingReferenceList FoldableRegions(
             Token[] tokens,
             Ast scriptAst)
         {
-            var foldableRegions = new List<FoldingReference>();
+            var foldableRegions = new FoldingReferenceList();
 
             // Add regions from AST
-            foldableRegions.AddRange(AstOperations.FindFoldsInDocument(scriptAst));
+            AstOperations.FindFoldsInDocument(scriptAst, ref foldableRegions);
 
             // Add regions from Tokens
-            foldableRegions.AddRange(TokenOperations.FoldableRegions(tokens));
+            TokenOperations.FoldableRegions(tokens, ref foldableRegions);
 
-            // Sort the FoldingReferences, starting at the top of the document,
-            // and ensure that, in the case of multiple ranges starting the same line,
-            // that the largest range (i.e. most number of lines spanned) is sorted
-            // first. This is needed to detect duplicate regions. The first in the list
-            // will be used and subsequent duplicates ignored.
-            foldableRegions.Sort();
-
-            // It's possible to have duplicate or overlapping ranges, that is, regions which have the same starting
-            // line number as the previous region. Therefore only emit ranges which have a different starting line
-            // than the previous range.
-            foldableRegions.RemoveAll( (FoldingReference item) => {
-                // Note - I'm not happy with searching here, but as the RemoveAll
-                // doesn't expose the index in the List, we need to calculate it. Fortunately the
-                // list is sorted at this point, so we can use BinarySearch.
-                int index = foldableRegions.BinarySearch(item);
-                if (index == 0) { return false; }
-                return (item.StartLine == foldableRegions[index - 1].StartLine);
-            });
-
-            return foldableRegions.ToArray();
+            return foldableRegions;
         }
     }
 }

--- a/src/PowerShellEditorServices/Language/FoldingOperations.cs
+++ b/src/PowerShellEditorServices/Language/FoldingOperations.cs
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// Provides common operations for code folding in a script
+    /// </summary>
+    internal static class FoldingOperations
+    {
+        /// <summary>
+        /// Extracts all of the unique foldable regions in a script given a script AST and the list tokens
+        /// used to generate the AST
+        /// </summary>
+        internal static FoldingReference[] FoldableRegions(
+            Token[] tokens,
+            Ast scriptAst)
+        {
+            var foldableRegions = new List<FoldingReference>();
+
+            // Add regions from AST
+            foldableRegions.AddRange(AstOperations.FindFoldsInDocument(scriptAst));
+
+            // Add regions from Tokens
+            foldableRegions.AddRange(TokenOperations.FoldableRegions(tokens));
+
+            // Sort the FoldingReferences, starting at the top of the document,
+            // and ensure that, in the case of multiple ranges starting the same line,
+            // that the largest range (i.e. most number of lines spanned) is sorted
+            // first. This is needed to detect duplicate regions. The first in the list
+            // will be used and subsequent duplicates ignored.
+            foldableRegions.Sort();
+
+            // It's possible to have duplicate or overlapping ranges, that is, regions which have the same starting
+            // line number as the previous region. Therefore only emit ranges which have a different starting line
+            // than the previous range.
+            foldableRegions.RemoveAll( (FoldingReference item) => {
+                // Note - I'm not happy with searching here, but as the RemoveAll
+                // doesn't expose the index in the List, we need to calculate it. Fortunately the
+                // list is sorted at this point, so we can use BinarySearch.
+                int index = foldableRegions.BinarySearch(item);
+                if (index == 0) { return false; }
+                return (item.StartLine == foldableRegions[index - 1].StartLine);
+            });
+
+            return foldableRegions.ToArray();
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Language/FoldingReference.cs
+++ b/src/PowerShellEditorServices/Language/FoldingReference.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -58,6 +59,35 @@ namespace Microsoft.PowerShell.EditorServices
 
             // They're the same range, but what about kind
             return string.Compare(this.Kind, that.Kind);
+        }
+    }
+
+    /// <summary>
+    /// A class that holds a list of FoldingReferences and ensures that when adding a reference that the
+    /// folding rules are obeyed, e.g. Only one fold per start line
+    /// </summary>
+    public class FoldingReferenceList : Dictionary<int, FoldingReference>
+    {
+        /// <summary>
+        /// Adds a FoldingReference to the list and enforces ordering rules e.g. Only one fold per start line
+        /// </summary>
+        public void SafeAdd(FoldingReference item)
+        {
+            if (item == null) { return; }
+            FoldingReference currentItem;
+            TryGetValue(item.StartLine, out currentItem);
+            // Only add the item if it hasn't been seen before or it's the largest range
+            if ((currentItem == null) || (currentItem.CompareTo(item) == 1)) { this[item.StartLine] = item; }
+        }
+
+        /// <summary>
+        /// Helper method to easily convert the Dictionary Values into an array
+        /// </summary>
+        public FoldingReference[] ToArray()
+        {
+            var result = new FoldingReference[Count];
+            Values.CopyTo(result, 0);
+            return result;
         }
     }
 }

--- a/src/PowerShellEditorServices/Language/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Language/TokenOperations.cs
@@ -10,7 +10,6 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.PowerShell.EditorServices
 {
-
     /// <summary>
     /// Provides common operations for the tokens of a parsed script.
     /// </summary>
@@ -21,100 +20,75 @@ namespace Microsoft.PowerShell.EditorServices
         private const string RegionKindRegion = "region";
         private const string RegionKindNone = null;
 
-        // Opening tokens for { } and @{ }
-        private static readonly TokenKind[] s_openingBraces = new []
-        {
-            TokenKind.LCurly,
-            TokenKind.AtCurly
-        };
-
-        // Opening tokens for ( ), @( ), $( )
-        private static readonly TokenKind[] s_openingParens = new []
-        {
-            TokenKind.LParen,
-            TokenKind.AtParen,
-            TokenKind.DollarParen
-        };
+        // These regular expressions are used to match lines which mark the start and end of region comment in a PowerShell
+        // script. They are based on the defaults in the VS Code Language Configuration at;
+        // https://github.com/Microsoft/vscode/blob/64186b0a26/extensions/powershell/language-configuration.json#L26-L31
+        static private readonly Regex s_startRegionTextRegex = new Regex(
+           @"^\s*#region\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        static private readonly Regex s_endRegionTextRegex = new Regex(
+           @"^\s*#endregion\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// Extracts all of the unique foldable regions in a script given the list tokens
         /// </summary>
         internal static FoldingReference[] FoldableRegions(
-            Token[] tokens,
-            bool ShowLastLine)
+            Token[] tokens)
         {
-            List<FoldingReference> foldableRegions = new List<FoldingReference>();
+            var foldableRegions = new List<FoldingReference>();
+            var tokenCommentRegionStack = new Stack<Token>();
+            Token blockStartToken = null;
+            int blockNextLine = -1;
 
-            // Find matching braces  { -> }
-            // Find matching hashes @{ -> }
-            foldableRegions.AddRange(
-                MatchTokenElements(tokens, s_openingBraces, TokenKind.RCurly, RegionKindNone)
-            );
+            for (int index = 0; index < tokens.Length; index++)
+            {
+                Token token = tokens[index];
+                if (token.Kind != TokenKind.Comment) { continue; }
+                // Processing for comment regions <# -> #>
+                if (token.Extent.StartLineNumber != token.Extent.EndLineNumber)
+                {
+                    FoldingReference foldRef = CreateFoldingReference(token, token, RegionKindComment);
+                    if (foldRef != null) { foldableRegions.Add(foldRef); }
+                    continue;
+                }
 
-            // Find matching parentheses     ( -> )
-            // Find matching array literals @( -> )
-            // Find matching subexpressions $( -> )
-            foldableRegions.AddRange(
-                MatchTokenElements(tokens, s_openingParens, TokenKind.RParen, RegionKindNone)
-            );
-
-            // Find contiguous here strings @' -> '@
-            foldableRegions.AddRange(
-                MatchTokenElement(tokens, TokenKind.HereStringLiteral, RegionKindNone)
-            );
-
-            // Find unopinionated variable names ${ \n \n }
-            foldableRegions.AddRange(
-                MatchTokenElement(tokens, TokenKind.Variable, RegionKindNone)
-            );
-
-            // Find contiguous here strings @" -> "@
-            foldableRegions.AddRange(
-                MatchTokenElement(tokens, TokenKind.HereStringExpandable, RegionKindNone)
-            );
-
-            // Find matching comment regions   #region -> #endregion
-            foldableRegions.AddRange(
-                MatchCustomCommentRegionTokenElements(tokens, RegionKindRegion)
-            );
-
-            // Find blocks of line comments # comment1\n# comment2\n...
-            foldableRegions.AddRange(
-                MatchBlockCommentTokenElement(tokens, RegionKindComment)
-            );
-
-            // Find comments regions <# -> #>
-            foldableRegions.AddRange(
-                MatchTokenElement(tokens, TokenKind.Comment, RegionKindComment)
-            );
-
-            // Remove any null entries. Nulls appear if the folding reference is invalid
-            // or missing
-            foldableRegions.RemoveAll(item => item == null);
-
-            // Sort the FoldingReferences, starting at the top of the document,
-            // and ensure that, in the case of multiple ranges starting the same line,
-            // that the largest range (i.e. most number of lines spanned) is sorted
-            // first. This is needed to detect duplicate regions. The first in the list
-            // will be used and subsequent duplicates ignored.
-            foldableRegions.Sort();
-
-            // It's possible to have duplicate or overlapping ranges, that is, regions which have the same starting
-            // line number as the previous region. Therefore only emit ranges which have a different starting line
-            // than the previous range.
-            foldableRegions.RemoveAll( (FoldingReference item) => {
-                // Note - I'm not happy with searching here, but as the RemoveAll
-                // doesn't expose the index in the List, we need to calculate it. Fortunately the
-                // list is sorted at this point, so we can use BinarySearch.
-                int index = foldableRegions.BinarySearch(item);
-                if (index == 0) { return false; }
-                return (item.StartLine == foldableRegions[index - 1].StartLine);
-            });
-
-            // Some editors have different folding UI, sometimes the lastline should be displayed
-            // If we do want to show the last line, just change the region to be one line less
-            if (ShowLastLine) {
-                foldableRegions.ForEach( item => { item.EndLine--; });
+                if (!IsBlockComment(index, tokens)) { continue; }
+                // Regex's are very expensive.  Use them sparingly!
+                // Processing for # region -> # endregion
+                if (s_startRegionTextRegex.IsMatch(token.Text))
+                {
+                    tokenCommentRegionStack.Push(token);
+                    continue;
+                }
+                if (s_endRegionTextRegex.IsMatch(token.Text))
+                {
+                    // Mismatched regions in the script can cause bad stacks.
+                    if (tokenCommentRegionStack.Count > 0)
+                    {
+                        FoldingReference foldRef = CreateFoldingReference(tokenCommentRegionStack.Pop(), token, RegionKindRegion);
+                        if (foldRef != null) { foldableRegions.Add(foldRef); }
+                    }
+                    continue;
+                }
+                // If it's neither a start or end region then it could be block line comment
+                // Processing for blocks of line comments # comment1\n# comment2\n...
+                int thisLine = token.Extent.StartLineNumber - 1;
+                if ((blockStartToken != null) && (thisLine != blockNextLine))
+                {
+                    FoldingReference foldRef = CreateFoldingReference(blockStartToken, blockNextLine - 1, RegionKindComment);
+                    if (foldRef != null) { foldableRegions.Add(foldRef); }
+                    blockStartToken = token;
+                }
+                if (blockStartToken == null) { blockStartToken = token; }
+                blockNextLine = thisLine + 1;
+            }
+            // If we exit the token array and we're still processing comment lines, then the
+            // comment block simply ends at the end of document
+            if (blockStartToken != null)
+            {
+                FoldingReference foldRef = CreateFoldingReference(blockStartToken, blockNextLine - 1, RegionKindComment);
+                if (foldRef != null) { foldableRegions.Add(foldRef); }
             }
 
             return foldableRegions.ToArray();
@@ -161,47 +135,6 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
-        /// Given an array of tokens, find matching regions which start (array of tokens) and end with a different TokenKind
-        /// </summary>
-        static private List<FoldingReference> MatchTokenElements(
-            Token[] tokens,
-            TokenKind[] startTokenKind,
-            TokenKind endTokenKind,
-            string matchKind)
-        {
-            List<FoldingReference> result = new List<FoldingReference>();
-            Stack<Token> tokenStack = new Stack<Token>();
-            foreach (Token token in tokens)
-            {
-                if (Array.IndexOf(startTokenKind, token.Kind) != -1) {
-                    tokenStack.Push(token);
-                }
-                if ((tokenStack.Count > 0) && (token.Kind == endTokenKind)) {
-                    result.Add(CreateFoldingReference(tokenStack.Pop(), token, matchKind));
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Given an array of token, finds a specific token
-        /// </summary>
-        static private List<FoldingReference> MatchTokenElement(
-            Token[] tokens,
-            TokenKind tokenKind,
-            string matchKind)
-        {
-            List<FoldingReference> result = new List<FoldingReference>();
-            foreach (Token token in tokens)
-            {
-                if ((token.Kind == tokenKind) && (token.Extent.StartLineNumber != token.Extent.EndLineNumber)) {
-                    result.Add(CreateFoldingReference(token, token, matchKind));
-                }
-            }
-            return result;
-        }
-
-        /// <summary>
         /// Returns true if a Token is a block comment;
         /// - Must be a TokenKind.comment
         /// - Must be preceeded by TokenKind.NewLine
@@ -214,80 +147,6 @@ namespace Microsoft.PowerShell.EditorServices
             if (index == 0) { return true; }
             if (tokens[index - 1].Kind != TokenKind.NewLine) { return false; }
             return thisToken.Text.StartsWith("#");
-        }
-
-        // This regular expressions is used to detect a line comment (as opposed to an inline comment), that is not a region
-        // block directive i.e.
-        // - No text between the beginning of the line and `#`
-        // - Comment does start with region
-        // - Comment does start with endregion
-        static private readonly Regex s_nonRegionLineCommentRegex = new Regex(
-            @"\s*#(?!region\b|endregion\b)",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        /// <summary>
-        /// Finding blocks of comment tokens is more complicated as the newline characters are not
-        /// classed as comments.  To workaround this we search for valid block comments (See IsBlockCmment)
-        /// and then determine contiguous line numbers from there
-        /// </summary>
-        static private List<FoldingReference> MatchBlockCommentTokenElement(
-            Token[] tokens,
-            string matchKind)
-        {
-            List<FoldingReference> result = new List<FoldingReference>();
-            Token startToken = null;
-            int nextLine = -1;
-            for (int index = 0; index < tokens.Length; index++)
-            {
-                Token thisToken = tokens[index];
-                if (IsBlockComment(index, tokens) && s_nonRegionLineCommentRegex.IsMatch(thisToken.Text)) {
-                    int thisLine = thisToken.Extent.StartLineNumber - 1;
-                    if ((startToken != null) && (thisLine != nextLine)) {
-                        result.Add(CreateFoldingReference(startToken, nextLine - 1, matchKind));
-                        startToken = thisToken;
-                    }
-                    if (startToken == null) { startToken = thisToken; }
-                    nextLine = thisLine + 1;
-                }
-            }
-            // If we exit the token array and we're still processing comment lines, then the
-            // comment block simply ends at the end of document
-            if (startToken != null) {
-                result.Add(CreateFoldingReference(startToken, nextLine - 1, matchKind));
-            }
-            return result;
-        }
-
-        /// <summary>
-        /// Given a list of tokens, find the tokens that are comments and
-        /// the comment text is either `# region` or `# endregion`, and then use a stack to determine
-        /// the ranges they span
-        /// </summary>
-        static private List<FoldingReference> MatchCustomCommentRegionTokenElements(
-            Token[] tokens,
-            string matchKind)
-        {
-            // These regular expressions are used to match lines which mark the start and end of region comment in a PowerShell
-            // script. They are based on the defaults in the VS Code Language Configuration at;
-            // https://github.com/Microsoft/vscode/blob/64186b0a26/extensions/powershell/language-configuration.json#L26-L31
-            string startRegionText = @"^\s*#region\b";
-            string endRegionText = @"^\s*#endregion\b";
-
-            List<FoldingReference> result = new List<FoldingReference>();
-            Stack<Token> tokenStack = new Stack<Token>();
-            for (int index = 0; index < tokens.Length; index++)
-            {
-                if (IsBlockComment(index, tokens)) {
-                    Token token = tokens[index];
-                    if (Regex.IsMatch(token.Text, startRegionText, RegexOptions.IgnoreCase)) {
-                        tokenStack.Push(token);
-                    }
-                    if ((tokenStack.Count > 0) && (Regex.IsMatch(token.Text, endRegionText, RegexOptions.IgnoreCase))) {
-                        result.Add(CreateFoldingReference(tokenStack.Pop(), token, matchKind));
-                    }
-                }
-            }
-            return result;
         }
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -20,9 +20,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 text,
                 Version.Parse("5.0"));
 
-            return Microsoft.PowerShell.EditorServices.FoldingOperations.FoldableRegions(
+            var result = Microsoft.PowerShell.EditorServices.FoldingOperations.FoldableRegions(
                 scriptFile.ScriptTokens,
-                scriptFile.ScriptAst);
+                scriptFile.ScriptAst).ToArray();
+            // The foldable regions need to be deterministic for testing so sort the array.
+            Array.Sort(result);
+            return result;
         }
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -13,13 +13,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         /// <summary>
         /// Helper method to create a stub script file and then call FoldableRegions
         /// </summary>
-        private FoldingReference[] GetRegions(string text, bool showLastLine = true) {
+        private FoldingReference[] GetRegions(string text) {
             ScriptFile scriptFile = new ScriptFile(
                 "testfile",
                 "clienttestfile",
                 text,
                 Version.Parse("5.0"));
-            return Microsoft.PowerShell.EditorServices.TokenOperations.FoldableRegions(scriptFile.ScriptTokens, showLastLine);
+
+            return Microsoft.PowerShell.EditorServices.FoldingOperations.FoldableRegions(
+                scriptFile.ScriptTokens,
+                scriptFile.ScriptAst);
         }
 
         /// <summary>
@@ -122,22 +125,22 @@ is
 valid} = 5
 ";
         private FoldingReference[] expectedAllInOneScriptFolds = {
-            CreateFoldingReference(0,   0,  3, 10, "region"),
-            CreateFoldingReference(1,   0,  2,  2, "comment"),
-            CreateFoldingReference(10,  0, 14,  2, "comment"),
-            CreateFoldingReference(16, 30, 62,  1, null),
-            CreateFoldingReference(17,  0, 21,  2, "comment"),
-            CreateFoldingReference(23,  7, 25,  2, null),
-            CreateFoldingReference(31,  5, 33,  2, null),
-            CreateFoldingReference(38,  2, 39,  0, "comment"),
-            CreateFoldingReference(42,  2, 51, 14, "region"),
-            CreateFoldingReference(44,  4, 47, 14, "region"),
-            CreateFoldingReference(54,  7, 55,  3, null),
-            CreateFoldingReference(59,  7, 61,  3, null),
-            CreateFoldingReference(67,  0, 68,  0, "comment"),
-            CreateFoldingReference(70,  0, 74, 26, "region"),
-            CreateFoldingReference(71,  0, 72,  0, "comment"),
-            CreateFoldingReference(78,  0, 79,  6, null),
+            CreateFoldingReference(0,   0,  4, 10, "region"),
+            CreateFoldingReference(1,   0,  3,  2, "comment"),
+            CreateFoldingReference(10,  0, 15,  2, "comment"),
+            CreateFoldingReference(16, 30, 63,  1, null),
+            CreateFoldingReference(17,  0, 22,  2, "comment"),
+            CreateFoldingReference(23,  7, 26,  2, null),
+            CreateFoldingReference(31,  5, 34,  2, null),
+            CreateFoldingReference(38,  2, 40,  0, "comment"),
+            CreateFoldingReference(42,  2, 52, 14, "region"),
+            CreateFoldingReference(44,  4, 48, 14, "region"),
+            CreateFoldingReference(54,  7, 56,  3, null),
+            CreateFoldingReference(59,  7, 62,  3, null),
+            CreateFoldingReference(67,  0, 69,  0, "comment"),
+            CreateFoldingReference(70,  0, 75, 26, "region"),
+            CreateFoldingReference(71,  0, 73,  0, "comment"),
+            CreateFoldingReference(78,  0, 80,  6, null),
         };
 
         /// <summary>
@@ -147,6 +150,8 @@ valid} = 5
             FoldingReference[] expected,
             FoldingReference[] actual)
         {
+            int minValue = expected.Length;
+            if (minValue < actual.Length) { minValue = actual.Length; }
             for (int index = 0; index < expected.Length; index++)
             {
                 Assert.Equal(expected[index], actual[index]);
@@ -179,19 +184,6 @@ valid} = 5
         }
 
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithoutLastLine() {
-            FoldingReference[] result = GetRegions(allInOneScript, false);
-            // Incrememnt the end line of the expected regions by one as we will
-            // be hiding the last line
-            FoldingReference[] expectedFolds = expectedAllInOneScriptFolds.Clone() as FoldingReference[];
-            for (int index = 0; index < expectedFolds.Length; index++)
-            {
-                expectedFolds[index].EndLine++;
-            }
-            AssertFoldingReferenceArrays(expectedFolds, result);
-        }
-
-        [Fact]
         public void LaguageServiceFindsFoldablRegionsWithMismatchedRegions() {
             string testString =
 @"#endregion should not fold - mismatched
@@ -203,7 +195,7 @@ $something = 'foldable'
 #region should not fold - mismatched
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(2, 0, 3, 10, "region")
+                CreateFoldingReference(2, 0, 4, 10, "region")
             };
 
             FoldingReference[] result = GetRegions(testString);
@@ -220,8 +212,8 @@ $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
 })
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(1, 64, 1, 27, null),
-                CreateFoldingReference(2, 35, 3,  2, null)
+                CreateFoldingReference(1, 64, 2, 27, null),
+                CreateFoldingReference(2, 35, 4,  2, null)
             };
 
             FoldingReference[] result = GetRegions(testString);
@@ -245,9 +237,40 @@ $y = $(
 )
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(0, 19, 4, 1, null),
-                CreateFoldingReference(2,  9, 3, 5, null),
-                CreateFoldingReference(7,  5, 8, 1, null)
+                CreateFoldingReference(0, 19, 5, 1, null),
+                CreateFoldingReference(2,  9, 4, 5, null),
+                CreateFoldingReference(7,  5, 9, 1, null)
+            };
+
+            FoldingReference[] result = GetRegions(testString);
+
+            AssertFoldingReferenceArrays(expectedFolds, result);
+        }
+
+        // A simple PowerShell Classes test
+        [Fact]
+        public void LaguageServiceFindsFoldablRegionsWithClasses() {
+            string testString =
+@"class TestClass {
+    [string[]] $TestProperty = @(
+        'first',
+        'second',
+        'third')
+
+    [string] TestMethod() {
+        return $this.TestProperty[0]
+    }
+}
+";
+            // FoldingReference[] expectedFolds = {
+            //     CreateFoldingReference(0,  16, 8,  1, null),
+            //     CreateFoldingReference(1,  31, 3, 16, null),
+            //     CreateFoldingReference(6,  26, 7,  5, null)
+            // };
+            FoldingReference[] expectedFolds = {
+                CreateFoldingReference(0,  0, 9,  1, null),
+                CreateFoldingReference(1,  31, 4, 16, null),
+                CreateFoldingReference(6,  26, 8,  5, null)
             };
 
             FoldingReference[] result = GetRegions(testString);


### PR DESCRIPTION
Requires #825 to be merged first and that merged back to the 2.0.0 branch

DO NOT MERGE

The AST contains the most correct version of how a script is interpreted. This
includes regions of text. Currently the code folder only uses the Tokens which
requires the folder to re-implement some of the AST behaviour e.g. matching
token pairs for arrays etc.  The code folder should be implemented using as much
of the AST as possible.  This commit;

* Moves most of the region detection to use the AST Extents and uses a new
  FindFoldsASTVisitor.
* Modifies the tests and language server to use the new method fold detection
  class.

---

Managed to go from 32ms to 20ms