### PR TITLE
WIP Move to runspace synchronizer from completions

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -1453,6 +1453,9 @@ function __Expand-Alias {
             executeTask.ContinueWith(
                 (task) =>
                 {
+                    // This is the equivalent of hitting ENTER in the Integrated Console
+                    // so we need to activate the RunspaceSynchronizer for completions.
+                    RunspaceSynchronizer.Activate();
                     // Return an empty result since the result value is irrelevant
                     // for this request in the LanguageServer
                     return

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -12,12 +12,10 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Management.Automation.Language;
-using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices
 {
     using System.Management.Automation;
-    using System.Management.Automation.Language;
 
     /// <summary>
     /// Provides common operations for the syntax tree of a parsed script.
@@ -73,6 +71,7 @@ namespace Microsoft.PowerShell.EditorServices
 
             if (!RunspaceSynchronizer.IsReadyForEvents)
             {
+                pwsh.Runspace.Name = "RunspaceSynchronizerTargetRunspace";
                 RunspaceSynchronizer.InitializeRunspaces(powerShellContext.CurrentRunspace.Runspace, pwsh.Runspace);
             }
 
@@ -97,7 +96,10 @@ namespace Microsoft.PowerShell.EditorServices
 
                 var stopwatch = new Stopwatch();
 
-                if (powerShellContext.IsPSReadLineEnabled)
+                // Static class members in Windows PowerShell had a thread synchronization issue.
+                // This issue was fixed in PowerShell 6+ so we only use the new completions if PSReadLine is enabled
+                // and we're running in .NET Core.
+                if (powerShellContext.IsPSReadLineEnabled && Utils.IsNetCore)
                 {
                     stopwatch.Start();
 

--- a/src/PowerShellEditorServices/Language/AstOperations.cs
+++ b/src/PowerShellEditorServices/Language/AstOperations.cs
@@ -32,6 +32,8 @@ namespace Microsoft.PowerShell.EditorServices
 
         private static readonly SemaphoreSlim s_completionHandle = AsyncUtils.CreateSimpleLockingSemaphore();
 
+        private static PowerShell pwsh = PowerShell.Create();
+
         /// <summary>
         /// Gets completions for the symbol found in the Ast at
         /// the given file offset.
@@ -69,6 +71,11 @@ namespace Microsoft.PowerShell.EditorServices
                 return null;
             }
 
+            if (!RunspaceSynchronizer.IsReadyForEvents)
+            {
+                RunspaceSynchronizer.InitializeRunspaces(powerShellContext.CurrentRunspace.Runspace, pwsh.Runspace);
+            }
+
             try
             {
                 IScriptPosition cursorPosition = (IScriptPosition)s_extentCloneWithNewOffset.Invoke(
@@ -90,49 +97,65 @@ namespace Microsoft.PowerShell.EditorServices
 
                 var stopwatch = new Stopwatch();
 
+                stopwatch.Start();
+
+                try
+                {
+                return CommandCompletion.CompleteInput(
+                    scriptAst,
+                    currentTokens,
+                    cursorPosition,
+                    options: null,
+                    powershell: pwsh);
+                }
+                finally
+                {
+                    stopwatch.Stop();
+                    logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
+                }
                 // If the current runspace is out of process we can use
                 // CommandCompletion.CompleteInput because PSReadLine won't be taking up the
                 // main runspace.
-                if (powerShellContext.IsCurrentRunspaceOutOfProcess())
-                {
-                    using (RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandleAsync(cancellationToken))
-                    using (PowerShell powerShell = PowerShell.Create())
-                    {
-                        powerShell.Runspace = runspaceHandle.Runspace;
-                        stopwatch.Start();
-                        try
-                        {
-                            return CommandCompletion.CompleteInput(
-                                scriptAst,
-                                currentTokens,
-                                cursorPosition,
-                                options: null,
-                                powershell: powerShell);
-                        }
-                        finally
-                        {
-                            stopwatch.Stop();
-                            logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
-                        }
-                    }
-                }
+                // if (powerShellContext.IsCurrentRunspaceOutOfProcess())
+                // {
+                //     using (RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandleAsync(cancellationToken))
+                //     using (PowerShell powerShell = PowerShell.Create())
+                //     {
+                //         powerShell.Runspace = runspaceHandle.Runspace;
+                //         stopwatch.Start();
+                //         try
+                //         {
+                //             return CommandCompletion.CompleteInput(
+                //                 scriptAst,
+                //                 currentTokens,
+                //                 cursorPosition,
+                //                 options: null,
+                //                 powershell: powerShell);
+                //         }
+                //         finally
+                //         {
+                //             stopwatch.Stop();
+                //             logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
+                //         }
+                //     }
+                // }
 
-                CommandCompletion commandCompletion = null;
-                await powerShellContext.InvokeOnPipelineThreadAsync(
-                    pwsh =>
-                    {
-                        stopwatch.Start();
-                        commandCompletion = CommandCompletion.CompleteInput(
-                            scriptAst,
-                            currentTokens,
-                            cursorPosition,
-                            options: null,
-                            powershell: pwsh);
-                    });
-                stopwatch.Stop();
-                logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
+                // CommandCompletion commandCompletion = null;
+                // await powerShellContext.InvokeOnPipelineThreadAsync(
+                //     pwsh =>
+                //     {
+                //         stopwatch.Start();
+                //         commandCompletion = CommandCompletion.CompleteInput(
+                //             scriptAst,
+                //             currentTokens,
+                //             cursorPosition,
+                //             options: null,
+                //             powershell: pwsh);
+                //     });
+                // stopwatch.Stop();
+                // logger.Write(LogLevel.Verbose, $"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
 
-                return commandCompletion;
+                // return commandCompletion;
             }
             finally
             {

--- a/src/PowerShellEditorServices/Language/RunspaceSychronizer.cs
+++ b/src/PowerShellEditorServices/Language/RunspaceSychronizer.cs
@@ -1,0 +1,281 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Management.Automation.Runspaces;
+using System.Reflection;
+
+namespace Microsoft.PowerShell.EditorServices
+{
+    using System.Management.Automation;
+    /// <summary>
+    /// Does a thing
+    /// </summary>
+    public class RunspaceSynchronizer
+    {
+        /// <summary>
+        /// Does a thing
+        /// </summary>
+        private static bool SourceActionEnabled = false;
+
+        // 'moduleCache' keeps track of all modules imported in the source Runspace.
+        // when there is a `Import-Module -Force`, the new module object would be a
+        // different instance with different hashcode, so we can tell if there is a
+        // force loading of an already loaded module.
+        private static HashSet<PSModuleInfo> moduleCache = new HashSet<PSModuleInfo>();
+
+        // 'variableCache' keeps all global scope variable names and their value type.
+        // As long as the value type doesn't change, we don't need to update the variable
+        // in the target Runspace, because all tab completion needs is the type information.
+        private static Dictionary<string, Type> variableCache = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+
+        private static List<PSModuleInfo> moduleToImport = new List<PSModuleInfo>();
+        private static List<PSVariable> variablesToSet = new List<PSVariable>();
+
+        private static Runspace sourceRunspace;
+        private static Runspace targetRunspace;
+        private static EngineIntrinsics sourceEngineIntrinsics;
+        private static EngineIntrinsics targetEngineIntrinsics;
+
+        private static object syncObj = new object();
+
+        /// <summary>
+        /// Does a thing
+        /// </summary>
+        public static bool IsReadyForEvents { get; private set; }
+
+        private static void HandleRunspaceStateChange(object sender, PSEventArgs args)
+        {
+            if (!SourceActionEnabled)
+            {
+                return;
+            }
+
+            SourceActionEnabled = false;
+
+            try
+            {
+                // Maybe also track the latest history item id ($h = Get-History -Count 1; $h.Id)
+                // to make sure we do the collection only if there was actually any input.
+
+                var newOrChangedModules = new List<PSModuleInfo>();
+                List<PSModuleInfo> modules = ReflectionUtils.GetModules(sourceRunspace);
+                foreach (PSModuleInfo module in modules)
+                {
+                    if (moduleCache.Add(module))
+                    {
+                        newOrChangedModules.Add(module);
+                    }
+                }
+
+
+                var newOrChangedVars = new List<PSVariable>();
+
+                var variables = sourceEngineIntrinsics.GetVariables();
+                foreach (var variable in variables)
+                {
+                    // TODO: first filter out the built-in variables.
+                    if(!variableCache.TryGetValue(variable.Name, out Type value) || value != variable.Value?.GetType())
+                    {
+                        variableCache[variable.Name] = variable.Value?.GetType();
+
+                        newOrChangedVars.Add(variable);
+                    }
+                }
+
+                if (newOrChangedModules.Count == 0 && newOrChangedVars.Count == 0)
+                {
+                    return;
+                }
+
+                lock (syncObj)
+                {
+                    moduleToImport.AddRange(newOrChangedModules);
+                    variablesToSet.AddRange(newOrChangedVars);
+                }
+
+                // Enable the action in target Runspace
+                UpdateTargetRunspaceState();
+            } catch (Exception ex) {
+                System.Console.WriteLine(ex.Message);
+                System.Console.WriteLine(ex.StackTrace);
+            }
+        }
+
+        private static void UpdateTargetRunspaceState()
+        {
+            List<PSModuleInfo> newOrChangedModules;
+            List<PSVariable> newOrChangedVars;
+
+            lock (syncObj)
+            {
+                newOrChangedModules = new List<PSModuleInfo>(moduleToImport);
+                newOrChangedVars = new List<PSVariable>(variablesToSet);
+
+                moduleToImport.Clear();
+                variablesToSet.Clear();
+            }
+
+            if (newOrChangedModules.Count > 0)
+            {
+                // Import the modules with -Force
+                using (PowerShell pwsh = PowerShell.Create())
+                {
+                    pwsh.Runspace = targetRunspace;
+
+                    foreach (PSModuleInfo moduleInfo in newOrChangedModules)
+                    {
+                        if(moduleInfo.Path != null)
+                        {
+                            pwsh.AddCommand("Import-Module")
+                                .AddParameter("Name", moduleInfo.Path)
+                                .AddParameter("Force")
+                                .AddStatement();
+                        }
+                    }
+
+                    pwsh.Invoke();
+                }
+            }
+
+            if (newOrChangedVars.Count > 0)
+            {
+                // Set or update the variables.
+                foreach (PSVariable variable in newOrChangedVars)
+                {
+                    targetEngineIntrinsics.SetVariable(variable);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Does a thing
+        /// </summary>
+        public static void InitializeRunspaces(Runspace runspaceSource, Runspace runspaceTarget)
+        {
+            sourceRunspace = runspaceSource;
+            sourceEngineIntrinsics = ReflectionUtils.GetEngineIntrinsics(sourceRunspace);
+            IsReadyForEvents = true;
+
+            targetRunspace = runspaceTarget;
+            targetEngineIntrinsics = ReflectionUtils.GetEngineIntrinsics(runspaceTarget);
+
+            if(sourceEngineIntrinsics != null)
+            {
+                sourceEngineIntrinsics.Events.SubscribeEvent(
+                    source: null,
+                    eventName: null,
+                    sourceIdentifier: PSEngineEvent.OnIdle.ToString(),
+                    data: null,
+                    handlerDelegate: HandleRunspaceStateChange,
+                    supportEvent: true,
+                    forwardEvent: false);
+            }
+
+            Activate();
+            // Trigger events
+            HandleRunspaceStateChange(sender: null, args: null);
+        }
+
+        /// <summary>
+        /// Does a thing
+        /// </summary>
+        public static void Activate()
+        {
+            SourceActionEnabled = true;
+        }
+
+        internal class ReflectionUtils
+        {
+            private static BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Default;
+
+            internal static List<PSModuleInfo> GetModules(Runspace runspace)
+            {
+                var executionContext = typeof(Runspace)
+                    .GetProperty("ExecutionContext", bindingFlags)
+                    .GetValue(runspace);
+                var ModuleIntrinsics = executionContext.GetType()
+                    .GetProperty("Modules", bindingFlags)
+                    .GetValue(executionContext);
+                var modules = ModuleIntrinsics.GetType()
+                    .GetMethod("GetModules", bindingFlags, null, new Type[] { typeof(string[]), typeof(bool) }, null)
+                    .Invoke(ModuleIntrinsics, new object[] { new string[] { "*" }, false }) as List<PSModuleInfo>;
+                return modules;
+            }
+
+            internal static EngineIntrinsics GetEngineIntrinsics(Runspace runspace)
+            {
+                var executionContext = typeof(Runspace)
+                    .GetProperty("ExecutionContext", bindingFlags)
+                    .GetValue(runspace);
+                var engineIntrinsics = executionContext.GetType()
+                    .GetProperty("EngineIntrinsics", bindingFlags)
+                    .GetValue(executionContext) as EngineIntrinsics;
+                return engineIntrinsics;
+            }
+        }
+    }
+
+    internal static class EngineIntrinsicsExtensions
+    {
+        internal static List<PSVariable> GetVariables(this EngineIntrinsics engineIntrinsics)
+        {
+            List<PSVariable> variables = new List<PSVariable>();
+            foreach (PSObject psobject in engineIntrinsics.GetItems(ItemType.Variable))
+            {
+                var variable = (PSVariable) psobject.BaseObject;
+                variables.Add(variable);
+            }
+            return variables;
+        }
+
+        internal static void SetVariable(this EngineIntrinsics engineIntrinsics, PSVariable variable)
+        {
+            engineIntrinsics.SetItem(ItemType.Variable, variable.Name, variable.Value);
+        }
+
+        private static Collection<PSObject> GetItems(this EngineIntrinsics engineIntrinsics, ItemType itemType)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    return engineIntrinsics.InvokeProvider.Item.Get($@"{itemType.ToString()}:\*");
+                }
+                catch(Exception)
+                {
+                    // InvokeProvider.Item.Get is not threadsafe so let's try a couple times
+                    // to get results from it.
+                }
+            }
+            return new Collection<PSObject>();
+        }
+
+        private static void SetItem(this EngineIntrinsics engineIntrinsics, ItemType itemType, string name, object value)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    engineIntrinsics.InvokeProvider.Item.Set($@"{itemType}:\{name}", value);
+                    return;
+                }
+                catch (Exception)
+                {
+                    // InvokeProvider.Item.Set is not threadsafe so let's try a couple times to set.
+                }
+            }
+        }
+
+        private enum ItemType
+        {
+            Variable,
+            Function,
+            Alias
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Language/RunspaceSynchronizer.cs
+++ b/src/PowerShellEditorServices/Language/RunspaceSynchronizer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices
         // 'variableCache' keeps all global scope variable names and their value type.
         // As long as the value type doesn't change, we don't need to update the variable
         // in the target Runspace, because all tab completion needs is the type information.
-        private static Dictionary<string, Type> variableCache = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, object> variableCache = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
         private static Runspace sourceRunspace;
         private static Runspace targetRunspace;
@@ -132,13 +132,13 @@ namespace Microsoft.PowerShell.EditorServices
             {
                 // If the variable is a magic variable or it's type has not changed, then skip it.
                 if(POWERSHELL_MAGIC_VARIABLES.Contains(variable.Name) ||
-                    (variableCache.TryGetValue(variable.Name, out Type value) && value == variable.Value?.GetType()))
+                    (variableCache.TryGetValue(variable.Name, out object value) && value == variable.Value))
                 {
                     continue;
                 }
 
                 // Add the variable to the cache and mark it as a newOrChanged variable.
-                variableCache[variable.Name] = variable.Value?.GetType();
+                variableCache[variable.Name] = variable.Value;
                 newOrChangedVars.Add(variable);
             }
 

--- a/test/PowerShellEditorServices.Test.Shared/RunspaceSynchronizer/testModule.psm1
+++ b/test/PowerShellEditorServices.Test.Shared/RunspaceSynchronizer/testModule.psm1
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+function Search-Foo {
+    param ()
+    "success"
+}
+
+Set-Alias sfoo Search-Foo
+
+Export-ModuleMember -Function Search-Foo -Alias sfoo

--- a/test/PowerShellEditorServices.Test/Language/RunspaceSynchronizerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/RunspaceSynchronizerTests.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Language
+{
+    using System.Management.Automation;
+
+    public class RunspaceSynchronizerTests
+    {
+        [Trait("Category", "RunspaceSynchronizer")]
+        [Theory]
+        // variable test
+        [InlineData("$foo = 'foo'", "$foo", "foo")]
+        // module functions test
+        [InlineData("Import-Module ../../../../PowerShellEditorServices.Test.Shared/RunspaceSynchronizer/testModule.psm1", "Search-Foo", "success")]
+        // module aliases test
+        [InlineData("Import-Module ../../../../PowerShellEditorServices.Test.Shared/RunspaceSynchronizer/testModule.psm1", "(Get-Alias sfoo).Definition", "Search-Foo")]
+        public void TestRunspaceSynchronizerSyncsData(string sourceScript, string targetScript, object expected)
+        {
+            using (PowerShell pwshSource = PowerShell.Create())
+            using (PowerShell pwshTarget = PowerShell.Create())
+            {
+                RunspaceSynchronizer.InitializeRunspaces(pwshSource.Runspace, pwshTarget.Runspace);
+                AssertExpectedIsSynced(pwshSource, pwshTarget, sourceScript, targetScript, expected);
+            }
+        }
+
+        [Fact]
+        public void TestRunspaceSynchronizerOverwritesTypes()
+        {
+            using (PowerShell pwshSource = PowerShell.Create())
+            using (PowerShell pwshTarget = PowerShell.Create())
+            {
+                RunspaceSynchronizer.InitializeRunspaces(pwshSource.Runspace, pwshTarget.Runspace);
+                AssertExpectedIsSynced(pwshSource, pwshTarget, "$foo = 444", "$foo.GetType().Name", "Int32");
+                AssertExpectedIsSynced(pwshSource, pwshTarget, "$foo = 'change to string'", "$foo.GetType().Name", "String");
+            }
+        }
+
+        private static void AssertExpectedIsSynced(
+            PowerShell pwshSource,
+            PowerShell pwshTarget,
+            string sourceScript,
+            string targetScript,
+            object expected)
+        {
+            pwshSource.AddScript(sourceScript).Invoke();
+            RunspaceSynchronizer.Activate();
+
+            // We need to allow the event some time to fire.
+            System.Threading.Thread.Sleep(1000);
+
+            var results = pwshTarget.AddScript(targetScript).Invoke<PSObject>();
+
+            Assert.Single(results);
+            Assert.NotNull(results[0].BaseObject);
+            Assert.Equal(expected, results[0].BaseObject);
+        }
+    }
+}


### PR DESCRIPTION
This `RunspaceSynchronizer` is used to "sync" the state of one runspace to another.
It's done by copying over variables and reimporting modules into the target runspace.
It doesn't rely on the pipeline of the source runspace at all, instead leverages Reflection to access internal properties and methods on the Runspace type. 

Lastly, in order to trigger the synchronizing, you must call the `Activate` method which will trigger the syncing on the next `OnIdle` event. This is added to the `PSReadLine` key handler for `ENTER`.

Let me know what you think of the overall design. From my tests, it appears to be a bit faster 🙂

The idea is, we separate everything that uses the primary runspace (where PSRL likes to hang out)... and if we can achieve that, we can let PSRL take over the whole thread if it wants... Also, by moving the completions to another runspace, when we add async message handling, Completions wont be blocked by access to the default runspace.

~TODO: add tests~ *added*