### PR TITLE
Add devcontainer support for building in container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1.602
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1.802
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,12 +9,16 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.1.602
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+RUN apt-get update && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \
-    #
+    # Install PowerShell
+    && apt-get install curl gnupg apt-transport-https -y \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list \
+    && apt-get update \
+    && apt-get install -y powershell
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
@@ -34,6 +38,6 @@ ENV DEBIAN_FRONTEND=dialog
 SHELL ["/usr/bin/pwsh", "-Command"]
 
 # Install PowerShell modules required for building and testing
-RUN Install-Module InvokeBuild -Force; Install-Module Pester -Force
-RUN Install-Module platyPS -Force; Install-Module Pester -Force
-RUN Install-Module Pester -Force; Install-Module Pester -Force
+RUN Install-Module InvokeBuild -Force
+RUN Install-Module platyPS -Force
+RUN Install-Module Pester -Force

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1.602
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git procps lsb-release \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PowerShell
+RUN apt-get update \
+    && apt-get install curl gnupg apt-transport-https -y \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list \
+    && apt-get update \
+    && apt-get install -y powershell
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+SHELL ["/usr/bin/pwsh", "-Command"]
+
+# Install PowerShell modules required for building and testing
+RUN Install-Module InvokeBuild -Force; Install-Module Pester -Force
+RUN Install-Module platyPS -Force; Install-Module Pester -Force
+RUN Install-Module Pester -Force; Install-Module Pester -Force

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update && apt-get -y install --no-install-recommends apt-utils 2>&1 \
-    #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \
     # Install PowerShell
@@ -18,7 +17,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends apt-utils 2>&1 
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list \
     && apt-get update \
-    && apt-get install -y powershell
+    && apt-get install -y powershell \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,14 +23,6 @@ RUN apt-get update && apt-get -y install --no-install-recommends apt-utils 2>&1 
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PowerShell
-RUN apt-get update \
-    && apt-get install curl gnupg apt-transport-https -y \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list \
-    && apt-get update \
-    && apt-get install -y powershell
-
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "C# (.NET Core 2.1) and PowerShell on Debian 9",
+	"dockerFile": "Dockerfile",
+
+	"postCreateCommand": "dotnet restore",
+
+	"extensions": [
+        "ms-vscode.csharp",
+        "ms-vscode.powershell",
+        "davidanson.vscode-markdownlint",
+        "editorconfig.editorconfig"
+	]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 
 	"extensions": [
         "ms-vscode.csharp",
-        "ms-vscode.powershell",
+        "ms-vscode.powershell-preview",
         "davidanson.vscode-markdownlint",
         "editorconfig.editorconfig"
 	]


### PR DESCRIPTION
See below link for instructions but basically one just needs to have Docker running in Linux mode with file sharing enabled, install the `ms-vscode-remote.remote-containers` and then just open VS-Code in that folder and use the command to re-open the folder in a container. Because it is early days, one cannot set the default shell to PowerShell yet, but one can define the following user setting to have the shell that is attached to the container starting with PowerShell instead of bash.
`"terminal.integrated.shell.linux": "/usr/bin/pwsh",`
https://code.visualstudio.com/docs/remote/containers