### PR TITLE
Cherry pick PR 1750 to legacy/1.x branch, fix more issues 

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/CodeLensFeature.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 codeLensResponse[i] = codeLensResults[i].ToProtocolCodeLens(
                     new CodeLensData
                     {
-                        Uri = codeLensResults[i].File.ClientFilePath,
+                        Uri = codeLensResults[i].File.DocumentUri,
                         ProviderId = codeLensResults[i].Provider.ProviderId
                     },
                     _jsonSerializer);

--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -3,11 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Commands;
 using Microsoft.PowerShell.EditorServices.Symbols;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
@@ -52,11 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Run tests",
-                        new object[] {
-                            scriptFile.DocumentUri,
-                            false /* No debug */,
-                            pesterSymbol.TestName,
-                            pesterSymbol.ScriptRegion?.StartLineNumber })),
+                        new object[] { scriptFile.ClientFilePath, false /* No debug */, pesterSymbol.TestName })),
 
                 new CodeLens(
                     this,
@@ -65,11 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Debug tests",
-                        new object[] {
-                            scriptFile.DocumentUri,
-                            true /* Run in the debugger */,
-                            pesterSymbol.TestName,
-                            pesterSymbol.ScriptRegion?.StartLineNumber })),
+                        new object[] { scriptFile.ClientFilePath, true /* Run in debugger */, pesterSymbol.TestName })),
             };
 
             return codeLensResults;

--- a/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/PesterCodeLensProvider.cs
@@ -3,13 +3,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Commands;
-using Microsoft.PowerShell.EditorServices.Symbols;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerShell.EditorServices.Commands;
+using Microsoft.PowerShell.EditorServices.Symbols;
 
 namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
@@ -54,7 +52,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Run tests",
-                        new object[] { scriptFile.ClientFilePath, false /* No debug */, pesterSymbol.TestName })),
+                        new object[] {
+                            scriptFile.DocumentUri,
+                            false /* No debug */,
+                            pesterSymbol.TestName,
+                            pesterSymbol.ScriptRegion?.StartLineNumber })),
 
                 new CodeLens(
                     this,
@@ -63,7 +65,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     new ClientCommand(
                         "PowerShell.RunPesterTests",
                         "Debug tests",
-                        new object[] { scriptFile.ClientFilePath, true /* Run in debugger */, pesterSymbol.TestName })),
+                        new object[] {
+                            scriptFile.DocumentUri,
+                            true /* Run in the debugger */,
+                            pesterSymbol.TestName,
+                            pesterSymbol.ScriptRegion?.StartLineNumber })),
             };
 
             return codeLensResults;

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     GetReferenceCountHeader(referenceLocations.Length),
                     new object[]
                     {
-                        codeLens.File.ClientFilePath,
+                        codeLens.File.DocumentUri,
                         codeLens.ScriptExtent.ToRange().Start,
                         referenceLocations,
                     }

--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             // If the file isn't untitled, return a URI-style path
             return
                 !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
-                    ? new Uri("file://" + filePath).AbsoluteUri
+                    ? Workspace.ConvertPathToDocumentUri(filePath)
                     : filePath;
         }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1738,7 +1738,7 @@ function __Expand-Alias {
                 diagnostics.Add(markerDiagnostic);
             }
 
-            correctionIndex[scriptFile.ClientFilePath] = fileCorrections;
+            correctionIndex[scriptFile.DocumentUri] = fileCorrections;
 
             // Always send syntax and semantic errors.  We want to
             // make sure no out-of-date markers are being displayed.
@@ -1746,7 +1746,7 @@ function __Expand-Alias {
                 PublishDiagnosticsNotification.Type,
                 new PublishDiagnosticsNotification
                 {
-                    Uri = scriptFile.ClientFilePath,
+                    Uri = scriptFile.DocumentUri,
                     Diagnostics = diagnostics.ToArray()
                 });
         }

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -3,13 +3,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
+using System.Runtime.InteropServices;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices
 {
@@ -51,6 +52,19 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the path which the editor client uses to identify this file.
         /// </summary>
         public string ClientFilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the file path in LSP DocumentUri form.  The ClientPath property must not be null.
+        /// </summary>
+        public string DocumentUri
+        {
+            get
+            {
+                return this.ClientFilePath == null
+                    ? string.Empty
+                    : Workspace.ConvertPathToDocumentUri(this.ClientFilePath);
+            }
+        }
 
         /// <summary>
         /// Gets or sets a boolean that determines whether

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -350,7 +350,7 @@ namespace Microsoft.PowerShell.EditorServices
                     this.logger.WriteHandledException(
                         $"Could not enumerate files in the path '{folderPath}' due to an exception",
                         e);
-                    
+
                     continue;
                 }
 
@@ -399,7 +399,7 @@ namespace Microsoft.PowerShell.EditorServices
                 this.logger.WriteHandledException(
                     $"Could not enumerate directories in the path '{folderPath}' due to an exception",
                     e);
-                
+
                 return;
             }
 
@@ -622,6 +622,69 @@ namespace Microsoft.PowerShell.EditorServices
             sb.Append(fileUri.Substring(12)); // The rest of the URI after the colon
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Converts a file system path into a DocumentUri required by Language Server Protocol.
+        /// </summary>
+        /// <remarks>
+        /// When sending a document path to a LSP client, the path must be provided as a
+        /// DocumentUri in order to features like the Problems window or peek definition
+        /// to be able to open the specified file.
+        /// </remarks>
+        /// <param name="path">
+        /// A file system path. Note: if the path is already a DocumentUri, it will be returned unmodified.
+        /// </param>
+        /// <returns>The file system path encoded as a DocumentUri.</returns>
+        internal static string ConvertPathToDocumentUri(string path)
+        {
+            const string fileUriPrefix = "file:///";
+
+            if (path.StartsWith("untitled:", StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            if (path.StartsWith(fileUriPrefix, StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On a Linux filesystem, you can have multiple colons in a filename e.g. foo:bar:baz.txt
+                string absoluteUri = new Uri(path).AbsoluteUri;
+
+                // First colon is part of the protocol scheme, see if there are other colons in the path
+                int firstColonIndex = absoluteUri.IndexOf(':');
+                if (absoluteUri.IndexOf(':', firstColonIndex + 1) > firstColonIndex)
+                {
+                    absoluteUri = new StringBuilder(absoluteUri)
+                        .Replace(
+                            oldValue: ":",
+                            newValue: "%3A",
+                            startIndex: firstColonIndex + 1,
+                            count: absoluteUri.Length - firstColonIndex - 1)
+                        .ToString();
+                }
+
+                return absoluteUri;
+            }
+
+            // VSCode file URIs on Windows need the drive letter lowercase, and the colon
+            // URI encoded. System.Uri won't do that, so we manually create the URI.
+            var newUri = new StringBuilder(System.Web.HttpUtility.UrlPathEncode(path));
+            int colonIndex = path.IndexOf(':');
+            if (colonIndex > 0)
+            {
+                int driveLetterIndex = colonIndex - 1;
+                char driveLetter = char.ToLowerInvariant(path[driveLetterIndex]);
+                newUri
+                    .Replace(path[driveLetterIndex], driveLetter, driveLetterIndex, 1)
+                    .Replace(":", "%3A", colonIndex, 1);
+            }
+
+            return newUri.Replace('\\', '/').Insert(0, fileUriPrefix).ToString();
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -636,7 +636,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// A file system path. Note: if the path is already a DocumentUri, it will be returned unmodified.
         /// </param>
         /// <returns>The file system path encoded as a DocumentUri.</returns>
-        internal static string ConvertPathToDocumentUri(string path)
+        public static string ConvertPathToDocumentUri(string path)
         {
             const string fileUriPrefix = "file:///";
 
@@ -650,41 +650,37 @@ namespace Microsoft.PowerShell.EditorServices
                 return path;
             }
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // On a Linux filesystem, you can have multiple colons in a filename e.g. foo:bar:baz.txt
-                string absoluteUri = new Uri(path).AbsoluteUri;
+            string escapedPath = Uri.EscapeDataString(path);
+            var docUriStrBld = new StringBuilder(escapedPath);
 
-                // First colon is part of the protocol scheme, see if there are other colons in the path
-                int firstColonIndex = absoluteUri.IndexOf(':');
-                if (absoluteUri.IndexOf(':', firstColonIndex + 1) > firstColonIndex)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // VSCode file URIs on Windows need the drive letter lowercase.
+                if (path.Contains(':'))
                 {
-                    absoluteUri = new StringBuilder(absoluteUri)
-                        .Replace(
-                            oldValue: ":",
-                            newValue: "%3A",
-                            startIndex: firstColonIndex + 1,
-                            count: absoluteUri.Length - firstColonIndex - 1)
-                        .ToString();
+                    for (int i = 1; i < docUriStrBld.Length - 2; i++)
+                    {
+                        if ((docUriStrBld[i] == '%') && (docUriStrBld[i + 1] == '3') && (docUriStrBld[i + 2] == 'A'))
+                        {
+                            int driveLetterIndex = i - 1;
+                            char driveLetter = char.ToLowerInvariant(docUriStrBld[driveLetterIndex]);
+                            docUriStrBld.Replace(path[driveLetterIndex], driveLetter, driveLetterIndex, 1);
+                            break;
+                        }
+                    }
                 }
 
-                return absoluteUri;
+                // Uri.EscapeDataString goes a bit far, encoding \ chars. Besides VSCode wants / instead of \.
+                docUriStrBld.Replace("%5C", "/");
             }
-
-            // VSCode file URIs on Windows need the drive letter lowercase, and the colon
-            // URI encoded. System.Uri won't do that, so we manually create the URI.
-            var newUri = new StringBuilder(System.Web.HttpUtility.UrlPathEncode(path));
-            int colonIndex = path.IndexOf(':');
-            if (colonIndex > 0)
+            else
             {
-                int driveLetterIndex = colonIndex - 1;
-                char driveLetter = char.ToLowerInvariant(path[driveLetterIndex]);
-                newUri
-                    .Replace(path[driveLetterIndex], driveLetter, driveLetterIndex, 1)
-                    .Replace(":", "%3A", colonIndex, 1);
+                // Uri.EscapeDataString goes a bit far, encoding / chars.
+                docUriStrBld.Replace("%2F", "", 0, 3).Replace("%2F", "/");
             }
 
-            return newUri.Replace('\\', '/').Insert(0, fileUriPrefix).ToString();
+            // ' is not always encoded.  I've seen this in Windows PowerShell.
+            return docUriStrBld.Replace("'", "%27").Insert(0, fileUriPrefix).ToString();
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Workspace/Workspace.cs
+++ b/src/PowerShellEditorServices/Workspace/Workspace.cs
@@ -680,7 +680,7 @@ namespace Microsoft.PowerShell.EditorServices
                 // Because we will prefix later with file:///, remove the initial encoded / if this is an absolute path.
                 // See https://docs.microsoft.com/en-us/dotnet/api/system.uri?view=netframework-4.7.2#implicit-file-path-support
                 // Uri.EscapeDataString goes a bit far, encoding / chars.
-                docUriStrBld.Replace("%2F", "", 0, 3).Replace("%2F", "/");
+                docUriStrBld.Replace("%2F", string.Empty, 0, 3).Replace("%2F", "/");
             }
 
             // ' is not always encoded.  I've seen this in Windows PowerShell.

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         }
 
         [Theory]
-        [MemberData("DebuggerAcceptsScriptArgsTestData")]
+        [MemberData(nameof(DebuggerAcceptsScriptArgsTestData))]
         public async Task DebuggerAcceptsScriptArgs(string[] args)
         {
             // The path is intentionally odd (some escaped chars but not all) because we are testing

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -570,12 +570,43 @@ First line
 
                 Assert.Equal(path, scriptFile.FilePath);
                 Assert.Equal(path, scriptFile.ClientFilePath);
+                Assert.Equal(path, scriptFile.DocumentUri);
                 Assert.True(scriptFile.IsAnalysisEnabled);
                 Assert.True(scriptFile.IsInMemory);
                 Assert.Empty(scriptFile.ReferencedFiles);
                 Assert.Empty(scriptFile.SyntaxMarkers);
                 Assert.Equal(10, scriptFile.ScriptTokens.Length);
                 Assert.Equal(3, scriptFile.FileLines.Count);
+            }
+        }
+
+        [Fact]
+        public void DocumentUriRetunsCorrectStringForAbsolutePath()
+        {
+            string path;
+            ScriptFile scriptFile;
+            var emptyStringReader = new StringReader("");
+
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+            }
+            else
+            {
+                // Test the following only on Linux and macOS.
+                path = "/home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+                path = "/home/NaomiNagata/projects/Rocinate/Proto:Mole:cule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/NaomiNagata/projects/Rocinate/Proto%3AMole%3Acule.ps1", scriptFile.DocumentUri);
+
+                path = "/home/JamesHolden/projects/Rocinate/Proto:Mole\\cule.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/JamesHolden/projects/Rocinate/Proto%3AMole%5Ccule.ps1", scriptFile.DocumentUri);
             }
         }
     }

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -592,6 +592,10 @@ First line
                 path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
                 Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+                path = @"c:\Users\BobbyDraper\projects\Rocinate\foo's_~#-[@] +,;=%.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///c%3A/Users/BobbyDraper/projects/Rocinate/foo%27s_~%23-%5B%40%5D%20%2B%2C%3B%3D%25.ps1", scriptFile.DocumentUri);
             }
             else
             {
@@ -599,6 +603,10 @@ First line
                 path = "/home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
                 Assert.Equal("file:///home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+                path = "/home/BobbyDraper/projects/Rocinate/foo's_~#-[@] +,;=%.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/BobbyDraper/projects/Rocinate/foo%27s_~%23-%5B%40%5D%20%2B%2C%3B%3D%25.ps1", scriptFile.DocumentUri);
 
                 path = "/home/NaomiNagata/projects/Rocinate/Proto:Mole:cule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);


### PR DESCRIPTION
I think I've worked around the compilation issue by replacing `HttpUtility.EncodePath()` with `Uri.EscapeDataPath()`.  The latter API is a much closer match to the RFC 3986 spec that VSCode uses.

Also fixed another bug in the ReferenceCodeLensProvider where it was not properly creating a DocumentUri based on my abusive file name of `foo's_~#-[@] +,;=%.ps1`.  That filename now works when using the symbol ref code lens.