### PR TITLE
Remove native named pipes implementation

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -257,32 +257,6 @@ function Test-NamedPipeName {
     return !(Test-Path $path)
 }
 
-function Set-NamedPipeMode {
-    param(
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $PipeFile
-    )
-
-    if (($PSVersionTable.PSVersion.Major -le 5) -or $IsWindows) {
-        return
-    }
-
-    chmod $DEFAULT_USER_MODE $PipeFile
-
-    if ($IsLinux) {
-        $mode = /usr/bin/stat -c "%a" $PipeFile
-    }
-    elseif ($IsMacOS) {
-        $mode = /usr/bin/stat -f "%A" $PipeFile
-    }
-
-    if ($mode -ne $DEFAULT_USER_MODE) {
-        ExitWithError "Permissions to the pipe file were not set properly. Expected: $DEFAULT_USER_MODE Actual: $mode for file: $PipeFile"
-    }
-}
-
 LogSection "Console Encoding"
 Log $OutputEncoding
 
@@ -316,9 +290,6 @@ function Set-PipeFileResult {
     )
 
     $ResultTable[$PipeNameKey] = Get-NamedPipePath -PipeName $PipeNameValue
-    if (($PSVersionTable.PSVersion.Major -ge 6) -and ($IsLinux -or $IsMacOS)) {
-        Set-NamedPipeMode -PipeFile $ResultTable[$PipeNameKey]
-    }
 }
 
 # Add BundledModulesPath to $env:PSModulePath

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -142,7 +142,8 @@ function WriteSessionFile($sessionInfo) {
 }
 
 # Are we running in PowerShell 2 or earlier?
-if ($PSVersionTable.PSVersion.Major -le 2) {
+$version = $PSVersionTable.PSVersion
+if (($version.Major -le 2) -or ($version.Major -eq 6 -and $version.Minor -eq 0)) {
     # No ConvertTo-Json on PSv2 and below, so write out the JSON manually
     "{`"status`": `"failed`", `"reason`": `"unsupported`", `"powerShellVersion`": `"$($PSVersionTable.PSVersion.ToString())`"}" |
         Microsoft.PowerShell.Management\Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -160,13 +160,12 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 // Respond to the disconnect request and stop the server
                 await _disconnectRequestContext.SendResultAsync(null);
                 Stop();
+                return;
             }
-            else
-            {
-                await _messageSender.SendEventAsync(
-                    TerminatedEvent.Type,
-                    new TerminatedEvent());
-            }
+
+            await _messageSender.SendEventAsync(
+                TerminatedEvent.Type,
+                new TerminatedEvent());
         }
 
         protected void Stop()


### PR DESCRIPTION
Now that PowerShell Core 6.0 is EOL, all PowerShell Core versions are built on .NET Core 2.1!

This means that we can take advantage of things added to 2.1, namely the CurrentUserOnly flag on PipeOptions which sets up your named pipes so that only the current user can access them.

Because of this, we can remove the Native Pipe implementation that we took from PowerShell Core.

This needs a PR over to vscode-powershell that says PowerShell Core 6.0 is not supported... but the important change is in this PR.