### PR TITLE
Fix faulty netfx check

### DIFF
--- a/src/PowerShellEditorServices/Session/PowerShellContext.cs
+++ b/src/PowerShellEditorServices/Session/PowerShellContext.cs
@@ -34,14 +34,12 @@ namespace Microsoft.PowerShell.EditorServices
     /// </summary>
     public class PowerShellContext : IDisposable, IHostSupportsInteractiveSession
     {
-        private const string DotNetFrameworkDescription = ".NET Framework";
-
         private static readonly Action<Runspace, ApartmentState> s_runspaceApartmentStateSetter;
 
         static PowerShellContext()
         {
             // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection
-            if (RuntimeInformation.FrameworkDescription.Equals(DotNetFrameworkDescription))
+            if (!Utils.IsNetCore)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
@@ -195,7 +193,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             // Windows PowerShell must be hosted in STA mode
             // This must be set on the runspace *before* it is opened
-            if (RuntimeInformation.FrameworkDescription.Equals(DotNetFrameworkDescription))
+            if (s_runspaceApartmentStateSetter != null)
             {
                 s_runspaceApartmentStateSetter(runspace, ApartmentState.STA);
             }

--- a/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
+++ b/src/PowerShellEditorServices/Utility/ExecutionTimer.cs
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/PowerShellEditorServices/Utility/Logging.cs
+++ b/src/PowerShellEditorServices/Utility/Logging.cs
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Collections.Generic;
 using Serilog;

--- a/src/PowerShellEditorServices/Utility/PsesLogger.cs
+++ b/src/PowerShellEditorServices/Utility/PsesLogger.cs
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/PowerShellEditorServices/Utility/Utils.cs
+++ b/src/PowerShellEditorServices/Utility/Utils.cs
@@ -15,6 +15,6 @@ namespace Microsoft.PowerShell.EditorServices
         /// <summary>
         /// True if we are running on .NET Core, false otherwise.
         /// </summary>
-        public static bool IsNetCore { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+        public static bool IsNetCore { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.Ordinal);
     }
 }

--- a/src/PowerShellEditorServices/Utility/Utils.cs
+++ b/src/PowerShellEditorServices/Utility/Utils.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerShell.EditorServices

--- a/src/PowerShellEditorServices/Utility/Utils.cs
+++ b/src/PowerShellEditorServices/Utility/Utils.cs
@@ -1,0 +1,20 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    /// <summary>
+    /// General purpose common utilities to prevent reimplementation.
+    /// </summary>
+    internal static class Utils
+    {
+        /// <summary>
+        /// True if we are running on .NET Core, false otherwise.
+        /// </summary>
+        public static bool IsNetCore { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1571.

Also provides a neater API to check Core vs Desktop.

If we ever have a bug with this, we can also use `typeof(object).Assembly.GetName().Name != "mscorlib"`...