### PR TITLE
Fix breakpoint setting deadlock

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string reason = "changed";
 
-            if (_debugStateService.SetBreakpointInProgress)
+            if (_debugStateService.IsSetBreakpointInProgress)
             {
                 // Don't send breakpoint update notifications when setting
                 // breakpoints on behalf of the client.

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 {
     internal class DebugStateService
     {
-        private SemaphoreSlim _setBreakpointInProgressHandle = AsyncUtils.CreateSimpleLockingSemaphore();
+        private readonly SemaphoreSlim _setBreakpointInProgressHandle = AsyncUtils.CreateSimpleLockingSemaphore();
 
         internal bool NoDebug { get; set; }
 
@@ -43,7 +43,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         internal async Task WaitForSetBreakpointHandleAsync()
         {
-            await _setBreakpointInProgressHandle.WaitAsync();
+            await _setBreakpointInProgressHandle.WaitAsync()
+                .ConfigureAwait(continueOnCapturedContext: false);
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             CommandBreakpointDetails[] updatedBreakpointDetails = breakpointDetails;
             if (!_debugStateService.NoDebug)
             {
-                _debugStateService.SetBreakpointInProgress = true;
+                await _debugStateService.WaitForSetBreakpointHandleAsync();
 
                 try
                 {
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
                 finally
                 {
-                    _debugStateService.SetBreakpointInProgress = false;
+                    _debugStateService.ReleaseSetBreakpointHandle();
                 }
             }
 
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             BreakpointDetails[] updatedBreakpointDetails = breakpointDetails;
             if (!_debugStateService.NoDebug)
             {
-                _debugStateService.SetBreakpointInProgress = true;
+                await _debugStateService.WaitForSetBreakpointHandleAsync();
 
                 try
                 {
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
                 finally
                 {
-                    _debugStateService.SetBreakpointInProgress = false;
+                    _debugStateService.ReleaseSetBreakpointHandle();
                 }
             }
 


### PR DESCRIPTION
We were using a boolean as a check for if something was currently happening... and when we moved to Omnisharp lib it was kinda being used as a lock :)

This caused a deadlock. Proper thread safety has prevented the deadlock.