### PR TITLE
Fix unicode character uri bug

### DIFF
--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.14.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
@@ -40,6 +40,6 @@
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Include="UnixConsoleEcho" Version="0.1.0" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.14.0" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.14.1" />
   </ItemGroup>
 </Project>

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             // Grab the workspace path from the parameters
                             if (request.RootUri != null)
                             {
-                                workspaceService.WorkspacePath = workspaceService.ResolveFilePath(request.RootUri.ToString());
+                                workspaceService.WorkspacePath = workspaceService.ResolveFileUri(request.RootUri).OriginalString;
                             }
 
                             // Set the working directory of the PowerShell session to the workspace path

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public EditorContext ConvertClientEditorContext(
             ClientEditorContext clientContext)
         {
-            ScriptFile scriptFile = _workspaceService.CreateScriptFileFromFileBuffer(
+            ScriptFile scriptFile = _workspaceService.GetFileBuffer(
                 clientContext.CurrentFilePath,
                 clientContext.CurrentFileContent);
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
         {
-            IReadOnlyDictionary<string, MarkerCorrection> corrections = await _analysisService.GetMostRecentCodeActionsForFileAsync(request.TextDocument.Uri.ToString());
+            IReadOnlyDictionary<string, MarkerCorrection> corrections = await _analysisService.GetMostRecentCodeActionsForFileAsync(request.TextDocument.Uri.OriginalString);
 
             if (corrections == null)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -61,8 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<CodeLensContainer> Handle(CodeLensParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile = _workspaceService.GetFile(
-                request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             CodeLens[] codeLensResults = ProvideCodeLenses(scriptFile);
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -65,9 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             int cursorLine = (int) request.Position.Line + 1;
             int cursorColumn = (int) request.Position.Character + 1;
 
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             CompletionResults completionResults =
                 await GetCompletionsInFileAsync(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -52,9 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<LocationOrLocationLinks> Handle(DefinitionParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolReference foundSymbol =
                 _symbolsService.FindSymbolAtLocation(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             DocumentHighlightParams request,
             CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile = _workspaceService.GetFile(PathUtils.FromUri(request.TextDocument.Uri));
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             IReadOnlyList<SymbolReference> symbolOccurrences = _symbolsService.FindOccurrencesInFile(
                 scriptFile,

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -60,9 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<SymbolInformationOrDocumentSymbolContainer> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             IEnumerable<SymbolReference> foundSymbols =
                 this.ProvideDocumentSymbols(scriptFile);

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Perhaps a better option would be to parse the contents of the document as a string
             // as opposed to reading a file but the scenario of "no backing file" probably doesn't
             // warrant the extra effort.
-            if (!_workspaceService.TryGetFile(request.TextDocument.Uri.ToString(), out ScriptFile scriptFile)) { return null; }
+            if (!_workspaceService.TryGetFile(request.TextDocument.Uri, out ScriptFile scriptFile)) { return null; }
 
             var result = new List<FoldingRange>();
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<TextEditContainer> Handle(DocumentFormattingParams request, CancellationToken cancellationToken)
         {
-            var scriptFile = _workspaceService.GetFile(request.TextDocument.Uri.ToString());
+            var scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
             var pssaSettings = _configurationService.CurrentSettings.CodeFormatting.GetPSSASettingsHashtable(
                 (int)request.Options.TabSize,
                 request.Options.InsertSpaces);
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<TextEditContainer> Handle(DocumentRangeFormattingParams request, CancellationToken cancellationToken)
         {
-            var scriptFile = _workspaceService.GetFile(request.TextDocument.Uri.ToString());
+            var scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
             var pssaSettings = _configurationService.CurrentSettings.CodeFormatting.GetPSSASettingsHashtable(
                 (int)request.Options.TabSize,
                 request.Options.InsertSpaces);

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -54,9 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<Hover> Handle(HoverParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolDetails symbolDetails =
                 await _symbolsService.FindSymbolDetailsAtLocationAsync(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -48,9 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolReference foundSymbol =
                 _symbolsService.FindSymbolAtLocation(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -58,9 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<SignatureHelp> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
         {
-            ScriptFile scriptFile =
-                _workspaceService.GetFile(
-                    request.TextDocument.Uri.ToString());
+            ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             ParameterSetSignatures parameterSets =
                 await _symbolsService.FindParameterSetsInFileAsync(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
         {
-            ScriptFile changedFile = _workspaceService.GetFile(notification.TextDocument.Uri.ToString());
+            ScriptFile changedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
             // A text change notification can batch multiple change requests
             foreach (TextDocumentContentChangeEvent textChange in notification.ContentChanges)
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             ScriptFile openedFile =
                 _workspaceService.GetFileBuffer(
-                    notification.TextDocument.Uri.ToString(),
+                    notification.TextDocument.Uri,
                     notification.TextDocument.Text);
 
             // TODO: Get all recently edited files in the workspace
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
         {
             // Find and close the file in the current session
-            var fileToClose = _workspaceService.GetFile(notification.TextDocument.Uri.ToString());
+            var fileToClose = _workspaceService.GetFile(notification.TextDocument.Uri);
 
             if (fileToClose != null)
             {
@@ -120,9 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<Unit> Handle(DidSaveTextDocumentParams notification, CancellationToken token)
         {
-            ScriptFile savedFile =
-                _workspaceService.GetFile(
-                    notification.TextDocument.Uri.ToString());
+            ScriptFile savedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
             if (savedFile != null)
             {

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -90,15 +90,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return symbolName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        // private static string GetFileUri(string filePath)
-        // {
-        //     // If the file isn't untitled, return a URI-style path
-        //     return
-        //         !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
-        //             ? new Uri("file://" + filePath).AbsoluteUri
-        //             : filePath;
-        // }
-
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)
         {
             return new Range

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -90,14 +90,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return symbolName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
-        private static string GetFileUri(string filePath)
-        {
-            // If the file isn't untitled, return a URI-style path
-            return
-                !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
-                    ? new Uri("file://" + filePath).AbsoluteUri
-                    : filePath;
-        }
+        // private static string GetFileUri(string filePath)
+        // {
+        //     // If the file isn't untitled, return a URI-style path
+        //     return
+        //         !filePath.StartsWith("untitled") && !filePath.StartsWith("inmemory")
+        //             ? new Uri("file://" + filePath).AbsoluteUri
+        //             : filePath;
+        // }
 
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)
         {

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -208,7 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="filePath">The file path for which a buffer will be retrieved.</param>
         /// <returns>A ScriptFile instance if there is a buffer for the path, null otherwise.</returns>
-        public ScriptFile GetFileBuffer(string filePath) => GetFileBuffer(filePath, null);
+        public ScriptFile GetFileBuffer(string filePath) => GetFileBuffer(filePath, initialBuffer: null);
 
         /// <summary>
         /// Gets a new ScriptFile instance which is identified by the given file
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="fileUri">The file Uri for which a buffer will be retrieved.</param>
         /// <returns>A ScriptFile instance if there is a buffer for the path, null otherwise.</returns>
-        public ScriptFile GetFileBuffer(Uri fileUri) => GetFileBuffer(fileUri, null);
+        public ScriptFile GetFileBuffer(Uri fileUri) => GetFileBuffer(fileUri, initialBuffer: null);
 
         /// <summary>
         /// Gets a new ScriptFile instance which is identified by the given file

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -96,33 +96,18 @@ namespace Microsoft.PowerShell.EditorServices.Services
         #region Public Methods
 
         /// <summary>
-        /// Creates a new ScriptFile instance which is identified by the given file
-        /// path and initially contains the given buffer contents.
+        /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.
+        /// <para>IMPORTANT: Not all documents have a backing file e.g. untitled: scheme documents.  Consider using
+        /// <see cref="WorkspaceService.TryGetFile(string, out ScriptFile)"/> instead.</para>
         /// </summary>
-        /// <param name="filePath">The file path for which a buffer will be retrieved.</param>
-        /// <param name="initialBuffer">The initial buffer contents if there is not an existing ScriptFile for this path.</param>
-        /// <returns>A ScriptFile instance for the specified path.</returns>
-        public ScriptFile CreateScriptFileFromFileBuffer(string filePath, string initialBuffer)
-        {
-            Validate.IsNotNullOrEmptyString("filePath", filePath);
-
-            // Resolve the full file path
-            string resolvedFilePath = this.ResolveFilePath(filePath);
-            string keyName = resolvedFilePath.ToLower();
-
-            ScriptFile scriptFile =
-                new ScriptFile(
-                    resolvedFilePath,
-                    filePath,
-                    initialBuffer,
-                    powerShellVersion);
-
-            workspaceFiles[keyName] = scriptFile;
-
-            logger.LogDebug("Opened file as in-memory buffer: " + resolvedFilePath);
-
-            return scriptFile;
-        }
+        /// <param name="filePath">The file path at which the script resides.</param>
+        /// <exception cref="FileNotFoundException">
+        /// <paramref name="filePath"/> is not found.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="filePath"/> contains a null or empty string.
+        /// </exception>
+        public ScriptFile GetFile(string filePath) => GetFile(new Uri(filePath));
 
         /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.
@@ -136,33 +121,36 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <exception cref="ArgumentException">
         /// <paramref name="filePath"/> contains a null or empty string.
         /// </exception>
-        public ScriptFile GetFile(string filePath)
+        public ScriptFile GetFile(Uri fileUri)
         {
-            Validate.IsNotNullOrEmptyString("filePath", filePath);
+            Validate.IsNotNull(nameof(fileUri), fileUri);
 
             // Resolve the full file path
-            string resolvedFilePath = this.ResolveFilePath(filePath);
-            string keyName = resolvedFilePath.ToLower();
+            Uri resolvedFileUri = ResolveFileUri(fileUri);
+
+            string keyName = VersionUtils.IsLinux
+                ? resolvedFileUri.OriginalString
+                : resolvedFileUri.OriginalString.ToLower();
 
             // Make sure the file isn't already loaded into the workspace
             if (!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile))
             {
                 // This method allows FileNotFoundException to bubble up
                 // if the file isn't found.
-                using (FileStream fileStream = new FileStream(resolvedFilePath, FileMode.Open, FileAccess.Read))
+                using (FileStream fileStream = new FileStream(resolvedFileUri.LocalPath, FileMode.Open, FileAccess.Read))
                 using (StreamReader streamReader = new StreamReader(fileStream, Encoding.UTF8))
                 {
                     scriptFile =
                         new ScriptFile(
-                            resolvedFilePath,
-                            filePath,
+                            resolvedFileUri.LocalPath,
+                            resolvedFileUri.OriginalString,
                             streamReader,
                             this.powerShellVersion);
 
                     this.workspaceFiles.Add(keyName, scriptFile);
                 }
 
-                this.logger.LogDebug("Opened file on disk: " + resolvedFilePath);
+                this.logger.LogDebug("Opened file on disk: " + resolvedFileUri.OriginalString);
             }
 
             return scriptFile;
@@ -173,10 +161,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="filePath">The file path at which the script resides.</param>
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
-        public bool TryGetFile(string filePath, out ScriptFile scriptFile)
-        {
-            var fileUri = new Uri(filePath);
+        public bool TryGetFile(string filePath, out ScriptFile scriptFile) =>
+            TryGetFile(new Uri(filePath), out scriptFile);
 
+        /// <summary>
+        /// Tries to get an open file in the workspace. Returns true if it succeeds, false otherwise.
+        /// </summary>
+        /// <param name="fileUri">The file uri at which the script resides.</param>
+        /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
+        public bool TryGetFile(Uri fileUri, out ScriptFile scriptFile)
+        {
             switch (fileUri.Scheme)
             {
                 // List supported schemes here
@@ -191,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             try
             {
-                scriptFile = GetFile(filePath);
+                scriptFile = GetFile(fileUri);
                 return true;
             }
             catch (Exception e) when (
@@ -203,7 +197,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 e is SecurityException ||
                 e is UnauthorizedAccessException)
             {
-                this.logger.LogWarning($"Failed to get file for {nameof(filePath)}: '{filePath}'", e);
+                this.logger.LogWarning($"Failed to get file for fileUri: '{fileUri.OriginalString}'", e);
                 scriptFile = null;
                 return false;
             }
@@ -214,10 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="filePath">The file path for which a buffer will be retrieved.</param>
         /// <returns>A ScriptFile instance if there is a buffer for the path, null otherwise.</returns>
-        public ScriptFile GetFileBuffer(string filePath)
-        {
-            return this.GetFileBuffer(filePath, null);
-        }
+        public ScriptFile GetFileBuffer(string filePath) => GetFileBuffer(filePath, null);
 
         /// <summary>
         /// Gets a new ScriptFile instance which is identified by the given file
@@ -226,27 +217,46 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="filePath">The file path for which a buffer will be retrieved.</param>
         /// <param name="initialBuffer">The initial buffer contents if there is not an existing ScriptFile for this path.</param>
         /// <returns>A ScriptFile instance for the specified path.</returns>
-        public ScriptFile GetFileBuffer(string filePath, string initialBuffer)
+        public ScriptFile GetFileBuffer(string filePath, string initialBuffer) => GetFileBuffer(new Uri(filePath), initialBuffer);
+
+        /// <summary>
+        /// Gets a new ScriptFile instance which is identified by the given file path.
+        /// </summary>
+        /// <param name="fileUri">The file Uri for which a buffer will be retrieved.</param>
+        /// <returns>A ScriptFile instance if there is a buffer for the path, null otherwise.</returns>
+        public ScriptFile GetFileBuffer(Uri fileUri) => GetFileBuffer(fileUri, null);
+
+        /// <summary>
+        /// Gets a new ScriptFile instance which is identified by the given file
+        /// path and initially contains the given buffer contents.
+        /// </summary>
+        /// <param name="fileUri">The file Uri for which a buffer will be retrieved.</param>
+        /// <param name="initialBuffer">The initial buffer contents if there is not an existing ScriptFile for this path.</param>
+        /// <returns>A ScriptFile instance for the specified path.</returns>
+        public ScriptFile GetFileBuffer(Uri fileUri, string initialBuffer)
         {
-            Validate.IsNotNullOrEmptyString("filePath", filePath);
+            Validate.IsNotNull(nameof(fileUri), fileUri);
 
             // Resolve the full file path
-            string resolvedFilePath = this.ResolveFilePath(filePath);
-            string keyName = resolvedFilePath.ToLower();
+            Uri resolvedFileUri = ResolveFileUri(fileUri);
+
+            string keyName = VersionUtils.IsLinux
+                ? resolvedFileUri.OriginalString
+                : resolvedFileUri.OriginalString.ToLower();
 
             // Make sure the file isn't already loaded into the workspace
             if (!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile) && initialBuffer != null)
             {
                 scriptFile =
                     new ScriptFile(
-                        resolvedFilePath,
-                        filePath,
+                        resolvedFileUri.LocalPath,
+                        resolvedFileUri.OriginalString,
                         initialBuffer,
                         this.powerShellVersion);
 
-                this.workspaceFiles.Add(keyName, scriptFile);
+                this.workspaceFiles[keyName] = scriptFile;
 
-                this.logger.LogDebug("Opened file as in-memory buffer: " + resolvedFilePath);
+                this.logger.LogDebug("Opened file as in-memory buffer: " + resolvedFileUri.OriginalString);
             }
 
             return scriptFile;
@@ -452,6 +462,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return filePath;
         }
 
+        internal Uri ResolveFileUri(Uri fileUri)
+        {
+            if (fileUri.IsFile)
+            {
+                fileUri = WorkspaceService.UnescapeDriveColon(fileUri);
+            }
+
+            this.logger.LogDebug("Resolved path: " + fileUri.OriginalString);
+            return fileUri;
+        }
+
         internal static bool IsPathInMemory(string filePath)
         {
             bool isInMemory = false;
@@ -588,6 +609,42 @@ namespace Microsoft.PowerShell.EditorServices.Services
             sb.Append(fileUri.Substring(12)); // The rest of the URI after the colon
 
             return sb.ToString();
+        }
+
+        private static Uri UnescapeDriveColon(Uri fileUri)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return fileUri;
+            }
+
+            string driveSegment = fileUri.Segments[1];
+            // Check here that we have something like "file:///C%3A/" as a prefix (caller must check the file:// part)
+            if (!(char.IsLetter(driveSegment[0]) &&
+                  driveSegment[1] == '%' &&
+                  driveSegment[2] == '3' &&
+                  driveSegment[3] == 'A' &&
+                  driveSegment[4] == '/'))
+            {
+                return fileUri;
+            }
+
+            // We lost "%3A" and gained ":", so length - 2
+            var sb = new StringBuilder(fileUri.OriginalString.Length - 2);
+            sb.Append("file:///");
+
+            // The drive letter.
+            sb.Append(driveSegment[0]);
+            sb.Append(":/");
+
+            // The rest of the URI after the colon.
+            // Skip the first two segments which are / and the drive.
+            for (int i = 2; i < fileUri.Segments.Length; i++)
+            {
+                sb.Append(fileUri.Segments[i]);
+            }
+
+            return new Uri(sb.ToString());
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Utility/PathUtils.cs
+++ b/src/PowerShellEditorServices/Utility/PathUtils.cs
@@ -53,20 +53,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             return new Uri($"file://{filePath}");
         }
 
-        public static string FromUri(Uri uri)
-        {
-            if (uri.Segments.Length > 1)
-            {
-                // On windows of the Uri contains %3a local path
-                // doesn't come out as a proper windows path
-                if (uri.Segments[1].IndexOf("%3a", StringComparison.OrdinalIgnoreCase) > -1)
-                {
-                    return FromUri(new Uri(uri.AbsoluteUri.Replace("%3a", ":").Replace("%3A", ":")));
-                }
-            }
-            return uri.LocalPath;
-        }
-
         /// <summary>
         /// Converts all alternate path separators to the current platform's main path separators.
         /// </summary>

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -53,6 +53,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// True if we are running in on Windows, false otherwise.
         /// </summary>
         public static bool IsWindows { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        /// <summary>
+        /// True if we are running in on macOS, false otherwise.
+        /// </summary>
+        public static bool IsMacOS { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        /// <summary>
+        /// True if we are running in on Linux, false otherwise.
+        /// </summary>
+        public static bool IsLinux { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
     }
 
     internal static class PowerShellReflectionUtils

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.14.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.14.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2324

This removes  any usage of `Uri.ToString()` and creates a `worspaceService.GetFile(` that takes a `Uri` to better abstract this away.

This also revs the Omnisharp lib that contains my fix that also removes usages of `Uri.ToString()`