### PR TITLE
Fix VSCODE 1683 - HelpCommentReqHdlr crash on GetFile

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1162,7 +1162,15 @@ function __Expand-Alias {
            CommentHelpRequestParams requestParams,
            RequestContext<CommentHelpRequestResult> requestContext)
         {
-            ScriptFile scriptFile = this.editorSession.Workspace.GetFile(requestParams.DocumentUri);
+            var result = new CommentHelpRequestResult();
+
+            ScriptFile scriptFile;
+            if (!this.editorSession.Workspace.TryGetFile(requestParams.DocumentUri, out scriptFile))
+            {
+                await requestContext.SendResult(result);
+                return;
+            }
+
             int triggerLine = requestParams.TriggerPosition.Line + 1;
 
             string helpLocation;
@@ -1170,8 +1178,6 @@ function __Expand-Alias {
                 scriptFile,
                 triggerLine,
                 out helpLocation);
-
-            var result = new CommentHelpRequestResult();
 
             if (functionDefinitionAst == null)
             {


### PR DESCRIPTION
Fix for one of the issues documented in https://github.com/PowerShell/vscode-powershell/issues/1683

This is a quick fix, still need to make a pass through and look at all uses of `GetFile()`.