### PR TITLE
Fix #827 Pester TestName w/expandable str returns nothing

### DIFF
--- a/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
@@ -141,12 +141,8 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
                 testName = testNameStrAst.Value;
                 return true;
             }
-            else if (commandElementAst is ExpandableStringExpressionAst)
-            {
-                return true;
-            }
 
-            return false;
+            return (commandElementAst is ExpandableStringExpressionAst);
         }
     }
 

--- a/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Symbols/PesterDocumentSymbolProvider.cs
@@ -32,8 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
 
             return commandAsts.OfType<CommandAst>()
                               .Where(IsPesterCommand)
-                              .Select(ast => ConvertPesterAstToSymbolReference(scriptFile, ast))
-                              .Where(pesterSymbol => pesterSymbol?.TestName != null);
+                              .Select(ast => ConvertPesterAstToSymbolReference(scriptFile, ast));
         }
 
         /// <summary>
@@ -105,20 +104,21 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
                 // Check for an explicit "-Name" parameter
                 if (currentCommandElement is CommandParameterAst parameterAst)
                 {
+                    // Found -Name parameter, move to next element which is the argument for -TestName
                     i++;
-                    if (parameterAst.ParameterName == "Name" && i < pesterCommandAst.CommandElements.Count)
+
+                    if (!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements[i], out testName))
                     {
-                        testName = alreadySawName ? null : (pesterCommandAst.CommandElements[i] as StringConstantExpressionAst)?.Value;
                         alreadySawName = true;
                     }
+
                     continue;
                 }
 
                 // Otherwise, if an argument is given with no parameter, we assume it's the name
                 // If we've already seen a name, we set the name to null
-                if (pesterCommandAst.CommandElements[i] is StringConstantExpressionAst testNameStrAst)
+                if (!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements[i], out testName))
                 {
-                    testName = alreadySawName ? null : testNameStrAst.Value;
                     alreadySawName = true;
                 }
             }
@@ -130,6 +130,23 @@ namespace Microsoft.PowerShell.EditorServices.Symbols
                 testName,
                 pesterCommandAst.Extent
             );
+        }
+
+        private static bool TryGetTestNameArgument(CommandElementAst commandElementAst, out string testName)
+        {
+            testName = null;
+
+            if (commandElementAst is StringConstantExpressionAst testNameStrAst)
+            {
+                testName = testNameStrAst.Value;
+                return true;
+            }
+            else if (commandElementAst is ExpandableStringExpressionAst)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
This update will return null to indicate that the TestName arg was
present but not something we could evaluate.  The extension will see the
null value and pop a dialog box.