### PR TITLE
Simplify logic of determining Reference definition

### DIFF
--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         }
 
         /// <summary>
-        /// Check whether a SymbolReference is not a reference to another defined symbol.
+        /// Check whether a SymbolReference is the actual definition of that symbol.
         /// </summary>
         /// <param name="definition">The symbol definition that may be referenced.</param>
         /// <param name="reference">The reference symbol to check.</param>
@@ -148,11 +148,15 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             SymbolReference definition,
             SymbolReference reference)
         {
+            // First check if we are in the same file as the definition. if we are...
+            // check if it's on the same line number.
+
+            // TODO: Do we care about two symbol definitions of the same name?
+            // if we do, how could we possibly know that a reference in one file is a reference
+            // of a particular symbol definition?
             return
-                definition.FilePath != reference.FilePath
-                || definition.ScriptRegion.StartLineNumber != reference.ScriptRegion.StartLineNumber
-                || definition.SymbolType != reference.SymbolType
-                || !string.Equals(definition.SymbolName, reference.SymbolName, StringComparison.OrdinalIgnoreCase);
+                definition.FilePath == reference.FilePath &&
+                definition.ScriptRegion.StartLineNumber == reference.ScriptRegion.StartLineNumber;
         }
 
         /// <summary>


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2374

Before, I had the logic backwards and the CodeLens would only show 1 reference (the reference definition!).

After, now we only check file path and line number. Simpler logic.

I added a TODO to think about what would happen if we find two of the same named function definitions:
fileA
```
function Test-Foo { }
```
fileB
```
function Test-Foo { }
```
The references will probably show up... but I think there's not much we can do since the symbol reference doesn't seem to give us anything on whether it's a definition or not which is really a shame.