### PR TITLE
Fixes no prompt showing up

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2317,7 +2317,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             // We've hit a breakpoint so go to a new line so that the prompt can be rendered.
-            this.WriteOutput("", true);
+            this.WriteOutput("", includeNewLine: true);
 
             if (CurrentRunspace.Context == RunspaceContext.Original)
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2316,6 +2316,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 _languageServer.SendNotification("powerShell/startDebugger");
             }
 
+            // We've hit a breakpoint so go to a new line so that the prompt can be rendered.
+            this.WriteOutput("", true);
+
             if (CurrentRunspace.Context == RunspaceContext.Original)
             {
                 StartCommandLoopOnRunspaceAvailable();


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/1850

After reading the code, I realized that this was much simpler than I initially thought. No newline was written when a breakpoint was hit and so no prompt was being written because the cursor position was in the same location.

I'm not sure if this also fixes the mixed output... I don't think it does.