### PR TITLE
Add PSAvoidAssignmentToAutomaticVariable to the default set of PSSA rules

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// no settings file is specified.
         /// </summary>
         private static readonly string[] s_includedRules = {
+            "PSAvoidAssignmentToAutomaticVariable",
             "PSUseToExportFieldsInManifest",
             "PSMisleadingBacktick",
             "PSAvoidUsingCmdletAliases",


### PR DESCRIPTION
See docs below for info. The rule warns only on read-only, automatic variables where assignment would cause an error to be thrown at runtime, therefore there is no scope for false positives.
https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/AvoidAssignmentToAutomaticVariable.md

Example of what  would happen at runtime in the console if one ignored such a violation:
```
> $error = 42
WriteError: Cannot overwrite variable Error because it is read-only or constant.
```

We should back-port this change