### PR TITLE
Speed up travis builds by skipping the .net core initialisation optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: cpp
 
 git:
   depth: 1000
+  
+env:
+  # Avoid expensive initialization of dotnet cli, see: https://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 matrix:
   include:


### PR DESCRIPTION
This makes the build nearly 1 minute faster. It is a trick that I already added to the PowerShell build [here](https://github.com/PowerShell/PowerShell/blob/master/.vsts-ci/windows.yml) last year