### PR TITLE
use -Option AllScope to fix Windows PowerShell error

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
@@ -14,5 +14,5 @@ function Clear-Host {
 }
 
 if (!$IsMacOS -or $IsLinux) {
-    Set-Alias -Name clear -Value Clear-Host -Option AllScope
+    Microsoft.PowerShell.Utility\Set-Alias -Name clear -Value Clear-Host -Option AllScope
 }

--- a/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
@@ -14,5 +14,5 @@ function Clear-Host {
 }
 
 if (!$IsMacOS -or $IsLinux) {
-    Set-Alias -Name clear -Value Clear-Host
+    Set-Alias -Name clear -Value Clear-Host -Option AllScope
 }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2379

Adds `-Option AllScope` to `Set-Alias` to fix an error Windows PowerShell was spitting out.