### PR TITLE
Last LSP messages

### DIFF
--- a/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
+++ b/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
@@ -117,6 +117,8 @@ namespace Microsoft.PowerShell.EditorServices.Engine
                     .WithHandler<TemplateHandlers>()
                     .WithHandler<GetCommentHelpHandler>()
                     .WithHandler<EvaluateHandler>()
+                    .WithHandler<GetCommandHandler>()
+                    .WithHandler<ShowHelpHandler>()
                     .OnInitialize(
                         async (languageServer, request) =>
                         {

--- a/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
+++ b/src/PowerShellEditorServices.Engine/LanguageServer/OmnisharpLanguageServer.cs
@@ -119,6 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Engine
                     .WithHandler<EvaluateHandler>()
                     .WithHandler<GetCommandHandler>()
                     .WithHandler<ShowHelpHandler>()
+                    .WithHandler<ExpandAliasHandler>()
                     .OnInitialize(
                         async (languageServer, request) =>
                         {

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
@@ -1,0 +1,82 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Linq;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices;
+using OmniSharp.Extensions.Embedded.MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    [Serial, Method("powerShell/expandAlias")]
+    public interface IExpandAliasHandler : IJsonRpcRequestHandler<ExpandAliasParams, ExpandAliasResult> { }
+
+    public class ExpandAliasParams : IRequest<ExpandAliasResult>
+    {
+        public string Text { get; set; }
+    }
+
+    public class ExpandAliasResult
+    {
+        public string Text { get; set; }
+    }
+
+    public class ExpandAliasHandler : IExpandAliasHandler
+    {
+        private readonly ILogger _logger;
+        private readonly PowerShellContextService _powerShellContextService;
+
+        public ExpandAliasHandler(ILoggerFactory factory, PowerShellContextService powerShellContextService)
+        {
+            _logger = factory.CreateLogger<ExpandAliasHandler>();
+            _powerShellContextService = powerShellContextService;
+        }
+
+        public async Task<ExpandAliasResult> Handle(ExpandAliasParams request, CancellationToken cancellationToken)
+        {
+            const string script = @"
+function __Expand-Alias {
+
+    param($targetScript)
+
+    [ref]$errors=$null
+
+    $tokens = [System.Management.Automation.PsParser]::Tokenize($targetScript, $errors).Where({$_.type -eq 'command'}) |
+                    Sort-Object Start -Descending
+
+    foreach ($token in  $tokens) {
+        $definition=(Get-Command ('`'+$token.Content) -CommandType Alias -ErrorAction SilentlyContinue).Definition
+
+        if($definition) {
+            $lhs=$targetScript.Substring(0, $token.Start)
+            $rhs=$targetScript.Substring($token.Start + $token.Length)
+
+            $targetScript=$lhs + $definition + $rhs
+       }
+    }
+
+    $targetScript
+}";
+
+            // TODO: Refactor to not rerun the function definition every time.
+            var psCommand = new PSCommand();
+            psCommand
+                .AddScript(script)
+                .AddStatement()
+                .AddCommand("__Expand-Alias")
+                .AddArgument(request.Text);
+            var result = await _powerShellContextService.ExecuteCommandAsync<string>(psCommand);
+
+            return new ExpandAliasResult
+            {
+                Text = result.First()
+            };
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -1,0 +1,81 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices;
+using OmniSharp.Extensions.Embedded.MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    [Serial, Method("powerShell/getCommand")]
+    public interface IGetCommandHandler : IJsonRpcRequestHandler<GetCommandParams, List<PSCommandMessage>> { }
+
+    public class GetCommandParams : IRequest<List<PSCommandMessage>> { }
+
+    /// <summary>
+    /// Describes the message to get the details for a single PowerShell Command
+    /// from the current session
+    /// </summary>
+    public class PSCommandMessage
+    {
+        public string Name { get; set; }
+        public string ModuleName { get; set; }
+        public string DefaultParameterSet { get; set; }
+        public Dictionary<string, ParameterMetadata> Parameters { get; set; }
+        public System.Collections.ObjectModel.ReadOnlyCollection<CommandParameterSetInfo> ParameterSets { get; set; }
+    }
+
+    public class GetCommandHandler : IGetCommandHandler
+    {
+        private readonly ILogger<GetCommandHandler> _logger;
+        private readonly PowerShellContextService _powerShellContextService;
+
+        public GetCommandHandler(ILoggerFactory factory, PowerShellContextService powerShellContextService)
+        {
+            _logger = factory.CreateLogger<GetCommandHandler>();
+            _powerShellContextService = powerShellContextService;
+        }
+
+        public async Task<List<PSCommandMessage>> Handle(GetCommandParams request, CancellationToken cancellationToken)
+        {
+            PSCommand psCommand = new PSCommand();
+
+            // Executes the following:
+            // Get-Command -CommandType Function,Cmdlet,ExternalScript | Select-Object -Property Name,ModuleName | Sort-Object -Property Name
+            psCommand
+                .AddCommand("Microsoft.PowerShell.Core\\Get-Command")
+                    .AddParameter("CommandType", new[] { "Function", "Cmdlet", "ExternalScript" })
+                .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
+                    .AddParameter("Property", new[] { "Name", "ModuleName" })
+                .AddCommand("Microsoft.PowerShell.Utility\\Sort-Object")
+                    .AddParameter("Property", "Name");
+
+            IEnumerable<PSObject> result = await _powerShellContextService.ExecuteCommandAsync<PSObject>(psCommand);
+
+            var commandList = new List<PSCommandMessage>();
+            if (result != null)
+            {
+                foreach (dynamic command in result)
+                {
+                    commandList.Add(new PSCommandMessage
+                    {
+                        Name = command.Name,
+                        ModuleName = command.ModuleName,
+                        Parameters = command.Parameters,
+                        ParameterSets = command.ParameterSets,
+                        DefaultParameterSet = command.DefaultParameterSet
+                    });
+                }
+            }
+
+            return commandList;
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -15,7 +15,7 @@ namespace PowerShellEditorServices.Engine.Services.Handlers
             _logger = factory.CreateLogger<GetVersionHandler>();
         }
 
-        public Task<PowerShellVersionDetails> Handle(GetVersionParams request, CancellationToken cancellationToken)
+        public Task<PowerShellVersion> Handle(GetVersionParams request, CancellationToken cancellationToken)
         {
             var architecture = PowerShellProcessArchitecture.Unknown;
             // This should be changed to using a .NET call sometime in the future... but it's just for logging purposes.
@@ -32,7 +32,8 @@ namespace PowerShellEditorServices.Engine.Services.Handlers
                 }
             }
 
-            return Task.FromResult(new PowerShellVersionDetails {
+            return Task.FromResult(new PowerShellVersion
+            {
                 Version = VersionUtils.PSVersion.ToString(),
                 Edition = VersionUtils.PSEdition,
                 DisplayVersion = VersionUtils.PSVersion.ToString(2),

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
@@ -1,17 +1,43 @@
+using Microsoft.PowerShell.EditorServices.Session;
 using OmniSharp.Extensions.Embedded.MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace PowerShellEditorServices.Engine.Services.Handlers
 {
     [Serial, Method("powerShell/getVersion")]
-    public interface IGetVersionHandler : IJsonRpcRequestHandler<GetVersionParams, PowerShellVersionDetails> { }
+    public interface IGetVersionHandler : IJsonRpcRequestHandler<GetVersionParams, PowerShellVersion> { }
 
-    public class GetVersionParams : IRequest<PowerShellVersionDetails> { }
+    public class GetVersionParams : IRequest<PowerShellVersion> { }
 
-    public class PowerShellVersionDetails {
+    public class PowerShellVersion
+    {
         public string Version { get; set; }
         public string DisplayVersion { get; set; }
         public string Edition { get; set; }
         public string Architecture { get; set; }
+
+        public PowerShellVersion()
+        {
+        }
+
+        public PowerShellVersion(PowerShellVersionDetails versionDetails)
+        {
+            this.Version = versionDetails.VersionString;
+            this.DisplayVersion = $"{versionDetails.Version.Major}.{versionDetails.Version.Minor}";
+            this.Edition = versionDetails.Edition;
+
+            switch (versionDetails.Architecture)
+            {
+                case PowerShellProcessArchitecture.X64:
+                    this.Architecture = "x64";
+                    break;
+                case PowerShellProcessArchitecture.X86:
+                    this.Architecture = "x86";
+                    break;
+                default:
+                    this.Architecture = "Architecture Unknown";
+                    break;
+            }
+        }
     }
 }

--- a/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices.Engine/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
@@ -1,0 +1,81 @@
+﻿//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices;
+using OmniSharp.Extensions.Embedded.MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace PowerShellEditorServices.Engine.Services.Handlers
+{
+    [Serial, Method("powerShell/showHelp")]
+    public interface IShowHelpHandler : IJsonRpcNotificationHandler<ShowHelpParams> { }
+
+    public class ShowHelpParams : IRequest
+    {
+        public string Text { get; set; }
+    }
+
+    public class ShowHelpHandler : IShowHelpHandler
+    {
+        private readonly ILogger _logger;
+        private readonly PowerShellContextService _powerShellContextService;
+
+        public ShowHelpHandler(ILoggerFactory factory, PowerShellContextService powerShellContextService)
+        {
+            _logger = factory.CreateLogger<ShowHelpHandler>();
+            _powerShellContextService = powerShellContextService;
+        }
+
+        public async Task<Unit> Handle(ShowHelpParams request, CancellationToken cancellationToken)
+        {
+            const string CheckHelpScript = @"
+                [CmdletBinding()]
+                param (
+                    [String]$CommandName
+                )
+                try {
+                    $command = Microsoft.PowerShell.Core\Get-Command $CommandName -ErrorAction Stop
+                } catch [System.Management.Automation.CommandNotFoundException] {
+                    $PSCmdlet.ThrowTerminatingError($PSItem)
+                }
+                try {
+                    $helpUri = [Microsoft.PowerShell.Commands.GetHelpCodeMethods]::GetHelpUri($command)
+
+                    $oldSslVersion = [System.Net.ServicePointManager]::SecurityProtocol
+                    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+                    # HEAD means we don't need the content itself back, just the response header
+                    $status = (Microsoft.PowerShell.Utility\Invoke-WebRequest -Method Head -Uri $helpUri -TimeoutSec 5 -ErrorAction Stop).StatusCode
+                    if ($status -lt 400) {
+                        $null = Microsoft.PowerShell.Core\Get-Help $CommandName -Online
+                        return
+                    }
+                } catch {
+                    # Ignore - we want to drop out to Get-Help -Full
+                } finally {
+                    [System.Net.ServicePointManager]::SecurityProtocol = $oldSslVersion
+                }
+
+                return Microsoft.PowerShell.Core\Get-Help $CommandName -Full
+                ";
+
+            string helpParams = request.Text;
+            if (string.IsNullOrEmpty(helpParams)) { helpParams = "Get-Help"; }
+
+            PSCommand checkHelpPSCommand = new PSCommand()
+                .AddScript(CheckHelpScript, useLocalScope: true)
+                .AddArgument(helpParams);
+
+            // TODO: Rather than print the help in the console, we should send the string back
+            //       to VSCode to display in a help pop-up (or similar)
+            await _powerShellContextService.ExecuteCommandAsync<PSObject>(checkHelpPSCommand, sendOutputToHost: true);
+            return Unit.Value;
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -102,8 +102,8 @@ namespace PowerShellEditorServices.Test.E2E
         [Fact]
         public async Task CanSendPowerShellGetVersionRequest()
         {
-            PowerShellVersionDetails details
-                = await LanguageClient.SendRequest<PowerShellVersionDetails>("powerShell/getVersion", new GetVersionParams());
+            PowerShellVersion details
+                = await LanguageClient.SendRequest<PowerShellVersion>("powerShell/getVersion", new GetVersionParams());
 
             if(PwshExe == "powershell")
             {
@@ -796,6 +796,17 @@ function CanSendGetCommentHelpRequest {
             // These always gets returned so this test really just makes sure we get _any_ response.
             Assert.Equal("", evaluateResponseBody.Result);
             Assert.Equal(0, evaluateResponseBody.VariablesReference);
+        }
+
+        [Fact]
+        public async Task CanSendGetCommandRequest()
+        {
+            List<PSCommandMessage> pSCommandMessages =
+                await LanguageClient.SendRequest<List<PSCommandMessage>>("powerShell/getCommand", new GetCommandParams());
+
+            Assert.NotEmpty(pSCommandMessages);
+            // There should be at least 20 commands or so.
+            Assert.True(pSCommandMessages.Count > 20);
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -808,5 +808,20 @@ function CanSendGetCommentHelpRequest {
             // There should be at least 20 commands or so.
             Assert.True(pSCommandMessages.Count > 20);
         }
+
+        [Fact]
+        public async Task CanSendExpandAliasRequest()
+        {
+            ExpandAliasResult expandAliasResult =
+                await LanguageClient.SendRequest<ExpandAliasResult>(
+                    "powerShell/expandAlias",
+                    new ExpandAliasParams
+                    {
+                        Text = "gci"
+                    }
+                );
+
+            Assert.Equal("Get-ChildItem", expandAliasResult.Text);
+        }
     }
 }


### PR DESCRIPTION
This includes:

`powerShell/runspaceChanged` - this one was implemented so strangely... I couldn't really improve much. See my TODO comment about the 4 types.

`powerShell/getCommand` & `powerShell/showHelp` for Command Explorer (@corbob)

`powerShell/expandAlias`

Also, the last 3 sent string messages - csharp-lsp doesn't support this so I wrapped them in very thin object wrappers. As such, this means that there needs to be a change to vscode-powershell which is here:



Lastly, I took an approach of including the handler interface with the implementation in this PR. I like it better and will likely move over others.