### PR TITLE
backport #881 in a different way

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -49,8 +49,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         // This code only lives in the v1.X of the extension.
         // The 2.x version of the code can be found here:
         // https://github.com/PowerShell/PowerShellEditorServices/pull/881
-        private static readonly Type s_namedPipeConnectionInfoType = typeof(PSObject).GetTypeInfo().Assembly.GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo");
-        private static readonly ConstructorInfo s_namedPipeConnectionInfoCtor = s_namedPipeConnectionInfoType.GetConstructor(new [] { typeof(int) });
+        private static readonly ConstructorInfo s_namedPipeConnectionInfoCtor = typeof(PSObject).GetTypeInfo().Assembly
+            .GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo")
+            ?.GetConstructor(new [] { typeof(int) });
 
         private ILogger Logger;
         private bool profilesLoaded;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         // This code only lives in the v1.X of the extension.
         // The 2.x version of the code can be found here:
         // https://github.com/PowerShell/PowerShellEditorServices/pull/881
-        private static readonly Type s_namedPipeConnectionInfoType = Type.GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo, System.Management.Automation");
+        private static readonly Type s_namedPipeConnectionInfoType = typeof(PSObject).GetTypeInfo().Assembly.GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo");
         private static readonly ConstructorInfo s_namedPipeConnectionInfoCtor = s_namedPipeConnectionInfoType.GetConstructor(new [] { typeof(int) });
 
         private ILogger Logger;

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -1241,13 +1242,10 @@ function __Expand-Alias {
         // The 2.x version of the code can be found here:
         // https://github.com/PowerShell/PowerShellEditorServices/pull/881
         private static Type _namedPipeConnectionInfoType = Type.GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo, System.Management.Automation");
-
+        private static ConstructorInfo _namedPipeConnectionInfoCtor = _namedPipeConnectionInfoType.GetConstructor(new [] { typeof(int) });
         private static Runspace GetRemoteRunspace(int pid)
         {
-            var namedPipeConnectionInfoInstance = Activator.CreateInstance(
-                _namedPipeConnectionInfoType,
-                pid);
-
+            var namedPipeConnectionInfoInstance = _namedPipeConnectionInfoCtor.Invoke(new object[] { pid });
             return RunspaceFactory.CreateRunspace(namedPipeConnectionInfoInstance as RunspaceConnectionInfo);
         }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -18,7 +18,6 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -1237,19 +1236,19 @@ function __Expand-Alias {
         }
 
         // Since the NamedPipeConnectionInfo type is only available in 5.1+
-        // we have to use reflection to support older version of PS.
+        // we have to use Activator to support older version of PS.
         // This code only lives in the v1.X of the extension.
         // The 2.x version of the code can be found here:
         // https://github.com/PowerShell/PowerShellEditorServices/pull/881
         private static Type _namedPipeConnectionInfoType = Type.GetType("System.Management.Automation.Runspaces.NamedPipeConnectionInfo, System.Management.Automation");
-        private static MethodInfo _runspaceFactoryCreateRunspaceMethod = typeof(RunspaceFactory)
-                .GetMethod("CreateRunspace", new Type[] { _namedPipeConnectionInfoType });
-        private Runspace GetRemoteRunspace(int pid)
+
+        private static Runspace GetRemoteRunspace(int pid)
         {
             var namedPipeConnectionInfoInstance = Activator.CreateInstance(
                 _namedPipeConnectionInfoType,
                 pid);
-            return _runspaceFactoryCreateRunspaceMethod.Invoke(null, new [] { namedPipeConnectionInfoInstance }) as Runspace;
+
+            return RunspaceFactory.CreateRunspace(namedPipeConnectionInfoInstance as RunspaceConnectionInfo);
         }
 
         protected async Task HandleGetRunspaceRequestAsync(


### PR DESCRIPTION
Since legacy still supports v3/4, we don't have access to the `NamedPipeConnectionInfo` type.

This will grab that and call `CreateRunspace` via reflection.

This change is only going into legacy... in master it was implemented without reflection in #881.