### PR TITLE
Fix Import-EditorCommand bug

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
@@ -57,14 +57,11 @@ function Import-EditorCommand {
                 return $moduleInfo.ExportedFunctions.Values
             }
         }
-        $flags = [Reflection.BindingFlags]'Instance, NonPublic'
-        $extensionService = $psEditor.GetType().
-                                      GetField('_extensionService', $flags).
-                                      GetValue($psEditor)
+        $editorCommands = @{}
 
-        $editorCommands = $extensionService.GetType().
-                                            GetField('editorCommands', $flags).
-                                            GetValue($extensionService)
+        foreach ($existingCommand in $psEditor.GetCommands()) {
+            $editorCommands[$existingCommand.Name] = $existingCommand
+        }
     }
     process {
         switch ($PSCmdlet.ParameterSetName) {

--- a/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
@@ -59,7 +59,7 @@ function Import-EditorCommand {
         }
         $flags = [Reflection.BindingFlags]'Instance, NonPublic'
         $extensionService = $psEditor.GetType().
-                                      GetField('extensionService', $flags).
+                                      GetField('_extensionService', $flags).
                                       GetValue($psEditor)
 
         $editorCommands = $extensionService.GetType().


### PR DESCRIPTION
It appears that PR #1056 involved renaming the `extensionService` field to `_extensionService` but this wasn't changed in the `Import-EditorCommand` function causing an error when trying to use it.

Following a discussion with @TylerLeonhardt on the PowerShell Discord server I've submitted this PR to fix the error by updating the field name in `Import-EditorCommand`.

I didn't see any tests or anything that needed to be changed but let me know if you need me to do anything else in order for this to be accepted 🙂 