### PR TITLE
Improve Clean and Build tasks

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -170,19 +170,19 @@ task CreateBuildInfo -Before Build {
     $buildVersion = "<development-build>"
     $buildOrigin = "<development>"
 
-    $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
-    $propsBody = $propsXml.Project.PropertyGroup
-    $buildVersion = $propsBody.VersionPrefix
-
-    if ($propsBody.VersionSuffix)
-    {
-        $buildVersion += '-' + $propsBody.VersionSuffix
-    }
-
     # Set build info fields on build platforms
     if ($env:TF_BUILD)
     {
         $buildOrigin = "VSTS"
+
+        $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
+        $propsBody = $propsXml.Project.PropertyGroup
+        $buildVersion = $propsBody.VersionPrefix
+
+        if ($propsBody.VersionSuffix)
+        {
+            $buildVersion += '-' + $propsBody.VersionSuffix
+        }
     }
 
     # Allow override of build info fields (except date)

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -168,12 +168,12 @@ task GetProductVersion -Before PackageModule, UploadArtifacts {
 
 task CreateBuildInfo -Before Build {
     $buildVersion = "<development-build>"
-    $buildOrigin = "<development>"
+    $buildOrigin = "Development"
 
     # Set build info fields on build platforms
     if ($env:TF_BUILD)
     {
-        $buildOrigin = "Release"
+        $buildOrigin = "AzDO"
 
         $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
         $propsBody = $propsXml.Project.PropertyGroup

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -18,6 +18,10 @@ param(
 
 #Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.2.1"}
 
+if ($env:TF_BUILD) {
+    Write-Host "AGENT_JOBNAME: $env:AGENT_JOBNAME"
+}
+
 $script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
 $script:RequiredSdkVersion = (Get-Content (Join-Path $PSScriptRoot 'global.json') | ConvertFrom-Json).sdk.version
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")
@@ -172,9 +176,9 @@ task CreateBuildInfo -Before Build {
 
     # Set build info fields on build platforms
     if ($env:TF_BUILD) {
-        if ($env:BUILD_BUILDNUMBER -like "PR*") {
+        if ($env:BUILD_BUILDNUMBER -like "PR-*") {
             $buildOrigin = "PR"
-        } elseif ($env:BUILD_BUILDNUMBER -like "CI*") {
+        } elseif ($env:BUILD_BUILDNUMBER -like "master-*") {
             $buildOrigin = "CI"
         } else {
             $buildOrigin = "Release"

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -18,18 +18,6 @@ param(
 
 #Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.2.1"}
 
-if ($env:TF_BUILD) {
-    Write-Host "BULD_DEFINITIONNAME: $env:BUILD_DEFINITIONNAME"
-    Write-Host "BULD_DEFINITIONVERSION: $env:BUILD_DEFINITIONVERSION"
-    Write-Host "BULD_REASON: $env:BUILD_REASON"
-    Write-Host "ENVIRONMENT_NAME: $env:ENVIRONMENT_NAME"
-    Write-Host "SYSTEM_DEFINITIONID: $env:SYSTEM_DEFINITIONID"
-    Write-Host "SYSTEM_JOBID: $env:SYSTEM_JOBID"
-    Write-Host "SYSTEM_JOBNAME: $env:SYSTEM_JOBNAME"
-    Write-Host "SYSTEM_STAGENAME: $env:SYSTEM_STAGENAME"
-    Write-Host "AGENT_JOBNAME: $env:AGENT_JOBNAME"
-}
-
 $script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
 $script:RequiredSdkVersion = (Get-Content (Join-Path $PSScriptRoot 'global.json') | ConvertFrom-Json).sdk.version
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")
@@ -186,7 +174,7 @@ task CreateBuildInfo -Before Build {
     if ($env:TF_BUILD) {
         if ($env:BUILD_BUILDNUMBER -like "PR-*") {
             $buildOrigin = "PR"
-        } elseif ($env:BUILD_BUILDNUMBER -like "master-*") {
+        } elseif ($env:BUILD_DEFINITIONNAME -like "*-CI") {
             $buildOrigin = "CI"
         } else {
             $buildOrigin = "Release"

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -19,6 +19,14 @@ param(
 #Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.2.1"}
 
 if ($env:TF_BUILD) {
+    Write-Host "BULD_DEFINITIONNAME: $env:BUILD_DEFINITIONNAME"
+    Write-Host "BULD_DEFINITIONVERSION: $env:BUILD_DEFINITIONVERSION"
+    Write-Host "BULD_REASON: $env:BUILD_REASON"
+    Write-Host "ENVIRONMENT_NAME: $env:ENVIRONMENT_NAME"
+    Write-Host "SYSTEM_DEFINITIONID: $env:SYSTEM_DEFINITIONID"
+    Write-Host "SYSTEM_JOBID: $env:SYSTEM_JOBID"
+    Write-Host "SYSTEM_JOBNAME: $env:SYSTEM_JOBNAME"
+    Write-Host "SYSTEM_STAGENAME: $env:SYSTEM_STAGENAME"
     Write-Host "AGENT_JOBNAME: $env:AGENT_JOBNAME"
 }
 

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -170,11 +170,12 @@ task CreateBuildInfo -Before Build {
     $buildVersion = "<development-build>"
     $buildOrigin = "<development>"
 
+    $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
+    $propsBody = $propsXml.Project.PropertyGroup
+    $buildVersion = $propsBody.VersionPrefix
+
     if ($propsBody.VersionSuffix)
     {
-        $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
-        $propsBody = $propsXml.Project.PropertyGroup
-        $buildVersion = $propsBody.VersionPrefix
         $buildVersion += '-' + $propsBody.VersionSuffix
     }
 

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -136,7 +136,7 @@ task Clean BinClean,{
     if (Test-Path $moduleJsonPath) {
         Get-Content -Raw $moduleJsonPath |
             ConvertFrom-Json |
-            ForEach-Object { Remove-Item -Recurse "$PSScriptRoot/module/$($_.Name)" -Path -ErrorAction Ignore }
+            ForEach-Object { Remove-Item -Path "$PSScriptRoot/module/$($_.Name)" -Recurse -Force -ErrorAction Ignore }
     }
 }
 

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -133,7 +133,7 @@ task Clean BinClean,{
 
     # Remove bundled component modules
     $moduleJsonPath = "$PSScriptRoot\modules.json"
-    if (Test-Item $moduleJsonPath) {
+    if (Test-Path $moduleJsonPath) {
         Get-Content -Raw $moduleJsonPath |
             ConvertFrom-Json |
             ForEach-Object { Remove-Item -Recurse "$PSScriptRoot/module/$($_.Name)" -Path -ErrorAction Ignore }

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -18,6 +18,13 @@ param(
 
 #Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.2.1"}
 
+if ($env:TF_BUILD) {
+    Write-Host "BUILD_BUILDNUMBER: $env:BUILD_BUILDNUMBER"
+    Write-Host "BUILD_NUMBER: $env:BUILD_NUMBER"
+    Write-Host "System.BuildNumber: ${env:System.BuildNumber}"
+    Write-Host "BUILD_BUILDID: $env:BUILD_BUILDID"
+}
+
 $script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
 $script:RequiredSdkVersion = (Get-Content (Join-Path $PSScriptRoot 'global.json') | ConvertFrom-Json).sdk.version
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -173,7 +173,7 @@ task CreateBuildInfo -Before Build {
     # Set build info fields on build platforms
     if ($env:TF_BUILD)
     {
-        $buildOrigin = "VSTS"
+        $buildOrigin = "Release"
 
         $propsXml = [xml](Get-Content -Raw -LiteralPath "$PSScriptRoot/PowerShellEditorServices.Common.props")
         $propsBody = $propsXml.Project.PropertyGroup

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -136,7 +136,8 @@ task Clean BinClean,{
     if (Test-Path $moduleJsonPath) {
         Get-Content -Raw $moduleJsonPath |
             ConvertFrom-Json |
-            ForEach-Object { Remove-Item -Path "$PSScriptRoot/module/$($_.Name)" -Recurse -Force -ErrorAction Ignore }
+            ForEach-Object { $_.PSObject.Properties.Name } |
+            ForEach-Object { Remove-Item -Path "$PSScriptRoot/module/$_" -Recurse -Force -ErrorAction Ignore }
     }
 }
 


### PR DESCRIPTION
- Change `Build` to remove bin directories that must always be refreshed in the output binary
- Change `Clean` to also wash away the downloaded bundled modules

Also fixes https://github.com/PowerShell/PowerShellEditorServices/issues/1135.