### PR TITLE
Backport PSSA 1.18.0 PRs

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -198,6 +198,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public bool WhitespaceBeforeOpenParen { get; set; }
         public bool WhitespaceAroundOperator { get; set; }
         public bool WhitespaceAfterSeparator { get; set; }
+        public bool WhitespaceInsideBrace { get; set; }
+        public bool WhitespaceAroundPipe { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
         public bool UseCorrectCasing { get; set; }
@@ -278,7 +280,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         {"CheckOpenBrace", WhitespaceBeforeOpenBrace},
                         {"CheckOpenParen", WhitespaceBeforeOpenParen},
                         {"CheckOperator", WhitespaceAroundOperator},
-                        {"CheckSeparator", WhitespaceAfterSeparator}
+                        {"CheckSeparator", WhitespaceAfterSeparator},
+                        {"CheckInnerBrace", WhitespaceInsideBrace},
+                        {"CheckPipe", WhitespaceAroundPipe},
                     }},
                     {"PSAlignAssignmentStatement", new Hashtable {
                         {"Enable", true},

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -200,6 +200,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public bool WhitespaceAfterSeparator { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
+        public bool UseCorrectCasing { get; set; }
 
 
         /// <summary>
@@ -282,6 +283,9 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     {"PSAlignAssignmentStatement", new Hashtable {
                         {"Enable", true},
                         {"CheckHashtable", AlignPropertyValuePairs}
+                    }},
+                    {"PSUseCorrectCasing", new Hashtable {
+                        {"Enable", true}
                     }},
                 }}
             };

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -141,6 +141,27 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         Stroustrup
     }
 
+    /// <summary>
+    /// Multi-line pipeline style settings.
+    /// </summary>
+    public enum PipelineIndentationStyle
+    {
+        /// <summary>
+        /// After the indentation level only once after the first pipeline and keep this level for the following pipelines.
+        /// </summary>
+        IncreaseIndentationForFirstPipeline,
+
+        /// <summary>
+        /// After every pipeline, keep increasing the indentation.
+        /// </summary>
+        IncreaseIndentationAfterEveryPipeline,
+
+        /// <summary>
+        /// Do not increase indentation level at all after pipeline.
+        /// </summary>
+        NoIndentation
+    }
+
     public class CodeFormattingSettings
     {
         /// <summary>
@@ -172,6 +193,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
         public bool OpenBraceOnSameLine { get; set; }
         public bool NewLineAfterOpenBrace { get; set; }
         public bool NewLineAfterCloseBrace { get; set; }
+        public PipelineIndentationStyle PipelineIndentationStyle { get; set; }
         public bool WhitespaceBeforeOpenBrace { get; set; }
         public bool WhitespaceBeforeOpenParen { get; set; }
         public bool WhitespaceAroundOperator { get; set; }
@@ -247,6 +269,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                     {"PSUseConsistentIndentation", new Hashtable {
                         {"Enable", true},
                         {"IndentationSize", tabSize},
+                        {"PipelineIndentation", PipelineIndentationStyle },
                         {"Kind", insertSpaces ? "space" : "tab"}
                     }},
                     {"PSUseConsistentWhitespace", new Hashtable {


### PR DESCRIPTION
Backport PR #836, #835 (which was no squash-merged!,hence the `-m` option) and #845 (in the same order below):

```sh
git cherry-pick 40cacf64ae7dada8dc5c04c2ad27186a2d001cf6
git cherry-pick -m 1 2316b35c4c05388111c4c2ef02d781c3c4551220
git cherry-pick d8e76fba5be5c792bca34e690c58a502ebdbc2a7
```