### PR TITLE
Run one invocation per SetBreakpoints request

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -189,12 +189,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     await this.ClearBreakpointsInFileAsync(scriptFile);
                 }
 
+                PSCommand psCommand = null;
                 foreach (BreakpointDetails breakpoint in breakpoints)
                 {
-                    PSCommand psCommand = new PSCommand();
-                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
-                    psCommand.AddParameter("Script", escapedScriptPath);
-                    psCommand.AddParameter("Line", breakpoint.LineNumber);
+                    // On first iteration psCommand will be null, every subsequent
+                    // iteration will need to start a new statement.
+                    psCommand?.AddStatement();
+                    (psCommand ??= new PSCommand())
+                        .AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint")
+                        .AddParameter("Script", escapedScriptPath)
+                        .AddParameter("Line", breakpoint.LineNumber);
 
                     // Check if the user has specified the column number for the breakpoint.
                     if (breakpoint.ColumnNumber.HasValue && breakpoint.ColumnNumber.Value > 0)
@@ -222,7 +226,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                         psCommand.AddParameter("Action", actionScriptBlock);
                     }
+                }
 
+                // If no PSCommand was created then there are no breakpoints to set.
+                if (psCommand != null)
+                {
                     IEnumerable<Breakpoint> configuredBreakpoints =
                         await this.powerShellContext.ExecuteCommandAsync<Breakpoint>(psCommand);
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -194,8 +194,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     // On first iteration psCommand will be null, every subsequent
                     // iteration will need to start a new statement.
-                    psCommand?.AddStatement();
-                    (psCommand ??= new PSCommand())
+                    if (psCommand == null)
+                    {
+                        psCommand = new PSCommand();
+                    }
+                    else
+                    {
+                        psCommand.AddStatement();
+                    }
+
+                    psCommand
                         .AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint")
                         .AddParameter("Script", escapedScriptPath)
                         .AddParameter("Line", breakpoint.LineNumber);


### PR DESCRIPTION
Previously for every `SetBreakpoints` request we would invoke `ExecuteCommandAsync` once for every single breakpoint. This change reduces that to a single call per request.

Before this change, if I followed the repro steps for PowerShell/vscode-powershell#2319, setting 10 breakpoints in File2 and File3, I couldn't even get it to launch once.  With this change I can consistently launch every time.

There's definitely some race conditions in how runspace handles are queued, and the way this request handler was set up was really pushing that to it's limits.  Those race conditions still need to be fixed, but this should help significantly in the mean time.