### PR TITLE
Use case insensitive dictionary for Pester keyword lookup so that code lens shows when using lower cased describe keyword

### DIFF
--- a/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
         internal static readonly IReadOnlyDictionary<string, PesterCommandType> PesterKeywords =
             Enum.GetValues(typeof(PesterCommandType))
                 .Cast<PesterCommandType>()
-                .ToDictionary(pct => pct.ToString(), pct => pct);
+                .ToDictionary(pct => pct.ToString(), pct => pct, StringComparer.OrdinalIgnoreCase);
 
         private static char[] DefinitionTrimChars = new char[] { ' ', '{' };
 


### PR DESCRIPTION
Should fix #822 by using a case insensitive dictionary so that when `PesterKeyWords.TryGetValue` gets called [here](https://github.com/PowerShell/PowerShellEditorServices/blob/master/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs#L203) the  code lens in VS-Code shows when using a lower cased describe keyword
H owever, I have not tested it, I came up with this purely just by looking at the code.