### PR TITLE
powerShell/getPSHostProcesses & powerShell/getRunspace

### DIFF
--- a/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
+++ b/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
@@ -92,7 +92,8 @@ namespace Microsoft.PowerShell.EditorServices.Engine
                     .WithHandler<DocumentRangeFormattingHandler>()
                     .WithHandler<ReferencesHandler>()
                     .WithHandler<DocumentSymbolHandler>()
-                    .WithHandler<DocumentHighlightHandler>();
+                    .WithHandler<DocumentHighlightHandler>()
+                    .WithHandler<PSHostProcessAndRunspaceHandlers>();
 
                 logger.LogInformation("Handlers added");
             });

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
@@ -1,0 +1,21 @@
+using OmniSharp.Extensions.Embedded.MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    [Serial, Method("powerShell/getPSHostProcesses")]
+    public interface IGetPSHostProcessesHandler : IJsonRpcRequestHandler<GetPSHostProcesssesParams, PSHostProcessResponse[]> { }
+
+    public class GetPSHostProcesssesParams : IRequest<PSHostProcessResponse[]> { }
+
+    public class PSHostProcessResponse
+    {
+        public string ProcessName { get; set; }
+
+        public int ProcessId { get; set; }
+
+        public string AppDomainName { get; set; }
+
+        public string MainWindowTitle { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
@@ -1,0 +1,22 @@
+using OmniSharp.Extensions.Embedded.MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    [Serial, Method("powerShell/getRunspace")]
+    public interface IGetRunspaceHandler : IJsonRpcRequestHandler<GetRunspaceParams, RunspaceResponse[]> { }
+
+    public class GetRunspaceParams : IRequest<RunspaceResponse[]>
+    {
+        public string ProcessId {get; set; }
+    }
+
+    public class RunspaceResponse
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Availability { get; set; }
+    }
+}

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    public class PSHostProcessAndRunspaceHandlers : IGetPSHostProcessesHandler, IGetRunspaceHandler
+    {
+        private readonly ILogger<GetVersionHandler> _logger;
+
+        public PSHostProcessAndRunspaceHandlers(ILoggerFactory factory)
+        {
+            _logger = factory.CreateLogger<GetVersionHandler>();
+        }
+
+        public Task<PSHostProcessResponse[]> Handle(GetPSHostProcesssesParams request, CancellationToken cancellationToken)
+        {
+            var psHostProcesses = new List<PSHostProcessResponse>();
+
+            int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
+
+            using (var pwsh = PowerShell.Create())
+            {
+                pwsh.AddCommand("Get-PSHostProcessInfo")
+                    .AddCommand("Where-Object")
+                        .AddParameter("Property", "ProcessId")
+                        .AddParameter("NE")
+                        .AddParameter("Value", processId.ToString());
+
+                var processes = pwsh.Invoke<PSObject>();
+
+                if (processes != null)
+                {
+                    foreach (dynamic p in processes)
+                    {
+                        psHostProcesses.Add(
+                            new PSHostProcessResponse
+                            {
+                                ProcessName = p.ProcessName,
+                                ProcessId = p.ProcessId,
+                                AppDomainName = p.AppDomainName,
+                                MainWindowTitle = p.MainWindowTitle
+                            });
+                    }
+                }
+            }
+
+            return Task.FromResult(psHostProcesses.ToArray());
+        }
+
+        public Task<RunspaceResponse[]> Handle(GetRunspaceParams request, CancellationToken cancellationToken)
+        {
+            IEnumerable<PSObject> runspaces = null;
+
+            if (request.ProcessId == null) {
+                request.ProcessId = "current";
+            }
+
+            // If the processId is a valid int, we need to run Get-Runspace within that process
+            // otherwise just use the current runspace.
+            if (int.TryParse(request.ProcessId, out int pid))
+            {
+                // Create a remote runspace that we will invoke Get-Runspace in.
+                using(var rs = RunspaceFactory.CreateRunspace(new NamedPipeConnectionInfo(pid)))
+                using(var ps = PowerShell.Create())
+                {
+                    rs.Open();
+                    ps.Runspace = rs;
+                    // Returns deserialized Runspaces. For simpler code, we use PSObject and rely on dynamic later.
+                    runspaces = ps.AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace").Invoke<PSObject>();
+                }
+            }
+            else
+            {
+                // TODO: Bring back
+                // var psCommand = new PSCommand().AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace");
+                // var sb = new StringBuilder();
+                // // returns (not deserialized) Runspaces. For simpler code, we use PSObject and rely on dynamic later.
+                // runspaces = await editorSession.PowerShellContext.ExecuteCommandAsync<PSObject>(psCommand, sb);
+            }
+
+            var runspaceResponses = new List<RunspaceResponse>();
+
+            if (runspaces != null)
+            {
+                foreach (dynamic runspace in runspaces)
+                {
+                    runspaceResponses.Add(
+                        new RunspaceResponse
+                        {
+                            Id = runspace.Id,
+                            Name = runspace.Name,
+                            Availability = runspace.RunspaceAvailability.ToString()
+                        });
+                }
+            }
+
+            return Task.FromResult(runspaceResponses.ToArray());
+        }
+    }
+}

--- a/tools/PsesPsClient/PsesPsClient.psd1
+++ b/tools/PsesPsClient/PsesPsClient.psd1
@@ -81,6 +81,7 @@ FunctionsToExport = @(
     'Send-LspDocumentSymbolRequest',
     'Send-LspDocumentHighlightRequest',
     'Send-LspReferencesRequest',
+    'Send-LspGetRunspaceRequest',
     'Send-LspShutdownRequest',
     'Get-LspNotification',
     'Get-LspResponse'

--- a/tools/PsesPsClient/PsesPsClient.psm1
+++ b/tools/PsesPsClient/PsesPsClient.psm1
@@ -487,6 +487,25 @@ function Send-LspDocumentHighlightRequest
     return Send-LspRequest -Client $Client -Method 'textDocument/documentHighlight' -Parameters $documentHighlightParams
 }
 
+function Send-LspGetRunspaceRequest
+{
+    [OutputType([PsesPsClient.LspRequest])]
+    param(
+        [Parameter(Position = 0, Mandatory)]
+        [PsesPsClient.PsesLspClient]
+        $Client,
+
+        [Parameter(Mandatory)]
+        [int]
+        $ProcessId
+    )
+
+    $params = [PowerShellEditorServices.Engine.Services.Handlers.GetRunspaceParams]@{
+        ProcessId = $ProcessId
+    }
+    return Send-LspRequest -Client $Client -Method 'powerShell/getRunspace' -Parameters $params
+}
+
 function Send-LspShutdownRequest
 {
     [OutputType([PsesPsClient.LspRequest])]


### PR DESCRIPTION
love the consistent casing lol

NOTE: this needed a change to vscode-powershell due to a limitation in the omnisharp lib.

They don't support sending just string messages, they have to be a json body. As such, I've changed the parameters for the `getRunspace` request from just a `string` representing the ProcessId to:

```csharp
 public class GetRunspaceParams : IRequest<RunspaceResponse[]>
    {
        public string ProcessId {get; set; }
    }
```

Nothing else should be impacted because I don't think any other editor supports debugging... but this is the FYI.