### PR TITLE
Fix duplicate diagnostics caused by DidChange handler

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
-using System.Linq;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {


### PR DESCRIPTION
I discovered that duplicate diagnostics were being sent to vscode because we iterated through the _ContentChanges_ and asked for diagnostics in that loop, even though, the changes pertained to the same file.

You can see the bug if you type really fast or use like the `##` comment generator and stuff like that because it will include multiple _ContentChanges_ to the _same file_ in 1 textDocument/DidChange event.

This properly runs diagnostics _after_ all code changes are applied.

Discovered this originally in #1078 (which has a similar change in it as well... thought it might affect us today and sure enough, it did!)

comes with a test too!