### PR TITLE
Fix an empty verbose message when importing an editor command

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
@@ -115,7 +115,7 @@ function Import-EditorCommand {
                     <# suppressOutput: #> $details.SuppressOutput,
                     <# scriptBlock:    #> $scriptBlock)
 
-                $PSCmdlet.WriteVerbose($Strings.EditorCommandRegistering -f $details.Name)
+                $PSCmdlet.WriteVerbose($Strings.EditorCommandImporting -f $details.Name)
                 $null = $psEditor.RegisterCommand($editorCommand)
 
                 if ($PassThru.IsPresent -and $editorCommand) {


### PR DESCRIPTION
Change $Strings.EditorCommandRegistering to $Strings.EditorCommandImporting to be in sync with the key name in the Strings.psd1 file.