### PR TITLE
Fix crash when untitled files are opened as PowerShell

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -649,7 +649,9 @@ namespace Microsoft.PowerShell.EditorServices
                     .ToArray();
 
             // Untitled files have no directory
-            // TODO: Make untitled files support dot-sourced references
+            // Discussed in https://github.com/PowerShell/PowerShellEditorServices/pull/815.
+            // Rather than working hard to enable things for untitled files like a phantom directory,
+            // users should save the file.
             if (IsUntitledPath(this.FilePath))
             {
                 return;

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -648,7 +648,14 @@ namespace Microsoft.PowerShell.EditorServices
                     .Select(ScriptFileMarker.FromParseError)
                     .ToArray();
 
-            //Get all dot sourced referenced files and store  them
+            // Untitled files have no directory
+            // TODO: Make untitled files support dot-sourced references
+            if (IsUntitledPath(this.FilePath))
+            {
+                return;
+            }
+
+            // Get all dot sourced referenced files and store them
             this.ReferencedFiles = AstOperations.FindDotSourcedIncludes(this.ScriptAst, Path.GetDirectoryName(this.FilePath));
         }
 


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1649.

Finding dot-sourced references when we parse script files currently relies on the file having a directory, which is not true for untitled files.

This is a simple fix for the crash that occurs as a result.

If there's interest, I could try and improve the situation by changing the visitor to have a null PSScriptRoot mean ignore PSScriptRoot paths, or even try to make an untitled dir... (1st feels like it has merit, second maybe not).