### PR TITLE
Map new powershell.codeFormatting settings for new rule in PSSA 1.18: PSUseCorrectCasing

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -178,6 +178,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public bool WhitespaceAfterSeparator { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
+        public bool UseCorrectCasing { get; set; }
 
 
         /// <summary>
@@ -259,6 +260,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     {"PSAlignAssignmentStatement", new Hashtable {
                         {"Enable", true},
                         {"CheckHashtable", AlignPropertyValuePairs}
+                    }},
+                    {"PSUseCorrectCasing", new Hashtable {
+                        {"Enable", true}
                     }},
                 }}
             };


### PR DESCRIPTION
# This PR can only be merged once PSSA 1.18 has released

This wires up new PSSA settings from this [PR ](https://github.com/PowerShell/PSScriptAnalyzer/pull/1117)with new vscode-powershell settings [here](https://github.com/PowerShell/vscode-powershell/pull/1687)