### PR TITLE
Catch NotSupportedException which can be thrown by FilleStream ctor

### DIFF
--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -148,11 +148,12 @@ namespace Microsoft.PowerShell.EditorServices
                 return true;
             }
             catch (Exception e) when (
-                e is IOException ||
-                e is SecurityException ||
+                e is NotSupportedException ||
                 e is FileNotFoundException ||
                 e is DirectoryNotFoundException ||
                 e is PathTooLongException ||
+                e is IOException ||
+                e is SecurityException ||
                 e is UnauthorizedAccessException)
             {
                 this.logger.WriteHandledException($"Failed to get file for {nameof(filePath)}: '{filePath}'", e);


### PR DESCRIPTION
The 7 exceptions that are caught now are doc'd in:
https://docs.microsoft.com/en-us/dotnet/api/system.io.filestream.-ctor?view=netframework-4.7.2#System_IO_FileStream__ctor_System_String_System_IO_FileMode_System_IO_FileAccess_

Another fix for https://github.com/PowerShell/vscode-powershell/issues/1676