### PR TITLE
Update NewtonSoft.Json dependency from 10.0.3 to 11.02 since PS 6.0 has been deprecated

### DIFF
--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\PowerShellEditorServices\PowerShellEditorServices.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="4.5.1" />
   </ItemGroup>

--- a/tools/PsesPsClient/PsesPsClient.csproj
+++ b/tools/PsesPsClient/PsesPsClient.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update NewtonSoft.Json dependency to 11.02 since PowerShell 6.0 has been deprecated. This version of Newtonsoft is the one shipped with PS 6.1, see source code [here](https://github.com/PowerShell/PowerShell/blob/v6.1.0/src/System.Management.Automation/System.Management.Automation.csproj#L12). It's  version cannot be higher than the one shipped in PowerShell due to DLL unloading not being possible.

Context: At the moment, I am experimenting with attaching PSSA as a .Net NuGet library directly to it and it fails because it detects the package downgrade (PSSA already updated Newtonsoft directly after PS 6.0 had been deprecated)

This is a candidate for 1.x as well but the might need to be done manually in that branch itself as its csproj layout is probably too different.