### PR TITLE
Add attach to local runspace.

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -41,9 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="pesterSymbol">The Pester symbol to get CodeLenses for.</param>
         /// <param name="scriptFile">The script file the Pester symbol comes from.</param>
         /// <returns>All CodeLenses for the given Pester symbol.</returns>
-        private CodeLens[] GetPesterLens(
-            PesterSymbolReference pesterSymbol,
-            ScriptFile scriptFile)
+        private CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
         {
             var codeLensResults = new CodeLens[]
             {
@@ -54,7 +52,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Run tests",
-                        new object[] { scriptFile.ClientFilePath, false /* No debug */, pesterSymbol.TestName })),
+                        new object[] {
+                            scriptFile.ClientFilePath,
+                            false /* No debug */,
+                            pesterSymbol.TestName,
+                            pesterSymbol.ScriptRegion?.StartLineNumber })),
 
                 new CodeLens(
                     this,
@@ -63,7 +65,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Debug tests",
-                        new object[] { scriptFile.ClientFilePath, true /* Run in debugger */, pesterSymbol.TestName })),
+                        new object[] {
+                            scriptFile.ClientFilePath,
+                            true /* Run in the debugger */,
+                            pesterSymbol.TestName,
+                            pesterSymbol.ScriptRegion?.StartLineNumber })),
             };
 
             return codeLensResults;
@@ -99,9 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="codeLens">The code lens to resolve.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The given CodeLens, wrapped in a task.</returns>
-        public Task<CodeLens> ResolveCodeLensAsync(
-            CodeLens codeLens,
-            CancellationToken cancellationToken)
+        public Task<CodeLens> ResolveCodeLensAsync(CodeLens codeLens, CancellationToken cancellationToken)
         {
             // This provider has no specific behavior for
             // resolving CodeLenses.

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public string ProcessId { get; set; }
 
-        public int RunspaceId { get; set; }
-
-        public string LocalRunspaceId { get; set; }
+        public string RunspaceId { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
@@ -21,5 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
         public string ProcessId { get; set; }
 
         public int RunspaceId { get; set; }
+
+        public string LocalRunspaceId { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/GetRunspaceRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/GetRunspaceRequest.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Protocol.MessageProtocol;
+
+namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
+{
+    public class GetRunspaceRequest
+    {
+        public static readonly
+            RequestType<object, GetRunspaceResponse[], object, object> Type =
+                RequestType<object, GetRunspaceResponse[], object, object>.Create("powerShell/getRunspace");
+    }
+
+    public class GetRunspaceResponse
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Availability { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.Protocol/LanguageServer/GetRunspaceRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/LanguageServer/GetRunspaceRequest.cs
@@ -10,8 +10,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.LanguageServer
     public class GetRunspaceRequest
     {
         public static readonly
-            RequestType<object, GetRunspaceResponse[], object, object> Type =
-                RequestType<object, GetRunspaceResponse[], object, object>.Create("powerShell/getRunspace");
+            RequestType<string, GetRunspaceResponse[], object, object> Type =
+                RequestType<string, GetRunspaceResponse[], object, object>.Create("powerShell/getRunspace");
     }
 
     public class GetRunspaceResponse

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -439,22 +439,18 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // event gets fired with the attached runspace.
 
                 int runspaceId = 1;
-                if (string.IsNullOrEmpty(attachParams.LocalRunspaceId))
+                if (int.TryParse(attachParams.RunspaceId, out runspaceId))
                 {
-                    runspaceId = attachParams.RunspaceId > 0 ? attachParams.RunspaceId : 1;
-                }
-                else if (int.TryParse(attachParams.LocalRunspaceId, out int localRunspaceId))
-                {
-                    runspaceId = localRunspaceId;
+                    runspaceId = runspaceId > 0 ? runspaceId : 1;
                 }
                 else
                 {
                     Logger.Write(
                         LogLevel.Error,
-                        $"Attach request failed, '{attachParams.LocalRunspaceId}' is an invalid value for the processId.");
+                        $"Attach request failed, '{attachParams.RunspaceId}' is an invalid value for the processId.");
 
                     await requestContext.SendErrorAsync(
-                        "A positive integer must be specified for the LocalRunspaceId field.");
+                        "A positive integer must be specified for the RunspaceId field.");
 
                     return;
                 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -417,18 +417,16 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     return;
                 }
 
-                if (attachParams.ProcessId != "current") {
-                    await _editorSession.PowerShellContext.ExecuteScriptStringAsync(
+                await _editorSession.PowerShellContext.ExecuteScriptStringAsync(
                     $"Enter-PSHostProcess -Id {processId}",
                     errorMessages);
 
-                    if (errorMessages.Length > 0)
-                    {
-                        await requestContext.SendErrorAsync(
-                            $"Could not attach to process '{processId}'");
+                if (errorMessages.Length > 0)
+                {
+                    await requestContext.SendErrorAsync(
+                        $"Could not attach to process '{processId}'");
 
-                        return;
-                    }
+                    return;
                 }
             }
             else if (customPipeNameIsSet)

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -471,11 +471,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // event gets fired with the attached runspace.
 
             int runspaceId = 1;
-            if (int.TryParse(attachParams.RunspaceId, out runspaceId))
-            {
-                runspaceId = runspaceId > 0 ? runspaceId : 1;
-            }
-            else
+            if (!int.TryParse(attachParams.RunspaceId, out runspaceId) || runspaceId <= 0)
             {
                 Logger.Write(
                     LogLevel.Error,

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1235,7 +1235,7 @@ function __Expand-Alias {
                 var runspaces = await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
                 if (runspaces != null)
                 {
-                    foreach (dynamic p in runspaces) //.Select(m => m.BaseObject as Runspace))
+                    foreach (dynamic p in runspaces)
                     {
                         runspaceResponses.Add(
                             new GetRunspaceResponse

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1232,10 +1232,10 @@ function __Expand-Alias {
                 var psCommand = new PSCommand();
                 psCommand.AddCommand("Get-Runspace");
 
-                var runspaces = await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand);
+                IEnumerable<Runspace> runspaces = await editorSession.PowerShellContext.ExecuteCommandAsync<Runspace>(psCommand);
                 if (runspaces != null)
                 {
-                    foreach (dynamic p in runspaces)
+                    foreach (var p in runspaces)
                     {
                         runspaceResponses.Add(
                             new GetRunspaceResponse

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1222,7 +1222,7 @@ function __Expand-Alias {
         }
 
         protected async Task HandleGetRunspaceRequestAsync(
-            object processId,
+            string processId,
             RequestContext<GetRunspaceResponse[]> requestContext)
         {
             var runspaceResponses = new List<GetRunspaceResponse>();
@@ -1233,9 +1233,11 @@ function __Expand-Alias {
                     processId = "current";
                 }
 
+                var isNotCurrentProcess = processId != null && processId != "current";
+
                 var psCommand = new PSCommand();
 
-                if (processId != null && processId.ToString() != "current") {
+                if (isNotCurrentProcess) {
                     psCommand.AddCommand("Enter-PSHostProcess").AddParameter("Id", processId).AddStatement();
                 }
 
@@ -1257,7 +1259,7 @@ function __Expand-Alias {
                     }
                 }
 
-                if (processId != null && processId.ToString() != "current") {
+                if (isNotCurrentProcess) {
                     var exitCommand = new PSCommand();
                     exitCommand.AddCommand("Exit-PSHostProcess");
                     await editorSession.PowerShellContext.ExecuteCommandAsync(exitCommand);


### PR DESCRIPTION
Adds support for attaching to a local runspace. This extends the existing support for attaching to a runspace in a remote process. This enables debugging for modules that create additional runspaces such as ThreadJob, PoshRSJob and UnivesalDashboard. 