### PR TITLE
New colors supported by PS7

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
@@ -90,6 +90,28 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             /// <summary>
+            /// The Accent Color for Formatting
+            /// </summary>
+            public ConsoleColor FormatAccentColor
+            {
+                get
+                { return _hostUserInterface.FormatAccentColor; }
+                set
+                { _hostUserInterface.FormatAccentColor = value; }
+            }
+
+            /// <summary>
+            /// The Accent Color for Error
+            /// </summary>
+            public ConsoleColor ErrorAccentColor
+            {
+                get
+                { return _hostUserInterface.ErrorAccentColor; }
+                set
+                { _hostUserInterface.ErrorAccentColor = value; }
+            }
+
+            /// <summary>
             /// The ForegroundColor for Error
             /// </summary>
             public ConsoleColor ErrorForegroundColor

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -789,6 +789,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         internal static ConsoleColor BackgroundColor { get; set; }
 
+        internal ConsoleColor FormatAccentColor { get; set; } = ConsoleColor.Green;
+        internal ConsoleColor ErrorAccentColor { get; set; } = ConsoleColor.Cyan;
+
         internal ConsoleColor ErrorForegroundColor { get; set; } = ConsoleColor.Red;
         internal ConsoleColor ErrorBackgroundColor { get; set; } = BackgroundColor;
 


### PR DESCRIPTION
Add FormatAccentColor and ErrorAccentColor used by PS7 for new ConciseView and Resolve-ErrorRecord cmdlets (and likely tables and list formatting)