### PR TITLE
Fix silent failure by using Id for dictionary since multiple pages could have the same title

### DIFF
--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
@@ -16,20 +16,20 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
     {
         protected IMessageSender messageSender;
         protected ILogger logger;
-        private Dictionary<string, TView> viewIndex;
+        private Dictionary<Guid, TView> viewIndex;
 
         public CustomViewFeatureBase(
             IMessageSender messageSender,
             ILogger logger)
         {
-            this.viewIndex = new Dictionary<string, TView>();
+            this.viewIndex = new Dictionary<Guid, TView>();
             this.messageSender = messageSender;
             this.logger = logger;
         }
 
         protected void AddView(TView view)
         {
-            this.viewIndex.Add(view.Title, view);
+            this.viewIndex.Add(view.Id, view);
         }
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
     {
         protected IMessageSender messageSender;
         protected ILogger logger;
-        private Dictionary<Guid, TView> viewIndex;
+        private readonly Dictionary<Guid, TView> viewIndex;
 
         public CustomViewFeatureBase(
             IMessageSender messageSender,


### PR DESCRIPTION
I want to be clear that this is _only_ fixing a bug where:

```powershell
$v = New-VSCodeHtmlContentView -Title foo
$v = New-VSCodeHtmlContentView -Title foo
```

the first time would be an object we expect, the second time, `$v` would be `null` because `.Add` throws if the key already exists. After switching it to use `Id`, there should be no collision.

Ideally this feature could use a `Get-VSCodeHtmlContentView` that pulls from that Dictionary... but that's out of scope.