### PR TITLE
Cherry pick PR 1750 merge commit to legacy/v1.x, has additional fixes

### DIFF
--- a/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices.Host/CodeLens/ReferencesCodeLensProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             // If the file isn't untitled, return a URI-style path
             return
                 !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
-                    ? new Uri("file://" + filePath).AbsoluteUri
+                    ? Workspace.ConvertPathToDocumentUri(filePath)
                     : filePath;
         }
 

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -594,6 +594,10 @@ First line
                 path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
                 Assert.Equal("file:///c%3A/Users/AmosBurton/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+                path = @"c:\Users\BobbyDraper\projects\Rocinate\foo's_~#-[@] +,;=%.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///c%3A/Users/BobbyDraper/projects/Rocinate/foo%27s_~%23-%5B%40%5D%20%2B%2C%3B%3D%25.ps1", scriptFile.DocumentUri);
             }
             else
             {
@@ -601,6 +605,10 @@ First line
                 path = "/home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
                 Assert.Equal("file:///home/AlexKamal/projects/Rocinate/ProtoMolecule.ps1", scriptFile.DocumentUri);
+
+                path = "/home/BobbyDraper/projects/Rocinate/foo's_~#-[@] +,;=%.ps1";
+                scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);
+                Assert.Equal("file:///home/BobbyDraper/projects/Rocinate/foo%27s_~%23-%5B%40%5D%20%2B%2C%3B%3D%25.ps1", scriptFile.DocumentUri);
 
                 path = "/home/NaomiNagata/projects/Rocinate/Proto:Mole:cule.ps1";
                 scriptFile = new ScriptFile(path, path, emptyStringReader, PowerShellVersion);


### PR DESCRIPTION
This PR merges the original PR 1750 cherry-pick merge down to the legacy/v1.x branch.  Turns out that merge had an additional fix to the reference code lens provider and better conversion to RFC 3986 URIs.