### PR TITLE
(maint) Reinstate test filtering

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -348,9 +348,9 @@ function UploadTestLogs {
     }
 }
 
-function XunitTraitFilter {
+function DotNetTestFilter {
     # Reference https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests
-    if ($TestFilter) { "-trait $TestFilter" } else { "" }
+    if ($TestFilter) { @("--filter",$TestFilter) } else { "" }
 }
 
 task Test TestServer,TestProtocol
@@ -359,11 +359,11 @@ task TestServer {
     Set-Location .\test\PowerShellEditorServices.Test\
 
     if (-not $script:IsUnix) {
-        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop }
+        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop (DotNetTestFilter) }
     }
 
     Invoke-WithCreateDefaultHook -NewModulePath $script:PSCoreModulePath {
-        exec { & $script:dotnetExe test -f $script:TestRuntime.Core }
+        exec { & $script:dotnetExe test -f $script:TestRuntime.Core (DotNetTestFilter) }
     }
 }
 
@@ -371,11 +371,11 @@ task TestProtocol {
     Set-Location .\test\PowerShellEditorServices.Test.Protocol\
 
     if (-not $script:IsUnix) {
-        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop }
+        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop (DotNetTestFilter) }
     }
 
     Invoke-WithCreateDefaultHook {
-        exec { & $script:dotnetExe test -f $script:TestRuntime.Core }
+        exec { & $script:dotnetExe test -f $script:TestRuntime.Core (DotNetTestFilter) }
     }
 }
 
@@ -384,11 +384,11 @@ task TestHost {
 
     if (-not $script:IsUnix) {
         exec { & $script:dotnetExe build -f $script:TestRuntime.Desktop }
-        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop }
+        exec { & $script:dotnetExe test -f $script:TestRuntime.Desktop (DotNetTestFilter) }
     }
 
     exec { & $script:dotnetExe build -c $Configuration -f $script:TestRuntime.Core }
-    exec { & $script:dotnetExe test -f $script:TestRuntime.Core }
+    exec { & $script:dotnetExe test -f $script:TestRuntime.Core (DotNetTestFilter) }
 }
 
 task CITest ?Test, {


### PR DESCRIPTION
Previously in commit b13bef14d7771d6ee86c399868a the ability to filter
which tests were run in order to speed up development.  However in commit
449cc21d30ccfc0a7 this was removed. This commit resinstates the test
filtering and uses the new command line arguemnt --filter instead of
the old xunit command.