### PR TITLE
Initial switch to breakpoint APIs

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
+++ b/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 .AddSingleton(languageServiceProvider.GetService<RemoteFileManagerService>())
                 .AddSingleton<PsesDebugServer>(psesDebugServer)
                 .AddSingleton<DebugService>()
+                .AddSingleton<BreakpointService>()
                 .AddSingleton<DebugStateService>(new DebugStateService
                 {
                      OwnsEditorSession = useTempSession

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -331,7 +331,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        private bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
+        private static bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
         {
             message = string.Empty;
 
@@ -363,7 +363,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return true;
         }
 
-        private string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
+        private static string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
         {
             string[] messageLines = parseException.Message.Split('\n');
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -1,0 +1,412 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Logging;
+using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
+using Microsoft.PowerShell.EditorServices.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.Services
+{
+    internal class BreakpointService
+    {
+        private const string s_psesGlobalVariableNamePrefix = "__psEditorServices_";
+        private readonly ILogger<BreakpointService> _logger;
+        private readonly PowerShellContextService _powerShellContextService;
+
+        private readonly ConcurrentDictionary<string, List<Breakpoint>> _breakpointsPerFile =
+            new ConcurrentDictionary<string, List<Breakpoint>>();
+
+        private static int breakpointHitCounter;
+
+        public BreakpointService(
+            ILoggerFactory factory,
+            PowerShellContextService powerShellContextService)
+        {
+            _logger = factory.CreateLogger<BreakpointService>();
+            _powerShellContextService = powerShellContextService;
+        }
+
+        public async Task<BreakpointDetails[]> SetBreakpointsAsync(string escapedScriptPath, IEnumerable<BreakpointDetails> breakpoints)
+        {
+            if (VersionUtils.IsPS7OrGreater)
+            {
+                return BreakpointApiUtils.SetBreakpoints(
+                    _powerShellContextService.CurrentRunspace.Runspace.Debugger,
+                    breakpoints)
+                    .Select(BreakpointDetails.Create).ToArray();
+            }
+
+            // Legacy behavior
+            PSCommand psCommand = null;
+            List<BreakpointDetails> configuredBreakpoints = new List<BreakpointDetails>();
+            foreach (BreakpointDetails breakpoint in breakpoints)
+            {
+                // On first iteration psCommand will be null, every subsequent
+                // iteration will need to start a new statement.
+                if (psCommand == null)
+                {
+                    psCommand = new PSCommand();
+                }
+                else
+                {
+                    psCommand.AddStatement();
+                }
+
+                psCommand
+                    .AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint")
+                    .AddParameter("Script", escapedScriptPath)
+                    .AddParameter("Line", breakpoint.LineNumber);
+
+                // Check if the user has specified the column number for the breakpoint.
+                if (breakpoint.ColumnNumber.HasValue && breakpoint.ColumnNumber.Value > 0)
+                {
+                    // It bums me out that PowerShell will silently ignore a breakpoint
+                    // where either the line or the column is invalid.  I'd rather have an
+                    // error or warning message I could relay back to the client.
+                    psCommand.AddParameter("Column", breakpoint.ColumnNumber.Value);
+                }
+
+                // Check if this is a "conditional" line breakpoint.
+                if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+                    !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
+                {
+                    ScriptBlock actionScriptBlock =
+                        GetBreakpointActionScriptBlock(breakpoint);
+
+                    // If there was a problem with the condition string,
+                    // move onto the next breakpoint.
+                    if (actionScriptBlock == null)
+                    {
+                        configuredBreakpoints.Add(breakpoint);
+                        continue;
+                    }
+
+                    psCommand.AddParameter("Action", actionScriptBlock);
+                }
+            }
+
+            // If no PSCommand was created then there are no breakpoints to set.
+            if (psCommand != null)
+            {
+                IEnumerable<Breakpoint> setBreakpoints =
+                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
+                configuredBreakpoints.AddRange(
+                    setBreakpoints.Select(BreakpointDetails.Create));
+            }
+
+            return configuredBreakpoints.ToArray();
+        }
+
+        public async Task<IEnumerable<CommandBreakpointDetails>> SetCommandBreakpoints(IEnumerable<CommandBreakpointDetails> breakpoints)
+        {
+            if (VersionUtils.IsPS7OrGreater)
+            {
+                return BreakpointApiUtils.SetBreakpoints(
+                    _powerShellContextService.CurrentRunspace.Runspace.Debugger,
+                    breakpoints)
+                    .Select(CommandBreakpointDetails.Create);
+            }
+
+            // Legacy behavior
+            PSCommand psCommand = null;
+            List<CommandBreakpointDetails> configuredBreakpoints = new List<CommandBreakpointDetails>();
+            foreach (CommandBreakpointDetails breakpoint in breakpoints)
+            {
+                // On first iteration psCommand will be null, every subsequent
+                // iteration will need to start a new statement.
+                if (psCommand == null)
+                {
+                    psCommand = new PSCommand();
+                }
+                else
+                {
+                    psCommand.AddStatement();
+                }
+
+                psCommand
+                    .AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint")
+                    .AddParameter("Command", breakpoint.Name);
+
+                // Check if this is a "conditional" line breakpoint.
+                if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+                    !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
+                {
+                    ScriptBlock actionScriptBlock =
+                        GetBreakpointActionScriptBlock(breakpoint);
+
+                    // If there was a problem with the condition string,
+                    // move onto the next breakpoint.
+                    if (actionScriptBlock == null)
+                    {
+                        configuredBreakpoints.Add(breakpoint);
+                        continue;
+                    }
+
+                    psCommand.AddParameter("Action", actionScriptBlock);
+                }
+            }
+
+            // If no PSCommand was created then there are no breakpoints to set.
+            if (psCommand != null)
+            {
+                IEnumerable<Breakpoint> setBreakpoints =
+                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
+                configuredBreakpoints.AddRange(
+                    setBreakpoints.Select(CommandBreakpointDetails.Create));
+            }
+
+            return configuredBreakpoints;
+        }
+
+        /// <summary>
+        /// Clears all breakpoints in the current session.
+        /// </summary>
+        public async Task RemoveAllBreakpointsAsync()
+        {
+            try
+            {
+                if (VersionUtils.IsPS7OrGreater)
+                {
+                    foreach (Breakpoint breakpoint in BreakpointApiUtils.GetBreakpoints(
+                            _powerShellContextService.CurrentRunspace.Runspace.Debugger))
+                    {
+                        BreakpointApiUtils.RemoveBreakpoint(
+                            _powerShellContextService.CurrentRunspace.Runspace.Debugger,
+                            breakpoint);
+                    }
+
+                    return;
+                }
+
+                // Legacy behavior
+
+                PSCommand psCommand = new PSCommand();
+                psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
+                psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
+
+                await _powerShellContextService.ExecuteCommandAsync<object>(psCommand);
+            }
+            catch (Exception e)
+            {
+                _logger.LogException("Caught exception while clearing breakpoints from session", e);
+            }
+        }
+
+        public async Task RemoveBreakpoints(IEnumerable<Breakpoint> breakpoints)
+        {
+            if (VersionUtils.IsPS7OrGreater)
+            {
+                foreach (Breakpoint breakpoint in breakpoints)
+                {
+                    BreakpointApiUtils.RemoveBreakpoint(
+                        _powerShellContextService.CurrentRunspace.Runspace.Debugger,
+                        breakpoint);
+                }
+
+                return;
+            }
+
+            // Legacy behavior
+            var breakpointIds = breakpoints.Select(b => b.Id).ToArray();
+            if(breakpointIds.Length > 0)
+            {
+                PSCommand psCommand = new PSCommand();
+                psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
+                psCommand.AddParameter("Id", breakpoints.Select(b => b.Id).ToArray());
+
+                await _powerShellContextService.ExecuteCommandAsync<object>(psCommand);
+            }
+        }
+
+        /// <summary>
+        /// Inspects the condition, putting in the appropriate scriptblock template
+        /// "if (expression) { break }".  If errors are found in the condition, the
+        /// breakpoint passed in is updated to set Verified to false and an error
+        /// message is put into the breakpoint.Message property.
+        /// </summary>
+        /// <param name="breakpoint"></param>
+        /// <returns></returns>
+        private ScriptBlock GetBreakpointActionScriptBlock(
+            BreakpointDetailsBase breakpoint)
+        {
+            try
+            {
+                ScriptBlock actionScriptBlock;
+                int? hitCount = null;
+
+                // If HitCondition specified, parse and verify it.
+                if (!(string.IsNullOrWhiteSpace(breakpoint.HitCondition)))
+                {
+                    if (int.TryParse(breakpoint.HitCondition, out int parsedHitCount))
+                    {
+                        hitCount = parsedHitCount;
+                    }
+                    else
+                    {
+                        breakpoint.Verified = false;
+                        breakpoint.Message = $"The specified HitCount '{breakpoint.HitCondition}' is not valid. " +
+                                              "The HitCount must be an integer number.";
+                        return null;
+                    }
+                }
+
+                // Create an Action scriptblock based on condition and/or hit count passed in.
+                if (hitCount.HasValue && string.IsNullOrWhiteSpace(breakpoint.Condition))
+                {
+                    // In the HitCount only case, this is simple as we can just use the HitCount
+                    // property on the breakpoint object which is represented by $_.
+                    string action = $"if ($_.HitCount -eq {hitCount}) {{ break }}";
+                    actionScriptBlock = ScriptBlock.Create(action);
+                }
+                else if (!string.IsNullOrWhiteSpace(breakpoint.Condition))
+                {
+                    // Must be either condition only OR condition and hit count.
+                    actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
+
+                    // Check for simple, common errors that ScriptBlock parsing will not catch
+                    // e.g. $i == 3 and $i > 3
+                    if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out string message))
+                    {
+                        breakpoint.Verified = false;
+                        breakpoint.Message = message;
+                        return null;
+                    }
+
+                    // Check for "advanced" condition syntax i.e. if the user has specified
+                    // a "break" or  "continue" statement anywhere in their scriptblock,
+                    // pass their scriptblock through to the Action parameter as-is.
+                    Ast breakOrContinueStatementAst =
+                        actionScriptBlock.Ast.Find(
+                            ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
+
+                    // If this isn't advanced syntax then the conditions string should be a simple
+                    // expression that needs to be wrapped in a "if" test that conditionally executes
+                    // a break statement.
+                    if (breakOrContinueStatementAst == null)
+                    {
+                        string wrappedCondition;
+
+                        if (hitCount.HasValue)
+                        {
+                            string globalHitCountVarName =
+                                $"$global:{s_psesGlobalVariableNamePrefix}BreakHitCounter_{breakpointHitCounter++}";
+
+                            wrappedCondition =
+                                $"if ({breakpoint.Condition}) {{ if (++{globalHitCountVarName} -eq {hitCount}) {{ break }} }}";
+                        }
+                        else
+                        {
+                            wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
+                        }
+
+                        actionScriptBlock = ScriptBlock.Create(wrappedCondition);
+                    }
+                }
+                else
+                {
+                    // Shouldn't get here unless someone called this with no condition and no hit count.
+                    actionScriptBlock = ScriptBlock.Create("break");
+                    _logger.LogWarning("No condition and no hit count specified by caller.");
+                }
+
+                return actionScriptBlock;
+            }
+            catch (ParseException ex)
+            {
+                // Failed to create conditional breakpoint likely because the user provided an
+                // invalid PowerShell expression. Let the user know why.
+                breakpoint.Verified = false;
+                breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
+                return null;
+            }
+        }
+
+        private bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
+        {
+            message = string.Empty;
+
+            // We are only inspecting a few simple scenarios in the EndBlock only.
+            if (conditionAst is ScriptBlockAst scriptBlockAst &&
+                scriptBlockAst.BeginBlock == null &&
+                scriptBlockAst.ProcessBlock == null &&
+                scriptBlockAst.EndBlock != null &&
+                scriptBlockAst.EndBlock.Statements.Count == 1)
+            {
+                StatementAst statementAst = scriptBlockAst.EndBlock.Statements[0];
+                string condition = statementAst.Extent.Text;
+
+                if (statementAst is AssignmentStatementAst)
+                {
+                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-eq' instead of '=='.");
+                    return false;
+                }
+
+                if (statementAst is PipelineAst pipelineAst
+                    && pipelineAst.PipelineElements.Count == 1
+                    && pipelineAst.PipelineElements[0].Redirections.Count > 0)
+                {
+                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-gt' instead of '>'.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
+        {
+            string[] messageLines = parseException.Message.Split('\n');
+
+            // Skip first line - it is a location indicator "At line:1 char: 4"
+            for (int i = 1; i < messageLines.Length; i++)
+            {
+                string line = messageLines[i];
+                if (line.StartsWith("+"))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    // Note '==' and '>" do not generate parse errors
+                    if (line.Contains("'!='"))
+                    {
+                        line += " Use operator '-ne' instead of '!='.";
+                    }
+                    else if (line.Contains("'<'") && condition.Contains("<="))
+                    {
+                        line += " Use operator '-le' instead of '<='.";
+                    }
+                    else if (line.Contains("'<'"))
+                    {
+                        line += " Use operator '-lt' instead of '<'.";
+                    }
+                    else if (condition.Contains(">="))
+                    {
+                        line += " Use operator '-ge' instead of '>='.";
+                    }
+
+                    return FormatInvalidBreakpointConditionMessage(condition, line);
+                }
+            }
+
+            // If the message format isn't in a form we expect, just return the whole message.
+            return FormatInvalidBreakpointConditionMessage(condition, parseException.Message);
+        }
+
+        private string FormatInvalidBreakpointConditionMessage(string condition, string message)
+        {
+            return $"'{condition}' is not a valid PowerShell expression. {message}";
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -281,6 +281,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
                                 bps.Remove(lineBreakpoint);
                             }
                             break;
+                        default:
+                            throw new ArgumentException("Unsupported breakpoint type.");
                     }
                 }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -86,17 +86,18 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition) ||
                     !string.IsNullOrWhiteSpace(breakpoint.LogMessage))
                 {
-                    try
-                    {
-                        actionScriptBlock = BreakpointApiUtils.GetBreakpointActionScriptBlock(
-                            breakpoint.Condition,
-                            breakpoint.HitCondition,
-                            breakpoint.LogMessage);
-                    }
-                    catch (InvalidOperationException e)
+                    actionScriptBlock = BreakpointApiUtils.GetBreakpointActionScriptBlock(
+                        breakpoint.Condition,
+                        breakpoint.HitCondition,
+                        breakpoint.LogMessage,
+                        out string errorMessage);
+
+                    if (!string.IsNullOrEmpty(errorMessage))
                     {
                         breakpoint.Verified = false;
-                        breakpoint.Message = e.Message;
+                        breakpoint.Message = errorMessage;
+                        configuredBreakpoints.Add(breakpoint);
+                        continue;
                     }
                 }
 
@@ -188,12 +189,18 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
                 {
                     ScriptBlock actionScriptBlock =
-                        BreakpointApiUtils.GetBreakpointActionScriptBlock(breakpoint);
+                        BreakpointApiUtils.GetBreakpointActionScriptBlock(
+                            breakpoint.Condition,
+                            breakpoint.HitCondition,
+                            logMessage: null,
+                            out string errorMessage);
 
                     // If there was a problem with the condition string,
                     // move onto the next breakpoint.
-                    if (actionScriptBlock == null)
+                    if (!string.IsNullOrEmpty(errorMessage))
                     {
+                        breakpoint.Verified = false;
+                        breakpoint.Message = errorMessage;
                         configuredBreakpoints.Add(breakpoint);
                         continue;
                     }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -62,7 +62,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     try
                     {
                         BreakpointApiUtils.SetBreakpoint(_powerShellContextService.CurrentRunspace.Runspace.Debugger, breakpointDetails, _debugStateService.RunspaceId);
-
                     }
                     catch(InvalidOperationException e)
                     {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -20,11 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 {
     internal class BreakpointService
     {
-        private const string s_psesGlobalVariableNamePrefix = "__psEditorServices_";
         private readonly ILogger<BreakpointService> _logger;
         private readonly PowerShellContextService _powerShellContextService;
-
-        private static int breakpointHitCounter;
 
         public BreakpointService(
             ILoggerFactory factory,
@@ -79,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
                 {
                     ScriptBlock actionScriptBlock =
-                        GetBreakpointActionScriptBlock(breakpoint);
+                        BreakpointApiUtils.GetBreakpointActionScriptBlock(breakpoint);
 
                     // If there was a problem with the condition string,
                     // move onto the next breakpoint.
@@ -140,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
                 {
                     ScriptBlock actionScriptBlock =
-                        GetBreakpointActionScriptBlock(breakpoint);
+                        BreakpointApiUtils.GetBreakpointActionScriptBlock(breakpoint);
 
                     // If there was a problem with the condition string,
                     // move onto the next breakpoint.
@@ -200,7 +197,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        public async Task RemoveBreakpoints(IEnumerable<Breakpoint> breakpoints)
+        public async Task RemoveBreakpointsAsync(IEnumerable<Breakpoint> breakpoints)
         {
             if (VersionUtils.IsPS7OrGreater)
             {
@@ -226,187 +223,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        /// <summary>
-        /// Inspects the condition, putting in the appropriate scriptblock template
-        /// "if (expression) { break }".  If errors are found in the condition, the
-        /// breakpoint passed in is updated to set Verified to false and an error
-        /// message is put into the breakpoint.Message property.
-        /// </summary>
-        /// <param name="breakpoint"></param>
-        /// <returns></returns>
-        private ScriptBlock GetBreakpointActionScriptBlock(
-            BreakpointDetailsBase breakpoint)
-        {
-            try
-            {
-                ScriptBlock actionScriptBlock;
-                int? hitCount = null;
 
-                // If HitCondition specified, parse and verify it.
-                if (!(string.IsNullOrWhiteSpace(breakpoint.HitCondition)))
-                {
-                    if (int.TryParse(breakpoint.HitCondition, out int parsedHitCount))
-                    {
-                        hitCount = parsedHitCount;
-                    }
-                    else
-                    {
-                        breakpoint.Verified = false;
-                        breakpoint.Message = $"The specified HitCount '{breakpoint.HitCondition}' is not valid. " +
-                                              "The HitCount must be an integer number.";
-                        return null;
-                    }
-                }
-
-                // Create an Action scriptblock based on condition and/or hit count passed in.
-                if (hitCount.HasValue && string.IsNullOrWhiteSpace(breakpoint.Condition))
-                {
-                    // In the HitCount only case, this is simple as we can just use the HitCount
-                    // property on the breakpoint object which is represented by $_.
-                    string action = $"if ($_.HitCount -eq {hitCount}) {{ break }}";
-                    actionScriptBlock = ScriptBlock.Create(action);
-                }
-                else if (!string.IsNullOrWhiteSpace(breakpoint.Condition))
-                {
-                    // Must be either condition only OR condition and hit count.
-                    actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
-
-                    // Check for simple, common errors that ScriptBlock parsing will not catch
-                    // e.g. $i == 3 and $i > 3
-                    if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out string message))
-                    {
-                        breakpoint.Verified = false;
-                        breakpoint.Message = message;
-                        return null;
-                    }
-
-                    // Check for "advanced" condition syntax i.e. if the user has specified
-                    // a "break" or  "continue" statement anywhere in their scriptblock,
-                    // pass their scriptblock through to the Action parameter as-is.
-                    Ast breakOrContinueStatementAst =
-                        actionScriptBlock.Ast.Find(
-                            ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
-
-                    // If this isn't advanced syntax then the conditions string should be a simple
-                    // expression that needs to be wrapped in a "if" test that conditionally executes
-                    // a break statement.
-                    if (breakOrContinueStatementAst == null)
-                    {
-                        string wrappedCondition;
-
-                        if (hitCount.HasValue)
-                        {
-                            Interlocked.Increment(ref breakpointHitCounter);
-
-                            string globalHitCountVarName =
-                                $"$global:{s_psesGlobalVariableNamePrefix}BreakHitCounter_{breakpointHitCounter}";
-
-                            wrappedCondition =
-                                $"if ({breakpoint.Condition}) {{ if (++{globalHitCountVarName} -eq {hitCount}) {{ break }} }}";
-                        }
-                        else
-                        {
-                            wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
-                        }
-
-                        actionScriptBlock = ScriptBlock.Create(wrappedCondition);
-                    }
-                }
-                else
-                {
-                    // Shouldn't get here unless someone called this with no condition and no hit count.
-                    actionScriptBlock = ScriptBlock.Create("break");
-                    _logger.LogWarning("No condition and no hit count specified by caller.");
-                }
-
-                return actionScriptBlock;
-            }
-            catch (ParseException ex)
-            {
-                // Failed to create conditional breakpoint likely because the user provided an
-                // invalid PowerShell expression. Let the user know why.
-                breakpoint.Verified = false;
-                breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
-                return null;
-            }
-        }
-
-        private static bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
-        {
-            message = string.Empty;
-
-            // We are only inspecting a few simple scenarios in the EndBlock only.
-            if (conditionAst is ScriptBlockAst scriptBlockAst &&
-                scriptBlockAst.BeginBlock == null &&
-                scriptBlockAst.ProcessBlock == null &&
-                scriptBlockAst.EndBlock != null &&
-                scriptBlockAst.EndBlock.Statements.Count == 1)
-            {
-                StatementAst statementAst = scriptBlockAst.EndBlock.Statements[0];
-                string condition = statementAst.Extent.Text;
-
-                if (statementAst is AssignmentStatementAst)
-                {
-                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-eq' instead of '=='.");
-                    return false;
-                }
-
-                if (statementAst is PipelineAst pipelineAst
-                    && pipelineAst.PipelineElements.Count == 1
-                    && pipelineAst.PipelineElements[0].Redirections.Count > 0)
-                {
-                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-gt' instead of '>'.");
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
-        {
-            string[] messageLines = parseException.Message.Split('\n');
-
-            // Skip first line - it is a location indicator "At line:1 char: 4"
-            for (int i = 1; i < messageLines.Length; i++)
-            {
-                string line = messageLines[i];
-                if (line.StartsWith("+"))
-                {
-                    continue;
-                }
-
-                if (!string.IsNullOrWhiteSpace(line))
-                {
-                    // Note '==' and '>" do not generate parse errors
-                    if (line.Contains("'!='"))
-                    {
-                        line += " Use operator '-ne' instead of '!='.";
-                    }
-                    else if (line.Contains("'<'") && condition.Contains("<="))
-                    {
-                        line += " Use operator '-le' instead of '<='.";
-                    }
-                    else if (line.Contains("'<'"))
-                    {
-                        line += " Use operator '-lt' instead of '<'.";
-                    }
-                    else if (condition.Contains(">="))
-                    {
-                        line += " Use operator '-ge' instead of '>='.";
-                    }
-
-                    return FormatInvalidBreakpointConditionMessage(condition, line);
-                }
-            }
-
-            // If the message format isn't in a form we expect, just return the whole message.
-            return FormatInvalidBreakpointConditionMessage(condition, parseException.Message);
-        }
-
-        private static string FormatInvalidBreakpointConditionMessage(string condition, string message)
-        {
-            return $"'{condition}' is not a valid PowerShell expression. {message}";
-        }
     }
 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -4,18 +4,13 @@
 //
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Language;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
-using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Services
 {
@@ -44,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<List<Breakpoint>> GetBreakpointsAsync()
         {
-            if (VersionUtils.IsPS7OrGreater)
+            if (BreakpointApiUtils.SupportsBreakpointApis)
             {
                 return BreakpointApiUtils.GetBreakpoints(
                     _powerShellContextService.CurrentRunspace.Runspace.Debugger,
@@ -60,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<IEnumerable<BreakpointDetails>> SetBreakpointsAsync(string escapedScriptPath, IEnumerable<BreakpointDetails> breakpoints)
         {
-            if (VersionUtils.IsPS7OrGreater)
+            if (BreakpointApiUtils.SupportsBreakpointApis)
             {
                 foreach (BreakpointDetails breakpointDetails in breakpoints)
                 {
@@ -150,7 +145,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<IEnumerable<CommandBreakpointDetails>> SetCommandBreakpoints(IEnumerable<CommandBreakpointDetails> breakpoints)
         {
-            if (VersionUtils.IsPS7OrGreater)
+            if (BreakpointApiUtils.SupportsBreakpointApis)
             {
                 foreach (CommandBreakpointDetails commandBreakpointDetails in breakpoints)
                 {
@@ -226,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             try
             {
-                if (VersionUtils.IsPS7OrGreater)
+                if (BreakpointApiUtils.SupportsBreakpointApis)
                 {
                     foreach (Breakpoint breakpoint in BreakpointApiUtils.GetBreakpoints(
                             _powerShellContextService.CurrentRunspace.Runspace.Debugger,
@@ -266,7 +261,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task RemoveBreakpointsAsync(IEnumerable<Breakpoint> breakpoints)
         {
-            if (VersionUtils.IsPS7OrGreater)
+            if (BreakpointApiUtils.SupportsBreakpointApis)
             {
                 foreach (Breakpoint breakpoint in breakpoints)
                 {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -31,12 +31,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private const string PsesGlobalVariableNamePrefix = "__psEditorServices_";
         private const string TemporaryScriptFileName = "Script Listing.ps1";
+        private readonly BreakpointDetails[] s_emptyBreakpointDetailsArray = new BreakpointDetails[0];
 
         private readonly ILogger logger;
         private readonly PowerShellContextService powerShellContext;
+        private readonly BreakpointService _breakpointService;
         private RemoteFileManagerService remoteFileManager;
 
         // TODO: This needs to be managed per nested session
+        // TODO: Move to BreakpointService
         private readonly Dictionary<string, List<Breakpoint>> breakpointsPerFile =
             new Dictionary<string, List<Breakpoint>>();
 
@@ -104,12 +107,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public DebugService(
             PowerShellContextService powerShellContext,
             RemoteFileManagerService remoteFileManager,
+            BreakpointService breakpointService,
             ILoggerFactory factory)
         {
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
             this.logger = factory.CreateLogger<DebugService>();
             this.powerShellContext = powerShellContext;
+            _breakpointService = breakpointService;
             this.powerShellContext.DebuggerStop += this.OnDebuggerStopAsync;
             this.powerShellContext.DebuggerResumed += this.OnDebuggerResumed;
 
@@ -140,8 +145,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             BreakpointDetails[] breakpoints,
             bool clearExisting = true)
         {
-            var resultBreakpointDetails = new List<BreakpointDetails>();
-
             var dscBreakpoints =
                 this.powerShellContext
                     .CurrentRunspace
@@ -157,7 +160,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     this.logger.LogTrace(
                         $"Could not set breakpoints for local path '{scriptPath}' in a remote session.");
 
-                    return resultBreakpointDetails.ToArray();
+                    return s_emptyBreakpointDetailsArray;
                 }
 
                 string mappedPath =
@@ -174,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.logger.LogTrace(
                     $"Could not set breakpoint on temporary script listing path '{scriptPath}'.");
 
-                return resultBreakpointDetails.ToArray();
+                return s_emptyBreakpointDetailsArray;
             }
 
             // Fix for issue #123 - file paths that contain wildcard chars [ and ] need to
@@ -189,75 +192,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     await this.ClearBreakpointsInFileAsync(scriptFile).ConfigureAwait(false);
                 }
 
-                PSCommand psCommand = null;
-                foreach (BreakpointDetails breakpoint in breakpoints)
-                {
-                    // On first iteration psCommand will be null, every subsequent
-                    // iteration will need to start a new statement.
-                    if (psCommand == null)
-                    {
-                        psCommand = new PSCommand();
-                    }
-                    else
-                    {
-                        psCommand.AddStatement();
-                    }
-
-                    psCommand
-                        .AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint")
-                        .AddParameter("Script", escapedScriptPath)
-                        .AddParameter("Line", breakpoint.LineNumber);
-
-                    // Check if the user has specified the column number for the breakpoint.
-                    if (breakpoint.ColumnNumber.HasValue && breakpoint.ColumnNumber.Value > 0)
-                    {
-                        // It bums me out that PowerShell will silently ignore a breakpoint
-                        // where either the line or the column is invalid.  I'd rather have an
-                        // error or warning message I could relay back to the client.
-                        psCommand.AddParameter("Column", breakpoint.ColumnNumber.Value);
-                    }
-
-                    // Check if this is a "conditional" line breakpoint.
-                    if (!String.IsNullOrWhiteSpace(breakpoint.Condition) ||
-                        !String.IsNullOrWhiteSpace(breakpoint.HitCondition))
-                    {
-                        ScriptBlock actionScriptBlock =
-                            GetBreakpointActionScriptBlock(breakpoint);
-
-                        // If there was a problem with the condition string,
-                        // move onto the next breakpoint.
-                        if (actionScriptBlock == null)
-                        {
-                            resultBreakpointDetails.Add(breakpoint);
-                            continue;
-                        }
-
-                        psCommand.AddParameter("Action", actionScriptBlock);
-                    }
-                }
-
-                // If no PSCommand was created then there are no breakpoints to set.
-                if (psCommand != null)
-                {
-                    IEnumerable<Breakpoint> configuredBreakpoints =
-                        await this.powerShellContext.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
-
-                    // The order in which the breakpoints are returned is significant to the
-                    // VSCode client and should match the order in which they are passed in.
-                    resultBreakpointDetails.AddRange(
-                        configuredBreakpoints.Select(BreakpointDetails.Create));
-                }
-            }
-            else
-            {
-                resultBreakpointDetails =
-                    await dscBreakpoints.SetLineBreakpointsAsync(
-                        powerShellContext,
-                        escapedScriptPath,
-                        breakpoints).ConfigureAwait(false);
+                return await _breakpointService.SetBreakpointsAsync(escapedScriptPath, breakpoints).ConfigureAwait(false);
             }
 
-            return resultBreakpointDetails.ToArray();
+            return await dscBreakpoints.SetLineBreakpointsAsync(
+                this.powerShellContext,
+                escapedScriptPath,
+                breakpoints);
         }
 
         /// <summary>
@@ -270,49 +211,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
             CommandBreakpointDetails[] breakpoints,
             bool clearExisting = true)
         {
-            var resultBreakpointDetails = new List<CommandBreakpointDetails>();
+            CommandBreakpointDetails[] resultBreakpointDetails = null;
 
             if (clearExisting)
             {
-                await this.ClearCommandBreakpointsAsync().ConfigureAwait(false);
+                // Flatten dictionary values into one list and remove them all.
+                await _breakpointService.RemoveBreakpoints(this.breakpointsPerFile.Values.SelectMany( i => i ).Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
             }
 
             if (breakpoints.Length > 0)
             {
-                foreach (CommandBreakpointDetails breakpoint in breakpoints)
-                {
-                    PSCommand psCommand = new PSCommand();
-                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Set-PSBreakpoint");
-                    psCommand.AddParameter("Command", breakpoint.Name);
-
-                    // Check if this is a "conditional" command breakpoint.
-                    if (!String.IsNullOrWhiteSpace(breakpoint.Condition) ||
-                        !String.IsNullOrWhiteSpace(breakpoint.HitCondition))
-                    {
-                        ScriptBlock actionScriptBlock = GetBreakpointActionScriptBlock(breakpoint);
-
-                        // If there was a problem with the condition string,
-                        // move onto the next breakpoint.
-                        if (actionScriptBlock == null)
-                        {
-                            resultBreakpointDetails.Add(breakpoint);
-                            continue;
-                        }
-
-                        psCommand.AddParameter("Action", actionScriptBlock);
-                    }
-
-                    IEnumerable<Breakpoint> configuredBreakpoints =
-                        await this.powerShellContext.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
-
-                    // The order in which the breakpoints are returned is significant to the
-                    // VSCode client and should match the order in which they are passed in.
-                    resultBreakpointDetails.AddRange(
-                        configuredBreakpoints.Select(CommandBreakpointDetails.Create));
-                }
+                resultBreakpointDetails = (await _breakpointService.SetCommandBreakpoints(breakpoints).ConfigureAwait(false)).ToArray();
             }
 
-            return resultBreakpointDetails.ToArray();
+            return resultBreakpointDetails ?? new CommandBreakpointDetails[0];
         }
 
         /// <summary>
@@ -753,25 +665,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             };
         }
 
-        /// <summary>
-        /// Clears all breakpoints in the current session.
-        /// </summary>
-        public async Task ClearAllBreakpointsAsync()
-        {
-            try
-            {
-                PSCommand psCommand = new PSCommand();
-                psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
-                psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
-
-                await this.powerShellContext.ExecuteCommandAsync<object>(psCommand).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                logger.LogException("Caught exception while clearing breakpoints from session", e);
-            }
-        }
-
         #endregion
 
         #region Private Methods
@@ -783,26 +676,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 if (breakpoints.Count > 0)
                 {
-                    PSCommand psCommand = new PSCommand();
-                    psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
-                    psCommand.AddParameter("Id", breakpoints.Select(b => b.Id).ToArray());
-
-                    await this.powerShellContext.ExecuteCommandAsync<object>(psCommand).ConfigureAwait(false);
+                    await _breakpointService.RemoveBreakpoints(breakpoints).ConfigureAwait(false);
 
                     // Clear the existing breakpoints list for the file
                     breakpoints.Clear();
                 }
             }
-        }
-
-        private async Task ClearCommandBreakpointsAsync()
-        {
-            PSCommand psCommand = new PSCommand();
-            psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
-            psCommand.AddParameter("Type", "Command");
-            psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
-
-            await this.powerShellContext.ExecuteCommandAsync<object>(psCommand).ConfigureAwait(false);
         }
 
         private async Task FetchStackFramesAndVariablesAsync(string scriptNameOverride)
@@ -996,187 +875,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             this.powerShellContext.CurrentRunspace);
                 }
             }
-        }
-
-        /// <summary>
-        /// Inspects the condition, putting in the appropriate scriptblock template
-        /// "if (expression) { break }".  If errors are found in the condition, the
-        /// breakpoint passed in is updated to set Verified to false and an error
-        /// message is put into the breakpoint.Message property.
-        /// </summary>
-        /// <param name="breakpoint"></param>
-        /// <returns></returns>
-        private ScriptBlock GetBreakpointActionScriptBlock(
-            BreakpointDetailsBase breakpoint)
-        {
-            try
-            {
-                ScriptBlock actionScriptBlock;
-                int? hitCount = null;
-
-                // If HitCondition specified, parse and verify it.
-                if (!(String.IsNullOrWhiteSpace(breakpoint.HitCondition)))
-                {
-                    if (Int32.TryParse(breakpoint.HitCondition, out int parsedHitCount))
-                    {
-                        hitCount = parsedHitCount;
-                    }
-                    else
-                    {
-                        breakpoint.Verified = false;
-                        breakpoint.Message = $"The specified HitCount '{breakpoint.HitCondition}' is not valid. " +
-                                              "The HitCount must be an integer number.";
-                        return null;
-                    }
-                }
-
-                // Create an Action scriptblock based on condition and/or hit count passed in.
-                if (hitCount.HasValue && string.IsNullOrWhiteSpace(breakpoint.Condition))
-                {
-                    // In the HitCount only case, this is simple as we can just use the HitCount
-                    // property on the breakpoint object which is represented by $_.
-                    string action = $"if ($_.HitCount -eq {hitCount}) {{ break }}";
-                    actionScriptBlock = ScriptBlock.Create(action);
-                }
-                else if (!string.IsNullOrWhiteSpace(breakpoint.Condition))
-                {
-                    // Must be either condition only OR condition and hit count.
-                    actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
-
-                    // Check for simple, common errors that ScriptBlock parsing will not catch
-                    // e.g. $i == 3 and $i > 3
-                    if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out string message))
-                    {
-                        breakpoint.Verified = false;
-                        breakpoint.Message = message;
-                        return null;
-                    }
-
-                    // Check for "advanced" condition syntax i.e. if the user has specified
-                    // a "break" or  "continue" statement anywhere in their scriptblock,
-                    // pass their scriptblock through to the Action parameter as-is.
-                    Ast breakOrContinueStatementAst =
-                        actionScriptBlock.Ast.Find(
-                            ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
-
-                    // If this isn't advanced syntax then the conditions string should be a simple
-                    // expression that needs to be wrapped in a "if" test that conditionally executes
-                    // a break statement.
-                    if (breakOrContinueStatementAst == null)
-                    {
-                        string wrappedCondition;
-
-                        if (hitCount.HasValue)
-                        {
-                            string globalHitCountVarName =
-                                $"$global:{PsesGlobalVariableNamePrefix}BreakHitCounter_{breakpointHitCounter++}";
-
-                            wrappedCondition =
-                                $"if ({breakpoint.Condition}) {{ if (++{globalHitCountVarName} -eq {hitCount}) {{ break }} }}";
-                        }
-                        else
-                        {
-                            wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
-                        }
-
-                        actionScriptBlock = ScriptBlock.Create(wrappedCondition);
-                    }
-                }
-                else
-                {
-                    // Shouldn't get here unless someone called this with no condition and no hit count.
-                    actionScriptBlock = ScriptBlock.Create("break");
-                    this.logger.LogWarning("No condition and no hit count specified by caller.");
-                }
-
-                return actionScriptBlock;
-            }
-            catch (ParseException ex)
-            {
-                // Failed to create conditional breakpoint likely because the user provided an
-                // invalid PowerShell expression. Let the user know why.
-                breakpoint.Verified = false;
-                breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
-                return null;
-            }
-        }
-
-        private bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
-        {
-            message = string.Empty;
-
-            // We are only inspecting a few simple scenarios in the EndBlock only.
-            if (conditionAst is ScriptBlockAst scriptBlockAst &&
-                scriptBlockAst.BeginBlock == null &&
-                scriptBlockAst.ProcessBlock == null &&
-                scriptBlockAst.EndBlock != null &&
-                scriptBlockAst.EndBlock.Statements.Count == 1)
-            {
-                StatementAst statementAst = scriptBlockAst.EndBlock.Statements[0];
-                string condition = statementAst.Extent.Text;
-
-                if (statementAst is AssignmentStatementAst)
-                {
-                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-eq' instead of '=='.");
-                    return false;
-                }
-
-                if (statementAst is PipelineAst pipelineAst
-                    && pipelineAst.PipelineElements.Count == 1
-                    && pipelineAst.PipelineElements[0].Redirections.Count > 0)
-                {
-                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-gt' instead of '>'.");
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
-        {
-            string[] messageLines = parseException.Message.Split('\n');
-
-            // Skip first line - it is a location indicator "At line:1 char: 4"
-            for (int i = 1; i < messageLines.Length; i++)
-            {
-                string line = messageLines[i];
-                if (line.StartsWith("+"))
-                {
-                    continue;
-                }
-
-                if (!string.IsNullOrWhiteSpace(line))
-                {
-                    // Note '==' and '>" do not generate parse errors
-                    if (line.Contains("'!='"))
-                    {
-                        line += " Use operator '-ne' instead of '!='.";
-                    }
-                    else if (line.Contains("'<'") && condition.Contains("<="))
-                    {
-                        line += " Use operator '-le' instead of '<='.";
-                    }
-                    else if (line.Contains("'<'"))
-                    {
-                        line += " Use operator '-lt' instead of '<'.";
-                    }
-                    else if (condition.Contains(">="))
-                    {
-                        line += " Use operator '-ge' instead of '>='.";
-                    }
-
-                    return FormatInvalidBreakpointConditionMessage(condition, line);
-                }
-            }
-
-            // If the message format isn't in a form we expect, just return the whole message.
-            return FormatInvalidBreakpointConditionMessage(condition, parseException.Message);
-        }
-
-        private string FormatInvalidBreakpointConditionMessage(string condition, string message)
-        {
-            return $"'{condition}' is not a valid PowerShell expression. {message}";
         }
 
         private string TrimScriptListingLine(PSObject scriptLineObj, ref int prefixLength)

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (clearExisting)
             {
                 // Flatten dictionary values into one list and remove them all.
-                await _breakpointService.RemoveBreakpointsAsync(_breakpointService.GetBreakpoints().Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
+                await _breakpointService.RemoveBreakpointsAsync((await _breakpointService.GetBreakpointsAsync()).Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
             }
 
             if (breakpoints.Length > 0)
@@ -672,8 +672,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // {
                 // if (breakpoints.Count > 0)
                 // {
-                    await _breakpointService.RemoveBreakpointsAsync(_breakpointService.GetBreakpoints()
-                        .Where(bp => bp is LineBreakpoint lbp && string.Equals(lbp.Script, scriptFile.FilePath))).ConfigureAwait(false);
+                    await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
+                    // await _breakpointService.RemoveBreakpointsAsync((await _breakpointService.GetBreakpointsAsync())
+                    //     .Where(bp => bp is LineBreakpoint lbp && string.Equals(lbp.Script, scriptFile.FilePath))).ConfigureAwait(false);
 
                     // Clear the existing breakpoints list for the file
                     // breakpoints.Clear();

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -14,11 +14,9 @@ using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Utility;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
-using System.Collections.Concurrent;
 
 namespace Microsoft.PowerShell.EditorServices.Services
 {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (clearExisting)
             {
                 // Flatten dictionary values into one list and remove them all.
-                await _breakpointService.RemoveBreakpoints(this.breakpointsPerFile.Values.SelectMany( i => i ).Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
+                await _breakpointService.RemoveBreakpointsAsync(this.breakpointsPerFile.Values.SelectMany( i => i ).Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
             }
 
             if (breakpoints.Length > 0)
@@ -676,7 +676,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 if (breakpoints.Count > 0)
                 {
-                    await _breakpointService.RemoveBreakpoints(breakpoints).ConfigureAwait(false);
+                    await _breakpointService.RemoveBreakpointsAsync(breakpoints).ConfigureAwait(false);
 
                     // Clear the existing breakpoints list for the file
                     breakpoints.Clear();

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 if (clearExisting)
                 {
-                    await this.ClearBreakpointsInFileAsync(scriptFile).ConfigureAwait(false);
+                    await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
                 }
 
                 return (await _breakpointService.SetBreakpointsAsync(escapedScriptPath, breakpoints).ConfigureAwait(false)).ToArray();
@@ -664,23 +664,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
         #endregion
 
         #region Private Methods
-
-        private async Task ClearBreakpointsInFileAsync(ScriptFile scriptFile)
-        {
-            // Get the list of breakpoints for this file
-            // if (_breakpointService.BreakpointsPerFile.TryGetValue(scriptFile.Id, out HashSet<Breakpoint> breakpoints))
-            // {
-                // if (breakpoints.Count > 0)
-                // {
-                    await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
-                    // await _breakpointService.RemoveBreakpointsAsync((await _breakpointService.GetBreakpointsAsync())
-                    //     .Where(bp => bp is LineBreakpoint lbp && string.Equals(lbp.Script, scriptFile.FilePath))).ConfigureAwait(false);
-
-                    // Clear the existing breakpoints list for the file
-                    // breakpoints.Clear();
-                // }
-            // }
-        }
 
         private async Task FetchStackFramesAndVariablesAsync(string scriptNameOverride)
         {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
@@ -19,6 +19,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         internal bool IsRemoteAttach { get; set; }
 
+        internal int? RunspaceId { get; set; }
+
         internal bool IsAttachSession { get; set; }
 
         internal bool WaitingForAttach { get; set; }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -25,10 +25,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
         private static readonly Lazy<Func<Debugger, Breakpoint, bool>> s_removeBreakpointLazy;
 
-        private static readonly Lazy<Func<string, int, int, ScriptBlock, LineBreakpoint>> s_newLineBreakpointLazy;
-
-        private static readonly Lazy<Func<string, WildcardPattern, string, ScriptBlock, CommandBreakpoint>> s_newCommandBreakpointLazy;
-
         #endregion
 
         #region Static Constructor
@@ -94,10 +90,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         private static Func<Debugger, List<Breakpoint>> GetBreakpointsDelegate => s_getBreakpointsLazy.Value;
 
         private static Func<Debugger, Breakpoint, bool> RemoveBreakpointDelegate => s_removeBreakpointLazy.Value;
-
-        private static Func<string, int, int, ScriptBlock, LineBreakpoint> CreateLineBreakpointDelegate => s_newLineBreakpointLazy.Value;
-
-        private static Func<string, WildcardPattern, string, ScriptBlock, CommandBreakpoint> CreateCommandBreakpointDelegate => s_newCommandBreakpointLazy.Value;
 
         #endregion
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -5,14 +5,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Reflection;
 using System.Text;
 using System.Threading;
-using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
@@ -115,6 +113,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
         #endregion
 
+        #region Public Static Properties
+
+        // TODO: Try to compute this more dynamically. If we're launching a script in the PSIC, there are APIs are available in PS 5.1 and up.
+        // For now, only PS7 or greater gets this feature.
+        public static bool SupportsBreakpointApis => VersionUtils.IsPS7OrGreater;
+
+        #endregion
+
         #region Public Static Methods
 
         public static Breakpoint SetBreakpoint(Debugger debugger, BreakpointDetailsBase breakpoint, int? runspaceId = null)
@@ -172,7 +178,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     // In the HitCount only case, this is simple as we can just use the HitCount
                     // property on the breakpoint object which is represented by $_.
                     builder.Insert(0, $"if ($_.HitCount -eq {parsedHitCount}) {{ ")
-                        .Append(" }}");
+                        .Append(" }");
                 }
 
                 Interlocked.Increment(ref breakpointHitCounter);
@@ -181,7 +187,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     $"$global:{s_psesGlobalVariableNamePrefix}BreakHitCounter_{breakpointHitCounter}";
 
                 builder.Insert(0, $"if (++{globalHitCountVarName} -eq {parsedHitCount}) {{ ")
-                    .Append(" }}");
+                    .Append(" }");
             }
 
             if (!string.IsNullOrWhiteSpace(condition))

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -1,0 +1,145 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
+
+{
+    internal static class BreakpointApiUtils
+    {
+        #region Private Static Fields
+
+        private static readonly Lazy<Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint>> s_setLineBreakpointLazy;
+
+        private static readonly Lazy<Func<Debugger, string, ScriptBlock, string, CommandBreakpoint>> s_setCommandBreakpointLazy;
+
+        private static readonly Lazy<Func<Debugger, List<Breakpoint>>> s_getBreakpointsLazy;
+
+        private static readonly Lazy<Func<Debugger, Breakpoint, bool>> s_removeBreakpointLazy;
+
+        private static readonly Lazy<Func<string, int, int, ScriptBlock, LineBreakpoint>> s_newLineBreakpointLazy;
+
+        private static readonly Lazy<Func<string, WildcardPattern, string, ScriptBlock, CommandBreakpoint>> s_newCommandBreakpointLazy;
+
+        #endregion
+
+        #region Static Constructor
+
+        static BreakpointApiUtils()
+        {
+            // If this version of PowerShell does not support the new Breakpoint APIs introduced in PowerShell 7.0.0-preview.4,
+            // do nothing as this class will not get used.
+            if (typeof(Debugger).GetMethod("SetLineBreakpoint", BindingFlags.Public | BindingFlags.Instance) == null)
+            {
+                return;
+            }
+
+            s_setLineBreakpointLazy = new Lazy<Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint>>(() =>
+            {
+                MethodInfo setLineBreakpointMethod = typeof(Debugger).GetMethod("SetLineBreakpoint", BindingFlags.Public | BindingFlags.Instance);
+
+                return (Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint>)Delegate.CreateDelegate(
+                    typeof(Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint>),
+                    firstArgument: null,
+                    setLineBreakpointMethod);
+            });
+
+            s_setCommandBreakpointLazy = new Lazy<Func<Debugger, string, ScriptBlock, string, CommandBreakpoint>>(() =>
+            {
+                MethodInfo setCommandBreakpointMethod = typeof(Debugger).GetMethod("SetCommandBreakpoint", BindingFlags.Public | BindingFlags.Instance);
+
+                return (Func<Debugger, string, ScriptBlock, string, CommandBreakpoint>)Delegate.CreateDelegate(
+                    typeof(Func<Debugger, string, ScriptBlock, string, CommandBreakpoint>),
+                    firstArgument: null,
+                    setCommandBreakpointMethod);
+            });
+
+            s_getBreakpointsLazy = new Lazy<Func<Debugger, List<Breakpoint>>>(() =>
+            {
+                MethodInfo removeBreakpointMethod = typeof(Debugger).GetMethod("GetBreakpoints", BindingFlags.Public | BindingFlags.Instance);
+
+                return (Func<Debugger, List<Breakpoint>>)Delegate.CreateDelegate(
+                    typeof(Func<Debugger, List<Breakpoint>>),
+                    firstArgument: null,
+                    removeBreakpointMethod);
+            });
+
+            s_removeBreakpointLazy = new Lazy<Func<Debugger, Breakpoint, bool>>(() =>
+            {
+                MethodInfo removeBreakpointMethod = typeof(Debugger).GetMethod("RemoveBreakpoint", BindingFlags.Public | BindingFlags.Instance);
+
+                return (Func<Debugger, Breakpoint, bool>)Delegate.CreateDelegate(
+                    typeof(Func<Debugger, Breakpoint, bool>),
+                    firstArgument: null,
+                    removeBreakpointMethod);
+            });
+        }
+
+        #endregion
+
+        #region Public Static Properties
+
+        private static Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint> SetLineBreakpointDelegate => s_setLineBreakpointLazy.Value;
+
+        private static Func<Debugger, string, ScriptBlock, string, CommandBreakpoint> SetCommandBreakpointDelegate => s_setCommandBreakpointLazy.Value;
+
+        private static Func<Debugger, List<Breakpoint>> GetBreakpointsDelegate => s_getBreakpointsLazy.Value;
+
+        private static Func<Debugger, Breakpoint, bool> RemoveBreakpointDelegate => s_removeBreakpointLazy.Value;
+
+        private static Func<string, int, int, ScriptBlock, LineBreakpoint> CreateLineBreakpointDelegate => s_newLineBreakpointLazy.Value;
+
+        private static Func<string, WildcardPattern, string, ScriptBlock, CommandBreakpoint> CreateCommandBreakpointDelegate => s_newCommandBreakpointLazy.Value;
+
+        #endregion
+
+        #region Public Static Methods
+
+        public static IEnumerable<Breakpoint> SetBreakpoints(Debugger debugger, IEnumerable<BreakpointDetailsBase> breakpoints)
+        {
+            var psBreakpoints = new List<Breakpoint>(breakpoints.Count());
+
+            foreach (BreakpointDetailsBase breakpoint in breakpoints)
+            {
+                Breakpoint psBreakpoint;
+                switch (breakpoint)
+                {
+                    case BreakpointDetails lineBreakpoint:
+                        psBreakpoint = SetLineBreakpointDelegate(debugger, lineBreakpoint.Source, lineBreakpoint.LineNumber, lineBreakpoint.ColumnNumber ?? 0, null);
+                        break;
+
+                    case CommandBreakpointDetails commandBreakpoint:
+                        psBreakpoint = SetCommandBreakpointDelegate(debugger, commandBreakpoint.Name, null, null);
+                        break;
+
+                    default:
+                        throw new NotImplementedException("Other breakpoints not supported yet");
+                }
+
+                psBreakpoints.Add(psBreakpoint);
+            }
+
+            return psBreakpoints;
+        }
+
+        public static List<Breakpoint> GetBreakpoints(Debugger debugger)
+        {
+            return GetBreakpointsDelegate(debugger);
+        }
+
+        public static bool RemoveBreakpoint(Debugger debugger, Breakpoint breakpoint)
+        {
+            return RemoveBreakpointDelegate(debugger, breakpoint);
+        }
+
+        #endregion
+    }
+}

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -8,7 +8,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 using System.Reflection;
+using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
@@ -17,6 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
     {
         #region Private Static Fields
 
+        private const string s_psesGlobalVariableNamePrefix = "__psEditorServices_";
+
         private static readonly Lazy<Func<Debugger, string, int, int, ScriptBlock, LineBreakpoint>> s_setLineBreakpointLazy;
 
         private static readonly Lazy<Func<Debugger, string, ScriptBlock, string, CommandBreakpoint>> s_setCommandBreakpointLazy;
@@ -24,6 +29,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         private static readonly Lazy<Func<Debugger, List<Breakpoint>>> s_getBreakpointsLazy;
 
         private static readonly Lazy<Func<Debugger, Breakpoint, bool>> s_removeBreakpointLazy;
+
+        private static int breakpointHitCounter;
 
         #endregion
 
@@ -101,11 +108,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
             foreach (BreakpointDetailsBase breakpoint in breakpoints)
             {
+                ScriptBlock actionScriptBlock = null;
+                // Check if this is a "conditional" line breakpoint.
+                if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+                    !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
+                {
+                    actionScriptBlock = GetBreakpointActionScriptBlock(breakpoint);
+                }
+
                 Breakpoint psBreakpoint;
                 switch (breakpoint)
                 {
                     case BreakpointDetails lineBreakpoint:
-                        psBreakpoint = SetLineBreakpointDelegate(debugger, lineBreakpoint.Source, lineBreakpoint.LineNumber, lineBreakpoint.ColumnNumber ?? 0, null);
+                        psBreakpoint = SetLineBreakpointDelegate(debugger, lineBreakpoint.Source, lineBreakpoint.LineNumber, lineBreakpoint.ColumnNumber ?? 0, actionScriptBlock);
                         break;
 
                     case CommandBreakpointDetails commandBreakpoint:
@@ -130,6 +145,188 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         public static bool RemoveBreakpoint(Debugger debugger, Breakpoint breakpoint)
         {
             return RemoveBreakpointDelegate(debugger, breakpoint);
+        }
+
+        /// <summary>
+        /// Inspects the condition, putting in the appropriate scriptblock template
+        /// "if (expression) { break }".  If errors are found in the condition, the
+        /// breakpoint passed in is updated to set Verified to false and an error
+        /// message is put into the breakpoint.Message property.
+        /// </summary>
+        /// <param name="breakpoint"></param>
+        /// <returns>ScriptBlock</returns>
+        public static ScriptBlock GetBreakpointActionScriptBlock(
+            BreakpointDetailsBase breakpoint)
+        {
+            try
+            {
+                ScriptBlock actionScriptBlock;
+                int? hitCount = null;
+
+                // If HitCondition specified, parse and verify it.
+                if (!(string.IsNullOrWhiteSpace(breakpoint.HitCondition)))
+                {
+                    if (int.TryParse(breakpoint.HitCondition, out int parsedHitCount))
+                    {
+                        hitCount = parsedHitCount;
+                    }
+                    else
+                    {
+                        breakpoint.Verified = false;
+                        breakpoint.Message = $"The specified HitCount '{breakpoint.HitCondition}' is not valid. " +
+                                              "The HitCount must be an integer number.";
+                        return null;
+                    }
+                }
+
+                // Create an Action scriptblock based on condition and/or hit count passed in.
+                if (hitCount.HasValue && string.IsNullOrWhiteSpace(breakpoint.Condition))
+                {
+                    // In the HitCount only case, this is simple as we can just use the HitCount
+                    // property on the breakpoint object which is represented by $_.
+                    string action = $"if ($_.HitCount -eq {hitCount}) {{ break }}";
+                    actionScriptBlock = ScriptBlock.Create(action);
+                }
+                else if (!string.IsNullOrWhiteSpace(breakpoint.Condition))
+                {
+                    // Must be either condition only OR condition and hit count.
+                    actionScriptBlock = ScriptBlock.Create(breakpoint.Condition);
+
+                    // Check for simple, common errors that ScriptBlock parsing will not catch
+                    // e.g. $i == 3 and $i > 3
+                    if (!ValidateBreakpointConditionAst(actionScriptBlock.Ast, out string message))
+                    {
+                        breakpoint.Verified = false;
+                        breakpoint.Message = message;
+                        return null;
+                    }
+
+                    // Check for "advanced" condition syntax i.e. if the user has specified
+                    // a "break" or  "continue" statement anywhere in their scriptblock,
+                    // pass their scriptblock through to the Action parameter as-is.
+                    Ast breakOrContinueStatementAst =
+                        actionScriptBlock.Ast.Find(
+                            ast => (ast is BreakStatementAst || ast is ContinueStatementAst), true);
+
+                    // If this isn't advanced syntax then the conditions string should be a simple
+                    // expression that needs to be wrapped in a "if" test that conditionally executes
+                    // a break statement.
+                    if (breakOrContinueStatementAst == null)
+                    {
+                        string wrappedCondition;
+
+                        if (hitCount.HasValue)
+                        {
+                            Interlocked.Increment(ref breakpointHitCounter);
+
+                            string globalHitCountVarName =
+                                $"$global:{s_psesGlobalVariableNamePrefix}BreakHitCounter_{breakpointHitCounter}";
+
+                            wrappedCondition =
+                                $"if ({breakpoint.Condition}) {{ if (++{globalHitCountVarName} -eq {hitCount}) {{ break }} }}";
+                        }
+                        else
+                        {
+                            wrappedCondition = $"if ({breakpoint.Condition}) {{ break }}";
+                        }
+
+                        actionScriptBlock = ScriptBlock.Create(wrappedCondition);
+                    }
+                }
+                else
+                {
+                    // Shouldn't get here unless someone called this with no condition and no hit count.
+                    actionScriptBlock = ScriptBlock.Create("break");
+                }
+
+                return actionScriptBlock;
+            }
+            catch (ParseException ex)
+            {
+                // Failed to create conditional breakpoint likely because the user provided an
+                // invalid PowerShell expression. Let the user know why.
+                breakpoint.Verified = false;
+                breakpoint.Message = ExtractAndScrubParseExceptionMessage(ex, breakpoint.Condition);
+                return null;
+            }
+        }
+
+        private static bool ValidateBreakpointConditionAst(Ast conditionAst, out string message)
+        {
+            message = string.Empty;
+
+            // We are only inspecting a few simple scenarios in the EndBlock only.
+            if (conditionAst is ScriptBlockAst scriptBlockAst &&
+                scriptBlockAst.BeginBlock == null &&
+                scriptBlockAst.ProcessBlock == null &&
+                scriptBlockAst.EndBlock != null &&
+                scriptBlockAst.EndBlock.Statements.Count == 1)
+            {
+                StatementAst statementAst = scriptBlockAst.EndBlock.Statements[0];
+                string condition = statementAst.Extent.Text;
+
+                if (statementAst is AssignmentStatementAst)
+                {
+                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-eq' instead of '=='.");
+                    return false;
+                }
+
+                if (statementAst is PipelineAst pipelineAst
+                    && pipelineAst.PipelineElements.Count == 1
+                    && pipelineAst.PipelineElements[0].Redirections.Count > 0)
+                {
+                    message = FormatInvalidBreakpointConditionMessage(condition, "Use '-gt' instead of '>'.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
+        {
+            string[] messageLines = parseException.Message.Split('\n');
+
+            // Skip first line - it is a location indicator "At line:1 char: 4"
+            for (int i = 1; i < messageLines.Length; i++)
+            {
+                string line = messageLines[i];
+                if (line.StartsWith("+"))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    // Note '==' and '>" do not generate parse errors
+                    if (line.Contains("'!='"))
+                    {
+                        line += " Use operator '-ne' instead of '!='.";
+                    }
+                    else if (line.Contains("'<'") && condition.Contains("<="))
+                    {
+                        line += " Use operator '-le' instead of '<='.";
+                    }
+                    else if (line.Contains("'<'"))
+                    {
+                        line += " Use operator '-lt' instead of '<'.";
+                    }
+                    else if (condition.Contains(">="))
+                    {
+                        line += " Use operator '-ge' instead of '>='.";
+                    }
+
+                    return FormatInvalidBreakpointConditionMessage(condition, line);
+                }
+            }
+
+            // If the message format isn't in a form we expect, just return the whole message.
+            return FormatInvalidBreakpointConditionMessage(condition, parseException.Message);
+        }
+
+        private static string FormatInvalidBreakpointConditionMessage(string condition, string message)
+        {
+            return $"'{condition}' is not a valid PowerShell expression. {message}";
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -36,6 +36,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// </summary>
         public int? ColumnNumber { get; private set; }
 
+        public string LogMessage { get; private set; }
+
         private BreakpointDetails()
         {
         }
@@ -55,7 +57,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             int line,
             int? column = null,
             string condition = null,
-            string hitCondition = null)
+            string hitCondition = null,
+            string logMessage = null)
         {
             Validate.IsNotNull("source", source);
 
@@ -66,7 +69,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 LineNumber = line,
                 ColumnNumber = column,
                 Condition = condition,
-                HitCondition = hitCondition
+                HitCondition = hitCondition,
+                LogMessage = logMessage
             };
         }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
     /// Provides details about a breakpoint that is set in the
     /// PowerShell debugger.
     /// </summary>
-    public class BreakpointDetails : BreakpointDetailsBase
+    internal class BreakpointDetails : BreakpointDetailsBase
     {
         /// <summary>
         /// Gets the unique ID of the breakpoint.
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="condition"></param>
         /// <param name="hitCondition"></param>
         /// <returns></returns>
-        public static BreakpointDetails Create(
+        internal static BreakpointDetails Create(
             string source,
             int line,
             int? column = null,
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// </summary>
         /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
         /// <returns>A new instance of the BreakpointDetails class.</returns>
-        public static BreakpointDetails Create(Breakpoint breakpoint)
+        internal static BreakpointDetails Create(Breakpoint breakpoint)
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
     /// <summary>
     /// Provides details about a command breakpoint that is set in the PowerShell debugger.
     /// </summary>
-    public class CommandBreakpointDetails : BreakpointDetailsBase
+    internal class CommandBreakpointDetails : BreakpointDetailsBase
     {
         /// <summary>
         /// Gets the name of the command on which the command breakpoint has been set.
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="condition">Condition string that would be applied to the breakpoint Action parameter.</param>
         /// <param name="hitCondition">Hit condition string that would be applied to the breakpoint Action parameter.</param>
         /// <returns></returns>
-        public static CommandBreakpointDetails Create(
+        internal static CommandBreakpointDetails Create(
             string name,
             string condition = null,
             string hitCondition = null)
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// </summary>
         /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
         /// <returns>A new instance of the BreakpointDetails class.</returns>
-        public static CommandBreakpointDetails Create(Breakpoint breakpoint)
+        internal static CommandBreakpointDetails Create(Breakpoint breakpoint)
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             string fileExtension = Path.GetExtension(scriptFile?.FilePath ?? "")?.ToLower();
             bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
             if ((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
-                (!VersionUtils.IsPS7OrGreater && isUntitledPath))
+                (!BreakpointApiUtils.SupportsBreakpointApis && isUntitledPath))
             {
                 _logger.LogWarning(
                     $"Attempted to set breakpoints on a non-PowerShell file: {request.Source.Path}");
@@ -189,7 +189,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     (int)srcBreakpoint.Line,
                     (int?)srcBreakpoint.Column,
                     srcBreakpoint.Condition,
-                    srcBreakpoint.HitCondition))
+                    srcBreakpoint.HitCondition,
+                    srcBreakpoint.LogMessage))
                 .ToArray();
 
             // If this is a "run without debugging (Ctrl+F5)" session ignore requests to set breakpoints.

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -141,13 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<SetBreakpointsResponse> Handle(SetBreakpointsArguments request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile = null;
-            bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
-
-            // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
-            // the Source.Path comes through as Untitled-X. That's why we check for IsUntitledPath.
-            if (!_workspaceService.TryGetFile(request.Source.Path, out scriptFile) &&
-                !isUntitledPath)
+            if (!_workspaceService.TryGetFile(request.Source.Path, out ScriptFile scriptFile))
             {
                 string message = _debugStateService.NoDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
                 var srcBreakpoints = request.Breakpoints
@@ -163,6 +157,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Verify source file is a PowerShell script file.
             string fileExtension = Path.GetExtension(scriptFile?.FilePath ?? "")?.ToLower();
+            bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
             if ((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
                 (!BreakpointApiUtils.SupportsBreakpointApis && isUntitledPath))
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -145,10 +145,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
             // the Source.Path comes through as Untitled-X. That's why we check for IsUntitledPath.
-            if (!ScriptFile.IsUntitledPath(request.Source.Path) &&
-                !_workspaceService.TryGetFile(
-                    request.Source.Path,
-                    out scriptFile))
+            if (!_workspaceService.TryGetFile(request.Source.Path, out scriptFile) &&
+                !ScriptFile.IsUntitledPath(request.Source.Path))
             {
                 string message = _debugStateService.NoDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
                 var srcBreakpoints = request.Breakpoints
@@ -164,7 +162,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Verify source file is a PowerShell script file.
             string fileExtension = Path.GetExtension(scriptFile?.FilePath ?? "")?.ToLower();
-            if (string.IsNullOrEmpty(fileExtension) || ((fileExtension != ".ps1") && (fileExtension != ".psm1")))
+            bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
+            if ((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
+                (!VersionUtils.IsPS7OrGreater && isUntitledPath))
             {
                 _logger.LogWarning(
                     $"Attempted to set breakpoints on a non-PowerShell file: {request.Source.Path}");

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -142,11 +142,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public async Task<SetBreakpointsResponse> Handle(SetBreakpointsArguments request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = null;
+            bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
 
             // When you set a breakpoint in the right pane of a Git diff window on a PS1 file,
             // the Source.Path comes through as Untitled-X. That's why we check for IsUntitledPath.
             if (!_workspaceService.TryGetFile(request.Source.Path, out scriptFile) &&
-                !ScriptFile.IsUntitledPath(request.Source.Path))
+                !isUntitledPath)
             {
                 string message = _debugStateService.NoDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
                 var srcBreakpoints = request.Breakpoints
@@ -162,7 +163,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Verify source file is a PowerShell script file.
             string fileExtension = Path.GetExtension(scriptFile?.FilePath ?? "")?.ToLower();
-            bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
             if ((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
                 (!BreakpointApiUtils.SupportsBreakpointApis && isUntitledPath))
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     ScriptBlockAst ast = Parser.ParseInput(untitledScript.Contents, untitledScript.DocumentUri, out Token[] tokens, out ParseError[] errors);
 
                     // This seems to be the simplest way to invoke a script block (which contains breakpoint information) via the PowerShell API.
-                    var cmd = new PSCommand().AddScript("& $args[0]").AddArgument(ast.GetScriptBlock());
+                    var cmd = new PSCommand().AddScript(". $args[0]").AddArgument(ast.GetScriptBlock());
                     await _powerShellContextService
                         .ExecuteCommandAsync<object>(cmd, sendOutputToHost: true, sendErrorToHost:true)
                         .ConfigureAwait(false);

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/InitializeHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/InitializeHandler.cs
@@ -15,19 +15,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     {
         private readonly ILogger<InitializeHandler> _logger;
         private readonly DebugService _debugService;
+        private readonly BreakpointService _breakpointService;
 
         public InitializeHandler(
             ILoggerFactory factory,
-            DebugService debugService)
+            DebugService debugService,
+            BreakpointService breakpointService)
         {
             _logger = factory.CreateLogger<InitializeHandler>();
             _debugService = debugService;
+            _breakpointService = breakpointService;
         }
 
         public async Task<InitializeResponse> Handle(InitializeRequestArguments request, CancellationToken cancellationToken)
         {
             // Clear any existing breakpoints before proceeding
-            await _debugService.ClearAllBreakpointsAsync().ConfigureAwait(false);
+            await _breakpointService.RemoveAllBreakpointsAsync().ConfigureAwait(false);
 
             // Now send the Initialize response to continue setup
             return new InitializeResponse

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/InitializeHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/InitializeHandler.cs
@@ -35,10 +35,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Now send the Initialize response to continue setup
             return new InitializeResponse
                 {
+                    SupportsConditionalBreakpoints = true,
                     SupportsConfigurationDoneRequest = true,
                     SupportsFunctionBreakpoints = true,
-                    SupportsConditionalBreakpoints = true,
                     SupportsHitConditionalBreakpoints = true,
+                    SupportsLogPoints = true,
                     SupportsSetVariable = true
                 };
         }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Management.Automation;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -341,10 +342,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             string debugRunspaceCmd;
             if (request.RunspaceName != null)
             {
-                var ids = await _powerShellContextService.ExecuteScriptStringAsync($"Get-Runspace -Name {request.RunspaceName} | % Id");
+                IEnumerable<int?> ids = await _powerShellContextService.ExecuteCommandAsync<int?>(new PSCommand()
+                    .AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace")
+                    .AddParameter("Name", request.RunspaceName)
+                    .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
+                    .AddParameter("ExpandProperty", "Id"));
                 foreach (var id in ids)
                 {
-                    _debugStateService.RunspaceId = (int?) id;
+                    _debugStateService.RunspaceId = id;
                     break;
                 }
                 debugRunspaceCmd = $"\nDebug-Runspace -Name '{request.RunspaceName}'";

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -212,6 +212,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private readonly ILogger<AttachHandler> _logger;
         private readonly DebugService _debugService;
+        private readonly BreakpointService _breakpointService;
         private readonly PowerShellContextService _powerShellContextService;
         private readonly DebugStateService _debugStateService;
         private readonly DebugEventHandlerService _debugEventHandlerService;
@@ -223,11 +224,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             DebugService debugService,
             PowerShellContextService powerShellContextService,
             DebugStateService debugStateService,
+            BreakpointService breakpointService,
             DebugEventHandlerService debugEventHandlerService)
         {
             _logger = factory.CreateLogger<AttachHandler>();
             _jsonRpcServer = jsonRpcServer;
             _debugService = debugService;
+            _breakpointService = breakpointService;
             _powerShellContextService = powerShellContextService;
             _debugStateService = debugStateService;
             _debugEventHandlerService = debugEventHandlerService;
@@ -323,7 +326,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             // Clear any existing breakpoints before proceeding
-            await _debugService.ClearAllBreakpointsAsync().ConfigureAwait(continueOnCapturedContext: false);
+            await _breakpointService.RemoveAllBreakpointsAsync().ConfigureAwait(continueOnCapturedContext: false);
 
             // Execute the Debug-Runspace command but don't await it because it
             // will block the debug adapter initialization process.  The
@@ -357,6 +360,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .ExecuteScriptStringAsync(debugRunspaceCmd)
                 .ContinueWith(OnExecutionCompletedAsync);
 
+            _jsonRpcServer.SendNotification(EventNames.Initialized);
             return Unit.Value;
         }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -16,6 +16,7 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Events;
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
@@ -183,7 +184,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _debugStateService.Arguments = arguments;
             _debugStateService.IsUsingTempIntegratedConsole = request.CreateTemporaryIntegratedConsole;
 
-            // TODO: Bring this back
+            if (request.CreateTemporaryIntegratedConsole
+                && !string.IsNullOrEmpty(request.Script)
+                && ScriptFile.IsUntitledPath(request.Script))
+            {
+                throw new RpcErrorException(0, "Running an Untitled file in a temporary integrated console is currently not supported.");
+            }
+
             // If the current session is remote, map the script path to the remote
             // machine if necessary
             if (_debugStateService.ScriptToLaunch != null &&

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -370,7 +370,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .ExecuteScriptStringAsync(debugRunspaceCmd)
                 .ContinueWith(OnExecutionCompletedAsync);
 
-            _jsonRpcServer.SendNotification(EventNames.Initialized);
             return Unit.Value;
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         static PowerShellContextService()
         {
             // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection
-            if (!VersionUtils.IsNetCore || VersionUtils.IsPS7)
+            if (!VersionUtils.IsNetCore || VersionUtils.IsPS7OrGreater)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private Dictionary<string, int[]> breakpointsPerFile =
             new Dictionary<string, int[]>();
 
-        public async Task<List<BreakpointDetails>> SetLineBreakpointsAsync(
+        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
             PowerShellContextService powerShellContext,
             string scriptPath,
             BreakpointDetails[] breakpoints)
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 breakpoint.Verified = true;
             }
 
-            return breakpoints.ToList();
+            return breakpoints.ToArray();
         }
 
         public bool IsDscResourcePath(string scriptPath)

--- a/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
@@ -4,9 +4,9 @@ using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Utility
 {
-    public static class LspDebugUtils
+    internal static class LspDebugUtils
     {
-        public static Breakpoint CreateBreakpoint(
+        internal static Breakpoint CreateBreakpoint(
             BreakpointDetails breakpointDetails)
         {
             Validate.IsNotNull(nameof(breakpointDetails), breakpointDetails);
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             };
         }
 
-        public static Breakpoint CreateBreakpoint(
+        internal static Breakpoint CreateBreakpoint(
             CommandBreakpointDetails breakpointDetails)
         {
             Validate.IsNotNull(nameof(breakpointDetails), breakpointDetails);

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -47,11 +47,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <summary>
         /// True if we are running in PowerShell 7, false otherwise.
         /// </summary>
-        public static bool IsPS7 { get; } = PSVersion.Major == 7;
-
-        /// <summary>
-        /// True if we are running in PowerShell 7, false otherwise.
-        /// </summary>
         public static bool IsPS7OrGreater { get; } = PSVersion.Major >= 7;
 
         /// <summary>

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -50,6 +50,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static bool IsPS7 { get; } = PSVersion.Major == 7;
 
         /// <summary>
+        /// True if we are running in PowerShell 7, false otherwise.
+        /// </summary>
+        public static bool IsPS7OrGreater { get; } = PSVersion.Major >= 7;
+
+        /// <summary>
         /// True if we are running in on Windows, false otherwise.
         /// </summary>
         public static bool IsWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);


### PR DESCRIPTION
This moves to the new breakpoint APIs in PS 7 which enables the ability to debug actual untitled files!

This will also allow things like Azure Functions to not need a Wait-Debugger in their script.

I also accidentally supported Log Points!

To do this, I created a new service `BreakpointService` that helps manage this.

I took a bunch of the reflection code from @rjmholt's branch of a similar feature.

NOTE: We should probably discuss the Function breakpoints feature... Today, it works in _all_ versions of PowerShell by creating a temp file on the fly and using that for debugging. That doesn't seem like the best approach... because temp files could go south. Ideally we should use same strategy that I'm doing here for function breakpoints as well... but I feel like that's out of scope for this PR. 

### Testing checklist

#### lauch and attaches

* [x] Launch current file
* [x] Launch current file temp console
* [x] attach to process 6.2 to 6.2 (to test legacy behavior)
* [x] attach to process 7.0 to 7.0 (to test new behavior)
* [x] attach to process 7.0 to 6.2 (to test legacy behavior)
* [x] attach to process 6.2 to 7.0 (to test legacy behavior)
* [x] all breakpoint types

#### Untitled files

* [x] Launch current file
* [x] ~Launch current file temp console~ can't be supported without a language server in the temp session... [so fail nicely](https://github.com/PowerShell/vscode-powershell/pull/2458)
* [x] all breakpoint types

#### Breakpoint types

* [x] Regular
* [x] Hit count
* [x] expression
* [x] Log points (new!)

#### Other

* [x] Watch expresssions