### PR TITLE
Fix XUnit warnings that better assertion operators should be used.

### DIFF
--- a/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
+++ b/test/PowerShellEditorServices.Test.Host/LanguageServerTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     PublishDiagnosticsNotification.Type);
 
             // Was there a syntax error?
-            Assert.NotEqual(0, diagnostics.Diagnostics.Length);
+            Assert.NotEmpty(diagnostics.Diagnostics);
             Assert.False(
                 string.IsNullOrEmpty(diagnostics.Diagnostics[0].Message));
         }
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     PublishDiagnosticsNotification.Type);
 
             // Was there a semantic error?
-            Assert.NotEqual(0, diagnostics.Diagnostics.Length);
+            Assert.NotEmpty(diagnostics.Diagnostics);
             Assert.Contains("unapproved", diagnostics.Diagnostics[0].Message);
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     PublishDiagnosticsNotification.Type);
 
             // Was there a syntax error?
-            Assert.Equal(0, diagnostics.Diagnostics.Length);
+            Assert.Empty(diagnostics.Diagnostics);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(completions);
-            Assert.NotEqual(completions.Length, 0);
+            Assert.NotEmpty(completions);
 
             // TODO: Add more asserts
         }
@@ -279,7 +279,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                 });
 
             Assert.NotNull(locations);
-            Assert.Equal(locations.Length, 3);
+            Assert.Equal(3, locations.Length);
 
             Assert.Equal(5, locations[0].Range.Start.Line);
             Assert.Equal(0, locations[0].Range.Start.Character);
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(0, locations.Length);
+            Assert.Empty(locations);
         }
 
         [Fact]
@@ -400,7 +400,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(1, locations.Length);
+            Assert.Single(locations);
             Assert.Equal(0, locations[0].Range.Start.Line);
             Assert.Equal(9, locations[0].Range.Start.Character);
         }
@@ -427,7 +427,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(0, locations.Length);
+            Assert.Empty(locations);
         }
 
         [Fact]
@@ -452,7 +452,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(1, locations.Length);
+            Assert.Single(locations);
             Assert.Equal(5, locations[0].Range.Start.Line);
             Assert.Equal(0, locations[0].Range.Start.Character);
             Assert.Equal(5, locations[0].Range.End.Line);
@@ -481,7 +481,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(1, locations.Length);
+            Assert.Single(locations);
             Assert.EndsWith("VariableDefinition.ps1", locations[0].Uri);
             Assert.Equal(0, locations[0].Range.Start.Line);
             Assert.Equal(0, locations[0].Range.Start.Character);
@@ -511,7 +511,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(locations);
-            Assert.Equal(1, locations.Length);
+            Assert.Single(locations);
             Assert.EndsWith("FindReferences.ps1", locations[0].Uri);
             Assert.Equal(17, locations[0].Range.Start.Line);
             Assert.Equal(0, locations[0].Range.Start.Character);
@@ -567,7 +567,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Host
                     });
 
             Assert.NotNull(signatureHelp);
-            Assert.Equal(1, signatureHelp.Signatures.Length);
+            Assert.Single(signatureHelp.Signatures);
             Assert.Equal(2, signatureHelp.Signatures[0].Parameters.Length);
             Assert.Equal(
                 "Write-Output [-InputObject] <psobject[]> [-NoEnumerate] [<CommonParameters>]",

--- a/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
+++ b/test/PowerShellEditorServices.Test.Protocol/Server/OutputDebouncerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Protocol.Server
             await SendOutput(debouncer, "for great justice");
 
             // Assert that there's only one event with the expected string
-            Assert.Equal(1, messageSender.OutputEvents.Count);
+            Assert.Single(messageSender.OutputEvents);
             Assert.Equal(
                 TestUtilities.NormalizeNewlines("This is a test\nAnother line"),
                 messageSender.OutputEvents[0].Output);

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -178,14 +178,14 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 await this.debugService.SetCommandBreakpointsAsync(
                     new[] { CommandBreakpointDetails.Create("Get-Host") });
 
-            Assert.Equal(1, breakpoints.Length);
+            Assert.Single(breakpoints);
             Assert.Equal("Get-Host", breakpoints[0].Name);
 
             breakpoints =
                 await this.debugService.SetCommandBreakpointsAsync(
                     new CommandBreakpointDetails[] {});
 
-            Assert.Equal(0, breakpoints.Length);
+            Assert.Empty(breakpoints);
         }
 
         [Fact]
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             confirmedBreakpoints = await this.GetConfirmedBreakpoints(this.debugScriptFile);
 
-            Assert.Equal(1, confirmedBreakpoints.Count());
+            Assert.Single(confirmedBreakpoints);
             Assert.Equal(2, breakpoints[0].LineNumber);
 
             await this.debugService.SetLineBreakpointsAsync(
@@ -843,8 +843,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal(2, childVars.Count);
             Assert.Contains("Age", childVars.Keys);
             Assert.Contains("Name", childVars.Keys);
-            Assert.Equal(childVars["Age"], "75");
-            Assert.Equal(childVars["Name"], "\"John\"");
+            Assert.Equal("75", childVars["Age"]);
+            Assert.Equal("\"John\"", childVars["Name"]);
 
             // Abort execution of the script
             this.powerShellContext.AbortExecution();
@@ -931,7 +931,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             DebuggerStoppedEventArgs eventArgs =
                 await this.debuggerStoppedQueue.DequeueAsync(new CancellationTokenSource(5000).Token);
 
-            Assert.Equal(0, eventArgs.OriginalEvent.Breakpoints.Count);
+            Assert.Empty(eventArgs.OriginalEvent.Breakpoints);
         }
 
         public async Task AssertDebuggerStopped(

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionServiceTests.cs
@@ -138,9 +138,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             await this.AssertExtensionEvent(EventType.Remove, "test.scriptblock");
 
             // Ensure that the command has been unregistered
-            await Assert.ThrowsAsync(
-                typeof(KeyNotFoundException),
-                () => extensionService.InvokeCommandAsync("test.scriptblock", this.commandContext));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() =>
+                extensionService.InvokeCommandAsync("test.scriptblock", this.commandContext));
         }
 
         private async Task<EditorCommand> AssertExtensionEvent(EventType expectedEventType, string expectedExtensionName)

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.GetCompletionResults(
                     CompleteCommandInFile.SourceDetails);
 
-            Assert.NotEqual(0, completionResults.Completions.Length);
+            Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
                 CompleteCommandInFile.ExpectedCompletion,
                 completionResults.Completions[0]);
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.GetCompletionResults(
                     CompleteCommandFromModule.SourceDetails);
 
-            Assert.NotEqual(0, completionResults.Completions.Length);
+            Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
                 CompleteCommandFromModule.ExpectedCompletion,
                 completionResults.Completions[0]);
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.GetCompletionResults(
                     CompleteVariableInFile.SourceDetails);
 
-            Assert.Equal(1, completionResults.Completions.Length);
+            Assert.Single(completionResults.Completions);
             Assert.Equal(
                 CompleteVariableInFile.ExpectedCompletion,
                 completionResults.Completions[0]);
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.GetCompletionResults(
                     CompleteAttributeValue.SourceDetails);
 
-            Assert.NotEqual(0, completionResults.Completions.Length);
+            Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
                 CompleteAttributeValue.ExpectedRange,
                 completionResults.ReplacedRange);
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.GetCompletionResults(
                     CompleteFilePath.SourceDetails);
 
-            Assert.NotEqual(0, completionResults.Completions.Length);
+            Assert.NotEmpty(completionResults.Completions);
             // TODO: Since this is a path completion, this test will need to be
             //       platform specific. Probably something like:
             //         - Windows: C:\Program
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             Assert.NotNull(paramSignatures);
             Assert.Equal("Write-Host", paramSignatures.CommandName);
-            Assert.Equal(1, paramSignatures.Signatures.Count());
+            Assert.Single(paramSignatures.Signatures);
         }
 
         [Fact]
@@ -299,9 +299,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 this.FindSymbolsInFile(
                     FindSymbolsInMultiSymbolFile.SourceDetails);
 
-            Assert.Equal(4, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Function).Count());
-            Assert.Equal(3, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Variable).Count());
-            Assert.Equal(1, symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Workflow).Count());
+            Assert.Equal(4, symbolsResult.FoundOccurrences.Where(symbolReference => symbolReference.SymbolType == SymbolType.Function).Count());
+            Assert.Equal(3, symbolsResult.FoundOccurrences.Where(symbolReference => symbolReference.SymbolType == SymbolType.Variable).Count());
+            Assert.Single(symbolsResult.FoundOccurrences.Where(symbolReference => symbolReference.SymbolType == SymbolType.Workflow));
 
             SymbolReference firstFunctionSymbol = symbolsResult.FoundOccurrences.Where(r => r.SymbolType == SymbolType.Function).First();
             Assert.Equal("AFunction", firstFunctionSymbol.SymbolName);
@@ -347,7 +347,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 this.FindSymbolsInFile(
                     FindSymbolsInNoSymbolsFile.SourceDetails);
 
-            Assert.Equal(0, symbolsResult.FoundOccurrences.Count());
+            Assert.Empty(symbolsResult.FoundOccurrences);
         }
 
         private ScriptFile GetScriptFile(ScriptRegion scriptRegion)

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -194,8 +194,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void ThrowsExceptionWithEditOutsideOfRange()
         {
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
                     this.AssertFileChange(
@@ -293,7 +292,7 @@ namespace PSLanguageService.Test
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(5, 1, 5, 10));
 
-            Assert.Equal(1, lines.Length);
+            Assert.Single(lines);
             Assert.Equal("Line Five", lines[0]);
         }
 
@@ -314,7 +313,7 @@ namespace PSLanguageService.Test
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(4, 3, 4, 8));
 
-            Assert.Equal(1, lines.Length);
+            Assert.Single(lines);
             Assert.Equal("ne Fo", lines[0]);
         }
 
@@ -325,7 +324,7 @@ namespace PSLanguageService.Test
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(4, 3, 4, 3));
 
-            Assert.Equal(1, lines.Length);
+            Assert.Single(lines);
             Assert.Equal("", lines[0]);
         }
 
@@ -386,7 +385,7 @@ namespace PSLanguageService.Test
         public void CanGetLineForEmptyString()
         {
             var emptyFile = ScriptFileChangeTests.CreateScriptFile(string.Empty);
-            Assert.Equal(1, emptyFile.FileLines.Count);
+            Assert.Single(emptyFile.FileLines);
             Assert.Equal(string.Empty, emptyFile.FileLines[0]);
         }
 
@@ -394,7 +393,7 @@ namespace PSLanguageService.Test
         public void CanGetLineForSpace()
         {
             var spaceFile = ScriptFileChangeTests.CreateScriptFile(" ");
-            Assert.Equal(1, spaceFile.FileLines.Count);
+            Assert.Single(spaceFile.FileLines);
             Assert.Equal(" ", spaceFile.FileLines[0]);
         }
     }
@@ -445,8 +444,7 @@ First line
         public void ThrowsWhenPositionOutOfRange()
         {
             // Less than line range
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
                     scriptFile.CalculatePosition(
@@ -455,8 +453,7 @@ First line
                 });
 
             // Greater than line range
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
                     scriptFile.CalculatePosition(
@@ -465,8 +462,7 @@ First line
                 });
 
             // Less than column range
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
                     scriptFile.CalculatePosition(
@@ -475,8 +471,7 @@ First line
                 });
 
             // Greater than column range
-            Assert.Throws(
-                typeof(ArgumentOutOfRangeException),
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
                     scriptFile.CalculatePosition(

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
 
             // At this point, numbers 0 through 299 should be in the outputItems
             IEnumerable<int> expectedItems = Enumerable.Range(0, 300);
-            Assert.Equal(0, expectedItems.Except(outputItems).Count());
+            Assert.Empty(expectedItems.Except(outputItems));
         }
 
         [Fact]


### PR DESCRIPTION
This also cleans up the build log