### PR TITLE
Override PSRL ReadKey on Windows as well

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
@@ -163,10 +163,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             s_consoleProxy.GetCursorTopAsync(cancellationToken);
 
         /// <summary>
-        /// On Unix platforms this method is sent to PSReadLine as a work around for issues
-        /// with the System.Console implementation for that platform. Functionally it is the
-        /// same as System.Console.ReadKey, with the exception that it will not lock the
-        /// standard input stream.
+        /// This method is sent to PSReadLine as a workaround for issues with the System.Console
+        /// implementation. Functionally it is the same as System.Console.ReadKey,
+        /// with the exception that it will not lock the standard input stream.
         /// </summary>
         /// <param name="intercept">
         /// Determines whether to display the pressed key in the console window.
@@ -181,11 +180,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// in a bitwise combination of ConsoleModifiers values, whether one or more Shift, Alt,
         /// or Ctrl modifier keys was pressed simultaneously with the console key.
         /// </returns>
-        internal static ConsoleKeyInfo UnixReadKey(bool intercept, CancellationToken cancellationToken)
+        internal static ConsoleKeyInfo SafeReadKey(bool intercept, CancellationToken cancellationToken)
         {
             try
             {
-                return ((UnixConsoleOperations)s_consoleProxy).ReadKey(intercept, cancellationToken);
+                return s_consoleProxy.ReadKey(intercept, cancellationToken);
             }
             catch (OperationCanceledException)
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -68,13 +68,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             _consoleReadLine = new ConsoleReadLine(powerShellContext);
             _readLineProxy = readLineProxy;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
 
             _readLineProxy.OverrideReadKey(
-                intercept => ConsoleProxy.UnixReadKey(
+                intercept => ConsoleProxy.SafeReadKey(
                     intercept,
                     _readLineCancellationSource.Token));
         }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1753

What this does is has PSRL override its ReadKey with ours on Windows as well so we can properly cancel the ReadKey when we need to for things like when you F8 a `Read-Host`.