### PR TITLE
Stop crash when workspace doesn't exist

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -215,7 +215,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             editorSession.Workspace.WorkspacePath = initializeParams.RootPath;
 
             // Set the working directory of the PowerShell session to the workspace path
-            if (editorSession.Workspace.WorkspacePath != null)
+            if (editorSession.Workspace.WorkspacePath != null
+                && Directory.Exists(editorSession.Workspace.WorkspacePath))
             {
                 await editorSession.PowerShellContext.SetWorkingDirectoryAsync(
                     editorSession.Workspace.WorkspacePath,


### PR DESCRIPTION
Fix https://github.com/PowerShell/vscode-powershell/issues/1933.

Checks that the workspace path exists before trying to set it as the working directory.