### PR TITLE
Use RootUri.LocalPath for workspace path

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             var workspaceService = serviceProvider.GetService<WorkspaceService>();
 
                             // Grab the workspace path from the parameters
-                            workspaceService.WorkspacePath = request.RootPath;
+                            workspaceService.WorkspacePath = request.RootUri.LocalPath;
 
                             // Set the working directory of the PowerShell session to the workspace path
                             if (workspaceService.WorkspacePath != null


### PR DESCRIPTION
Fixes #1093
Fixes https://github.com/PowerShell/vscode-powershell/issues/2288

`RootPath` is shorthand for `RootUri.AbsolutePath` which comes in the wrong format on Windows. This should use the correct `\` and the likes.

Also `RootPath` is deprecated.

cc @SeeminglyScience 