### PR TITLE
Grab prerelease if it's available from PSCurrentVersion

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -74,8 +74,8 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             _additionalModules))
                     .ConfigureLogging(builder => builder
                         .AddSerilog(Log.Logger)
+                        .AddLanguageServer(LogLevel.Trace)
                         .SetMinimumLevel(LogLevel.Trace))
-                    .AddDefaultLoggingProvider()
                     .WithHandler<WorkspaceSymbolsHandler>()
                     .WithHandler<TextDocumentHandler>()
                     .WithHandler<GetVersionHandler>()

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -45,8 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             _workspaceService = workspaceService;
             _symbolsService = symbolsService;
             // TODO: Pull this from components
-            _symbolProvider = new ScriptDocumentSymbolProvider(
-                VersionUtils.PSVersion);
+            _symbolProvider = new ScriptDocumentSymbolProvider();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             return Task.FromResult(new PowerShellVersion
             {
-                Version = VersionUtils.PSVersion.ToString(),
+                Version = VersionUtils.PSVersionString,
                 Edition = VersionUtils.PSEdition,
                 DisplayVersion = VersionUtils.PSVersion.ToString(2),
                 Architecture = architecture.ToString()

--- a/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
@@ -17,18 +17,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
     /// </summary>
     public class ScriptDocumentSymbolProvider : IDocumentSymbolProvider
     {
-        private Version powerShellVersion;
-
-        /// <summary>
-        /// Creates an instance of the ScriptDocumentSymbolProvider to
-        /// target the specified PowerShell version.
-        /// </summary>
-        /// <param name="powerShellVersion">The target PowerShell version.</param>
-        public ScriptDocumentSymbolProvider(Version powerShellVersion)
-        {
-            this.powerShellVersion = powerShellVersion;
-        }
-
         IEnumerable<SymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(
             ScriptFile scriptFile)
         {
@@ -37,10 +25,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 (scriptFile.FilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase) ||
                     scriptFile.FilePath.EndsWith(".psm1", StringComparison.OrdinalIgnoreCase)))
             {
-                return
-                    FindSymbolsInDocument(
-                        scriptFile.ScriptAst,
-                        this.powerShellVersion);
+                return FindSymbolsInDocument(scriptFile.ScriptAst);
             }
 
             return Enumerable.Empty<SymbolReference>();
@@ -52,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
         /// <param name="powerShellVersion">The PowerShell version the Ast was generated from</param>
         /// <returns>A collection of SymbolReference objects</returns>
-        static public IEnumerable<SymbolReference> FindSymbolsInDocument(Ast scriptAst, Version powerShellVersion)
+        static public IEnumerable<SymbolReference> FindSymbolsInDocument(Ast scriptAst)
         {
             IEnumerable<SymbolReference> symbolReferences = null;
 

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _workspaceService = workspaceService;
             _documentSymbolProviders = new IDocumentSymbolProvider[]
             {
-                new ScriptDocumentSymbolProvider(VersionUtils.PSVersion),
+                new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
                 new PesterDocumentSymbolProvider()
             };

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -44,8 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
             _providers = new IDocumentSymbolProvider[]
             {
-                new ScriptDocumentSymbolProvider(
-                    VersionUtils.PSVersion),
+                new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
                 new PesterDocumentSymbolProvider()
             };

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -20,14 +20,19 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static bool IsNetCore { get; } = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.Ordinal);
 
         /// <summary>
-        /// Get's the Version of PowerShell being used.
+        /// Gets the Version of PowerShell being used.
         /// </summary>
         public static Version PSVersion { get; } = PowerShellReflectionUtils.PSVersion;
 
         /// <summary>
-        /// Get's the Edition of PowerShell being used.
+        /// Gets the Edition of PowerShell being used.
         /// </summary>
         public static string PSEdition { get; } = PowerShellReflectionUtils.PSEdition;
+
+        /// <summary>
+        /// Gets the string of the PSVersion including prerelease tags if it applies.
+        /// </summary>
+        public static string PSVersionString { get; } = PowerShellReflectionUtils.PSVersionString;
 
         /// <summary>
         /// True if we are running in Windows PowerShell, false otherwise.
@@ -49,8 +54,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
     {
 
         private static readonly Type s_psVersionInfoType = typeof(System.Management.Automation.Runspaces.Runspace).Assembly.GetType("System.Management.Automation.PSVersionInfo");
+
+        // This property is a Version type in PowerShell. It's existed since 5.1, but it was only made public in 6.2.
         private static readonly PropertyInfo s_psVersionProperty = s_psVersionInfoType
             .GetProperty("PSVersion", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
+        // This property is a SemanticVersion in PowerShell that contains the prerelease tag as well.
+        // It was added in 6.2 so we can't depend on it for anything before.
+        private static readonly PropertyInfo s_psCurrentVersionProperty = s_psVersionInfoType
+            .GetProperty("PSCurrentVersion", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
         private static readonly PropertyInfo s_psEditionProperty = s_psVersionInfoType
             .GetProperty("PSEdition", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
 
@@ -64,5 +77,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// Get's the Edition of PowerShell being used.
         /// </summary>
         public static string PSEdition { get; } = s_psEditionProperty.GetValue(null) as string;
+
+        /// <summary>
+        /// Gets the stringified version of PowerShell including prerelease tags if it applies.
+        /// </summary>
+        public static string PSVersionString { get; } = s_psCurrentVersionProperty != null
+            ? s_psCurrentVersionProperty.GetValue(null).ToString()
+            : s_psVersionProperty.GetValue(null).ToString();
     }
 }


### PR DESCRIPTION
PSVersion is only a `Version` type so it has no information on prerelease tag. This caused an issue in vscode-powershell while trying to determine the version for the Update PowerShell feature.

This change will now expose a `PSVersionString` that will first check `PSCurrentVersion` if it's available and then fallback to `Version` if not.

I also removed some references to `VersionUtils.PSVersion` that were not needed.

Also, this includes a small change due to a breaking change in Omnisharp.