### PR TITLE
Remove extra newline in GetComment feature

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation.Language;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,22 +79,25 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     vscodeSnippetCorrection: true,
                     placement: helpLocation));
 
-            string helpText = analysisResults?.FirstOrDefault()?.Correction?.Edits[0].Text;
+            string helpText = analysisResults?[0]?.Correction?.Edits[0].Text;
 
             if (helpText == null)
             {
                 return result;
             }
 
-            result.Content = ScriptFile.GetLinesInternal(helpText).ToArray();
+            List<string> helpLines = ScriptFile.GetLinesInternal(helpText);
 
             if (helpLocation != null &&
                 !helpLocation.Equals("before", StringComparison.OrdinalIgnoreCase))
             {
                 // we need to trim the leading `{` and newline when helpLocation=="begin"
                 // we also need to trim the leading newline when helpLocation=="end"
-                result.Content = result.Content.Skip(1).ToArray();
+                helpLines = helpLines.GetRange(1, helpLines.Count - 1);
             }
+
+            // Trim trailing newline from help text.
+            result.Content = helpLines.GetRange(0, helpLines.Count - 1).ToArray();
 
             return result;
         }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -79,7 +79,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     vscodeSnippetCorrection: true,
                     placement: helpLocation));
 
-            string helpText = analysisResults?[0]?.Correction?.Edits[0].Text;
+            if (analysisResults == null || analysisResults.Count == 0)
+            {
+                return result;
+            }
+
+            string helpText = analysisResults[0]?.Correction?.Edits[0].Text;
 
             if (helpText == null)
             {
@@ -92,16 +97,19 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 !helpLocation.Equals("before", StringComparison.OrdinalIgnoreCase))
             {
                 // we need to trim the leading `{` and newline when helpLocation=="begin"
+                helpLines.RemoveAt(helpLines.Count - 1);
+
                 // we also need to trim the leading newline when helpLocation=="end"
-                helpLines = helpLines.GetRange(1, helpLines.Count - 1);
+                helpLines.RemoveAt(0);
             }
 
             // Trim trailing newline from help text.
             if (string.IsNullOrEmpty(helpLines[helpLines.Count - 1]))
             {
-                result.Content = helpLines.GetRange(0, helpLines.Count - 1).ToArray();
+                helpLines.RemoveAt(helpLines.Count - 1);
             }
 
+            result.Content = helpLines.ToArray();
             return result;
         }
     }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -97,7 +97,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             // Trim trailing newline from help text.
-            result.Content = helpLines.GetRange(0, helpLines.Count - 1).ToArray();
+            if (string.IsNullOrEmpty(helpLines[helpLines.Count - 1]))
+            {
+                result.Content = helpLines.GetRange(0, helpLines.Count - 1).ToArray();
+            }
 
             return result;
         }


### PR DESCRIPTION
The ## comment generation feature has started putting a new line between the comment and the function... That doesn't seem right.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/2644648/67947232-97741700-fbb9-11e9-987a-e4160f193033.png)

This trims that extra newline in PSES.