### PR TITLE
Lock OmniSharp dependencies

### DIFF
--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.0-*" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.4" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
@@ -29,6 +29,6 @@
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.6.0" />
     <PackageReference Include="UnixConsoleEcho" Version="0.1.0" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.14.0-*" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.14.0" />
   </ItemGroup>
 </Project>

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.14.0-*" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.14.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Lock OmniSharp LSP and DAP dependencies to 0.14.0