### PR TITLE
implement powerShell/startDebugger

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
         private readonly Stream _outputStream;
 
         private IJsonRpcServer _jsonRpcServer;
+
         private PowerShellContextService _powerShellContextService;
 
         public PsesDebugServer(

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -1191,7 +1191,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         public event EventHandler<DebuggerStoppedEventArgs> DebuggerStopped;
 
-        private async void OnDebuggerStopAsync(object sender, DebuggerStopEventArgs e)
+        internal async void OnDebuggerStopAsync(object sender, DebuggerStopEventArgs e)
         {
             bool noScriptName = false;
             string localScriptPath = e.InvocationInfo.ScriptName;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -73,9 +73,18 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 if (_debugService.IsDebuggerStopped)
                 {
-                    // If this is an interactive session and there's a pending breakpoint,
-                    // send that information along to the debugger client
-                    _debugEventHandlerService.TriggerDebuggerStopped(_debugService.CurrentDebuggerStoppedEventArgs);
+                    if (_debugService.CurrentDebuggerStoppedEventArgs != null)
+                    {
+                        // If this is an interactive session and there's a pending breakpoint,
+                        // send that information along to the debugger client
+                        _debugEventHandlerService.TriggerDebuggerStopped(_debugService.CurrentDebuggerStoppedEventArgs);
+                    }
+                    else
+                    {
+                        // If this is an interactive session and there's a pending breakpoint that has not been propagated through
+                        // the debug service, fire the debug service's OnDebuggerStop event.
+                        _debugService.OnDebuggerStopAsync(null, _powerShellContextService.CurrentDebuggerStopEventArgs);
+                    }
                 }
             }
 


### PR DESCRIPTION
This adds back support for the `powerShell/startDebugger` message with the added feature of being able to start the debugger even on a fresh open of vscode.

I couldn't find the issue, but there's a limitation in PSES currently where you have to start debugging at least once before the `startDebugger` message gets fired. This PR fixes that.