### PR TITLE
Alt: Handle clearTerminal message by using vscode clear command

### DIFF
--- a/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
+++ b/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
@@ -78,7 +78,8 @@ FunctionsToExport = @('Register-EditorCommand',
                       'Join-ScriptExtent',
                       'Test-ScriptExtent',
                       'Open-EditorFile',
-                      'New-EditorFile')
+                      'New-EditorFile',
+                      'Clear-Host')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
@@ -87,7 +88,7 @@ CmdletsToExport = @()
 VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @('psedit')
+AliasesToExport = @('psedit', 'cls', 'clear')
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
@@ -1,0 +1,24 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+Microsoft.PowerShell.Management\Get-Item function:Clear-Host | Microsoft.PowerShell.Management\Set-Item function:__clearhost
+
+function Clear-Host {
+    [Alias('cls')]
+    param(
+        [Parameter()]
+        [switch]
+        $All
+    )
+
+    __clearhost
+    if ($All.IsPresent) {
+        $psEditor.Window.Terminal.Clear()
+    }
+}
+
+if (!$IsMacOS -and !$IsLinux) {
+    Set-Alias clear Clear-Host
+}

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -179,5 +179,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 Timeout = timeout
             });
         }
+
+        public void ClearTerminal()
+        {
+            _languageServer.SendNotification("editor/clearTerminal");
+        }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/EditorTerminal.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/EditorTerminal.cs
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
+{
+    /// <summary>
+    /// Provides a PowerShell-facing API which allows scripts to
+    /// interact with the editor's terminal.
+    /// </summary>
+    public class EditorTerminal
+    {
+        #region Private Fields
+
+        private readonly IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the EditorTerminal class.
+        /// </summary>
+        /// <param name="editorOperations">An IEditorOperations implementation which handles operations in the host editor.</param>
+        internal EditorTerminal(IEditorOperations editorOperations)
+        {
+            this.editorOperations = editorOperations;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Triggers to the editor to clear the terminal.
+        /// </summary>
+        public void Clear()
+        {
+            this.editorOperations.ClearTerminal();
+        }
+
+        #endregion
+    }
+}

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/EditorWindow.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/EditorWindow.cs
@@ -13,7 +13,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
     {
         #region Private Fields
 
-        private IEditorOperations editorOperations;
+        private readonly IEditorOperations editorOperations;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Gets the terminal interface for the editor API.
+        /// </summary>
+        public EditorTerminal Terminal { get; private set; }
 
         #endregion
 
@@ -26,6 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         internal EditorWindow(IEditorOperations editorOperations)
         {
             this.editorOperations = editorOperations;
+            this.Terminal = new EditorTerminal(editorOperations);
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Extensions/IEditorOperations.cs
@@ -124,5 +124,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="timeout">If non-null, a timeout in milliseconds for how long the message should remain visible.</param>
         /// <returns>A Task that can be tracked for completion.</returns>
         Task SetStatusBarMessageAsync(string message, int? timeout);
+
+        /// <summary>
+        /// Triggers to the editor to clear the terminal.
+        /// </summary>
+        void ClearTerminal();
     }
 }


### PR DESCRIPTION
This fixes an "issue" that comes up a lot that when you `Clear-Host` and are still able to scroll up.

This is an alt of #1108 

Instead, this doesn't use a vscode setting and allows the user to do `-All` to clear the scrollback buffer as well.

Pairs with: https://github.com/PowerShell/vscode-powershell/pull/2318