### PR TITLE
Rework log builder to support logging to files

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -66,6 +66,8 @@ $script:RequiredBuildAssets = @{
             'publish/OmniSharp.Extensions.LanguageServer.dll',
             'publish/OmniSharp.Extensions.DebugAdapter.dll',
             'publish/OmniSharp.Extensions.DebugAdapter.Server.dll',
+            'publish/MediatR.dll',
+            'publish/MediatR.Extensions.Microsoft.DependencyInjection.dll',
             'publish/runtimes/linux-64/native/libdisablekeyecho.so',
             'publish/runtimes/osx-64/native/libdisablekeyecho.dylib',
             'publish/Serilog.dll',

--- a/src/PowerShellEditorServices/Hosting/EditorServicesHost.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesHost.cs
@@ -189,6 +189,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             Log.Logger = new LoggerConfiguration().Enrich.FromLogContext()
                             .WriteTo.File(logFilePath)
+                            .MinimumLevel.Verbose()
                             .CreateLogger();
             _factory = new LoggerFactory().AddSerilog(Log.Logger);
             _logger = _factory.CreateLogger<EditorServicesHost>();

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -15,8 +15,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Handlers;
 using Microsoft.PowerShell.EditorServices.Hosting;
 using Microsoft.PowerShell.EditorServices.Services;
-using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using OmniSharp.Extensions.LanguageServer.Server;
+using Serilog;
 
 namespace Microsoft.PowerShell.EditorServices.Server
 {
@@ -59,59 +59,54 @@ namespace Microsoft.PowerShell.EditorServices.Server
         {
             LanguageServer = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
             {
-                options.AddDefaultLoggingProvider();
-                options.LoggerFactory = LoggerFactory;
-                ILogger logger = options.LoggerFactory.CreateLogger("OptionsStartup");
-                options.Services = new ServiceCollection()
-                    .AddSingleton<WorkspaceService>()
-                    .AddSingleton<SymbolsService>()
-                    .AddSingleton<ConfigurationService>()
-                    .AddSingleton<PowerShellContextService>(
-                        (provider) =>
-                            PowerShellContextService.Create(
-                                LoggerFactory,
-                                provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(),
-                                _profilePaths,
-                                _featureFlags,
-                                _enableConsoleRepl,
-                                _internalHost,
-                                _hostDetails,
-                                _additionalModules))
-                    .AddSingleton<TemplateService>()
-                    .AddSingleton<EditorOperationsService>()
-                    .AddSingleton<RemoteFileManagerService>()
-                    .AddSingleton<ExtensionService>(
-                        (provider) =>
-                        {
-                            var extensionService = new ExtensionService(
-                                provider.GetService<PowerShellContextService>(),
-                                provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>());
-                            extensionService.InitializeAsync(
-                                serviceProvider: provider,
-                                editorOperations: provider.GetService<EditorOperationsService>())
-                                .Wait();
-                            return extensionService;
-                        })
-                    .AddSingleton<AnalysisService>(
-                        (provider) =>
-                        {
-                            return AnalysisService.Create(
-                                provider.GetService<ConfigurationService>(),
-                                provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(),
-                                options.LoggerFactory.CreateLogger<AnalysisService>());
-                        });
-
+                var logger = LoggerFactory.CreateLogger("OptionsStartup");
                 (Stream input, Stream output) = GetInputOutputStreams();
 
                 options
                     .WithInput(input)
-                    .WithOutput(output);
-
-                options.MinimumLogLevel = _minimumLogLevel;
-
-                logger.LogInformation("Adding handlers");
-
-                options
+                    .WithOutput(output)
+                    .WithServices(serviceCollection => serviceCollection
+                        .AddSingleton<WorkspaceService>()
+                        .AddSingleton<SymbolsService>()
+                        .AddSingleton<ConfigurationService>()
+                        .AddSingleton<PowerShellContextService>(
+                            (provider) =>
+                                PowerShellContextService.Create(
+                                    provider.GetService<ILoggerFactory>(),
+                                    provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(),
+                                    _profilePaths,
+                                    _featureFlags,
+                                    _enableConsoleRepl,
+                                    _internalHost,
+                                    _hostDetails,
+                                    _additionalModules))
+                        .AddSingleton<TemplateService>()
+                        .AddSingleton<EditorOperationsService>()
+                        .AddSingleton<RemoteFileManagerService>()
+                        .AddSingleton<ExtensionService>(
+                            (provider) =>
+                            {
+                                var extensionService = new ExtensionService(
+                                    provider.GetService<PowerShellContextService>(),
+                                    provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>());
+                                extensionService.InitializeAsync(
+                                    serviceProvider: provider,
+                                    editorOperations: provider.GetService<EditorOperationsService>())
+                                    .Wait();
+                                return extensionService;
+                            })
+                        .AddSingleton<AnalysisService>(
+                            (provider) =>
+                            {
+                                return AnalysisService.Create(
+                                    provider.GetService<ConfigurationService>(),
+                                    provider.GetService<OmniSharp.Extensions.LanguageServer.Protocol.Server.ILanguageServer>(),
+                                    provider.GetService<ILoggerFactory>().CreateLogger<AnalysisService>());
+                            }))
+                    .ConfigureLogging(builder => builder
+                        .AddSerilog(Log.Logger)
+                        .SetMinimumLevel(LogLevel.Trace))
+                    .AddDefaultLoggingProvider()
                     .WithHandler<WorkspaceSymbolsHandler>()
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<GetVersionHandler>()
@@ -154,8 +149,6 @@ namespace Microsoft.PowerShell.EditorServices.Server
                                     isPathAlreadyEscaped: false);
                             }
                         });
-
-                logger.LogInformation("Handlers added");
             });
         }
 

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -59,7 +59,6 @@ namespace Microsoft.PowerShell.EditorServices.Server
         {
             LanguageServer = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
             {
-                var logger = LoggerFactory.CreateLogger("OptionsStartup");
                 (Stream input, Stream output) = GetInputOutputStreams();
 
                 options

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Events;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IEvaluateHandler.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
@@ -4,7 +4,7 @@
 //
 
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IInvokeExtensionCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IInvokeExtensionCommandHandler.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/InvokeExtensionCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/InvokeExtensionCommandHandler.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Configuration;
-using OmniSharp.Extensions.Embedded.MediatR;
+using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;


### PR DESCRIPTION
the title says it all... 3 cheers for the .NET builder pattern.

Here's what our logs look like.
[EditorServices.log](https://github.com/PowerShell/PowerShellEditorServices/files/3725937/EditorServices.log)

Note, we still need [this issue](https://github.com/OmniSharp/csharp-language-server-protocol/issues/181) to be resolved to get logs of the payload... but we can get the payloads... just not in the file logs... the user can add:

```
"powershell editor services.trace.server":"verbose"
```

in their settings which will give them an Output window in vscode that contains the payloads that is compliant with the [lsp inspector](https://microsoft.github.io/language-server-protocol/inspector/).

It's an extra process.. but it's the best we've got so far. It will get better.


Note this also updates the `using`s for `Mediatr` due to an Omnisharp change. 