### PR TITLE
Support -CustomPipeName

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
@@ -21,5 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public string ProcessId { get; set; }
 
         public int RunspaceId { get; set; }
+
+        public string CustomPipeName { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
 {
     public class DebugAdapter
     {
-        private static Version _minVersionForCustomPipeName = new Version(6, 2);
+        private static readonly Version _minVersionForCustomPipeName = new Version(6, 2);
 
         private EditorSession _editorSession;
 

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -461,7 +461,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             }
 
             // Clear any existing breakpoints before proceeding
-            await ClearSessionBreakpointsAsync();
+            await ClearSessionBreakpointsAsync().ConfigureAwait(false);
 
             // Execute the Debug-Runspace command but don't await it because it
             // will block the debug adapter initialization process.  The
@@ -470,9 +470,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             int runspaceId = attachParams.RunspaceId > 0 ? attachParams.RunspaceId : 1;
             _waitingForAttach = true;
             Task nonAwaitedTask =
-                _editorSession.PowerShellContext
-                    .ExecuteScriptStringAsync($"\nDebug-Runspace -Id {runspaceId}")
-                    .ContinueWith(OnExecutionCompletedAsync);
+            _editorSession.PowerShellContext
+                .ExecuteScriptStringAsync($"\nDebug-Runspace -Id {runspaceId}")
+                .ContinueWith(OnExecutionCompletedAsync);
 
             await requestContext.SendResultAsync(null);
         }


### PR DESCRIPTION
In PowerShell 6.2 RC we will introduce `-CustomPipeName`. The work is in this PR:
https://github.com/PowerShell/PowerShell/pull/8889

This, along with https://github.com/PowerShell/vscode-powershell/pull/1775 will add support for this parameter in the debug config that is passed to 

```powershell
Enter-PSHostProcess -CustomPipeName $foo
```

~marking this as a Draft PR until RC is released.~