### PR TITLE
Fix lock up that occurs when WinForms is executed on the pipeline thread

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -84,6 +84,11 @@ namespace Microsoft.PowerShell.EditorServices.Server
                         .Wait();
                 }
 
+                // We must also set a thread SynchronizationContext for the pipeline thread so that WinForms doesn't derail it
+                // TODO: For some reason this doesn't stop the blocking on first invocation, and moving it to the startup of PowerShellContext causes initialization to not respond
+                // TODO: Create a custom synchronization context that explicitly handles WinForms
+                _powerShellContextService.ExecuteScriptStringAsync("[System.Threading.SynchronizationContext]::SetSynchronizationContext([System.Threading.SynchronizationContext]::new())");
+
                 options.Services = new ServiceCollection()
                     .AddPsesDebugServices(ServiceProvider, this, _useTempSession);
 

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,7 +22,10 @@ namespace Microsoft.PowerShell.EditorServices.Server
     /// </summary>
     internal class PsesDebugServer : IDisposable
     {
-        private static bool s_hasRunPsrlStaticCtor = false;
+        /// <summary>
+        /// This is a bool but must be an int, since Interlocked.Exchange can't handle a bool
+        /// </summary>
+        private static int s_hasRunPsrlStaticCtor = 0;
 
         private readonly Stream _inputStream;
         private readonly Stream _outputStream;
@@ -59,12 +63,12 @@ namespace Microsoft.PowerShell.EditorServices.Server
         /// <returns>A task that completes when the server is ready.</returns>
         public async Task StartAsync()
         {
-            _jsonRpcServer = await JsonRpcServer.From(options =>
+            _jsonRpcServer = await JsonRpcServer.From(async options =>
             {
                 options.Serializer = new DapProtocolSerializer();
                 options.Reciever = new DapReciever();
                 options.LoggerFactory = _loggerFactory;
-                Extensions.Logging.ILogger logger = options.LoggerFactory.CreateLogger("DebugOptionsStartup");
+                ILogger logger = options.LoggerFactory.CreateLogger("DebugOptionsStartup");
 
                 // We need to let the PowerShell Context Service know that we are in a debug session
                 // so that it doesn't send the powerShell/startDebugger message.
@@ -72,12 +76,10 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 _powerShellContextService.IsDebugServerActive = true;
 
                 // Needed to make sure PSReadLine's static properties are initialized in the pipeline thread.
-                if (!s_hasRunPsrlStaticCtor && _usePSReadLine)
+                if (_usePSReadLine && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
                 {
-                    s_hasRunPsrlStaticCtor = true;
-                    _powerShellContextService
-                        .ExecuteScriptStringAsync("[System.Runtime.CompilerServices.RuntimeHelpers]::RunClassConstructor([Microsoft.PowerShell.PSConsoleReadLine].TypeHandle)")
-                        .Wait();
+                    await _powerShellContextService
+                        .ExecuteScriptStringAsync("[System.Runtime.CompilerServices.RuntimeHelpers]::RunClassConstructor([Microsoft.PowerShell.PSConsoleReadLine].TypeHandle)");
                 }
 
                 options.Services = new ServiceCollection()

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -84,11 +84,6 @@ namespace Microsoft.PowerShell.EditorServices.Server
                         .Wait();
                 }
 
-                // We must also set a thread SynchronizationContext for the pipeline thread so that WinForms doesn't derail it
-                // TODO: For some reason this doesn't stop the blocking on first invocation, and moving it to the startup of PowerShellContext causes initialization to not respond
-                // TODO: Create a custom synchronization context that explicitly handles WinForms
-                _powerShellContextService.ExecuteScriptStringAsync("[System.Threading.SynchronizationContext]::SetSynchronizationContext([System.Threading.SynchronizationContext]::new())");
-
                 options.Services = new ServiceCollection()
                     .AddPsesDebugServices(ServiceProvider, this, _useTempSession);
 

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -81,7 +81,8 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     // This must be run synchronously to ensure debugging works
                     _powerShellContextService
                         .ExecuteScriptStringAsync("[System.Runtime.CompilerServices.RuntimeHelpers]::RunClassConstructor([Microsoft.PowerShell.PSConsoleReadLine].TypeHandle)")
-                        .Wait();
+                        .GetAwaiter()
+                        .GetResult();
                 }
 
                 options.Services = new ServiceCollection()

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2356,18 +2356,18 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     PowerShellExecutionResult.Stopped,
                     null));
 
-                // Get the session details and push the current
-                // runspace if the session has changed
-                SessionDetails sessionDetails = null;
-                try
-                {
-                    sessionDetails = this.GetSessionDetailsInDebugger();
-                }
-                catch (InvalidOperationException)
-                {
-                    this.logger.LogTrace(
-                        "Attempting to get session details failed, most likely due to a running pipeline that is attempting to stop.");
-                }
+            // Get the session details and push the current
+            // runspace if the session has changed
+            SessionDetails sessionDetails = null;
+            try
+            {
+                sessionDetails = this.GetSessionDetailsInDebugger();
+            }
+            catch (InvalidOperationException)
+            {
+                this.logger.LogTrace(
+                    "Attempting to get session details failed, most likely due to a running pipeline that is attempting to stop.");
+            }
 
             if (!localThreadController.FrameExitTask.Task.IsCompleted)
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
@@ -78,9 +78,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// A task object representing the asynchronous operation. The Result property will return
         /// the retrieved pipeline execution request.
         /// </returns>
-        internal async Task<IPipelineExecutionRequest> TakeExecutionRequestAsync()
+        internal Task<IPipelineExecutionRequest> TakeExecutionRequestAsync()
         {
-            return await PipelineRequestQueue.DequeueAsync();
+            return PipelineRequestQueue.DequeueAsync();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Utility/AsyncQueue.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncQueue.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         {
             Task<T> requestTask;
 
-            using (await queueLock.LockAsync(cancellationToken))
+            using (await queueLock.LockAsync(cancellationToken).ConfigureAwait(false))
             {
                 if (this.itemQueue.Count > 0)
                 {
@@ -171,7 +171,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             }
 
             // Wait for the request task to complete outside of the lock
-            return await requestTask;
+            return await requestTask.ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2352.

Dequeuing work to execute on the pipeline thread used to be async/await without using `ConfigureAwait(false)`. This meant that introducing a thread synchronisation context (like WinForms does) could break our thread architecture.

Particularly in the WinForms case, the work dequeuing delegate would be marshalled back to the pipeline thread, which was blocked by the stopped debugger, so unable to execute.

Now we use `ConfigureAwait(false)` so that the lock delegate's execution is not influenced by the synchronisation context.