### PR TITLE
Fix issue where PipelineIndentationStyle setting is ignored

### DIFF
--- a/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices.Protocol/Server/LanguageServerSettings.cs
@@ -264,6 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Protocol.Server
                 {"PSUseConsistentIndentation", new Hashtable {
                     {"Enable", true},
                     {"IndentationSize", tabSize},
+                    {"PipelineIndentation", PipelineIndentationStyle },
                     {"Kind", insertSpaces ? "space" : "tab"}
                 }},
                 {"PSUseConsistentWhitespace", new Hashtable {


### PR DESCRIPTION
Somehow the commit from https://github.com/PowerShell/PowerShellEditorServices/pull/1050 is no longer in the legacy/1.x branch.

This PR reinstates that change.