### PR TITLE
Forwardport 1044 fixing UNC path completions

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Management.Automation;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -251,8 +252,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 // This causes the editing cursor to be placed *before* the final quote after completion,
                 // which makes subsequent path completions work. See this part of the LSP spec for details:
                 // https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
-                int len = completionDetails.CompletionText.Length;
-                completionText = completionDetails.CompletionText.Insert(len - 1, "$0");
+
+                // Since we want to use a "tab stop" we need to escape a few things for Textmate to render properly.
+                var sb = new StringBuilder(completionDetails.CompletionText)
+                    .Replace(@"\", @"\\")
+                    .Replace(@"}", @"\}")
+                    .Replace(@"$", @"\$");
+                completionText = sb.Insert(sb.Length - 1, "$0").ToString();
                 insertTextFormat = InsertTextFormat.Snippet;
             }
 


### PR DESCRIPTION
This brings #1044 into the omnisharp work. It fixes UNC path completions.