### PR TITLE
Switch to current lowercase names for powershell and mdlint exts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "ms-vscode.csharp",
-        "ms-vscode.PowerShell",
-        "EditorConfig.EditorConfig",
-        "DavidAnson.vscode-markdownlint"
+        "ms-vscode.powershell",
+        "davidanson.vscode-markdownlint",
+        "editorconfig.editorconfig"
     ]
 }


### PR DESCRIPTION
A couple of our recommended extensions are now listed on the marketplace with all lowercase names. Switch to the official name casing as currently displayed in the marketplace.