### PR TITLE
Fix uncaught exception when SafeToString returns null

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
@@ -194,9 +194,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 else
                 {
                     string valueToString = value.SafeToString();
-                    if (valueToString.Equals(objType.ToString()))
+                    if (valueToString == null || valueToString.Equals(objType.ToString()))
                     {
-                        // If the ToString() matches the type name, then display the type
+                        // If the ToString() matches the type name or is null, then display the type
                         // name in PowerShell format.
                         string shortTypeName = objType.Name;
 

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1
@@ -12,6 +12,7 @@ function Test-Variables {
 	$classVar.Name = "Test"
 	$classVar.Number = 42;
     $enumVar = $ErrorActionPreference
+    $nullString = [NullString]::Value
     $psObjVar = New-Object -TypeName PSObject -Property @{Name = 'John';  Age = 75}
     $psCustomObjVar = [PSCustomObject] @{Name = 'Paul'; Age = 73}
     $procVar = Get-Process system

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -816,6 +816,34 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         }
 
         [Fact]
+        public async Task DebufferVariableNullStringDisplaysCorrectly()
+        {
+            await this.debugService.SetLineBreakpointsAsync(
+                this.variableScriptFile,
+                new[] { BreakpointDetails.Create("", 18) });
+
+            // Execute the script and wait for the breakpoint to be hit
+            Task executeTask =
+                this.powerShellContext.ExecuteScriptStringAsync(
+                    this.variableScriptFile.FilePath);
+
+            await this.AssertDebuggerStopped(this.variableScriptFile.FilePath);
+
+            StackFrameDetails[] stackFrames = debugService.GetStackFrames();
+
+            VariableDetailsBase[] variables =
+                debugService.GetVariables(stackFrames[0].LocalVariables.Id);
+
+            var nullStringVar = variables.FirstOrDefault(v => v.Name == "$nullString");
+            Assert.NotNull(nullStringVar);
+            Assert.True("[NullString]".Equals(nullStringVar.ValueString));
+            Assert.True(nullStringVar.IsExpandable);
+
+            // Abort execution of the script
+            this.powerShellContext.AbortExecution();
+        }
+
+        [Fact]
         public async Task DebuggerVariablePSObjectDisplaysCorrectly()
         {
             await this.debugService.SetLineBreakpointsAsync(


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2386

Some values return `null` from `.ToString()`. This PR makes sure we check for null and return the type information if it is null.

A simple way to test this out is to store a var like `$var = [NullString]::Value` and debug the script with breakpoints. The powershell extension will error out.