### PR TITLE
🔧 update signing file tidy up build scripts

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -465,6 +465,13 @@ task RestorePsesModules -After Build {
         $moduleInfos.Add($name, $body)
     }
 
+    if ($moduleInfos.Keys.Count -gt 0) {
+        # `#Requires` doesn't display the version needed in the error message and `using module` doesn't work with InvokeBuild in Windows PowerShell
+        # so we'll just use Import-Module to check that PowerShellGet 1.6.0 or higher is installed.
+        # This is needed in order to use the `-AllowPrerelease` parameter
+        Import-Module -Name PowerShellGet -MinimumVersion 1.6.0 -ErrorAction Stop
+    }
+
     # Save each module in the modules.json file
     foreach ($moduleName in $moduleInfos.Keys)
     {

--- a/tools/releaseBuild/Image/DockerFile
+++ b/tools/releaseBuild/Image/DockerFile
@@ -17,15 +17,10 @@ RUN Import-Module PackageManagement; `
     Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force; `
     Install-Module platyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force;
 
-# Install .NET Framework 4.5.2 Developer Packs
-RUN Import-Module ./containerFiles/dockerInstall.psm1; `
-    Install-ChocolateyPackage -PackageName netfx-4.5.2-devpack;
+RUN Install-Module -Name PowerShellGet -Force;
 
 # Copy build script over
 COPY build.ps1 containerFiles/build.ps1
-
-# Add env var for release build logic
-ENV VSTS_BUILD=1
 
 # Uncomment to debug locally
 # RUN Import-Module ./containerFiles/dockerInstall.psm1; `
@@ -33,4 +28,3 @@ ENV VSTS_BUILD=1
 #     git clone https://github.com/PowerShell/PowerShellEditorServices;
 
 ENTRYPOINT ["C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-command"]
-

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Editor Services" approvers="vigarg;gstolt">
+    <!-- PowerShellEditorServices Script -->
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\PowerShellEditorServices.psd1" signType="Authenticode"
       dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\PowerShellEditorServices.psd1" />
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\PowerShellEditorServices.psm1" signType="Authenticode"
@@ -38,7 +39,15 @@
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\Commands\Public\Test-ScriptExtent.ps1" signType="Authenticode"
       dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\Commands\Public\Test-ScriptExtent.ps1" />
 
-    <!-- PowerShellEditorServices.VSCode -->
+    <!-- PowerShellEditorServices Binary -->
+    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.dll" signType="Authenticode"
+      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.dll" />
+    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.Host.dll" signType="Authenticode"
+      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.Host.dll" />
+    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.Protocol.dll" signType="Authenticode"
+      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Microsoft.PowerShell.EditorServices.Protocol.dll" />
+
+    <!-- PowerShellEditorServices.VSCode Script -->
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\PowerShellEditorServices.VSCode.psd1" signType="Authenticode"
       dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\PowerShellEditorServices.VSCode.psd1" />
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\PowerShellEditorServices.VSCode.psm1" signType="Authenticode"
@@ -53,30 +62,10 @@
       dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\Public\HtmlContentView\Show-VSCodeHtmlContentView.ps1" />
     <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\Public\HtmlContentView\Write-VSCodeHtmlContentView.ps1" signType="Authenticode"
       dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\Public\HtmlContentView\Write-VSCodeHtmlContentView.ps1" />
- </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Editor Services Desktop" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.dll" />
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.Host.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.Host.dll" />
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.Protocol.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Core\Microsoft.PowerShell.EditorServices.Protocol.dll" />
 
-    <!-- PowerShellEditorServices.VSCode -->
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Core\Microsoft.PowerShell.EditorServices.VSCode.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Core\Microsoft.PowerShell.EditorServices.VSCode.dll" />
- </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Editor Services Core" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.dll" />
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.Host.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.Host.dll" />
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.Protocol.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices\bin\Desktop\Microsoft.PowerShell.EditorServices.Protocol.dll" />
-
-    <!-- PowerShellEditorServices.VSCode -->
-    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Desktop\Microsoft.PowerShell.EditorServices.VSCode.dll" signType="Authenticode"
-      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Desktop\Microsoft.PowerShell.EditorServices.VSCode.dll" />
+    <!-- PowerShellEditorServices.VSCode Binary -->
+    <file src="__INPATHROOT__\release\out\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Microsoft.PowerShell.EditorServices.VSCode.dll" signType="Authenticode"
+      dest="__OUTPATHROOT__\PowerShellEditorServices\PowerShellEditorServices.VSCode\bin\Microsoft.PowerShell.EditorServices.VSCode.dll" />
  </job>
 </SignConfigXML>
 


### PR DESCRIPTION
This enables the release process to work again for the 2.0 changes. Mostly due to things using .NET Standard now.

Also #855 is fixed by warning the user that they need PowerShellGet 1.6.0 or higher due to needing `-AllowPrerelease`

fixes #855 
