### PR TITLE
Use public InternalHost from origin runspace

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psm1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psm1
@@ -109,7 +109,8 @@ function Start-EditorServicesHost {
             $EnableConsoleRepl.IsPresent,
             $WaitForDebugger.IsPresent,
             $AdditionalModules,
-            $FeatureFlags)
+            $FeatureFlags,
+            $Host)
 
     # Build the profile paths using the root paths of the current $profile variable
     $profilePaths =

--- a/src/PowerShellEditorServices.Host/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices.Host/EditorServicesHost.cs
@@ -16,13 +16,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Management.Automation.Runspaces;
-using System.Reflection;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.Management.Automation;
-using System.Management.Automation.Host;
 using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Management.Automation.Host;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Host
 {
@@ -89,7 +89,6 @@ namespace Microsoft.PowerShell.EditorServices.Host
         #endregion
 
         #region Constructors
-
 
         /// <summary>
         /// Initializes a new instance of the EditorServicesHost class and waits for

--- a/src/PowerShellEditorServices/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleProxy.cs
@@ -29,30 +29,136 @@ namespace Microsoft.PowerShell.EditorServices.Console
             s_consoleProxy = new UnixConsoleOperations();
         }
 
-        public static Task<ConsoleKeyInfo> ReadKeyAsync(CancellationToken cancellationToken) =>
-            s_consoleProxy.ReadKeyAsync(cancellationToken);
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user asynchronously.
+        /// Does not block when other console API's are called.
+        /// </summary>
+        /// <param name="intercept">
+        /// Determines whether to display the pressed key in the console window. <see langword="true" />
+        /// to not display the pressed key; otherwise, <see langword="false" />.
+        /// </param>
+        /// <param name="cancellationToken">The CancellationToken to observe.</param>
+        /// <returns>
+        /// An object that describes the <see cref="ConsoleKey" /> constant and Unicode character, if any,
+        /// that correspond to the pressed console key. The <see cref="ConsoleKeyInfo" /> object also
+        /// describes, in a bitwise combination of <see cref="ConsoleModifiers" /> values, whether
+        /// one or more Shift, Alt, or Ctrl modifier keys was pressed simultaneously with the console key.
+        /// </returns>
+        public static ConsoleKeyInfo ReadKey(bool intercept, CancellationToken cancellationToken) =>
+            s_consoleProxy.ReadKey(intercept, cancellationToken);
 
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user asynchronously.
+        /// Does not block when other console API's are called.
+        /// </summary>
+        /// <param name="intercept">
+        /// Determines whether to display the pressed key in the console window. <see langword="true" />
+        /// to not display the pressed key; otherwise, <see langword="false" />.
+        /// </param>
+        /// <param name="cancellationToken">The CancellationToken to observe.</param>
+        /// <returns>
+        /// A task that will complete with a result of the key pressed by the user.
+        /// </returns>
+        public static Task<ConsoleKeyInfo> ReadKeyAsync(bool intercept, CancellationToken cancellationToken) =>
+            s_consoleProxy.ReadKeyAsync(intercept, cancellationToken);
+
+        /// <summary>
+        /// Obtains the horizontal position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <returns>The horizontal position of the console cursor.</returns>
         public static int GetCursorLeft() =>
             s_consoleProxy.GetCursorLeft();
 
+        /// <summary>
+        /// Obtains the horizontal position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
+        /// <returns>The horizontal position of the console cursor.</returns>
         public static int GetCursorLeft(CancellationToken cancellationToken) =>
             s_consoleProxy.GetCursorLeft(cancellationToken);
 
+        /// <summary>
+        /// Obtains the horizontal position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{T}" /> representing the asynchronous operation. The
+        /// <see cref="Task{T}.Result" /> property will return the horizontal position
+        /// of the console cursor.
+        /// </returns>
         public static Task<int> GetCursorLeftAsync() =>
             s_consoleProxy.GetCursorLeftAsync();
 
+        /// <summary>
+        /// Obtains the horizontal position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
+        /// <returns>
+        /// A <see cref="Task{T}" /> representing the asynchronous operation. The
+        /// <see cref="Task{T}.Result" /> property will return the horizontal position
+        /// of the console cursor.
+        /// </returns>
         public static Task<int> GetCursorLeftAsync(CancellationToken cancellationToken) =>
             s_consoleProxy.GetCursorLeftAsync(cancellationToken);
 
+        /// <summary>
+        /// Obtains the vertical position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <returns>The vertical position of the console cursor.</returns>
         public static int GetCursorTop() =>
             s_consoleProxy.GetCursorTop();
 
+        /// <summary>
+        /// Obtains the vertical position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
+        /// <returns>The vertical position of the console cursor.</returns>
         public static int GetCursorTop(CancellationToken cancellationToken) =>
             s_consoleProxy.GetCursorTop(cancellationToken);
 
+        /// <summary>
+        /// Obtains the vertical position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task{T}" /> representing the asynchronous operation. The
+        /// <see cref="Task{T}.Result" /> property will return the vertical position
+        /// of the console cursor.
+        /// </returns>
         public static Task<int> GetCursorTopAsync() =>
             s_consoleProxy.GetCursorTopAsync();
 
+        /// <summary>
+        /// Obtains the vertical position of the console cursor. Use this method
+        /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
+        /// on Unix platforms.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
+        /// <returns>
+        /// A <see cref="Task{T}" /> representing the asynchronous operation. The
+        /// <see cref="Task{T}.Result" /> property will return the vertical position
+        /// of the console cursor.
+        /// </returns>
         public static Task<int> GetCursorTopAsync(CancellationToken cancellationToken) =>
             s_consoleProxy.GetCursorTopAsync(cancellationToken);
 

--- a/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Console/ConsoleReadLine.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
 
         private static async Task<ConsoleKeyInfo> ReadKeyAsync(CancellationToken cancellationToken)
         {
-            return await ConsoleProxy.ReadKeyAsync(cancellationToken);
+            return await ConsoleProxy.ReadKeyAsync(intercept: true, cancellationToken);
         }
 
         private async Task<string> ReadLineAsync(bool isCommandLine, CancellationToken cancellationToken)

--- a/src/PowerShellEditorServices/Console/IConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Console/IConsoleOperations.cs
@@ -18,16 +18,37 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// Obtains the next character or function key pressed by the user asynchronously.
         /// Does not block when other console API's are called.
         /// </summary>
+        /// <param name="intercept">
+        /// Determines whether to display the pressed key in the console window. <see langword="true" />
+        /// to not display the pressed key; otherwise, <see langword="false" />.
+        /// </param>
+        /// <param name="cancellationToken">The CancellationToken to observe.</param>
+        /// <returns>
+        /// An object that describes the <see cref="ConsoleKey" /> constant and Unicode character, if any,
+        /// that correspond to the pressed console key. The <see cref="ConsoleKeyInfo" /> object also
+        /// describes, in a bitwise combination of <see cref="ConsoleModifiers" /> values, whether
+        /// one or more Shift, Alt, or Ctrl modifier keys was pressed simultaneously with the console key.
+        /// </returns>
+        ConsoleKeyInfo ReadKey(bool intercept, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user asynchronously.
+        /// Does not block when other console API's are called.
+        /// </summary>
+        /// <param name="intercept">
+        /// Determines whether to display the pressed key in the console window. <see langword="true" />
+        /// to not display the pressed key; otherwise, <see langword="false" />.
+        /// </param>
         /// <param name="cancellationToken">The CancellationToken to observe.</param>
         /// <returns>
         /// A task that will complete with a result of the key pressed by the user.
         /// </returns>
-        Task<ConsoleKeyInfo> ReadKeyAsync(CancellationToken cancellationToken);
+        Task<ConsoleKeyInfo> ReadKeyAsync(bool intercept, CancellationToken cancellationToken);
 
         /// <summary>
         /// Obtains the horizontal position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <returns>The horizontal position of the console cursor.</returns>
@@ -36,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the horizontal position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
@@ -46,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the horizontal position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <returns>
@@ -59,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the horizontal position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorLeft" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
@@ -73,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the vertical position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <returns>The vertical position of the console cursor.</returns>
@@ -82,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the vertical position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>
@@ -92,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the vertical position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <returns>
@@ -105,7 +126,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
         /// <summary>
         /// Obtains the vertical position of the console cursor. Use this method
         /// instead of <see cref="System.Console.CursorTop" /> to avoid triggering
-        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(CancellationToken)" />
+        /// pending calls to <see cref="IConsoleOperations.ReadKeyAsync(bool, CancellationToken)" />
         /// on Unix platforms.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> to observe.</param>

--- a/src/PowerShellEditorServices/Console/UnixConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Console/UnixConsoleOperations.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             WaitForKeyAvailableAsync = LongWaitForKeyAsync;
         }
 
-        internal ConsoleKeyInfo ReadKey(bool intercept, CancellationToken cancellationToken)
+        public ConsoleKeyInfo ReadKey(bool intercept, CancellationToken cancellationToken)
         {
             s_readKeyHandle.Wait(cancellationToken);
 
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             }
         }
 
-        public async Task<ConsoleKeyInfo> ReadKeyAsync(CancellationToken cancellationToken)
+        public async Task<ConsoleKeyInfo> ReadKeyAsync(bool intercept, CancellationToken cancellationToken)
         {
             await s_readKeyHandle.WaitAsync(cancellationToken);
 
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Console
             await s_stdInHandle.WaitAsync(cancellationToken);
             try
             {
-                return System.Console.ReadKey(intercept: true);
+                return System.Console.ReadKey(intercept);
             }
             finally
             {

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -5,6 +5,7 @@
     <Description>Provides common PowerShell editor capabilities as a .NET library.</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices</AssemblyName>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <!-- Fail the release build if there are missing public API documentation comments -->
   <PropertyGroup>

--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -619,6 +619,8 @@ namespace Microsoft.PowerShell.EditorServices
             }
             else
             {
+                // Adding with a value of null here because we don't actually need a dictionary. We're
+                // only using ConcurrentDictionary<,> becuase there is no ConcurrentHashSet<>.
                 this.currentProgressMessages.TryAdd(new ProgressKey(sourceId, record), null);
             }
 

--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
+        private readonly HashSet<ProgressKey> currentProgressMessages = new HashSet<ProgressKey>();
         private PromptHandler activePromptHandler;
         private PSHostRawUserInterface rawUserInterface;
         private CancellationTokenSource commandLoopCancellationToken;
@@ -82,6 +83,11 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the ILogger implementation used for this host.
         /// </summary>
         protected ILogger Logger { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether writing progress is supported.
+        /// </summary>
+        internal protected virtual bool SupportsWriteProgress => false;
 
         #endregion
 
@@ -582,17 +588,74 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
-        ///
+        /// Invoked by <see cref="Cmdlet.WriteProgress(ProgressRecord)" /> to display a progress record.
         /// </summary>
-        /// <param name="sourceId"></param>
-        /// <param name="record"></param>
-        public override void WriteProgress(
+        /// <param name="sourceId">
+        /// Unique identifier of the source of the record. An int64 is used because typically,
+        /// the 'this' pointer of the command from whence the record is originating is used, and
+        /// that may be from a remote Runspace on a 64-bit machine.
+        /// </param>
+        /// <param name="record">
+        /// The record being reported to the host.
+        /// </param>
+        public sealed override void WriteProgress(
             long sourceId,
             ProgressRecord record)
         {
-            this.UpdateProgress(
-                sourceId,
-                ProgressDetails.Create(record));
+            // Maintain old behavior if this isn't overridden.
+            if (!this.SupportsWriteProgress)
+            {
+                this.UpdateProgress(sourceId, ProgressDetails.Create(record));
+                return;
+            }
+
+            // Keep a list of progress records we write so we can automatically
+            // clean them up after the pipeline ends.
+            if (record.RecordType == ProgressRecordType.Completed)
+            {
+                this.currentProgressMessages.Remove(new ProgressKey(sourceId, record));
+            }
+            else
+            {
+                this.currentProgressMessages.Add(new ProgressKey(sourceId, record));
+            }
+
+            this.WriteProgressImpl(sourceId, record);
+        }
+
+        /// <summary>
+        /// Invoked by <see cref="Cmdlet.WriteProgress(ProgressRecord)" /> to display a progress record.
+        /// </summary>
+        /// <param name="sourceId">
+        /// Unique identifier of the source of the record. An int64 is used because typically,
+        /// the 'this' pointer of the command from whence the record is originating is used, and
+        /// that may be from a remote Runspace on a 64-bit machine.
+        /// </param>
+        /// <param name="record">
+        /// The record being reported to the host.
+        /// </param>
+        protected virtual void WriteProgressImpl(long sourceId, ProgressRecord record)
+        {
+        }
+
+        internal void ClearProgress()
+        {
+            const string nonEmptyString = "noop";
+            if (!this.SupportsWriteProgress)
+            {
+                return;
+            }
+
+            foreach (ProgressKey key in this.currentProgressMessages)
+            {
+                // This constructor throws if the activity description is empty even
+                // with completed records.
+                var record = new ProgressRecord(key.ActivityId, nonEmptyString, nonEmptyString);
+                record.RecordType = ProgressRecordType.Completed;
+                this.WriteProgressImpl(key.SourceId, record);
+            }
+
+            this.currentProgressMessages.Clear();
         }
 
         #endregion
@@ -917,6 +980,8 @@ namespace Microsoft.PowerShell.EditorServices
             // The command loop should only be manipulated if it's already started
             if (eventArgs.ExecutionStatus == ExecutionStatus.Aborted)
             {
+                this.ClearProgress();
+
                 // When aborted, cancel any lingering prompts
                 if (this.activePromptHandler != null)
                 {
@@ -932,6 +997,8 @@ namespace Microsoft.PowerShell.EditorServices
                 // the display of the prompt
                 if (eventArgs.ExecutionStatus != ExecutionStatus.Running)
                 {
+                    this.ClearProgress();
+
                     // Execution has completed, start the input prompt
                     this.ShowCommandPrompt();
                     StartCommandLoop();
@@ -948,11 +1015,48 @@ namespace Microsoft.PowerShell.EditorServices
                 (eventArgs.ExecutionStatus == ExecutionStatus.Failed ||
                     eventArgs.HadErrors))
             {
+                this.ClearProgress();
                 this.WriteOutput(string.Empty, true);
                 var unusedTask = this.WritePromptStringToHostAsync(CancellationToken.None);
             }
         }
 
         #endregion
+
+        private readonly struct ProgressKey : IEquatable<ProgressKey>
+        {
+            internal readonly long SourceId;
+
+            internal readonly int ActivityId;
+
+            internal readonly int ParentActivityId;
+
+            internal ProgressKey(long sourceId, ProgressRecord record)
+            {
+                SourceId = sourceId;
+                ActivityId = record.ActivityId;
+                ParentActivityId = record.ParentActivityId;
+            }
+
+            public bool Equals(ProgressKey other)
+            {
+                return SourceId == other.SourceId
+                    && ActivityId == other.ActivityId
+                    && ParentActivityId == other.ParentActivityId;
+            }
+
+            public override int GetHashCode()
+            {
+                // Algorithm from https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 31 + SourceId.GetHashCode();
+                    hash = hash * 31 + ActivityId.GetHashCode();
+                    hash = hash * 31 + ParentActivityId.GetHashCode();
+                    return hash;
+                }
+            }
+        }
     }
 }

--- a/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -650,7 +650,11 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 // This constructor throws if the activity description is empty even
                 // with completed records.
-                var record = new ProgressRecord(key.ActivityId, nonEmptyString, nonEmptyString);
+                var record = new ProgressRecord(
+                    key.ActivityId,
+                    activity: nonEmptyString,
+                    statusDescription: nonEmptyString);
+
                 record.RecordType = ProgressRecordType.Completed;
                 this.WriteProgressImpl(key.SourceId, record);
             }


### PR DESCRIPTION
`ConsoleHost` from `powershell.exe`/`pwsh` still exists within the runspace created at process start. This change grabs the public reference to that host while initializing EditorServicesHost. We can then leverage that host so we can have a much closer to "default" experience.

Resolves #865, #384, PowerShell/vscode-powershell#140, PowerShell/vscode-powershell#1403

This adds support for the following host members:

## $Host.UI

- WriteProgress (including `Write-Progress`)

## $Host.UI.RawUI

- CursorSize (still doesn't work in xterm.js though)
- WindowTitle
- MaxPhysicalWindowSize
- MaxWindowSize
- ReadKey
- GetBufferContents
- ScrollBufferContents
- SetBufferContents

## TODO

- [x] Test RawUI members
- [x] Maybe write sync verison of ReadKey
- [ ] ~Maybe avoid TerminalPSHost* breaking changes (constructors)~ I can't really think of any scenarios where folks would be creating their own `TerminalPSHost*` instances
- [ ] ~Consider thread safety for progress record and `ReadKey` buffers~ Not sure it's necessary, open to suggestions though.