### PR TITLE
Fix temp debugging after it broke bringing in $psEditor

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -124,6 +124,13 @@ function New-EditorFile {
     }
 
     end {
+        # If editorContext is null, then we're in a Temp session and
+        # this cmdlet won't work so return early.
+        $editorContext = $psEditor.GetEditorContext()
+        if (!$editorContext) {
+            return
+        }
+
         if ($Path) {
             foreach ($fileName in $Path)
             {
@@ -142,7 +149,7 @@ function New-EditorFile {
                     }
 
                     $psEditor.Workspace.OpenFile($fileName, $preview)
-                    $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
+                    $editorContext.CurrentFile.InsertText(($valueList | Out-String))
                 } else {
                     $PSCmdlet.WriteError( (
                         New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
@@ -154,7 +161,7 @@ function New-EditorFile {
             }
         } else {
             $psEditor.Workspace.NewFile()
-            $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
+            $editorContext.CurrentFile.InsertText(($valueList | Out-String))
         }
     }
 }

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -256,7 +256,17 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 _loggerUnsubscribers.Add(_logger.Subscribe(hostLogger));
             }
 
-            string logPath = Path.Combine(GetLogDirPath(), "StartEditorServices.log");
+            string logDirPath = GetLogDirPath();
+            string logPath = Path.Combine(logDirPath, "StartEditorServices.log");
+
+            // Temp debugging sessions may try to reuse this same path,
+            // so we ensure they have a unique path
+            if (File.Exists(logPath))
+            {
+                int randomInt = new Random().Next();
+                logPath = Path.Combine(logDirPath, $"StartEditorServices-temp{randomInt.ToString("X")}.log");
+            }
+
             var fileLogger = StreamLogger.CreateWithNewFile(logPath);
             _disposableResources.Add(fileLogger);
             IDisposable fileLoggerUnsubscriber = _logger.Subscribe(fileLogger);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -17,18 +17,26 @@ namespace Microsoft.PowerShell.EditorServices.Services
         private const bool DefaultPreviewSetting = true;
 
         private WorkspaceService _workspaceService;
+        private PowerShellContextService _powerShellContextService;
         private ILanguageServer _languageServer;
 
         public EditorOperationsService(
             WorkspaceService workspaceService,
+            PowerShellContextService powerShellContextService,
             ILanguageServer languageServer)
         {
-            this._workspaceService = workspaceService;
-            this._languageServer = languageServer;
+            _workspaceService = workspaceService;
+            _powerShellContextService = powerShellContextService;
+            _languageServer = languageServer;
         }
 
         public async Task<EditorContext> GetEditorContextAsync()
         {
+            if (!TestHasLanguageServer())
+            {
+                return null;
+            };
+
             ClientEditorContext clientContext =
                 await _languageServer.SendRequest<GetEditorContextRequest, ClientEditorContext>(
                     "editor/getEditorContext",
@@ -39,6 +47,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task InsertTextAsync(string filePath, string text, BufferRange insertRange)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<InsertTextRequest>("editor/insertText", new InsertTextRequest
             {
                 FilePath = filePath,
@@ -62,6 +75,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task SetSelectionAsync(BufferRange selectionRange)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
 
             await _languageServer.SendRequest<SetSelectionRequest>("editor/setSelection", new SetSelectionRequest
             {
@@ -106,11 +123,21 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task NewFileAsync()
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<string>("editor/newFile", null);
         }
 
         public async Task OpenFileAsync(string filePath)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<OpenFileDetails>("editor/openFile", new OpenFileDetails
             {
                 FilePath = filePath,
@@ -120,6 +147,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task OpenFileAsync(string filePath, bool preview)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<OpenFileDetails>("editor/openFile", new OpenFileDetails
             {
                 FilePath = filePath,
@@ -129,6 +161,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task CloseFileAsync(string filePath)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<string>("editor/closeFile", filePath);
         }
 
@@ -139,6 +176,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task SaveFileAsync(string currentPath, string newSavePath)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<SaveFileDetails>("editor/saveFile", new SaveFileDetails
             {
                 FilePath = currentPath,
@@ -158,21 +200,41 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task ShowInformationMessageAsync(string message)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<string>("editor/showInformationMessage", message);
         }
 
         public async Task ShowErrorMessageAsync(string message)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<string>("editor/showErrorMessage", message);
         }
 
         public async Task ShowWarningMessageAsync(string message)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<string>("editor/showWarningMessage", message);
         }
 
         public async Task SetStatusBarMessageAsync(string message, int? timeout)
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             await _languageServer.SendRequest<StatusBarMessageDetails>("editor/setStatusBarMessage", new StatusBarMessageDetails
             {
                 Message = message,
@@ -182,7 +244,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public void ClearTerminal()
         {
+            if (!TestHasLanguageServer())
+            {
+                return;
+            };
+
             _languageServer.SendNotification("editor/clearTerminal");
+        }
+
+        private bool TestHasLanguageServer()
+        {
+            if (_languageServer != null)
+            {
+                return true;
+            }
+
+            _powerShellContextService.ExternalHost.UI.WriteWarningLine(
+                "Editor operations are not supported in temporary consoles. Re-run the command in the main PowerShell Intergrated Console.");
+            return false;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -16,9 +16,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
     {
         private const bool DefaultPreviewSetting = true;
 
-        private WorkspaceService _workspaceService;
-        private PowerShellContextService _powerShellContextService;
-        private ILanguageServer _languageServer;
+        private readonly WorkspaceService _workspaceService;
+        private readonly PowerShellContextService _powerShellContextService;
+        private readonly ILanguageServer _languageServer;
 
         public EditorOperationsService(
             WorkspaceService workspaceService,
@@ -233,7 +233,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (!TestHasLanguageServer())
             {
                 return;
-            };
+            }
 
             await _languageServer.SendRequest<StatusBarMessageDetails>("editor/setStatusBarMessage", new StatusBarMessageDetails
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void ExtensionService_ExtensionAddedAsync(object sender, EditorCommand e)
         {
-            _languageServer.SendNotification<ExtensionCommandAddedNotification>("powerShell/extensionCommandAdded",
+            _languageServer?.SendNotification<ExtensionCommandAddedNotification>("powerShell/extensionCommandAdded",
                 new ExtensionCommandAddedNotification
                 {
                     Name = e.Name,
@@ -232,7 +232,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void ExtensionService_ExtensionUpdatedAsync(object sender, EditorCommand e)
         {
-            _languageServer.SendNotification<ExtensionCommandUpdatedNotification>("powerShell/extensionCommandUpdated",
+            _languageServer?.SendNotification<ExtensionCommandUpdatedNotification>("powerShell/extensionCommandUpdated",
                 new ExtensionCommandUpdatedNotification
                 {
                     Name = e.Name,
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void ExtensionService_ExtensionRemovedAsync(object sender, EditorCommand e)
         {
-            _languageServer.SendNotification<ExtensionCommandRemovedNotification>("powerShell/extensionCommandRemoved",
+            _languageServer?.SendNotification<ExtensionCommandRemovedNotification>("powerShell/extensionCommandRemoved",
                 new ExtensionCommandRemovedNotification
                 {
                     Name = e.Name,

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private EngineIntrinsics EngineIntrinsics { get; set; }
 
-        private PSHost ExternalHost { get; set; }
+        internal PSHost ExternalHost { get; set; }
 
         /// <summary>
         /// Gets a boolean that indicates whether the debugger is currently stopped,


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2402

Apparently, when I added `$psEditor` back in, I broke Temp debugging again...

Now it works. The main changes are:

* Add a null `ILanguageServer` to the service collection so that the `EditorOperationsService` has something to retrieve
* If the languageServer is null, warn the user to use the main PowerShell Integrated Console
* Bring in @rjmholt 's change in #1148 
* Actually have `$psEditor` be available in the console by triggering the creation of the service that sets the psvariable