### PR TITLE
Fix '@' appearing in console

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
@@ -188,7 +188,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
             catch (OperationCanceledException)
             {
-                return new ConsoleKeyInfo(' ', ConsoleKey.DownArrow, shift: false, alt: false, control: false);
+                return new ConsoleKeyInfo(
+                    keyChar: ' ',
+                    ConsoleKey.DownArrow,
+                    shift: false,
+                    alt: false,
+                    control: false);
             }
         }
     }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
             catch (OperationCanceledException)
             {
-                return default(ConsoleKeyInfo);
+                return new ConsoleKeyInfo(' ', ConsoleKey.DownArrow, shift: false, alt: false, control: false);
             }
         }
     }


### PR DESCRIPTION
Changes the key we return to PSRL when the prompt is cancelled to a down arrow.

This resolves https://github.com/PowerShell/vscode-powershell/issues/2274.