### PR TITLE
Add new ParseError level to ScriptFileMarkerLevel and only have it send parse errors

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1725,7 +1725,7 @@ function __Expand-Alias {
                 {
                     await PublishScriptDiagnosticsAsync(
                         script,
-                        script.SyntaxMarkers,
+                        script.DiagnosticMarkers,
                         correctionIndex,
                         eventSender);
                 }
@@ -1758,12 +1758,12 @@ function __Expand-Alias {
                     semanticMarkers = new List<ScriptFileMarker>();
                 }
 
-                scriptFile.SyntaxMarkers.AddRange(semanticMarkers);
+                scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
 
                 await PublishScriptDiagnosticsAsync(
                     scriptFile,
                     // Concat script analysis errors to any existing parse errors
-                    scriptFile.SyntaxMarkers,
+                    scriptFile.DiagnosticMarkers,
                     correctionIndex,
                     eventSender);
             }

--- a/src/PowerShellEditorServices/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Analysis/AnalysisService.cs
@@ -52,11 +52,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// </summary>
         private static readonly PSObject[] s_emptyDiagnosticResult = new PSObject[0];
 
-        /// <summary>
-        /// An empty script marker result to return when no script markers can be returned.
-        /// </summary>
-        private static readonly List<ScriptFileMarker> s_emptyScriptMarkerResult = new List<ScriptFileMarker>();
-
         private static readonly string[] s_emptyGetRuleResult = new string[0];
 
         /// <summary>
@@ -394,7 +389,7 @@ namespace Microsoft.PowerShell.EditorServices
             else
             {
                 // Return an empty marker list
-                return s_emptyScriptMarkerResult;
+                return new List<ScriptFileMarker>();
             }
         }
 
@@ -412,7 +407,7 @@ namespace Microsoft.PowerShell.EditorServices
             else
             {
                 // Return an empty marker list
-                return s_emptyScriptMarkerResult;
+                return new List<ScriptFileMarker>();
             }
         }
 

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the list of syntax markers found by parsing this
         /// file's contents.
         /// </summary>
-        public List<ScriptFileMarker> SyntaxMarkers
+        public List<ScriptFileMarker> DiagnosticMarkers
         {
             get;
             private set;
@@ -654,7 +654,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             // Translate parse errors into syntax markers
-            this.SyntaxMarkers =
+            this.DiagnosticMarkers =
                 parseErrors
                     .Select(ScriptFileMarker.FromParseError)
                     .ToList();

--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the list of syntax markers found by parsing this
         /// file's contents.
         /// </summary>
-        public ScriptFileMarker[] SyntaxMarkers
+        public List<ScriptFileMarker> SyntaxMarkers
         {
             get;
             private set;
@@ -657,7 +657,7 @@ namespace Microsoft.PowerShell.EditorServices
             this.SyntaxMarkers =
                 parseErrors
                     .Select(ScriptFileMarker.FromParseError)
-                    .ToArray();
+                    .ToList();
 
             // Untitled files have no directory
             // Discussed in https://github.com/PowerShell/PowerShellEditorServices/pull/815.

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -164,31 +164,27 @@ namespace Microsoft.PowerShell.EditorServices
                 };
             }
 
+            string severity = diagnosticRecord.Severity.ToString();
+            if(!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
+            {
+                throw new ArgumentException(
+                string.Format(
+                        "The provided DiagnosticSeverity value '{0}' is unknown.",
+                        severity),
+                    "diagnosticSeverity");
+            }
+
             return new ScriptFileMarker
             {
                 Message = $"{diagnosticRecord.Message as string}",
                 RuleName = $"{diagnosticRecord.RuleName as string}",
-                Level = GetMarkerLevelFromDiagnosticSeverity((diagnosticRecord.Severity as Enum).ToString()),
+                Level = level,
                 ScriptRegion = ScriptRegion.Create(diagnosticRecord.Extent as IScriptExtent),
                 Correction = correction,
                 Source = "PSScriptAnalyzer"
             };
         }
 
-        private static ScriptFileMarkerLevel GetMarkerLevelFromDiagnosticSeverity(
-            string diagnosticSeverity)
-        {
-            if(Enum.TryParse(diagnosticSeverity, out ScriptFileMarkerLevel level))
-            {
-                return level;
-            }
-
-            throw new ArgumentException(
-                string.Format(
-                    "The provided DiagnosticSeverity value '{0}' is unknown.",
-                    diagnosticSeverity),
-                "diagnosticSeverity");
-        }
         #endregion
     }
 }

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -33,20 +33,22 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     public enum ScriptFileMarkerLevel
     {
-        /// <summary>
-        /// The marker represents an informational message.
-        /// </summary>
-        Information = 0,
-
-        /// <summary>
-        /// The marker represents a warning message.
-        /// </summary>
-        Warning,
-
-        /// <summary>
-        /// The marker represents an error message.
-        /// </summary>
-        Error
+        /// <summary>
+        /// Information: This warning is trivial, but may be useful. They are recommended by PowerShell best practice.
+        /// </summary>
+        Information = 0,
+        /// <summary>
+        /// WARNING: This warning may cause a problem or does not follow PowerShell's recommended guidelines.
+        /// </summary>
+        Warning = 1,
+        /// <summary>
+        /// ERROR: This warning is likely to cause a problem or does not follow PowerShell's required guidelines.
+        /// </summary>
+        Error = 2,
+        /// <summary>
+        /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
+        /// </summary>
+        ParseError = 3
     };
 
     /// <summary>
@@ -62,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets or sets the marker's message string.
         /// </summary>
         public string Message { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the ruleName associated with this marker.
         /// </summary>
@@ -176,21 +178,16 @@ namespace Microsoft.PowerShell.EditorServices
         private static ScriptFileMarkerLevel GetMarkerLevelFromDiagnosticSeverity(
             string diagnosticSeverity)
         {
-            switch (diagnosticSeverity)
+            if(Enum.TryParse(diagnosticSeverity, out ScriptFileMarkerLevel level))
             {
-                case "Information":
-                    return ScriptFileMarkerLevel.Information;
-                case "Warning":
-                    return ScriptFileMarkerLevel.Warning;
-                case "Error":
-                    return ScriptFileMarkerLevel.Error;
-                default:
-                    throw new ArgumentException(
-                        string.Format(
-                            "The provided DiagnosticSeverity value '{0}' is unknown.",
-                            diagnosticSeverity),
-                        "diagnosticSeverity");
+                return level;
             }
+
+            throw new ArgumentException(
+                string.Format(
+                    "The provided DiagnosticSeverity value '{0}' is unknown.",
+                    diagnosticSeverity),
+                "diagnosticSeverity");
         }
         #endregion
     }

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             string severity = diagnosticRecord.Severity.ToString();
-            if(!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
+            if (!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
             {
                 throw new ArgumentException(
                 string.Format(

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -168,9 +168,7 @@ namespace Microsoft.PowerShell.EditorServices
             if (!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
             {
                 throw new ArgumentException(
-                string.Format(
-                        "The provided DiagnosticSeverity value '{0}' is unknown.",
-                        severity),
+                    $"The provided DiagnosticSeverity value '{severity}' is unknown.",
                     "diagnosticSeverity");
             }
 

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -550,7 +550,7 @@ First line
             Assert.True(scriptFile.IsAnalysisEnabled);
             Assert.False(scriptFile.IsInMemory);
             Assert.Empty(scriptFile.ReferencedFiles);
-            Assert.Empty(scriptFile.SyntaxMarkers);
+            Assert.Null(scriptFile.SyntaxMarkers);
             Assert.Single(scriptFile.ScriptTokens);
             Assert.Single(scriptFile.FileLines);
         }
@@ -576,7 +576,7 @@ First line
                 Assert.True(scriptFile.IsAnalysisEnabled);
                 Assert.True(scriptFile.IsInMemory);
                 Assert.Empty(scriptFile.ReferencedFiles);
-                Assert.Empty(scriptFile.SyntaxMarkers);
+                Assert.Null(scriptFile.SyntaxMarkers);
                 Assert.Equal(10, scriptFile.ScriptTokens.Length);
                 Assert.Equal(3, scriptFile.FileLines.Count);
             }

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -550,7 +550,7 @@ First line
             Assert.True(scriptFile.IsAnalysisEnabled);
             Assert.False(scriptFile.IsInMemory);
             Assert.Empty(scriptFile.ReferencedFiles);
-            Assert.Null(scriptFile.SyntaxMarkers);
+            Assert.Empty(scriptFile.DiagnosticMarkers);
             Assert.Single(scriptFile.ScriptTokens);
             Assert.Single(scriptFile.FileLines);
         }
@@ -576,7 +576,7 @@ First line
                 Assert.True(scriptFile.IsAnalysisEnabled);
                 Assert.True(scriptFile.IsInMemory);
                 Assert.Empty(scriptFile.ReferencedFiles);
-                Assert.Null(scriptFile.SyntaxMarkers);
+                Assert.Empty(scriptFile.DiagnosticMarkers);
                 Assert.Equal(10, scriptFile.ScriptTokens.Length);
                 Assert.Equal(3, scriptFile.FileLines.Count);
             }


### PR DESCRIPTION
In PSScriptAnalyzer 1.18, they've added parse errors to the diagnostic records that get sent back from PSSA.

This broke us because they come in as a different `ScriptFileMarkerLevel` called `ParseError` that we didn't handle. 

This PR adds that additional enum member and also stops PSES sending its own Parse errors as Diagnostics for vscode in favor of PSSA doing all of the diagnostic sending.

cc @bergmeister 