### PR TITLE
(GH-824)(GH-812) Improve code folding speed

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1394,14 +1394,14 @@ function __Expand-Alias {
             // If we're showing the last line, decrement the Endline of all regions by one.
             int endLineOffset = this.currentSettings.CodeFolding.ShowLastLine ? -1 : 0;
 
-            foreach (KeyValuePair<int, FoldingReference> entry in TokenOperations.FoldableRegions(scriptFile.ScriptTokens))
+            foreach (FoldingReference fold in TokenOperations.FoldableReferences(scriptFile.ScriptTokens).References)
             {
                 result.Add(new FoldingRange {
-                    EndCharacter   = entry.Value.EndCharacter,
-                    EndLine        = entry.Value.EndLine + endLineOffset,
-                    Kind           = entry.Value.Kind,
-                    StartCharacter = entry.Value.StartCharacter,
-                    StartLine      = entry.Value.StartLine
+                    EndCharacter   = fold.EndCharacter,
+                    EndLine        = fold.EndLine + endLineOffset,
+                    Kind           = fold.Kind,
+                    StartCharacter = fold.StartCharacter,
+                    StartLine      = fold.StartLine
                 });
             }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -535,7 +535,7 @@ function __Expand-Alias {
         {
             PSCommand psCommand = new PSCommand();
             if (!string.IsNullOrEmpty(param))
-            {    
+            {
                 psCommand.AddCommand("Microsoft.PowerShell.Core\\Get-Command").AddArgument(param);
             }
             else
@@ -1267,7 +1267,7 @@ function __Expand-Alias {
                 }
             }
 
-            // Add "show documentation" commands last so they appear at the bottom of the client UI. 
+            // Add "show documentation" commands last so they appear at the bottom of the client UI.
             // These commands do not require code fixes. Sometimes we get a batch of diagnostics
             // to create commands for. No need to create multiple show doc commands for the same rule.
             var ruleNamesProcessed = new HashSet<string>();
@@ -1390,17 +1390,18 @@ function __Expand-Alias {
             if (!editorSession.Workspace.TryGetFile(documentUri, out scriptFile)) { return null; }
 
             var result = new List<FoldingRange>();
-            FoldingReference[] foldableRegions = 
-                TokenOperations.FoldableRegions(scriptFile.ScriptTokens, this.currentSettings.CodeFolding.ShowLastLine);
 
-            foreach (FoldingReference fold in foldableRegions)
+            // If we're showing the last line, decrement the Endline of all regions by one.
+            int endLineOffset = this.currentSettings.CodeFolding.ShowLastLine ? -1 : 0;
+
+            foreach (KeyValuePair<int, FoldingReference> entry in TokenOperations.FoldableRegions(scriptFile.ScriptTokens))
             {
                 result.Add(new FoldingRange {
-                    EndCharacter   = fold.EndCharacter,
-                    EndLine        = fold.EndLine,
-                    Kind           = fold.Kind,
-                    StartCharacter = fold.StartCharacter,
-                    StartLine      = fold.StartLine
+                    EndCharacter   = entry.Value.EndCharacter,
+                    EndLine        = entry.Value.EndLine + endLineOffset,
+                    Kind           = entry.Value.Kind,
+                    StartCharacter = entry.Value.StartCharacter,
+                    StartLine      = entry.Value.StartLine
                 });
             }
 
@@ -1744,7 +1745,7 @@ function __Expand-Alias {
                 });
         }
 
-        // Generate a unique id that is used as a key to look up the associated code action (code fix) when 
+        // Generate a unique id that is used as a key to look up the associated code action (code fix) when
         // we receive and process the textDocument/codeAction message.
         private static string GetUniqueIdFromDiagnostic(Diagnostic diagnostic)
         {

--- a/src/PowerShellEditorServices/Language/FoldingReference.cs
+++ b/src/PowerShellEditorServices/Language/FoldingReference.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -58,6 +59,41 @@ namespace Microsoft.PowerShell.EditorServices
 
             // They're the same range, but what about kind
             return string.Compare(this.Kind, that.Kind);
+        }
+    }
+
+    /// <summary>
+    /// A class that holds a list of FoldingReferences and ensures that when adding a reference that the
+    /// folding rules are obeyed, e.g. Only one fold per start line
+    /// </summary>
+    public class FoldingReferenceList : Dictionary<int, FoldingReference>
+    {
+        /// <summary>
+        /// Adds a FoldingReference to the list and enforces ordering rules e.g. Only one fold per start line
+        /// </summary>
+        public void SafeAdd(FoldingReference item)
+        {
+            if (item == null) { return; }
+
+            // Only add the item if it hasn't been seen before or it's the largest range
+            if (TryGetValue(item.StartLine, out FoldingReference currentItem))
+            {
+                if (currentItem.CompareTo(item) == 1) { this[item.StartLine] = item; }
+            }
+            else
+            {
+                this[item.StartLine] = item;
+            }
+        }
+
+        /// <summary>
+        /// Helper method to easily convert the Dictionary Values into an array
+        /// </summary>
+        public FoldingReference[] ToArray()
+        {
+            var result = new FoldingReference[Count];
+            Values.CopyTo(result, 0);
+            return result;
         }
     }
 }

--- a/src/PowerShellEditorServices/Language/FoldingReference.cs
+++ b/src/PowerShellEditorServices/Language/FoldingReference.cs
@@ -66,8 +66,21 @@ namespace Microsoft.PowerShell.EditorServices
     /// A class that holds a list of FoldingReferences and ensures that when adding a reference that the
     /// folding rules are obeyed, e.g. Only one fold per start line
     /// </summary>
-    public class FoldingReferenceList : Dictionary<int, FoldingReference>
+    public class FoldingReferenceList
     {
+        private readonly Dictionary<int, FoldingReference> references = new Dictionary<int, FoldingReference>();
+
+        /// <summary>
+        /// Return all references in the list
+        /// </summary>
+        public IEnumerable<FoldingReference> References
+        {
+            get
+            {
+                return references.Values;
+            }
+        }
+
         /// <summary>
         /// Adds a FoldingReference to the list and enforces ordering rules e.g. Only one fold per start line
         /// </summary>
@@ -76,13 +89,13 @@ namespace Microsoft.PowerShell.EditorServices
             if (item == null) { return; }
 
             // Only add the item if it hasn't been seen before or it's the largest range
-            if (TryGetValue(item.StartLine, out FoldingReference currentItem))
+            if (references.TryGetValue(item.StartLine, out FoldingReference currentItem))
             {
-                if (currentItem.CompareTo(item) == 1) { this[item.StartLine] = item; }
+                if (currentItem.CompareTo(item) == 1) { references[item.StartLine] = item; }
             }
             else
             {
-                this[item.StartLine] = item;
+                references[item.StartLine] = item;
             }
         }
 
@@ -91,8 +104,8 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public FoldingReference[] ToArray()
         {
-            var result = new FoldingReference[Count];
-            Values.CopyTo(result, 0);
+            var result = new FoldingReference[references.Count];
+            references.Values.CopyTo(result, 0);
             return result;
         }
     }

--- a/src/PowerShellEditorServices/Language/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Language/TokenOperations.cs
@@ -24,12 +24,11 @@ namespace Microsoft.PowerShell.EditorServices
         // These regular expressions are used to match lines which mark the start and end of region comment in a PowerShell
         // script. They are based on the defaults in the VS Code Language Configuration at;
         // https://github.com/Microsoft/vscode/blob/64186b0a26/extensions/powershell/language-configuration.json#L26-L31
+        // https://github.com/Microsoft/vscode/issues/49070
         static private readonly Regex s_startRegionTextRegex = new Regex(
-           @"^\s*#region\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+           @"^\s*#[rR]egion\b", RegexOptions.Compiled);
         static private readonly Regex s_endRegionTextRegex = new Regex(
-           @"^\s*#endregion\b",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+           @"^\s*#[eE]nd[rR]egion\b", RegexOptions.Compiled);
 
         /// <summary>
         /// Extracts all of the unique foldable regions in a script given the list tokens

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -276,5 +276,57 @@ $y = $(
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
+
+        // This tests DSC style keywords and param blocks
+        [Fact]
+        public void LaguageServiceFindsFoldablRegionsWithDSC() {
+            string testString =
+@"Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
+
+    Import-DscResource -Module ActiveDirectoryCSDsc
+
+    Node $AllNodes.NodeName
+    {
+        WindowsFeature ADCS-Cert-Authority
+        {
+            Ensure = 'Present'
+            Name   = 'ADCS-Cert-Authority'
+        }
+
+        AdcsCertificationAuthority CertificateAuthority
+        {
+            IsSingleInstance = 'Yes'
+            Ensure           = 'Present'
+            Credential       = $Credential
+            CAType           = 'EnterpriseRootCA'
+            DependsOn        = '[WindowsFeature]ADCS-Cert-Authority'
+        }
+    }
+}
+";
+            FoldingReference[] expectedFolds = {
+                CreateFoldingReference(1,  0, 33, 1, null),
+                CreateFoldingReference(3,  4, 12, 5, null),
+                CreateFoldingReference(17, 4, 32, 5, null),
+                CreateFoldingReference(19, 8, 22, 9, null),
+                CreateFoldingReference(25, 8, 31, 9, null)
+            };
+
+            FoldingReference[] result = GetRegions(testString);
+
+            AssertFoldingReferenceArrays(expectedFolds, result);
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -260,5 +260,31 @@ $y = $(
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
+
+        // A simple PowerShell Classes test
+        [Fact]
+        public void LaguageServiceFindsFoldablRegionsWithClasses() {
+            string testString =
+@"class TestClass {
+    [string[]] $TestProperty = @(
+        'first',
+        'second',
+        'third')
+
+    [string] TestMethod() {
+        return $this.TestProperty[0]
+    }
+}
+";
+            FoldingReference[] expectedFolds = {
+                CreateFoldingReference(0, 16, 8,  1, null),
+                CreateFoldingReference(1, 31, 3, 16, null),
+                CreateFoldingReference(6, 26, 7,  5, null)
+            };
+
+            FoldingReference[] result = GetRegions(testString);
+
+            AssertFoldingReferenceArrays(expectedFolds, result);
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 text,
                 Version.Parse("5.0"));
 
-            var result = Microsoft.PowerShell.EditorServices.TokenOperations.FoldableRegions(scriptFile.ScriptTokens).ToArray();
+            var result = Microsoft.PowerShell.EditorServices.TokenOperations.FoldableReferences(scriptFile.ScriptTokens).ToArray();
             // The foldable regions need to be deterministic for testing so sort the array.
             Array.Sort(result);
             return result;

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -43,11 +43,11 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         // folding regions and regions which should not be
         // detected.  Due to file encoding this could be CLRF or LF line endings
         private const string allInOneScript =
-@"#RegIon This should fold
+@"#Region This should fold
 <#
 Nested different comment types.  This should fold
 #>
-#EnDReGion
+#EndRegion
 
 # region This should not fold due to whitespace
 $shouldFold = $false
@@ -124,6 +124,10 @@ $something = $true
 ${this
 is
 valid} = 5
+
+#RegIon This should fold due to casing
+$foo = 'bar'
+#EnDReGion
 ";
         private FoldingReference[] expectedAllInOneScriptFolds = {
             CreateFoldingReference(0,   0,  4, 10, "region"),

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -13,13 +13,17 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         /// <summary>
         /// Helper method to create a stub script file and then call FoldableRegions
         /// </summary>
-        private FoldingReference[] GetRegions(string text, bool showLastLine = true) {
+        private FoldingReference[] GetRegions(string text) {
             ScriptFile scriptFile = new ScriptFile(
                 "testfile",
                 "clienttestfile",
                 text,
                 Version.Parse("5.0"));
-            return Microsoft.PowerShell.EditorServices.TokenOperations.FoldableRegions(scriptFile.ScriptTokens, showLastLine);
+
+            var result = Microsoft.PowerShell.EditorServices.TokenOperations.FoldableRegions(scriptFile.ScriptTokens).ToArray();
+            // The foldable regions need to be deterministic for testing so sort the array.
+            Array.Sort(result);
+            return result;
         }
 
         /// <summary>
@@ -122,22 +126,22 @@ is
 valid} = 5
 ";
         private FoldingReference[] expectedAllInOneScriptFolds = {
-            CreateFoldingReference(0,   0,  3, 10, "region"),
-            CreateFoldingReference(1,   0,  2,  2, "comment"),
-            CreateFoldingReference(10,  0, 14,  2, "comment"),
-            CreateFoldingReference(16, 30, 62,  1, null),
-            CreateFoldingReference(17,  0, 21,  2, "comment"),
-            CreateFoldingReference(23,  7, 25,  2, null),
-            CreateFoldingReference(31,  5, 33,  2, null),
-            CreateFoldingReference(38,  2, 39,  0, "comment"),
-            CreateFoldingReference(42,  2, 51, 14, "region"),
-            CreateFoldingReference(44,  4, 47, 14, "region"),
-            CreateFoldingReference(54,  7, 55,  3, null),
-            CreateFoldingReference(59,  7, 61,  3, null),
-            CreateFoldingReference(67,  0, 68,  0, "comment"),
-            CreateFoldingReference(70,  0, 74, 26, "region"),
-            CreateFoldingReference(71,  0, 72,  0, "comment"),
-            CreateFoldingReference(78,  0, 79,  6, null),
+            CreateFoldingReference(0,   0,  4, 10, "region"),
+            CreateFoldingReference(1,   0,  3,  2, "comment"),
+            CreateFoldingReference(10,  0, 15,  2, "comment"),
+            CreateFoldingReference(16, 30, 63,  1, null),
+            CreateFoldingReference(17,  0, 22,  2, "comment"),
+            CreateFoldingReference(23,  7, 26,  2, null),
+            CreateFoldingReference(31,  5, 34,  2, null),
+            CreateFoldingReference(38,  2, 40,  0, "comment"),
+            CreateFoldingReference(42,  2, 52, 14, "region"),
+            CreateFoldingReference(44,  4, 48, 14, "region"),
+            CreateFoldingReference(54,  7, 56,  3, null),
+            CreateFoldingReference(59,  7, 62,  3, null),
+            CreateFoldingReference(67,  0, 69,  0, "comment"),
+            CreateFoldingReference(70,  0, 75, 26, "region"),
+            CreateFoldingReference(71,  0, 73,  0, "comment"),
+            CreateFoldingReference(78,  0, 80,  6, null),
         };
 
         /// <summary>
@@ -182,20 +186,6 @@ valid} = 5
 
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithoutLastLine() {
-            FoldingReference[] result = GetRegions(allInOneScript, false);
-            // Incrememnt the end line of the expected regions by one as we will
-            // be hiding the last line
-            FoldingReference[] expectedFolds = expectedAllInOneScriptFolds.Clone() as FoldingReference[];
-            for (int index = 0; index < expectedFolds.Length; index++)
-            {
-                expectedFolds[index].EndLine++;
-            }
-            AssertFoldingReferenceArrays(expectedFolds, result);
-        }
-
-        [Trait("Category", "Folding")]
-        [Fact]
         public void LaguageServiceFindsFoldablRegionsWithMismatchedRegions() {
             string testString =
 @"#endregion should not fold - mismatched
@@ -207,7 +197,7 @@ $something = 'foldable'
 #region should not fold - mismatched
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(2, 0, 3, 10, "region")
+                CreateFoldingReference(2, 0, 4, 10, "region")
             };
 
             FoldingReference[] result = GetRegions(testString);
@@ -225,8 +215,8 @@ $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
 })
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(1, 64, 1, 27, null),
-                CreateFoldingReference(2, 35, 3,  2, null)
+                CreateFoldingReference(1, 64, 2, 27, null),
+                CreateFoldingReference(2, 35, 4,  2, null)
             };
 
             FoldingReference[] result = GetRegions(testString);
@@ -251,9 +241,9 @@ $y = $(
 )
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(0, 19, 4, 1, null),
-                CreateFoldingReference(2,  9, 3, 5, null),
-                CreateFoldingReference(7,  5, 8, 1, null)
+                CreateFoldingReference(0, 19, 5, 1, null),
+                CreateFoldingReference(2,  9, 4, 5, null),
+                CreateFoldingReference(7,  5, 9, 1, null)
             };
 
             FoldingReference[] result = GetRegions(testString);
@@ -277,9 +267,9 @@ $y = $(
 }
 ";
             FoldingReference[] expectedFolds = {
-                CreateFoldingReference(0, 16, 8,  1, null),
-                CreateFoldingReference(1, 31, 3, 16, null),
-                CreateFoldingReference(6, 26, 7,  5, null)
+                CreateFoldingReference(0, 16, 9,  1, null),
+                CreateFoldingReference(1, 31, 4, 16, null),
+                CreateFoldingReference(6, 26, 8,  5, null)
             };
 
             FoldingReference[] result = GetRegions(testString);


### PR DESCRIPTION
Previously there were no tests for PowerShell classes.  This commit adds a simple
test for this scenario to ensure future changes do not break folding.

Previously the folding provider created many intermediate arrays and lists and
required post-processing.  This commit changes the behaviour to use an
accumlator patter with an extended Dictionary class.  This new class adds a
`SafeAdd` method to add FoldingRanges, which then has the logic to determine if
the range should indeed be added, for example, passing nulls or pre-existing
larger ranges.

By passing around this list using ByReference we can avoid creating many objects
which are just then thrown away.

Previously each token type detection was separated into discrete blocks
to make reading the code easier. However this meant there were many
enumerations of the Tokens array as well as passing around intermediate
arrays/lists.  This commit takes the individual methods and overlaps them
to reduce the number of enumerations and regular expression matching to
a minimum.

Previously the code folding was not tested against DSC configuration scripts.
This commit adds tests for a sample DSC script to ensure the folding occurs at the correct
places

Fixes #824
Fixes #812 