### PR TITLE
legacy/1.x: Fix 'git cherry-pick' merge error causing pipelineIndentationStyle setting to not be correctly wired up

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -264,6 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 {"PSUseConsistentIndentation", new Hashtable {
                     {"Enable", true},
                     {"IndentationSize", tabSize},
+                    {"PipelineIndentation", PipelineIndentationStyle },
                     {"Kind", insertSpaces ? "space" : "tab"}
                 }},
                 {"PSUseConsistentWhitespace", new Hashtable {


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2214

The backport PR #1024 did a correct cherry-pick but git did not merge the code change correctly and undid a line that was added in an earlier PR.

Locally verified.