### PR TITLE
Win7 OSArchitecture crash workaround

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -161,9 +161,10 @@ if ($host.Runspace.LanguageMode -eq 'ConstrainedLanguage') {
     ExitWithError "PowerShell is configured with an unsupported LanguageMode (ConstrainedLanguage), language features are disabled."
 }
 
+# net45 is not supported, only net451 and up
 if ($PSVersionTable.PSVersion.Major -le 5) {
     $net451Version = 378675
-    $dotnetVersion = Get-ItemPropertyValue "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" "Release"
+    $dotnetVersion = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\").Release
     if ($dotnetVersion -lt $net451Version) {
         Write-SessionFile @{
             status = failed

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -161,6 +161,20 @@ if ($host.Runspace.LanguageMode -eq 'ConstrainedLanguage') {
     ExitWithError "PowerShell is configured with an unsupported LanguageMode (ConstrainedLanguage), language features are disabled."
 }
 
+if ($PSVersionTable.PSVersion.Major -le 5) {
+    $net451Version = 378675
+    $dotnetVersion = Get-ItemPropertyValue "HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" "Release"
+    if ($dotnetVersion -lt $net451Version) {
+        Write-SessionFile @{
+            status = failed
+            reason = "netversion"
+            detail = "$netVersion"
+        }
+
+        ExitWithError "Your .NET version is too low. Upgrade to net451 or higher to run the PowerShell extension."
+    }
+}
+
 # If PSReadline is present in the session, remove it so that runspace
 # management is easier
 if ((Microsoft.PowerShell.Core\Get-Module PSReadline).Count -gt 0) {

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -504,7 +504,7 @@ PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (PID {Pr
         {
 #if !CoreCLR
             // If on win7 (version 6.1.x), avoid System.Runtime.InteropServices.RuntimeInformation
-            if (Environment.OSVersion.Platform.Equals("Win32NT") && Environment.OSVersion.Version < new Version(6, 2))
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version < new Version(6, 2))
             {
                 if (Environment.Is64BitProcess)
                 {

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -514,7 +514,6 @@ PowerShell Editor Services Host v{fileVersionInfo.FileVersion} starting (PID {Pr
                 return "X86";
             }
 #endif
-
             return RuntimeInformation.OSArchitecture.ToString();
         }
 


### PR DESCRIPTION
Avoids calling the System.Runtime.InteropServices.RuntimeInformation API that crashes in Win7.

See https://github.com/PowerShell/vscode-powershell/issues/1633.