### PR TITLE
Refactor build logic to avoid saving modules in subfolders

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -353,14 +353,12 @@ task RestorePsesModules -After Build {
 
             Get-ChildItem -Path $moduleSubfolder -Recurse -Force | Move-Item -Destination $moduleInstallPath -Force
 
-            if ($null -eq (Get-ChildItem -Path $moduleSubfolder -Recurse -Force))
-            {
-                Remove-Item -Path $moduleSubfolder
-            }
-            else
+            if ($null -ne (Get-ChildItem -Path $moduleSubfolder -Recurse -Force))
             {
                 throw "Cannot remove folder $moduleSubfolder because it is not empty!"
             }
+
+            Remove-Item -Path $moduleSubfolder
         }
     }
     Write-Host "`n"


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2027

This PR refactors part of the build logic in `PowerShellEditorServices.build.ps1`, to avoid saving the modules defined in modules.json in versioned subfolders. This allows the modules (currently Plaster and PSScriptAnalyzer) to be loaded when running on PowerShell 3 and 4.

It also moves the modules out of a subfolder in case they're already present and saved from a previous build (wasn't sure if I could assume a clean build).

The build script itself also works in PowerShell 3 and up.

Build and extension both tested on Windows PowerShell 3 and 5.1 & PowerShell 7-preview.