### PR TITLE
legacy/1.x: Update minimum PSSA version to 1.18.3

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
     "PSScriptAnalyzer":{
-        "MinimumVersion":"1.18.2",
+        "MinimumVersion":"1.18.3",
         "MaximumVersion":"1.99",
         "AllowPrerelease":false
     },


### PR DESCRIPTION
This does not change anything (because it already pulls 1.18.3 down by default) but makes it consistent with the master branch to keep the difference between the 2 branches minimal to avoid future conflicts.