### PR TITLE
Fix unable to open files in problems/peek windows issue

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 codeLensResponse[i] = codeLensResults[i].ToProtocolCodeLens(
                     new CodeLensData
                     {
-                        Uri = codeLensResults[i].File.ClientFilePath,
+                        Uri = codeLensResults[i].File.DocumentUri,
                         ProviderId = codeLensResults[i].Provider.ProviderId
                     },
                     _jsonSerializer);

--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Commands;
-using Microsoft.PowerShell.EditorServices.Symbols;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Commands;
+using Microsoft.PowerShell.EditorServices.Symbols;
 
 namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
@@ -53,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                         "PowerShell.RunPesterTests",
                         "Run tests",
                         new object[] {
-                            scriptFile.ClientFilePath,
+                            scriptFile.DocumentUri,
                             false /* No debug */,
                             pesterSymbol.TestName,
                             pesterSymbol.ScriptRegion?.StartLineNumber })),
@@ -66,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                         "PowerShell.RunPesterTests",
                         "Debug tests",
                         new object[] {
-                            scriptFile.ClientFilePath,
+                            scriptFile.DocumentUri,
                             true /* Run in the debugger */,
                             pesterSymbol.TestName,
                             pesterSymbol.ScriptRegion?.StartLineNumber })),

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     GetReferenceCountHeader(referenceLocations.Length),
                     new object[]
                     {
-                        codeLens.File.ClientFilePath,
+                        codeLens.File.DocumentUri,
                         codeLens.ScriptExtent.ToRange().Start,
                         referenceLocations,
                     }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1757,7 +1757,7 @@ function __Expand-Alias {
                 diagnostics.Add(markerDiagnostic);
             }
 
-            correctionIndex[scriptFile.ClientFilePath] = fileCorrections;
+            correctionIndex[scriptFile.DocumentUri] = fileCorrections;
 
             // Always send syntax and semantic errors.  We want to
             // make sure no out-of-date markers are being displayed.
@@ -1765,7 +1765,7 @@ function __Expand-Alias {
                 PublishDiagnosticsNotification.Type,
                 new PublishDiagnosticsNotification
                 {
-                    Uri = scriptFile.ClientFilePath,
+                    Uri = scriptFile.DocumentUri,
                     Diagnostics = diagnostics.ToArray()
                 });
         }

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             get
             {
-                return (this.ClientFilePath == null )
+                return (this.ClientFilePath == null)
                     ? string.Empty
                     : Workspace.ConvertPathToDocumentUri(this.ClientFilePath);
             }

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -578,43 +578,6 @@ namespace Microsoft.PowerShell.EditorServices
 
         #region Private Methods
 
-        private static string GetPathAsClientPath(string path)
-        {
-            const string fileUriPrefix = "file:///";
-
-            if (path.StartsWith("untitled:", StringComparison.Ordinal))
-            {
-                return path;
-            }
-
-            if (path.StartsWith("file:///", StringComparison.Ordinal))
-            {
-                return path;
-            }
-
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return new Uri(path).AbsoluteUri;
-            }
-
-            // VSCode file URIs on Windows need the drive letter lowercase, and the colon
-            // URI encoded. System.Uri won't do that, so we manually create the URI.
-            var newUri = System.Web.HttpUtility.UrlPathEncode(path);
-            int colonIndex = path.IndexOf(":");
-            for (var i = colonIndex - 1; i >= 0; i--)
-            {
-                newUri.Remove(i, 1);
-                newUri.Insert(i, char.ToLowerInvariant(path[i]).ToString());
-            }
-
-            return newUri
-                .Remove(colonIndex, 1)
-                .Insert(colonIndex, "%3A")
-                .Replace("\\", "/")
-                .Insert(0, fileUriPrefix)
-                .ToString();
-        }
-
         private void SetFileContents(string fileContents)
         {
             // Split the file contents into lines and trim

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices
         {
             get
             {
-                return (this.ClientFilePath == null)
+                return this.ClientFilePath == null
                     ? string.Empty
                     : Workspace.ConvertPathToDocumentUri(this.ClientFilePath);
             }

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerShell.EditorServices
         };
 
         private Version powerShellVersion;
-        private string _clientPath;
 
         #endregion
 
@@ -52,18 +51,18 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// Gets the path which the editor client uses to identify this file.
         /// </summary>
-        public string ClientFilePath
+        public string ClientFilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the file path in LSP DocumentUri form.  The ClientPath property must not be null.
+        /// </summary>
+        public string DocumentUri
         {
-            get { return _clientPath; }
-
-            private set
+            get
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                _clientPath = GetPathAsClientPath(value);
+                return (this.ClientFilePath == null )
+                    ? string.Empty
+                    : Workspace.ConvertPathToDocumentUri(this.ClientFilePath);
             }
         }
 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -660,10 +660,12 @@ namespace Microsoft.PowerShell.EditorServices
                 int firstColonIndex = absoluteUri.IndexOf(':');
                 if (absoluteUri.IndexOf(':', firstColonIndex + 1) >= 0)
                 {
-                    absoluteUri = new StringBuilder()
-                        .Append(absoluteUri, firstColonIndex + 1, absoluteUri.Length - firstColonIndex - 1)
-                        .Replace(":", "%3A")
-                        .Insert(0, absoluteUri.ToCharArray(0, firstColonIndex + 1))
+                    absoluteUri = new StringBuilder(absoluteUri)
+                        .Replace(
+                            oldValue: ":",
+                            newValue: "%3A",
+                            startIndex: firstColonIndex + 1,
+                            count: absoluteUri.Length - firstColonIndex - 1)
                         .ToString();
                 }
 
@@ -679,9 +681,8 @@ namespace Microsoft.PowerShell.EditorServices
                 int driveLetterIndex = colonIndex - 1;
                 char driveLetter = char.ToLowerInvariant(path[driveLetterIndex]);
                 newUri
-                    .Remove(driveLetterIndex, 2)
-                    .Insert(driveLetterIndex, driveLetter)
-                    .Insert(driveLetterIndex + 1, "%3A");
+                    .Replace(path[driveLetterIndex], driveLetter, driveLetterIndex, 1)
+                    .Replace(":", "%3A", colonIndex, 1);
             }
 
             return newUri.Replace('\\', '/').Insert(0, fileUriPrefix).ToString();

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -658,7 +658,7 @@ namespace Microsoft.PowerShell.EditorServices
 
                 // First colon is part of the protocol scheme, see if there are other colons in the path
                 int firstColonIndex = absoluteUri.IndexOf(':');
-                if (absoluteUri.IndexOf(':', firstColonIndex + 1) >= 0)
+                if (absoluteUri.IndexOf(':', firstColonIndex + 1) > firstColonIndex)
                 {
                     absoluteUri = new StringBuilder(absoluteUri)
                         .Replace(

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -640,7 +640,6 @@ namespace Microsoft.PowerShell.EditorServices
         internal static string ConvertPathToDocumentUri(string path)
         {
             const string fileUriPrefix = "file:///";
-            int colonIndex;
 
             if (path.StartsWith("untitled:", StringComparison.Ordinal))
             {
@@ -671,8 +670,8 @@ namespace Microsoft.PowerShell.EditorServices
 
             // VSCode file URIs on Windows need the drive letter lowercase, and the colon
             // URI encoded. System.Uri won't do that, so we manually create the URI.
-            var newUri = System.Web.HttpUtility.UrlPathEncode(path);
-            colonIndex = path.IndexOf(':');
+            string newUri = System.Web.HttpUtility.UrlPathEncode(path);
+            int colonIndex = path.IndexOf(':');
             if (colonIndex > 0)
             {
                 int driveLetterIndex = colonIndex - 1;
@@ -681,10 +680,7 @@ namespace Microsoft.PowerShell.EditorServices
                 newUri = newUri.Insert(driveLetterIndex, driveLetter + "%3A");
             }
 
-            return newUri
-                .Replace('\\', '/')
-                .Insert(0, fileUriPrefix)
-                .ToString();
+            return newUri.Replace('\\', '/').Insert(0, fileUriPrefix);
         }
 
         #endregion

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         }
 
         [Theory]
-        [MemberData("DebuggerAcceptsScriptArgsTestData")]
+        [MemberData(nameof(DebuggerAcceptsScriptArgsTestData))]
         public async Task DebuggerAcceptsScriptArgs(string[] args)
         {
             // The path is intentionally odd (some escaped chars but not all) because we are testing

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -547,6 +547,7 @@ First line
 
             Assert.Equal(path, scriptFile.FilePath);
             Assert.Equal(path, scriptFile.ClientFilePath);
+            Assert.Equal("file:///TestFile.ps1", scriptFile.DocumentUri);
             Assert.True(scriptFile.IsAnalysisEnabled);
             Assert.False(scriptFile.IsInMemory);
             Assert.Empty(scriptFile.ReferencedFiles);
@@ -572,12 +573,33 @@ First line
 
                 Assert.Equal(path, scriptFile.FilePath);
                 Assert.Equal(path, scriptFile.ClientFilePath);
+                Assert.Equal(path, scriptFile.DocumentUri);
                 Assert.True(scriptFile.IsAnalysisEnabled);
                 Assert.True(scriptFile.IsInMemory);
                 Assert.Empty(scriptFile.ReferencedFiles);
                 Assert.Empty(scriptFile.SyntaxMarkers);
                 Assert.Equal(10, scriptFile.ScriptTokens.Length);
                 Assert.Equal(3, scriptFile.FileLines.Count);
+            }
+        }
+
+        [Fact]
+        public void DocumentUriRetunsCorrectStringForAbsolutePath()
+        {
+            string path;
+            ScriptFile scriptFile;
+            var emptyStringReader = new StringReader("");
+
+            path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
+            scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+            Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                // Test the following only on Linux and macOS.
+                path = "/home/AmosBurton/projects/Rocinate/Proto:Mole:cule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/AmosBurton/projects/Rocinate/Proto%3AMole%3Acule.ps1", scriptFile.DocumentUri);
             }
         }
     }

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -547,7 +547,6 @@ First line
 
             Assert.Equal(path, scriptFile.FilePath);
             Assert.Equal(path, scriptFile.ClientFilePath);
-            Assert.Equal("file:///TestFile.ps1", scriptFile.DocumentUri);
             Assert.True(scriptFile.IsAnalysisEnabled);
             Assert.False(scriptFile.IsInMemory);
             Assert.Empty(scriptFile.ReferencedFiles);
@@ -590,13 +589,19 @@ First line
             ScriptFile scriptFile;
             var emptyStringReader = new StringReader("");
 
-            path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
-            scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
-            Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
-
-            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+            }
+            else
             {
                 // Test the following only on Linux and macOS.
+                path = "/home/AmosBurton/projects/Rocinate/ProtoMolecule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
                 path = "/home/AmosBurton/projects/Rocinate/Proto:Mole:cule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
                 Assert.Equal("file:///home/AmosBurton/projects/Rocinate/Proto%3AMole%3Acule.ps1", scriptFile.DocumentUri);

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -598,13 +598,17 @@ First line
             else
             {
                 // Test the following only on Linux and macOS.
-                path = "/home/AmosBurton/projects/Rocinate/ProtoMolecule.ps1";
+                path = "/home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
-                Assert.Equal("file:///home/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+                Assert.Equal("file:///home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
 
-                path = "/home/AmosBurton/projects/Rocinate/Proto:Mole:cule.ps1";
+                path = "/home/NaomiNagata/projects/Rocinate/Proto:Mole:cule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
-                Assert.Equal("file:///home/AmosBurton/projects/Rocinate/Proto%3AMole%3Acule.ps1", scriptFile.DocumentUri);
+                Assert.Equal("file:///home/NaomiNagata/projects/Rocinate/Proto%3AMole%3Acule.ps1", scriptFile.DocumentUri);
+
+                path = "/home/JamesHolden/projects/Rocinate/Proto:Mole\\cule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/JamesHolden/projects/Rocinate/Proto%3AMole%5Ccule.ps1", scriptFile.DocumentUri);
             }
         }
     }


### PR DESCRIPTION
This is due to PSES not properly storing a language client path in the
ClientFilePath property of ScriptFile.  This change ensures that a
ClientFilePath is always stored in the text document Uri that a LSP
client expects.  This code has mostly been provided by
@seeminglyScience. Thanks for the reference to your code.
This fixes issue [1732 in the vscode-powershell repo](https://github.com/PowerShell/vscode-powershell/issues/1732).

BTW I've also verified that there are issues when you use the reference code lens where refs to other files that you haven't loaded, will not load when you click on the file in the peek window.