### PR TITLE
cherry pick #888 Add new ParseError level to ScriptFileMarkerLevel and only have it send parse errors

### DIFF
--- a/src/PowerShellEditorServices/Workspace/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFile.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets the list of syntax markers found by parsing this
         /// file's contents.
         /// </summary>
-        public ScriptFileMarker[] SyntaxMarkers
+        public List<ScriptFileMarker> DiagnosticMarkers
         {
             get;
             private set;
@@ -662,10 +662,10 @@ namespace Microsoft.PowerShell.EditorServices
             }
 
             // Translate parse errors into syntax markers
-            this.SyntaxMarkers =
+            this.DiagnosticMarkers =
                 parseErrors
                     .Select(ScriptFileMarker.FromParseError)
-                    .ToArray();
+                    .ToList();
 
             // Untitled files have no directory
             // Discussed in https://github.com/PowerShell/PowerShellEditorServices/pull/815.

--- a/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Workspace/ScriptFileMarker.cs
@@ -33,20 +33,22 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     public enum ScriptFileMarkerLevel
     {
-        /// <summary>
-        /// The marker represents an informational message.
-        /// </summary>
-        Information = 0,
-
-        /// <summary>
-        /// The marker represents a warning message.
-        /// </summary>
-        Warning,
-
-        /// <summary>
-        /// The marker represents an error message.
-        /// </summary>
-        Error
+        /// <summary>
+        /// Information: This warning is trivial, but may be useful. They are recommended by PowerShell best practice.
+        /// </summary>
+        Information = 0,
+        /// <summary>
+        /// WARNING: This warning may cause a problem or does not follow PowerShell's recommended guidelines.
+        /// </summary>
+        Warning = 1,
+        /// <summary>
+        /// ERROR: This warning is likely to cause a problem or does not follow PowerShell's required guidelines.
+        /// </summary>
+        Error = 2,
+        /// <summary>
+        /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
+        /// </summary>
+        ParseError = 3
     };
 
     /// <summary>
@@ -62,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices
         /// Gets or sets the marker's message string.
         /// </summary>
         public string Message { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the ruleName associated with this marker.
         /// </summary>
@@ -162,36 +164,25 @@ namespace Microsoft.PowerShell.EditorServices
                 };
             }
 
+            string severity = diagnosticRecord.Severity.ToString();
+            if (!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
+            {
+                throw new ArgumentException(
+                    $"The provided DiagnosticSeverity value '{severity}' is unknown.",
+                    "diagnosticSeverity");
+            }
+
             return new ScriptFileMarker
             {
                 Message = $"{diagnosticRecord.Message as string}",
                 RuleName = $"{diagnosticRecord.RuleName as string}",
-                Level = GetMarkerLevelFromDiagnosticSeverity((diagnosticRecord.Severity as Enum).ToString()),
+                Level = level,
                 ScriptRegion = ScriptRegion.Create(diagnosticRecord.Extent as IScriptExtent),
                 Correction = correction,
                 Source = "PSScriptAnalyzer"
             };
         }
 
-        private static ScriptFileMarkerLevel GetMarkerLevelFromDiagnosticSeverity(
-            string diagnosticSeverity)
-        {
-            switch (diagnosticSeverity)
-            {
-                case "Information":
-                    return ScriptFileMarkerLevel.Information;
-                case "Warning":
-                    return ScriptFileMarkerLevel.Warning;
-                case "Error":
-                    return ScriptFileMarkerLevel.Error;
-                default:
-                    throw new ArgumentException(
-                        string.Format(
-                            "The provided DiagnosticSeverity value '{0}' is unknown.",
-                            diagnosticSeverity),
-                        "diagnosticSeverity");
-            }
-        }
         #endregion
     }
 }

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -548,7 +548,7 @@ First line
             Assert.True(scriptFile.IsAnalysisEnabled);
             Assert.False(scriptFile.IsInMemory);
             Assert.Empty(scriptFile.ReferencedFiles);
-            Assert.Empty(scriptFile.SyntaxMarkers);
+            Assert.Empty(scriptFile.DiagnosticMarkers);
             Assert.Single(scriptFile.ScriptTokens);
             Assert.Single(scriptFile.FileLines);
         }
@@ -574,7 +574,7 @@ First line
                 Assert.True(scriptFile.IsAnalysisEnabled);
                 Assert.True(scriptFile.IsInMemory);
                 Assert.Empty(scriptFile.ReferencedFiles);
-                Assert.Empty(scriptFile.SyntaxMarkers);
+                Assert.Empty(scriptFile.DiagnosticMarkers);
                 Assert.Equal(10, scriptFile.ScriptTokens.Length);
                 Assert.Equal(3, scriptFile.FileLines.Count);
             }


### PR DESCRIPTION
Cherry picks #888 to legacy.