### PR TITLE
[Ignore] Prep for 2.0.0-preview.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ The v2.0.0-preview.1 version of the extension is built on .NET Standard (enablin
 
 It also contains PSReadLine support in the integrated console for Windows behind a feature flag. PSReadLine provides a consistent and rich interactive experience, including syntax coloring and multi-line editing and history, in the PowerShell console, in Cloud Shell, and now in VSCode terminal. For more information on the benefits of PSReadLine, check out their [documentation](https://docs.microsoft.com/en-us/powershell/module/psreadline/about/about_psreadline?view=powershell-6).
 
-To enable PSReadLine support in the Preview version on Windows, please add the following to your user settings:
+To enable PSReadLine support in the Preview version on Windows, please add the following flag to your `Start-EditorServices.ps1` call:
 
 ```
-"powershell.developer.featureFlags": [ "PSReadLine" ]
+-FeatureFlags @('PSReadLine')
 ```
 
 HUGE thanks to @SeeminglyScience for all his amazing work getting PSReadLine working in PowerShell Editor Services!
 
 #### Breaking Changes
 
-Due to the above changes, this version of the PowerShell Editor Services only works with PowerShell versions 5.1 and higher.
+Due to the above changes, this version of the PowerShell Editor Services only works with Windows PowerShell 5.1 and PowerShell Core 6.
 
 - [PowerShellEditorServices #792](https://github.com/PowerShell/PowerShellEditorServices/pull/792) -
   Add Async suffix to async methods (Thanks @dee-see!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## v2.0.0-preview.1
 ### Wednesday, January 23, 2019
 
+#### Preview builds of PowerShell Editor Services are now available
+
+#### What the first preview contains
+
+The v2.0.0-preview.1 version of the extension is built on .NET Standard (enabling support for both Windows PowerShell and PowerShell Core from one assembly)
+
+It also contains PSReadLine support in the integrated console for Windows behind a feature flag. PSReadLine provides a consistent and rich interactive experience, including syntax coloring and multi-line editing and history, in the PowerShell console, in Cloud Shell, and now in VSCode terminal. For more information on the benefits of PSReadLine, check out their [documentation](https://docs.microsoft.com/en-us/powershell/module/psreadline/about/about_psreadline?view=powershell-6).
+
+To enable PSReadLine support in the Preview version on Windows, please add the following to your user settings:
+
+```
+"powershell.developer.featureFlags": [ "PSReadLine" ]
+```
+
+HUGE thanks to @SeeminglyScience for all his amazing work getting PSReadLine working in PowerShell Editor Services!
+
+#### Breaking Changes
+
+Due to the above changes, this version of the PowerShell Editor Services only works with PowerShell versions 5.1 and higher.
+
 - [PowerShellEditorServices #792](https://github.com/PowerShell/PowerShellEditorServices/pull/792) -
   Add Async suffix to async methods (Thanks @dee-see!)
 - [PowerShellEditorServices #775](https://github.com/PowerShell/PowerShellEditorServices/pull/775) -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # PowerShell Editor Services Release History
 
+## v2.0.0-preview.1
+### Tuesday, January 22, 2019
+
+- [PowerShellEditorServices #792](https://github.com/PowerShell/PowerShellEditorServices/pull/792) -
+  Add Async suffix to async methods  (Thanks @dee-see!)
+- [PowerShellEditorServices #775](https://github.com/PowerShell/PowerShellEditorServices/pull/775) -
+  Removed ShowOnlineHelp Message  (Thanks @corbob!)
+- [PowerShellEditorServices #769](https://github.com/PowerShell/PowerShellEditorServices/pull/769) -
+  Set Runspaces to use STA when running in Windows PowerShell
+- [PowerShellEditorServices #741](https://github.com/PowerShell/PowerShellEditorServices/pull/741) -
+  Migrate to netstandard2.0 and PSStandard
+- [PowerShellEditorServices #672](https://github.com/PowerShell/PowerShellEditorServices/pull/672) -
+  PSReadLine integration  (Thanks @SeeminglyScience!)
+
 ## v1.10.2
 ### Tuesday, December 18, 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 ### Wednesday, January 23, 2019
 
 - [PowerShellEditorServices #792](https://github.com/PowerShell/PowerShellEditorServices/pull/792) -
-  Add Async suffix to async methods  (Thanks @dee-see!)
+  Add Async suffix to async methods (Thanks @dee-see!)
 - [PowerShellEditorServices #775](https://github.com/PowerShell/PowerShellEditorServices/pull/775) -
-  Removed ShowOnlineHelp Message  (Thanks @corbob!)
+  Removed ShowOnlineHelp Message (Thanks @corbob!)
 - [PowerShellEditorServices #769](https://github.com/PowerShell/PowerShellEditorServices/pull/769) -
   Set Runspaces to use STA when running in Windows PowerShell
 - [PowerShellEditorServices #741](https://github.com/PowerShell/PowerShellEditorServices/pull/741) -
   Migrate to netstandard2.0 and PSStandard
 - [PowerShellEditorServices #672](https://github.com/PowerShell/PowerShellEditorServices/pull/672) -
-  PSReadLine integration  (Thanks @SeeminglyScience!)
+  PSReadLine integration (Thanks @SeeminglyScience!)
 
 ## v1.10.2
 ### Tuesday, December 18, 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # PowerShell Editor Services Release History
 
 ## v2.0.0-preview.1
-### Tuesday, January 22, 2019
+### Wednesday, January 23, 2019
 
 - [PowerShellEditorServices #792](https://github.com/PowerShell/PowerShellEditorServices/pull/792) -
   Add Async suffix to async methods  (Thanks @dee-see!)

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSufix>preview.1</VersionSufix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSufix>preview.1</VersionSufix>
+    <VersionSuffix>preview.1</VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerShellEditorServices.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0'
+ModuleVersion = '2.0.0-preview.1'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerShellEditorServices.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0-preview.1'
+ModuleVersion = '2.0.0'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'


### PR DESCRIPTION
This PR is mostly for documentation purposes. After this, I'll change the version back to just `2.0.0`.

Note that this PR doesn't have the following changes:

- appveyor.yml: might as well leave this at 2.0.0 if it's just for doc purposes
- PowerShellEditorServices.psd1: PowerShell manifest files only support the version as 2.0.0, no SemVer suffix.

related PR: https://github.com/PowerShell/vscode-powershell/pull/1716