### PR TITLE
Fix FileNotFoundEx crash when Fold happens on untitled: scheme doc

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1386,8 +1386,8 @@ function __Expand-Alias {
             // Perhaps a better option would be to parse the contents of the document as a string
             // as opposed to reading a file but the senario of "no backing file" probably doesn't
             // warrant the extra effort.
-            ScriptFile scriptFile = editorSession.Workspace.GetFile(documentUri);
-            if (scriptFile == null) { return null; }
+            ScriptFile scriptFile;
+            if (!editorSession.Workspace.TryGetFile(documentUri, out scriptFile)) { return null; }
 
             var result = new List<FoldingRange>();
             FoldingReference[] foldableRegions = 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -109,9 +109,11 @@ namespace Microsoft.PowerShell.EditorServices
             string resolvedFilePath = this.ResolveFilePath(filePath);
             string keyName = resolvedFilePath.ToLower();
 
-            // Make sure the file isn't already loaded into the workspace
+            // Make sure the file isn't already loaded into the workspace and that the filePath isn't an "in-memory" path.
+            // There have been crashes caused by this method being called with an "untitled:" document uri. See:
+            // https://github.com/PowerShell/vscode-powershell/issues/1676
             ScriptFile scriptFile = null;
-            if (!this.workspaceFiles.TryGetValue(keyName, out scriptFile))
+            if (!this.workspaceFiles.TryGetValue(keyName, out scriptFile) && !IsPathInMemory(filePath))
             {
                 // This method allows FileNotFoundException to bubble up
                 // if the file isn't found.


### PR DESCRIPTION
Fix https://github.com/PowerShell/vscode-powershell/issues/1676

One change here that makes me a bit nervous is the added `IsPathInMemory()` test to the `GetFile()` method.  However, I observed `GetFile()` crashing when it was passed an `untitled:` path as part of the repro for vscode 1676:
```
    System.AggregateException: One or more errors occurred. (Could not find file 'C:\Users\Keith\GitHub\PowerShell\Plaster\untitled:Untitled-2'.) ---> System.IO.FileNotFoundException: Could not find file 'C:\Users\Keith\GitHub\PowerShell\Plaster\untitled:Untitled-2'.
       at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
       at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
       at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
       at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access)
       at Microsoft.PowerShell.EditorServices.Workspace.GetFile(String filePath) in C:\Users\Keith\GitHub\rkeithhill\PowerShellEditorServices\src\PowerShellEditorServices\Workspace\Workspace.cs:line 118
```
So it seems prudent to ensure we never try to create a FileStream given an in-memory document uri.  However, the `IsPathInMemory()` method utilizes exceptions in some cases to determine if the path is in-memory.  That is why I put it second in the short-circuiting `&&`.  So we would only do this test at the point we would actually try to open the file.

Another option would be to do the try/catch FileNotFoundEx in this method and then we could skip the `IsPathInMemory()` test.  Thoughts?