### PR TITLE
Fix New-EditorFile with no folder or no files open

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -136,6 +136,11 @@ function New-EditorFile {
                         $preview = $true
                     }
 
+                    # Resolve full path before passing to editor
+                    if (!([System.IO.Path]::IsPathRooted($fileName))) {
+                        $fileName = (Resolve-Path $fileName).Path
+                    }
+
                     $psEditor.Workspace.OpenFile($fileName, $preview)
                     $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
                 } else {

--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -138,7 +138,7 @@ function New-EditorFile {
 
                     # Resolve full path before passing to editor
                     if (!([System.IO.Path]::IsPathRooted($fileName))) {
-                        $fileName = (Resolve-Path $fileName).Path
+                        $fileName = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($fileName)
                     }
 
                     $psEditor.Workspace.OpenFile($fileName, $preview)


### PR DESCRIPTION
Without this, the file that gets passed in is relative... When it's relative, it hits this piece of code:

https://github.com/PowerShell/vscode-powershell/blob/d02adc54b1f20d2da7cd5efddae3c0a8400ffe2d/src/features/ExtensionCommands.ts#L533-L536

When it does and there is not Folder or File open in the editor, `vscode.workspace.rootPath` is set to `undefined` and thus causes something like `New-EditorFile -Path ./foo.txt` to fail.

With this change, we resolve any filepaths passed in first before sending them to the client.

fixes #905 