### PR TITLE
Clean up and pop dead runspace when using 'attach' for V2

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShell5Operations.cs
+++ b/src/PowerShellEditorServices/Session/PowerShell5Operations.cs
@@ -85,7 +85,11 @@ namespace Microsoft.PowerShell.EditorServices.Session
 
         public void StopCommandInDebugger(PowerShellContext powerShellContext)
         {
-            powerShellContext.CurrentRunspace.Runspace.Debugger.StopProcessCommand();
+            // If the RunspaceAvailability is None, the runspace is dead and we should not try to run anything in it.
+            if (powerShellContext.CurrentRunspace.Runspace.RunspaceAvailability != RunspaceAvailability.None)
+            {
+                powerShellContext.CurrentRunspace.Runspace.Debugger.StopProcessCommand();
+            }
         }
 
         public void ExitNestedPrompt(PSHost host)

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -765,10 +765,16 @@ namespace Microsoft.PowerShell.EditorServices
                         executionOptions,
                         true);
 
-                    throw e;
+                    throw;
                 }
                 finally
                 {
+                    if (this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.None)
+                    {
+                        this.AbortExecution(true);
+                        this.PopRunspace();
+                    }
+
                     // Get the new prompt before releasing the runspace handle
                     if (executionOptions.WriteOutputToHost)
                     {

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -771,7 +771,7 @@ namespace Microsoft.PowerShell.EditorServices
                 {
                     if (this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.None)
                     {
-                        this.AbortExecution(true);
+                        this.AbortExecution(shouldAbortDebugSession: true);
                         this.PopRunspace();
                     }
 

--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -769,6 +769,11 @@ namespace Microsoft.PowerShell.EditorServices
                 }
                 finally
                 {
+                    // If the RunspaceAvailability is None, it means that the runspace we're in is dead.
+                    // If this is the case, we should abort the execution which will clean up the runspace
+                    // (and clean up the debugger) and then pop it off the stack.
+                    // An example of when this happens is when the "attach" debug config is used and the
+                    // process you're attached to dies randomly.
                     if (this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.None)
                     {
                         this.AbortExecution(shouldAbortDebugSession: true);


### PR DESCRIPTION
Previously, when you used the `attach` launch config, if you killed the process that you were attaching to while PSES was attached to it, PSES would go into a bad state and hang forever.

This was because the Runspace wasn't getting cleaned up properly when the connection between the two processes broke.

This change checks for the bad runspace state, cleans up, and pops the bad runspace.

Here's what you see:

```
[DBG]: [Process:42420]: [Runspace1]: PS /Users/tyler/Downloads/anothertestfunc>> 

Command or script completed.
To end the debugging session type the 'Detach' command at the debugger prompt, or type 'Ctrl+C' otherwise.

Leaving debugged runspace on local machine Tylers-MacBook-Pro
The background process reported an error with the following message: "The named pipe target process has ended.".
At line:0 char:0
PS /Users/tyler/Downloads/anothertestfunc>
```

which is very consistent with what pwsh.exe shows when this happens.