### PR TITLE
Allow passing RunspaceName

### DIFF
--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public string RunspaceId { get; set; }
 
-        public object RunspaceName { get; set; }
+        public string RunspaceName { get; set; }
 
         public string CustomPipeName { get; set; }
     }

--- a/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
+++ b/src/PowerShellEditorServices.Protocol/DebugAdapter/AttachRequest.cs
@@ -22,6 +22,8 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.DebugAdapter
 
         public string RunspaceId { get; set; }
 
+        public object RunspaceName { get; set; }
+
         public string CustomPipeName { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/DebugAdapter.cs
@@ -471,11 +471,11 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
             // event gets fired with the attached runspace.
 
             string debugRunspaceCmd;
-            if(attachParams.RunspaceName != null)
+            if (attachParams.RunspaceName != null)
             {
                 debugRunspaceCmd = $"\nDebug-Runspace -Name '{attachParams.RunspaceName}'";
             }
-            else if(attachParams.RunspaceId != null)
+            else if (attachParams.RunspaceId != null)
             {
                 if (!int.TryParse(attachParams.RunspaceId, out int runspaceId) || runspaceId <= 0)
                 {


### PR DESCRIPTION
Paired with https://github.com/PowerShell/vscode-powershell/pull/1954

Folks will be able to specify a `runspaceName` in their `launch.json`. For example:

```json
{
    "type": "powershell",
    "request": "attach",
    "runspaceName":"PowerShellManager",
    "customPipeName":"AzureFunctionsPSWorker"
}
```

Some actually informative `launch.json`s instead of `runspaceId: 1`!