### PR TITLE
Map new powershell.codeFormatting settings for new options in PSSA 1.18: WhitespaceInsideBrace and WhitespaceAroundPipe

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -176,6 +176,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public bool WhitespaceBeforeOpenParen { get; set; }
         public bool WhitespaceAroundOperator { get; set; }
         public bool WhitespaceAfterSeparator { get; set; }
+        public bool WhitespaceInsideBrace { get; set; }
+        public bool WhitespaceAroundPipe { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
 
@@ -254,7 +256,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         {"CheckOpenBrace", WhitespaceBeforeOpenBrace},
                         {"CheckOpenParen", WhitespaceBeforeOpenParen},
                         {"CheckOperator", WhitespaceAroundOperator},
-                        {"CheckSeparator", WhitespaceAfterSeparator}
+                        {"CheckSeparator", WhitespaceAfterSeparator},
+                        {"CheckInnerBrace", WhitespaceInsideBrace},
+                        {"CheckPipe", WhitespaceAroundPipe},
                     }},
                     {"PSAlignAssignmentStatement", new Hashtable {
                         {"Enable", true},


### PR DESCRIPTION
# This PR can only be merged once PSSA 1.18 has released

This wires up new PSSA settings from this [PR ](https://github.com/PowerShell/PSScriptAnalyzer/pull/1092)with new vscode-powershell settings [here](https://github.com/PowerShell/vscode-powershell/pull/1668)