### PR TITLE
Fix UNC intellisense backslash

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -2014,8 +2014,8 @@ function __Expand-Alias {
                 // Since we want to use a "tab stop" we need to escape a few things for Textmate to render properly.
                 var sb = new StringBuilder(completionDetails.CompletionText)
                     .Replace(@"\", @"\\")
-                    .Replace("}", "\\}")
-                    .Replace("$", "\\$");
+                    .Replace(@"}", @"\}")
+                    .Replace(@"$", @"\$");
                 completionText = sb.Insert(sb.Length - 1, "$0").ToString();
                 insertTextFormat = InsertTextFormat.Snippet;
             }

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -2010,8 +2010,13 @@ function __Expand-Alias {
                 // This causes the editing cursor to be placed *before* the final quote after completion,
                 // which makes subsequent path completions work. See this part of the LSP spec for details:
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
-                int len = completionDetails.CompletionText.Length;
-                completionText = completionDetails.CompletionText.Insert(len - 1, "$0");
+
+                // Since we want to use a "tab stop" we need to escape a few things for Textmate to render properly.
+                var sb = new StringBuilder(completionDetails.CompletionText)
+                    .Replace("\\", "\\\\")
+                    .Replace("}", "\\}")
+                    .Replace("$", "\\$");
+                completionText = sb.Insert(sb.Length - 1, "$0").ToString();
                 insertTextFormat = InsertTextFormat.Snippet;
             }
 

--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs
@@ -2013,7 +2013,7 @@ function __Expand-Alias {
 
                 // Since we want to use a "tab stop" we need to escape a few things for Textmate to render properly.
                 var sb = new StringBuilder(completionDetails.CompletionText)
-                    .Replace("\\", "\\\\")
+                    .Replace(@"\", @"\\")
                     .Replace("}", "\\}")
                     .Replace("$", "\\$");
                 completionText = sb.Insert(sb.Length - 1, "$0").ToString();


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2116

This escapes all `\` `}` and `$` so that the intellisense is properly escaped for Textmate to render it.

(yes, we don't need to escape `{`)