### PR TITLE
Use LocalPath instead of OriginalString

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             // Grab the workspace path from the parameters
                             if (request.RootUri != null)
                             {
-                                workspaceService.WorkspacePath = workspaceService.ResolveFileUri(request.RootUri).OriginalString;
+                                workspaceService.WorkspacePath = workspaceService.ResolveFileUri(request.RootUri).LocalPath;
                             }
 
                             // Set the working directory of the PowerShell session to the workspace path


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2421

The WorkspacePath should be a _path_ not a _uri_. This changes that back so that things like `Directory.Exists(...)` works and the likes.

I made sure this still works with non-ascii characters and unix & Windows path styles:

```
❯❯❯ [Uri]::new("file:///C:/a/%E6%B5%8B.ps1").LocalPath
C:\a\测.ps1

❯❯❯ [Uri]::new("file:///C:/a/%E6%B5%8B.ps1").LocalPath
C:\a\测.ps1

❯❯❯ [Uri]::new("file:///C:/a/blah.ps1").LocalPath
C:\a\blah.ps1

❯❯❯ [Uri]::new("file:///Users/a/blah.ps1").LocalPath
/Users/a/blah.ps1

❯❯❯ [Uri]::new("file:///Users/a/%E6%B5%8B.ps1").LocalPath
/Users/a/测.ps1
```