### PR TITLE
Move temp folder into repo to avoid state that causes build errors from time to time when rebuilding locally (and packages have updated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ obj
 objd
 out/
 tmp/
+.tmp
 App_Data
 *.user
 *.sln.cache

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -129,7 +129,10 @@ function Restore-NugetAsmForRuntime {
         [string]$TargetRuntime = $script:WindowsPowerShellFrameworkTarget
     )
 
-    $tmpDir = [System.IO.Path]::GetTempPath()
+    $tmpDir = Join-Path $PSScriptRoot '.tmp'
+    if (-not (Test-Path $tmpDir)) {
+        New-Item -ItemType Directory -Path $tmpDir
+    }
 
     if (-not $DllName) {
         $DllName = "$PackageName.dll"

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -253,6 +253,7 @@ task SetupDotNet -Before Clean, Build, TestHost, TestServer, TestProtocol, Packa
 task Clean {
     exec { & $script:dotnetExe restore }
     exec { & $script:dotnetExe clean }
+    Remove-Item $PSScriptRoot\.tmp -Recurse -Force -ErrorAction Ignore
     Remove-Item $PSScriptRoot\module\PowerShellEditorServices\bin -Recurse -Force -ErrorAction Ignore
     Remove-Item $PSScriptRoot\module\PowerShellEditorServices.VSCode\bin -Recurse -Force -ErrorAction Ignore
     Get-ChildItem -Recurse $PSScriptRoot\src\*.nupkg | Remove-Item -Force -ErrorAction Ignore


### PR DESCRIPTION
Ideally, we should avoid this business and just use NuGet's global cache for that but this is a quickfix for not having to delete those folders in AppData that cause build errors when rebuilding. Now, a clean of the repo will sort this out (which is usually run when building the extension or PSES) to make those annoying local build errors disappear