### PR TITLE
Fix NullRefEx bug when accessing scriptFile.ReferencedFiles

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -146,17 +146,13 @@ namespace Microsoft.PowerShell.EditorServices
             TextReader textReader,
             Version powerShellVersion)
         {
-            this.powerShellVersion = powerShellVersion;
-
             this.FilePath = filePath;
             this.ClientFilePath = clientFilePath;
             this.IsAnalysisEnabled = true;
             this.IsInMemory = Workspace.IsPathInMemory(filePath);
-            this.ReferencedFiles = new string[0];
-            this.SyntaxMarkers = new ScriptFileMarker[0];
-            this.FileLines = new List<string>();
-            this.ScriptTokens = new Token[0];
+            this.powerShellVersion = powerShellVersion;
 
+            // SetFileContents() calls ParseFileContents() which initializes the rest of the properties.
             this.SetFileContents(textReader.ReadToEnd());
         }
 
@@ -628,8 +624,6 @@ namespace Microsoft.PowerShell.EditorServices
                             out scriptTokens,
                             out parseErrors);
                 }
-
-                this.ScriptTokens = scriptTokens;
 #else
                 this.ScriptAst =
                     Parser.ParseInput(
@@ -637,6 +631,8 @@ namespace Microsoft.PowerShell.EditorServices
                         out scriptTokens,
                         out parseErrors);
 #endif
+
+                this.ScriptTokens = scriptTokens;
             }
             catch (RuntimeException ex)
             {
@@ -663,6 +659,8 @@ namespace Microsoft.PowerShell.EditorServices
             // users should save the file.
             if (IsUntitledPath(this.FilePath))
             {
+                // Need to initialize the ReferencedFiles property to an empty array.
+                this.ReferencedFiles = new string[0];
                 return;
             }
 

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -164,10 +164,10 @@ namespace PSLanguageService.Test
         public void FindsDotSourcedFiles()
         {
             string exampleScriptContents =
-                @". .\athing.ps1"+"\r\n"+
-                @". .\somefile.ps1"+"\r\n" +
-                @". .\somefile.ps1"+"\r\n" +
-                @"Do-Stuff $uri"+"\r\n" +
+                @". .\athing.ps1" + "\r\n" +
+                @". .\somefile.ps1" + "\r\n" +
+                @". .\somefile.ps1" + "\r\n" +
+                @"Do-Stuff $uri" + "\r\n" +
                 @". simpleps.ps1";
 
             using (StringReader stringReader = new StringReader(exampleScriptContents))
@@ -530,6 +530,53 @@ First line
 
             Assert.Equal(expectedLine, newPosition.Line);
             Assert.Equal(expectedColumn, newPosition.Column);
+        }
+    }
+
+    public class ScriptFileConstructorTests
+    {
+        private static readonly Version PowerShellVersion = new Version("5.0");
+
+        [Fact]
+        public void PropertiesInitializedCorrectlyForFile()
+        {
+            var path = "TestFile.ps1";
+            var scriptFile = ScriptFileChangeTests.CreateScriptFile("");
+
+            Assert.Equal(path, scriptFile.FilePath);
+            Assert.Equal(path, scriptFile.ClientFilePath);
+            Assert.True(scriptFile.IsAnalysisEnabled);
+            Assert.False(scriptFile.IsInMemory);
+            Assert.Empty(scriptFile.ReferencedFiles);
+            Assert.Empty(scriptFile.SyntaxMarkers);
+            Assert.Single(scriptFile.ScriptTokens);
+            Assert.Single(scriptFile.FileLines);
+        }
+
+        [Fact]
+        public void PropertiesInitializedCorrectlyForUntitled()
+        {
+            var path = "untitled:untitled-1";
+
+            // 3 lines and 10 tokens in this script.
+            var script = @"function foo() {
+    'foo'
+}";
+
+            using (StringReader stringReader = new StringReader(script))
+            {
+                // Create an in-memory file from the StringReader
+                var scriptFile = new ScriptFile(path, path, stringReader, PowerShellVersion);
+
+                Assert.Equal(path, scriptFile.FilePath);
+                Assert.Equal(path, scriptFile.ClientFilePath);
+                Assert.True(scriptFile.IsAnalysisEnabled);
+                Assert.True(scriptFile.IsInMemory);
+                Assert.Empty(scriptFile.ReferencedFiles);
+                Assert.Empty(scriptFile.SyntaxMarkers);
+                Assert.Equal(10, scriptFile.ScriptTokens.Length);
+                Assert.Equal(3, scriptFile.FileLines.Count);
+            }
         }
     }
 }


### PR DESCRIPTION
This happens because the ScriptFile ctor does not initialize all its
public props.  I added initialization for the other public props
except for the ScriptAst prop.  I don't see an empty Ast.  Perhaps null
is OK for this prop?

This address vscode-powershell bug https://github.com/PowerShell/vscode-powershell/issues/1675

No real need for ScriptTokens to have a backing field. Make it auto like the other props.

Also, for the 2.0.0 branch, we should see if we can use Array.Empty<>()
for initialization.  It isn't availble to net45x.  :-(