### PR TITLE
update modules for PSScriptAnalyzer and PSReadLine.

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
     "PSScriptAnalyzer":{
-        "MinimumVersion":"1.18.2",
+        "MinimumVersion":"1.18.3",
         "MaximumVersion":"1.99",
         "AllowPrerelease":false
     },
@@ -10,7 +10,7 @@
         "AllowPrerelease":false
     },
     "PSReadLine":{
-        "MinimumVersion":"2.0.0-beta4",
+        "MinimumVersion":"2.0.0-beta5",
         "MaximumVersion":"2.1",
         "AllowPrerelease":true
     }


### PR DESCRIPTION
because PSGet was giving us beta4 instead of beta5 for PSReadLine.