### PR TITLE
Fix references on Windows due to bad WorkspacePath

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -111,7 +111,10 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             var workspaceService = serviceProvider.GetService<WorkspaceService>();
 
                             // Grab the workspace path from the parameters
-                            workspaceService.WorkspacePath = request.RootUri?.LocalPath;
+                            if (request.RootUri != null)
+                            {
+                                workspaceService.WorkspacePath = workspaceService.ResolveFilePath(request.RootUri.ToString());
+                            }
 
                             // Set the working directory of the PowerShell session to the workspace path
                             if (workspaceService.WorkspacePath != null

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 var acc = new List<Location>();
                 foreach (SymbolReference foundReference in referencesResult)
                 {
-                    if (!NotReferenceDefinition(foundSymbol, foundReference))
+                    if (IsReferenceDefinition(foundSymbol, foundReference))
                     {
                         continue;
                     }
@@ -144,12 +144,13 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="definition">The symbol definition that may be referenced.</param>
         /// <param name="reference">The reference symbol to check.</param>
         /// <returns>True if the reference is not a reference to the definition, false otherwise.</returns>
-        private static bool NotReferenceDefinition(
+        private static bool IsReferenceDefinition(
             SymbolReference definition,
             SymbolReference reference)
         {
             return
-                definition.ScriptRegion.StartLineNumber != reference.ScriptRegion.StartLineNumber
+                definition.FilePath != reference.FilePath
+                || definition.ScriptRegion.StartLineNumber != reference.ScriptRegion.StartLineNumber
                 || definition.SymbolType != reference.SymbolType
                 || !string.Equals(definition.SymbolName, reference.SymbolName, StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2306

The WorkspacePath change I made in #1094 was almost the right change for Windows... but not quite.

This will set the WorkspacePath to an _actual_ path - verified on Windows.

This also fixes a bug I discovered when a symbol reference and a definition were on the same line number but different files (they weren't being counted as a reference).