### PR TITLE
Fix debugging output location

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             EditorServicesPSHostUserInterface hostUserInterface =
                 hostStartupInfo.ConsoleReplEnabled
-                    ? (EditorServicesPSHostUserInterface)new TerminalPSHostUserInterface(powerShellContext, logger, hostStartupInfo.PSHost)
+                    ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, hostStartupInfo.PSHost, shouldUsePSReadLine, logger)
                     : new ProtocolPSHostUserInterface(languageServer, powerShellContext, logger);
 
             EditorServicesPSHost psHost =

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1076,9 +1076,19 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (writeInputToHost)
             {
+                // We need to abort ReadLine first because otherwise PSReadLine will attempt to reset
+                // the cursor position to the position it's at before the call to this.WriteOutput(...) below.
+                if (this.isPSReadLineEnabled)
+                {
+                    this.PromptContext.AbortReadLine();
+                }
+
+                // TODO: Figure out why with PSReadLine turned on, we get a random newline somewhere in our output.
+                // It appears to happen at this line but more testing needs to be done:
+                // https://github.com/PowerShell/PowerShellEditorServices/blob/3b890c3018b0ef8d92d77edf1215d345d55604eb/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs#L148
                 this.WriteOutput(
-                    script + Environment.NewLine,
-                    true);
+                    script,
+                    includeNewLine: true);
             }
 
             await this.ExecuteCommandAsync<object>(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1083,9 +1083,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     this.PromptContext.AbortReadLine();
                 }
 
-                // TODO: Figure out why with PSReadLine turned on, we get a random newline somewhere in our output.
-                // It appears to happen at this line but more testing needs to be done:
-                // https://github.com/PowerShell/PowerShellEditorServices/blob/3b890c3018b0ef8d92d77edf1215d345d55604eb/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs#L148
+                // Write the script path out and include a newline to start so the output can start
+                // on the next line.
                 this.WriteOutput(
                     script,
                     includeNewLine: true);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -680,7 +680,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     runspaceHandle = await this.GetRunspaceHandleAsync(executionOptions.IsReadLine).ConfigureAwait(false);
                     if (executionOptions.WriteInputToHost)
                     {
-                        this.WriteOutput(psCommand.Commands[0].CommandText, true);
+                        this.WriteOutput(
+                            psCommand.Commands[0].CommandText,
+                            includeNewLine: true);
                     }
 
                     if (executionTarget == ExecutionTarget.Debugger)
@@ -1074,27 +1076,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 command.AddCommand(script, false);
             }
 
-            if (writeInputToHost)
-            {
-                // We need to abort ReadLine first because otherwise PSReadLine will attempt to reset
-                // the cursor position to the position it's at before the call to this.WriteOutput(...) below.
-                if (this.isPSReadLineEnabled)
-                {
-                    this.PromptContext.AbortReadLine();
-                }
-
-                // Write the script path out and include a newline to start so the output can start
-                // on the next line.
-                this.WriteOutput(
-                    script,
-                    includeNewLine: true);
-            }
 
             await this.ExecuteCommandAsync<object>(
-                command,
-                errorMessages: null,
-                sendOutputToHost: true,
-                addToHistory: true).ConfigureAwait(false);
+                    command,
+                    errorMessages: null,
+                    new ExecutionOptions
+                    {
+                        WriteInputToHost = true,
+                        WriteOutputToHost = true,
+                        WriteErrorsToHost = true,
+                        AddToHistory = true,
+                    }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -34,10 +34,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private readonly ConcurrentDictionary<ProgressKey, object> currentProgressMessages =
             new ConcurrentDictionary<ProgressKey, object>();
+
+        private readonly bool _isPSReadLineEnabled;
         private PromptHandler activePromptHandler;
         private PSHostRawUserInterface rawUserInterface;
         private CancellationTokenSource commandLoopCancellationToken;
-        private readonly bool _isPSReadLineEnabled;
 
         /// <summary>
         /// The PowerShellContext to use for executing commands.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private PromptHandler activePromptHandler;
         private PSHostRawUserInterface rawUserInterface;
         private CancellationTokenSource commandLoopCancellationToken;
-        private bool _isPSReadLineEnabled;
+        private readonly bool _isPSReadLineEnabled;
 
         /// <summary>
         /// The PowerShellContext to use for executing commands.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -848,14 +848,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
                     Logger.LogException("Caught exception while reading command line", e);
                 }
-                finally
-                {
-                    if (!cancellationToken.IsCancellationRequested &&
-                        originalCursorTop == await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false))
-                    {
-                        this.WriteLine();
-                    }
-                }
 
                 if (!string.IsNullOrWhiteSpace(commandString))
                 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
@@ -30,7 +30,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             ILanguageServer languageServer,
             PowerShellContextService powerShellContext,
             ILogger logger)
-            : base(powerShellContext, new SimplePSHostRawUserInterface(logger), logger)
+            : base (
+                powerShellContext,
+                new SimplePSHostRawUserInterface(logger),
+                isPSReadLineEnabled: false,
+                logger)
         {
             _languageServer = languageServer;
         }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -37,11 +37,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="internalHost">The InternalHost instance from the origin runspace.</param>
         public TerminalPSHostUserInterface(
             PowerShellContextService powerShellContext,
-            ILogger logger,
-            PSHost internalHost)
-            : base(
+            PSHost internalHost,
+            bool isPSReadLineEnabled,
+            ILogger logger)
+            : base (
                 powerShellContext,
                 new TerminalPSHostRawUserInterface(logger, internalHost),
+                isPSReadLineEnabled,
                 logger)
         {
             this.internalHostUI = internalHost.UI;


### PR DESCRIPTION
This fixes a lot of the prompt/output issues that we've been seeing.

fixes https://github.com/PowerShell/vscode-powershell/issues/2372
fixes https://github.com/PowerShell/vscode-powershell/issues/2407
fixes https://github.com/PowerShell/vscode-powershell/issues/2408

* It removes a useless `this.WriteOutput` when instead `ExecuteCommandAsync` could just do it
* The `WriteOutput` in the finally block now only runs in the legacy readline experience

There's still a weird thing happening with prompts on F5... but that existed before this change so I'll try to address that in another PR.