### PR TITLE
Backport: Fix UseCorrectCasing to be actually configurable via"powershell.codeFormatting.useCorrectCasing"

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                         {"CheckHashtable", AlignPropertyValuePairs}
                     }},
                     {"PSUseCorrectCasing", new Hashtable {
-                        {"Enable", true}
+                        {"Enable", UseCorrectCasing}
                     }},
                 }}
             };


### PR DESCRIPTION
Backport of #910 