### PR TITLE
Protect against no RootUri (no open workspace)

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             var workspaceService = serviceProvider.GetService<WorkspaceService>();
 
                             // Grab the workspace path from the parameters
-                            workspaceService.WorkspacePath = request.RootUri.LocalPath;
+                            workspaceService.WorkspacePath = request.RootUri?.LocalPath;
 
                             // Set the working directory of the PowerShell session to the workspace path
                             if (workspaceService.WorkspacePath != null


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2311

As you can see, when WorkspacePath is null, it's handled on the next line and this is [consistent with the behavior of the legacy code](https://github.com/PowerShell/PowerShellEditorServices/blob/legacy/1.x/src/PowerShellEditorServices.Protocol/Server/LanguageServer.cs#L226-L235).