### PR TITLE
Fix diagnostics not showing in untitled files and now also show CodeLens

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -867,19 +867,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 fileLock.Release();
             }
 
-
-            var uriBuilder = new UriBuilder
-            {
-                Scheme = Uri.UriSchemeFile,
-                Path = scriptFile.FilePath,
-                Host = string.Empty,
-            };
-
             // Always send syntax and semantic errors.  We want to
             // make sure no out-of-date markers are being displayed.
             _languageServer.Document.PublishDiagnostics(new PublishDiagnosticsParams()
             {
-                Uri = uriBuilder.Uri,
+                Uri = new Uri(scriptFile.DocumentUri),
                 Diagnostics = new Container<Diagnostic>(diagnostics),
             });
         }

--- a/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
@@ -20,15 +20,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         IEnumerable<SymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(
             ScriptFile scriptFile)
         {
-            if (scriptFile != null &&
-                scriptFile.FilePath != null &&
-                (scriptFile.FilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase) ||
-                    scriptFile.FilePath.EndsWith(".psm1", StringComparison.OrdinalIgnoreCase)))
-            {
-                return FindSymbolsInDocument(scriptFile.ScriptAst);
-            }
-
-            return Enumerable.Empty<SymbolReference>();
+            // If we have an AST, then we know it's a PowerShell file
+            // so lets try to find symbols in the document.
+            return scriptFile?.ScriptAst != null
+                ? FindSymbolsInDocument(scriptFile.ScriptAst)
+                : Enumerable.Empty<SymbolReference>();
         }
 
         /// <summary>


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2290

It's both a fix (Diagnostics showing up in Untitled files again)
and a feature (CodeLens showing up in Untitled files now)

It does ask a greater question of - can `scriptFile`s have a reference to their `Uri` object now since O# does an awesome job at giving us the `Uri`s for files already.

Also I feel like the tests might have covered this regression... I really need to sit down and bring those back.