### PR TITLE
Workaround "attach to process" hang

### DIFF
--- a/src/PowerShellEditorServices/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Session/RunspaceDetails.cs
@@ -225,8 +225,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
                             defaultValue: string.Empty);
 
                 // hostname is 'ServerRemoteHost' when the user enters a session.
-                // ex. Enter-PSSession, Enter-PSHostProcess
-                if (hostName.Equals("ServerRemoteHost", StringComparison.Ordinal))
+                // ex. Enter-PSSession
+                // Attaching to process currently needs to be marked as a local session
+                // so we skip this if block if the runspace is from Enter-PSHostProcess
+                if (hostName.Equals("ServerRemoteHost", StringComparison.Ordinal)
+                    && !(runspace.OriginalConnectionInfo is NamedPipeConnectionInfo))
                 {
                     runspaceLocation = RunspaceLocation.Remote;
                     connectionString =


### PR DESCRIPTION
This fixes the "Attach to process" debug config. Originally broken in #801.

Unfortunately, I'm not 100% sure why the Enter-PSHostProcess session being treated as a Remote session causes issues but this code was majorly refactored in 2.0.0 branch so I'm just going to make this small change for now.

fixes https://github.com/PowerShell/vscode-powershell/issues/1684