### PR TITLE
v1.x: Update NewtonSoft.Json dependency from 10.0.3 to 11.02 since PS 6.0 has been deprecated. Backport of #981

### DIFF
--- a/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
+++ b/src/PowerShellEditorServices.Host/PowerShellEditorServices.Host.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.3</Version>
+      <Version>11.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>

--- a/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
+++ b/src/PowerShellEditorServices.Protocol/PowerShellEditorServices.Protocol.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\PowerShellEditorServices\PowerShellEditorServices.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3">
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2">
     </PackageReference>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.0-alpha13">
     </PackageReference>

--- a/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
+++ b/test/PowerShellEditorServices.Test.Protocol/PowerShellEditorServices.Test.Protocol.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="more.xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.3</Version>
+      <Version>11.0.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.PowerShell.SDK">
       <Version>6.0.0-alpha13</Version>


### PR DESCRIPTION
v1.x: Update NewtonSoft.Json dependency from 10.0.3 to 11.02 since PS 6.0 has been deprecated. Backport of #981
