### PR TITLE
(GH-879) Add filtering for CodeLens and References

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -56,6 +56,7 @@ $script:RequiredBuildAssets = @{
             'publish/Serilog.Sinks.Async.dll',
             'publish/Serilog.Sinks.Console.dll',
             'publish/Serilog.Sinks.File.dll',
+            'publish/Microsoft.Extensions.FileSystemGlobbing.dll',
             'Microsoft.PowerShell.EditorServices.dll',
             'Microsoft.PowerShell.EditorServices.pdb'
         )

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -727,6 +727,36 @@ function __Expand-Alias {
                     this.editorSession,
                     eventContext);
             }
+
+            // Convert the editor file glob patterns into an array for the Workspace
+            // Both the files.exclude and search.exclude hash tables look like (glob-text, is-enabled):
+            // "files.exclude" : {
+            //     "Makefile": true,
+            //     "*.html": true,
+            //     "build/*": true
+            // }
+            var excludeFilePatterns = new List<string>();
+            if (configChangeParams.Settings.Files?.Exclude != null)
+            {
+                foreach(KeyValuePair<string, bool> patternEntry in configChangeParams.Settings.Files.Exclude)
+                {
+                    if (patternEntry.Value) { excludeFilePatterns.Add(patternEntry.Key); }
+                }
+            }
+            if (configChangeParams.Settings.Search?.Exclude != null)
+            {
+                foreach(KeyValuePair<string, bool> patternEntry in configChangeParams.Settings.Files.Exclude)
+                {
+                    if (patternEntry.Value && !excludeFilePatterns.Contains(patternEntry.Key)) { excludeFilePatterns.Add(patternEntry.Key); }
+                }
+            }
+            editorSession.Workspace.ExcludeFilesGlob = excludeFilePatterns;
+
+            // Convert the editor file search options to Workspace properties
+            if (configChangeParams.Settings.Search?.FollowSymlinks != null)
+            {
+                editorSession.Workspace.FollowSymlinks = configChangeParams.Settings.Search.FollowSymlinks;
+            }
         }
 
         protected async Task HandleDefinitionRequestAsync(

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -6,6 +6,7 @@
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Security;
@@ -331,12 +332,51 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         }
     }
 
-    public class LanguageServerSettingsWrapper
-        {
-            // NOTE: This property is capitalized as 'Powershell' because the
-            // mode name sent from the client is written as 'powershell' and
-            // JSON.net is using camelCasing.
-
-            public LanguageServerSettings Powershell { get; set; }
-        }
+    /// <summary>
+    /// Additional settings from the Language Client that affect Language Server operations but
+    /// do not exist under the 'powershell' section
+    /// </summary>
+    public class EditorFileSettings
+    {
+        /// <summary>
+        /// Exclude files globs consists of hashtable with the key as the glob and a boolean value to indicate if the
+        /// the glob is in effect.
+        /// </summary>
+        public Dictionary<string, bool> Exclude { get; set; }
     }
+
+    /// <summary>
+    /// Additional settings from the Language Client that affect Language Server operations but
+    /// do not exist under the 'powershell' section
+    /// </summary>
+    public class EditorSearchSettings
+    {
+        /// <summary>
+        /// Exclude files globs consists of hashtable with the key as the glob and a boolean value to indicate if the
+        /// the glob is in effect.
+        /// </summary>
+        public Dictionary<string, bool> Exclude { get; set; }
+        /// <summary>
+        /// Whether to follow symlinks when searching
+        /// </summary>
+        public bool FollowSymlinks { get; set; } = true;
+    }
+
+    public class LanguageServerSettingsWrapper
+    {
+        // NOTE: This property is capitalized as 'Powershell' because the
+        // mode name sent from the client is written as 'powershell' and
+        // JSON.net is using camelCasing.
+        public LanguageServerSettings Powershell { get; set; }
+
+        // NOTE: This property is capitalized as 'Files' because the
+        // mode name sent from the client is written as 'files' and
+        // JSON.net is using camelCasing.
+        public EditorFileSettings Files { get; set; }
+
+        // NOTE: This property is capitalized as 'Search' because the
+        // mode name sent from the client is written as 'search' and
+        // JSON.net is using camelCasing.
+        public EditorSearchSettings Search { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.2.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -357,7 +357,7 @@ namespace Microsoft.PowerShell.EditorServices
             var fileMatchResult = matcher.Execute(fsFactory.RootDirectory);
             foreach (FilePatternMatch item in fileMatchResult.Files)
             {
-                yield return Path.Combine(WorkspacePath, item.Path.Replace('/', Path.DirectorySeparatorChar));
+                yield return Path.Combine(WorkspacePath, item.Path);
             }
         }
 

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -11,6 +11,8 @@ using System.IO;
 using System.Security;
 using System.Text;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -22,11 +24,29 @@ namespace Microsoft.PowerShell.EditorServices
     {
         #region Private Fields
 
-        private static readonly string[] s_psFilePatterns = new []
+        // List of all file extensions considered PowerShell files in the .Net Core Framework.
+        private static readonly string[] s_psFileExtensionsCoreFramework =
         {
-            "*.ps1",
-            "*.psm1",
-            "*.psd1"
+            ".ps1",
+            ".psm1",
+            ".psd1"
+        };
+
+        // .Net Core doesn't appear to use the same three letter pattern matching rule although the docs
+        // suggest it should be find the '.ps1xml' files because we search for the pattern '*.ps1'.
+        // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
+        private static readonly string[] s_psFileExtensionsFullFramework =
+        {
+            ".ps1",
+            ".psm1",
+            ".psd1",
+            ".ps1xml"
+        };
+
+        // An array of globs which includes everything.
+        private static readonly string[] s_psIncludeAllGlob = new []
+        {
+            "**/*"
         };
 
         private ILogger logger;
@@ -42,6 +62,16 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         public string WorkspacePath { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default list of file globs to exclude during workspace searches.
+        /// </summary>
+        public List<string> ExcludeFilesGlob { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the workspace should follow symlinks in search operations.
+        /// </summary>
+        public bool FollowSymlinks { get; set; }
+
         #endregion
 
         #region Constructors
@@ -55,6 +85,8 @@ namespace Microsoft.PowerShell.EditorServices
         {
             this.powerShellVersion = powerShellVersion;
             this.logger = logger;
+            this.ExcludeFilesGlob = new List<string>();
+            this.FollowSymlinks = true;
         }
 
         #endregion
@@ -282,135 +314,56 @@ namespace Microsoft.PowerShell.EditorServices
         }
 
         /// <summary>
-        /// Enumerate all the PowerShell (ps1, psm1, psd1) files in the workspace in a recursive manner
+        /// Enumerate all the PowerShell (ps1, psm1, psd1) files in the workspace in a recursive manner, using default values.
         /// </summary>
-        /// <returns>An enumerator over the PowerShell files found in the workspace</returns>
+        /// <returns>An enumerator over the PowerShell files found in the workspace.</returns>
         public IEnumerable<string> EnumeratePSFiles()
+        {
+            return EnumeratePSFiles(
+                ExcludeFilesGlob.ToArray(),
+                s_psIncludeAllGlob,
+                maxDepth: 64,
+                ignoreReparsePoints: !FollowSymlinks
+            );
+        }
+
+        /// <summary>
+        /// Enumerate all the PowerShell (ps1, psm1, psd1) files in the workspace in a recursive manner.
+        /// </summary>
+        /// <returns>An enumerator over the PowerShell files found in the workspace.</returns>
+        public IEnumerable<string> EnumeratePSFiles(
+            string[] excludeGlobs,
+            string[] includeGlobs,
+            int maxDepth,
+            bool ignoreReparsePoints
+        )
         {
             if (WorkspacePath == null || !Directory.Exists(WorkspacePath))
             {
-                return Enumerable.Empty<string>();
+                yield break;
             }
 
-            var foundFiles = new List<string>();
-            this.RecursivelyEnumerateFiles(WorkspacePath, ref foundFiles);
-            return foundFiles;
+            var matcher = new Microsoft.Extensions.FileSystemGlobbing.Matcher();
+            foreach (string pattern in includeGlobs) { matcher.AddInclude(pattern); }
+            foreach (string pattern in excludeGlobs) { matcher.AddExclude(pattern); }
+
+            var fsFactory = new WorkspaceFileSystemWrapperFactory(
+                WorkspacePath,
+                maxDepth,
+                Utils.IsNetCore ? s_psFileExtensionsCoreFramework : s_psFileExtensionsFullFramework,
+                ignoreReparsePoints,
+                logger
+            );
+            var fileMatchResult = matcher.Execute(fsFactory.RootDirectory);
+            foreach (FilePatternMatch item in fileMatchResult.Files)
+            {
+                yield return Path.Combine(WorkspacePath, item.Path.Replace('/', Path.DirectorySeparatorChar));
+            }
         }
 
         #endregion
 
         #region Private Methods
-
-        /// <summary>
-        /// Find PowerShell files recursively down from a given directory path.
-        /// Currently collects files in depth-first order.
-        /// Directory.GetFiles(folderPath, pattern, SearchOption.AllDirectories) would provide this,
-        /// but a cycle in the filesystem will cause that to enter an infinite loop.
-        /// </summary>
-        /// <param name="folderPath">The path of the current directory to find files in</param>
-        /// <param name="foundFiles">The accumulator for files found so far.</param>
-        /// <param name="currDepth">The current depth of the recursion from the original base directory.</param>
-        private void RecursivelyEnumerateFiles(string folderPath, ref List<string> foundFiles, int currDepth = 0)
-        {
-            const int recursionDepthLimit = 64;
-
-            // Look for any PowerShell files in the current directory
-            foreach (string pattern in s_psFilePatterns)
-            {
-                string[] psFiles;
-                try
-                {
-                    psFiles = Directory.GetFiles(folderPath, pattern, SearchOption.TopDirectoryOnly);
-                }
-                catch (DirectoryNotFoundException e)
-                {
-                    this.logger.WriteHandledException(
-                        $"Could not enumerate files in the path '{folderPath}' due to it being an invalid path",
-                        e);
-
-                    continue;
-                }
-                catch (PathTooLongException e)
-                {
-                    this.logger.WriteHandledException(
-                        $"Could not enumerate files in the path '{folderPath}' due to the path being too long",
-                        e);
-
-                    continue;
-                }
-                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
-                {
-                    this.logger.WriteHandledException(
-                        $"Could not enumerate files in the path '{folderPath}' due to the path not being accessible",
-                        e);
-
-                    continue;
-                }
-                catch (Exception e)
-                {
-                    this.logger.WriteHandledException(
-                        $"Could not enumerate files in the path '{folderPath}' due to an exception",
-                        e);
-
-                    continue;
-                }
-
-                foundFiles.AddRange(psFiles);
-            }
-
-            // Prevent unbounded recursion here
-            if (currDepth >= recursionDepthLimit)
-            {
-                this.logger.Write(LogLevel.Warning, $"Recursion depth limit hit for path {folderPath}");
-                return;
-            }
-
-            // Add the recursive directories to search next
-            string[] subDirs;
-            try
-            {
-                subDirs = Directory.GetDirectories(folderPath);
-            }
-            catch (DirectoryNotFoundException e)
-            {
-                this.logger.WriteHandledException(
-                    $"Could not enumerate directories in the path '{folderPath}' due to it being an invalid path",
-                    e);
-
-                return;
-            }
-            catch (PathTooLongException e)
-            {
-                this.logger.WriteHandledException(
-                    $"Could not enumerate directories in the path '{folderPath}' due to the path being too long",
-                    e);
-
-                return;
-            }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
-            {
-                this.logger.WriteHandledException(
-                    $"Could not enumerate directories in the path '{folderPath}' due to the path not being accessible",
-                    e);
-
-                return;
-            }
-            catch (Exception e)
-            {
-                this.logger.WriteHandledException(
-                    $"Could not enumerate directories in the path '{folderPath}' due to an exception",
-                    e);
-
-                return;
-            }
-
-
-            foreach (string subDir in subDirs)
-            {
-                RecursivelyEnumerateFiles(subDir, ref foundFiles, currDepth: currDepth + 1);
-            }
-        }
-
         /// <summary>
         /// Recusrively searches through referencedFiles in scriptFiles
         /// and builds a Dictonary of the file references

--- a/src/PowerShellEditorServices/Workspace/WorkspaceFileSystemWrapper.cs
+++ b/src/PowerShellEditorServices/Workspace/WorkspaceFileSystemWrapper.cs
@@ -1,0 +1,381 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.PowerShell.EditorServices.Utility;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+
+    /// <summary>
+    /// A FileSystem wrapper class which only returns files and directories that the consumer is interested in,
+    /// with a maximum recursion depth and silently ignores most file system errors. Typically this is used by the
+    /// Microsoft.Extensions.FileSystemGlobbing library.
+    /// </summary>
+    public class WorkspaceFileSystemWrapperFactory
+    {
+        private readonly DirectoryInfoBase _rootDirectory;
+        private readonly string[] _allowedExtensions;
+        private readonly bool _ignoreReparsePoints;
+
+        /// <summary>
+        /// Gets the maximum depth of the directories that will be searched
+        /// </summary>
+        internal int MaxRecursionDepth { get; }
+
+        /// <summary>
+        /// Gets the logging facility
+        /// </summary>
+        internal ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the directory where the factory is rooted. Only files and directories at this level, or deeper, will be visible
+        /// by the wrapper
+        /// </summary>
+        public DirectoryInfoBase RootDirectory
+        {
+            get { return _rootDirectory; }
+        }
+
+        /// <summary>
+        /// Creates a new FileWrapper Factory
+        /// </summary>
+        /// <param name="rootPath">The path to the root directory for the factory.</param>
+        /// <param name="recursionDepthLimit">The maximum directory depth.</param>
+        /// <param name="allowedExtensions">An array of file extensions that will be visible from the factory. For example [".ps1", ".psm1"]</param>
+        /// <param name="ignoreReparsePoints">Whether objects which are Reparse Points should be ignored. https://docs.microsoft.com/en-us/windows/desktop/fileio/reparse-points</param>
+        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        public WorkspaceFileSystemWrapperFactory(String rootPath, int recursionDepthLimit, string[] allowedExtensions, bool ignoreReparsePoints, ILogger logger)
+        {
+            MaxRecursionDepth = recursionDepthLimit;
+            _rootDirectory = new WorkspaceFileSystemDirectoryWrapper(this, new DirectoryInfo(rootPath), 0);
+            _allowedExtensions = allowedExtensions;
+            _ignoreReparsePoints = ignoreReparsePoints;
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Creates a wrapped <see cref="DirectoryInfoBase" /> object from <see cref="System.IO.DirectoryInfo" />.
+        /// </summary>
+        internal DirectoryInfoBase CreateDirectoryInfoWrapper(DirectoryInfo dirInfo, int depth) =>
+            new WorkspaceFileSystemDirectoryWrapper(this, dirInfo, depth >= 0 ? depth : 0);
+
+        /// <summary>
+        /// Creates a wrapped <see cref="FileInfoBase" /> object from <see cref="System.IO.FileInfo" />.
+        /// </summary>
+        internal FileInfoBase CreateFileInfoWrapper(FileInfo fileInfo, int depth) =>
+            new WorkspaceFileSystemFileInfoWrapper(this, fileInfo, depth >= 0 ? depth : 0);
+
+        /// <summary>
+        /// Enumerates all objects in the specified directory and ignores most errors
+        /// </summary>
+        internal IEnumerable<FileSystemInfo> SafeEnumerateFileSystemInfos(DirectoryInfo dirInfo)
+        {
+            // Find the subdirectories
+            string[] subDirs;
+            try
+            {
+                subDirs = Directory.GetDirectories(dirInfo.FullName, "*", SearchOption.TopDirectoryOnly);
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate directories in the path '{dirInfo.FullName}' due to it being an invalid path",
+                    e);
+
+                yield break;
+            }
+            catch (PathTooLongException e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate directories in the path '{dirInfo.FullName}' due to the path being too long",
+                    e);
+
+                yield break;
+            }
+            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate directories in the path '{dirInfo.FullName}' due to the path not being accessible",
+                    e);
+
+                yield break;
+            }
+            catch (Exception e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate directories in the path '{dirInfo.FullName}' due to an exception",
+                    e);
+
+                yield break;
+            }
+            foreach (string dirPath in subDirs)
+            {
+                var subDirInfo = new DirectoryInfo(dirPath);
+                if (_ignoreReparsePoints && (subDirInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
+                yield return subDirInfo;
+            }
+
+            // Find the files
+            string[] filePaths;
+            try
+            {
+                filePaths = Directory.GetFiles(dirInfo.FullName, "*", SearchOption.TopDirectoryOnly);
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate files in the path '{dirInfo.FullName}' due to it being an invalid path",
+                    e);
+
+                yield break;
+            }
+            catch (PathTooLongException e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate files in the path '{dirInfo.FullName}' due to the path being too long",
+                    e);
+
+                yield break;
+            }
+            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate files in the path '{dirInfo.FullName}' due to the path not being accessible",
+                    e);
+
+                yield break;
+            }
+            catch (Exception e)
+            {
+                Logger.WriteHandledException(
+                    $"Could not enumerate files in the path '{dirInfo.FullName}' due to an exception",
+                    e);
+
+                yield break;
+            }
+            foreach (string filePath in filePaths)
+            {
+                var fileInfo = new FileInfo(filePath);
+                if (_allowedExtensions == null || _allowedExtensions.Length == 0) { yield return fileInfo; continue; }
+                if (_ignoreReparsePoints && (fileInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
+                foreach (string extension in _allowedExtensions)
+                {
+                    if (fileInfo.Extension == extension) { yield return fileInfo; break; }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wraps an instance of <see cref="System.IO.DirectoryInfo" /> and provides implementation of
+    /// <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.DirectoryInfoBase" />.
+    /// Based on https://github.com/aspnet/Extensions/blob/c087cadf1dfdbd2b8785ef764e5ef58a1a7e5ed0/src/FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+    /// </summary>
+    public class WorkspaceFileSystemDirectoryWrapper : DirectoryInfoBase
+    {
+        private readonly DirectoryInfo _concreteDirectoryInfo;
+        private readonly bool _isParentPath;
+        private readonly WorkspaceFileSystemWrapperFactory _fsWrapperFactory;
+        private readonly int _depth;
+
+        /// <summary>
+        /// Initializes an instance of <see cref="WorkspaceFileSystemDirectoryWrapper" />.
+        /// </summary>
+        public WorkspaceFileSystemDirectoryWrapper(WorkspaceFileSystemWrapperFactory factory, DirectoryInfo directoryInfo, int depth)
+        {
+            _concreteDirectoryInfo = directoryInfo;
+            _isParentPath = (depth == 0);
+            _fsWrapperFactory = factory;
+            _depth = depth;
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
+        {
+            if (!_concreteDirectoryInfo.Exists || _depth >= _fsWrapperFactory.MaxRecursionDepth) { yield break; }
+            foreach (FileSystemInfo fileSystemInfo in _fsWrapperFactory.SafeEnumerateFileSystemInfos(_concreteDirectoryInfo))
+            {
+                switch (fileSystemInfo)
+                {
+                    case DirectoryInfo dirInfo:
+                        yield return _fsWrapperFactory.CreateDirectoryInfoWrapper(dirInfo, _depth + 1);
+                        break;
+                    case FileInfo fileInfo:
+                        yield return _fsWrapperFactory.CreateFileInfoWrapper(fileInfo, _depth);
+                        break;
+                    default:
+                        // We should NEVER get here, but if we do just continue on
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns an instance of <see cref="DirectoryInfoBase" /> that represents a subdirectory.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="name" /> equals '..', this returns the parent directory.
+        /// </remarks>
+        /// <param name="name">The directory name.</param>
+        /// <returns>The directory</returns>
+        public override DirectoryInfoBase GetDirectory(string name)
+        {
+            bool isParentPath = string.Equals(name, "..", StringComparison.Ordinal);
+
+            if (isParentPath) { return ParentDirectory; }
+
+            var dirs = _concreteDirectoryInfo.GetDirectories(name);
+
+            if (dirs.Length == 1) { return _fsWrapperFactory.CreateDirectoryInfoWrapper(dirs[0], _depth + 1); }
+            if (dirs.Length == 0) { return null; }
+            // This shouldn't happen. The parameter name isn't supposed to contain wild card.
+            throw new InvalidOperationException(
+                string.Format(
+                    System.Globalization.CultureInfo.CurrentCulture,
+                    "More than one sub directories are found under {0} with name {1}.",
+                    _concreteDirectoryInfo.FullName, name));
+        }
+
+        /// <inheritdoc />
+        public override FileInfoBase GetFile(string name) => _fsWrapperFactory.CreateFileInfoWrapper(new FileInfo(Path.Combine(_concreteDirectoryInfo.FullName, name)), _depth);
+
+        /// <inheritdoc />
+        public override string Name => _isParentPath ? ".." : _concreteDirectoryInfo.Name;
+
+        /// <summary>
+        /// Returns the full path to the directory.
+        /// </summary>
+        public override string FullName => _concreteDirectoryInfo.FullName;
+
+        /// <summary>
+        /// Safely calculates the parent of this directory, swallowing most errors.
+        /// </summary>
+        private DirectoryInfoBase SafeParentDirectory()
+        {
+            try
+            {
+                return _fsWrapperFactory.CreateDirectoryInfoWrapper(_concreteDirectoryInfo.Parent, _depth - 1);
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to it being an invalid path",
+                    e);
+            }
+            catch (PathTooLongException e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to the path being too long",
+                    e);
+            }
+            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to the path not being accessible",
+                    e);
+            }
+            catch (Exception e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to an exception",
+                    e);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the parent directory. (Overrides <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.ParentDirectory" />).
+        /// </summary>
+        public override DirectoryInfoBase ParentDirectory
+        {
+            get
+            {
+                return SafeParentDirectory();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wraps an instance of <see cref="System.IO.FileInfo" /> to provide implementation of <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileInfoBase" />.
+    /// </summary>
+    public class WorkspaceFileSystemFileInfoWrapper : FileInfoBase
+    {
+        private readonly FileInfo _concreteFileInfo;
+        private readonly WorkspaceFileSystemWrapperFactory _fsWrapperFactory;
+        private readonly int _depth;
+
+        /// <summary>
+        /// Initializes instance of <see cref="FileInfoWrapper" /> to wrap the specified object <see cref="System.IO.FileInfo" />.
+        /// </summary>
+        public WorkspaceFileSystemFileInfoWrapper(WorkspaceFileSystemWrapperFactory factory, FileInfo fileInfo, int depth)
+        {
+            _fsWrapperFactory = factory;
+            _concreteFileInfo = fileInfo;
+            _depth = depth;
+        }
+
+        /// <summary>
+        /// The file name. (Overrides <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.Name" />).
+        /// </summary>
+        public override string Name => _concreteFileInfo.Name;
+
+        /// <summary>
+        /// The full path of the file. (Overrides <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.FullName" />).
+        /// </summary>
+        public override string FullName => _concreteFileInfo.FullName;
+
+        /// <summary>
+        /// Safely calculates the parent of this file, swallowing most errors.
+        /// </summary>
+        private DirectoryInfoBase SafeParentDirectory()
+        {
+            try
+            {
+                return _fsWrapperFactory.CreateDirectoryInfoWrapper(_concreteFileInfo.Directory, _depth);
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteFileInfo.FullName}' due to it being an invalid path",
+                    e);
+            }
+            catch (PathTooLongException e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteFileInfo.FullName}' due to the path being too long",
+                    e);
+            }
+            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteFileInfo.FullName}' due to the path not being accessible",
+                    e);
+            }
+            catch (Exception e)
+            {
+                _fsWrapperFactory.Logger.WriteHandledException(
+                    $"Could not get parent of '{_concreteFileInfo.FullName}' due to an exception",
+                    e);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The directory containing the file. (Overrides <see cref="Microsoft.Extensions.FileSystemGlobbing.Abstractions.FileSystemInfoBase.ParentDirectory" />).
+        /// </summary>
+        public override DirectoryInfoBase ParentDirectory
+        {
+            get
+            {
+                return SafeParentDirectory();
+            }
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/donotfind.ps1
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/donotfind.ps1
@@ -1,0 +1,1 @@
+# donotfind.ps1

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/donotfind.txt
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/donotfind.txt
@@ -1,0 +1,1 @@
+donotfind.txt

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/nestedmodule.psd1
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/nestedmodule.psd1
@@ -1,0 +1,1 @@
+# nestedmodule.psd1

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/nestedmodule.psm1
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/nested/nestedmodule.psm1
@@ -1,0 +1,1 @@
+# nestedmodule.psm1

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.cdxml
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.cdxml
@@ -1,0 +1,1 @@
+<!-- other.cdxml -->

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.ps1xml
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.ps1xml
@@ -1,0 +1,1 @@
+<!-- other.ps1xml -->

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.psrc
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.psrc
@@ -1,0 +1,1 @@
+# other.psrc

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.pssc
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/other/other.pssc
@@ -1,0 +1,1 @@
+# other.pssc

--- a/test/PowerShellEditorServices.Test/Fixtures/Workspace/rootfile.ps1
+++ b/test/PowerShellEditorServices.Test/Fixtures/Workspace/rootfile.ps1
@@ -1,0 +1,1 @@
+# rootfile.ps1

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -27,6 +27,11 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Fixtures\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
   </PropertyGroup>

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -102,18 +102,18 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 // suggest it should be find the '.ps1xml' files because we search for the pattern '*.ps1'
                 // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
                 Assert.Equal(4, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "donotfind.ps1"), fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "nestedmodule.psd1"), fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "nestedmodule.psm1"), fileList[2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/donotfind.ps1", fileList[0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psm1", fileList[2]);
                 Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[3]);
             }
             else
             {
                 Assert.Equal(5, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "donotfind.ps1"), fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "nestedmodule.psd1"), fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "nestedmodule.psm1"), fileList[2]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"other", "other.ps1xml"), fileList[3]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/donotfind.ps1", fileList[0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psm1", fileList[2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath,"other") + "/other.ps1xml", fileList[3]);
                 Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[4]);
             }
         }
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             );
 
             Assert.Equal(2, fileList.Count);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested", "nestedmodule.psd1"), fileList[0]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[0]);
             Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[1]);
         }
 


### PR DESCRIPTION
Fixes #879 

## Code sites

`LanguageSevice.cs` : `HandleDefinitionRequestAsync` (DefinitionRequest Handler)
    `LanguageSevice.cs` : `GetDefinitionOfSymbolAsync`
        - Calls `EnumeratePSFiles` AFTER it parses currently loaded files


`LanguageSevice.cs` : `HandleReferencesRequestAsync` (ReferencesRequest Handler)
    `LanguageSevice.cs` : `FindReferencesOfSymbolAsync`
        - Calls `EnumeratePSFiles`

This is used in the CodeLensFeature, PesterCodeLensProvider and ReferencesCodeLensProvider

`ReferencesCodeLensProvider.cs` : `ResolveCodeLensAsync`
    `LanguageSevice.cs` : `FindReferencesOfSymbolAsync`
        - Calls `EnumeratePSFiles`


## Not used

`LanguageSevice.cs` : `HandleWorkspaceSymbolRequestAsync` (WorkspaceSymbolRequest Handler)
    - This is weird.  It only looks for symbols in the workspace OPENED files, not ALL files
      in the workspace. Seems like an oversight here.

 As per https://github.com/PowerShell/PowerShellEditorServices/commit/ba1c40edd5652a993f9b11facd051b4013e14d96 this is known broken.

---

Previously there were no tests for the Workspace.EnumeratePSFiles method.  This
commit adds tests for EnumeratePSFiles method using a set of static fixture
test files.

Note that the behaviour of EnumeratePSFiles changes depending on the .Net
Framework edition

---

Previously the Workspace.EnumeratePSFiles method could only filter files
based on file extension (*.ps1, *.psm1, *.psd1).  However editor settings tend
to use file glob patterns, but Editor Services did not have a library that could
parse them.

This commit:
* Updates Editor Services to use the Microsoft.Extensions.FileSystemGlobbing
  library
* Updated the build process to include the new FileSystemGlobbing DLL
* The FileSystemGlobbing library uses an abstract file system to search, not
  an actual System.IO.FileSystem object. So to implement the same error handling
  and maximum depth recursion, a WorkspaceFileSystemWrapperFactory is used to
  create the Directory and File objects needed for the globbing library

  The WorkspaceFileSystemWrapperFactory can filter on:
  - Maximum recursion depth
  - Reparse points (Note that these aren't strictly Symlinks on windows.  There
    are many other types of filesystem items which are reparse points
  - File system extension
  - Gracefully ignores any file access errors

* The EnumeratePSFiles has two method signatures.  One with no arguments which
  uses the Workspace object's default values and another where all arguments
  must be specified when enumerating the files

* Adds tests for the EnumeratePSFiles method to ensure that it filters on glob
  and recursion depth.

---

Previously the EnumeratePSFiles method was modified to be able to use globbing
patterns to filter workspace files. This commit

- Modifies the LanguageServerSettings class to capture the 'files' and 'search'
  Settings in order to determine the correct list of glob patterns to use when
  searching.  Currently the 'files.exclude' and 'search.exclude' are merged
  together to generate the list of globs and then set the Workspace settings
  appropriately

- Uses the 'search.followSymlinks' setting to determine whether to ignore
  reparse points

Note that the LanguageClient must be configured to send these settings during
the didChangeConfiguration events otherwise it will default to include
everything.

---

Work in Progress

- [x] Use a globbing library
- [x] Enforce a maxdepth rescursion
- [x] Don't care about errors. Just Carry on!
- [x] Ignore symlinks (Partial.  reparse points are too generic BUT they're Windows only so 🤷‍♂️...)
- [x] Inject `files.exclude`
- [x] More tests to ensure depth and pattern searching are legit
- [x] Remove redundant code
- [x] Address TODOs
- [x] Investigate the ReferencesCodeLensProvider call sites