### PR TITLE
Run single test in Pester v5

### DIFF
--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -49,7 +49,6 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             var word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
             var codeLensResults = new CodeLens[]
             {
-                
                 new CodeLens()
                 {
                     Range = pesterSymbol.ScriptRegion.ToRange(),

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
+using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
@@ -14,6 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {
     internal class PesterCodeLensProvider : ICodeLensProvider
     {
+        private readonly ConfigurationService _configurationService;
 
         /// <summary>
         /// The symbol provider to get symbols from to build code lenses with.
@@ -29,8 +32,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <summary>
         /// Create a new Pester CodeLens provider for a given editor session.
         /// </summary>
-        public PesterCodeLensProvider()
+        public PesterCodeLensProvider(ConfigurationService configurationService)
         {
+            _configurationService = configurationService;
             _symbolProvider = new PesterDocumentSymbolProvider();
         }
 
@@ -100,7 +104,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             {
                 if (symbol is PesterSymbolReference pesterSymbol)
                 {
-                    lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
+                    if (_configurationService.CurrentSettings.Pester.Pester5CodeLens 
+                        || pesterSymbol.Command == PesterCommandType.Describe)
+                    {
+                        lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
+                    }
                 }
             }
 

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     continue;
                 }
 
-                if (!_configurationService.CurrentSettings.Pester.EnableLegacyCodeLens
+                if (_configurationService.CurrentSettings.Pester.EnableLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {
                     continue;

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     continue;
                 }
 
-                if (!_configurationService.CurrentSettings.Pester.Pester5CodeLens
+                if (!_configurationService.CurrentSettings.Pester.EnableLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {
                     continue;

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -101,14 +101,18 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             var lenses = new List<CodeLens>();
             foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
-                if (symbol is PesterSymbolReference pesterSymbol)
+                if (!(symbol is PesterSymbolReference pesterSymbol))
                 {
-                    if (_configurationService.CurrentSettings.Pester.Pester5CodeLens 
-                        || pesterSymbol.Command == PesterCommandType.Describe)
-                    {
-                        lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
-                    }
+                    continue;
                 }
+
+                if (!_configurationService.CurrentSettings.Pester.Pester5CodeLens
+                        && pesterSymbol.Command != PesterCommandType.Describe)
+                {
+                    continue;
+                }
+
+                lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
             }
 
             return lenses.ToArray();

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <returns>All CodeLenses for the given Pester symbol.</returns>
         private CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
         {
-            var word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
+            string word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
             var codeLensResults = new CodeLens[]
             {
                 new CodeLens()

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     continue;
                 }
 
-                if (_configurationService.CurrentSettings.Pester.EnableLegacyCodeLens
+                if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {
                     continue;

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -42,9 +42,10 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <returns>All CodeLenses for the given Pester symbol.</returns>
         private CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
         {
-
+            var word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
             var codeLensResults = new CodeLens[]
             {
+                
                 new CodeLens()
                 {
                     Range = pesterSymbol.ScriptRegion.ToRange(),
@@ -55,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     Command = new Command()
                     {
                         Name = "PowerShell.RunPesterTests",
-                        Title = "Run tests",
+                        Title = $"Run {word}",
                         Arguments = JArray.FromObject(new object[] {
                             scriptFile.DocumentUri,
                             false /* No debug */,
@@ -74,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     Command = new Command()
                     {
                         Name = "PowerShell.RunPesterTests",
-                        Title = "Debug tests",
+                        Title = $"Debug {word}",
                         Arguments = JArray.FromObject(new object[] {
                             scriptFile.DocumentUri,
                             true /* No debug */,
@@ -99,11 +100,6 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             {
                 if (symbol is PesterSymbolReference pesterSymbol)
                 {
-                    if (pesterSymbol.Command != PesterCommandType.Describe)
-                    {
-                        continue;
-                    }
-
                     lenses.AddRange(GetPesterLens(pesterSymbol, scriptFile));
                 }
             }

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -51,7 +51,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public SymbolsService(
             ILoggerFactory factory,
             PowerShellContextService powerShellContextService,
-            WorkspaceService workspaceService)
+            WorkspaceService workspaceService,
+            ConfigurationService configurationService)
         {
             _logger = factory.CreateLogger<SymbolsService>();
             _powerShellContextService = powerShellContextService;
@@ -61,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var codeLensProviders = new ICodeLensProvider[]
             {
                 new ReferencesCodeLensProvider(_workspaceService, this),
-                new PesterCodeLensProvider(),
+                new PesterCodeLensProvider(configurationService),
             };
             foreach (ICodeLensProvider codeLensProvider in codeLensProviders)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -27,14 +27,16 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
+        private readonly ConfigurationService _configurationService;
 
         private CodeLensCapability _capability;
 
-        public CodeLensHandlers(ILoggerFactory factory, SymbolsService symbolsService, WorkspaceService workspaceService)
+        public CodeLensHandlers(ILoggerFactory factory, SymbolsService symbolsService, WorkspaceService workspaceService, ConfigurationService configurationService)
         {
             _logger = factory.CreateLogger<FoldingRangeHandler>();
             _workspaceService = workspaceService;
             _symbolsService = symbolsService;
+            _configurationService = configurationService;
         }
 
         CodeLensRegistrationOptions IRegistration<CodeLensRegistrationOptions>.GetRegistrationOptions()

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -35,7 +35,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _logger = factory.CreateLogger<FoldingRangeHandler>();
             _workspaceService = workspaceService;
             _symbolsService = symbolsService;
-            _configurationService = configurationService;
         }
 
         CodeLensRegistrationOptions IRegistration<CodeLensRegistrationOptions>.GetRegistrationOptions()

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -27,7 +27,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-        private readonly ConfigurationService _configurationService;
 
         private CodeLensCapability _capability;
 

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -26,11 +26,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
         public CodeFoldingSettings CodeFolding { get; set; }
 
+        public PesterSettings Pester { get; set; }
+
         public LanguageServerSettings()
         {
             this.ScriptAnalysis = new ScriptAnalysisSettings();
             this.CodeFormatting = new CodeFormattingSettings();
             this.CodeFolding = new CodeFoldingSettings();
+            this.Pester = new PesterSettings();
         }
 
         public void Update(
@@ -49,6 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                         logger);
                     this.CodeFormatting = new CodeFormattingSettings(settings.CodeFormatting);
                     this.CodeFolding.Update(settings.CodeFolding, logger);
+                    this.Pester = new PesterSettings(settings.Pester);
                 }
             }
         }
@@ -354,6 +358,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Pester settings
+    /// </summary>
+    public class PesterSettings
+    {
+        public PesterSettings()
+        {
+
+        }
+
+        public PesterSettings(PesterSettings settings)
+        {
+            Pester5CodeLens = settings.Pester5CodeLens;
+        }
+
+        /// <summary>
+        /// Whether integration features specific to Pester v5 are enabled
+        /// </summary>
+        public bool Pester5CodeLens { get; set; } = false;
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -367,7 +367,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
     {
         public PesterSettings()
         {
-
         }
 
         public PesterSettings(PesterSettings settings)

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -378,7 +378,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         /// <summary>
         /// Whether integration features specific to Pester v5 are enabled
         /// </summary>
-        public bool Pester5CodeLens { get; set; } = false;
+        public bool Pester5CodeLens { get; set; }
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -371,13 +371,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
         public PesterSettings(PesterSettings settings)
         {
-            Pester5CodeLens = settings.Pester5CodeLens;
+            EnableLegacyCodeLens = settings.EnableLegacyCodeLens;
         }
 
         /// <summary>
         /// Whether integration features specific to Pester v5 are enabled
         /// </summary>
-        public bool Pester5CodeLens { get; set; }
+        public bool EnableLegacyCodeLens { get; set; }
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -371,13 +371,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
         public PesterSettings(PesterSettings settings)
         {
-            EnableLegacyCodeLens = settings.EnableLegacyCodeLens;
+            UseLegacyCodeLens = settings.UseLegacyCodeLens;
         }
 
         /// <summary>
         /// Whether integration features specific to Pester v5 are enabled
         /// </summary>
-        public bool EnableLegacyCodeLens { get; set; }
+        public bool UseLegacyCodeLens { get; set; }
     }
 
     /// <summary>

--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -32,9 +32,9 @@ namespace PowerShellEditorServices.Test.E2E
             // Make sure Script Analysis is enabled because we'll need it in the tests.
             LanguageClient.Workspace.DidChangeConfiguration(JObject.Parse(@"
 {
-    ""PowerShell"": {
-        ""ScriptAnalysis"": {
-            ""Enable"": true
+    ""powershell"": {
+        ""scriptAnalysis"": {
+            ""enable"": true
         }
     }
 }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -557,7 +557,7 @@ Write-Host 'Goodbye'
 {
     ""powershell"": {
         ""pester"": {
-            ""enableLegacyCodeLens"": true
+            ""useLegacyCodeLens"": true
         }
     }
 }
@@ -616,7 +616,7 @@ Describe 'DescribeName' {
             {
                 ""powershell"": {
                     ""pester"": {
-                        ""enableLegacyCodeLens"": false
+                        ""useLegacyCodeLens"": false
                     }
                 }
             }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -198,9 +198,9 @@ function CanSendWorkspaceSymbolRequest {
                 {
                     Settings = JToken.Parse(@"
 {
-    ""PowerShell"": {
-        ""ScriptAnalysis"": {
-            ""Enable"": false
+    ""powershell"": {
+        ""scriptAnalysis"": {
+            ""enable"": false
         }
     }
 }
@@ -216,9 +216,9 @@ function CanSendWorkspaceSymbolRequest {
                 {
                     Settings = JToken.Parse(@"
 {
-    ""PowerShell"": {
-        ""ScriptAnalysis"": {
-            ""Enable"": true
+    ""powershell"": {
+        ""scriptAnalysis"": {
+            ""enable"": true
         }
     }
 }
@@ -550,8 +550,19 @@ Write-Host 'Goodbye'
         }
 
         [Fact]
-        public async Task CanSendPesterCodeLensRequest()
+        public async Task CanSendPesterLegacyCodeLensRequest()
         {
+            // Make sure LegacyCodeLens is enabled because we'll need it in this test.
+            LanguageClient.Workspace.DidChangeConfiguration(JObject.Parse(@"
+{
+    ""powershell"": {
+        ""pester"": {
+            ""enableLegacyCodeLens"": true
+        }
+    }
+}
+"));
+
             string filePath = NewTestFile(@"
 Describe 'DescribeName' {
     Context 'ContextName' {
@@ -594,6 +605,109 @@ Describe 'DescribeName' {
                     Assert.Equal(1, range.End.Character);
 
                     Assert.Equal("Debug tests", codeLens2.Command.Title);
+                });
+        }
+
+        [Fact]
+        public async Task CanSendPesterCodeLensRequest()
+        {
+            // Make sure Pester legacy CodeLens is disabled because we'll need it in this test.
+            LanguageClient.Workspace.DidChangeConfiguration(JObject.Parse(@"
+            {
+                ""powershell"": {
+                    ""pester"": {
+                        ""enableLegacyCodeLens"": false
+                    }
+                }
+            }
+            "));
+
+            string filePath = NewTestFile(@"
+Describe 'DescribeName' {
+    Context 'ContextName' {
+        It 'ItName' {
+            1 | Should - Be 1
+        }
+    }
+}
+", isPester: true);
+
+            CodeLensContainer codeLenses = await LanguageClient.SendRequest<CodeLensContainer>(
+                "textDocument/codeLens",
+                new CodeLensParams
+                {
+                    TextDocument = new TextDocumentIdentifier
+                    {
+                        Uri = new Uri(filePath)
+                    }
+                });
+
+            Assert.Collection(codeLenses,
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(1, range.Start.Line);
+                    Assert.Equal(0, range.Start.Character);
+                    Assert.Equal(7, range.End.Line);
+                    Assert.Equal(1, range.End.Character);
+
+                    Assert.Equal("Run tests", codeLens.Command.Title);
+                },
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(1, range.Start.Line);
+                    Assert.Equal(0, range.Start.Character);
+                    Assert.Equal(7, range.End.Line);
+                    Assert.Equal(1, range.End.Character);
+
+                    Assert.Equal("Debug tests", codeLens.Command.Title);
+                },
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(2, range.Start.Line);
+                    Assert.Equal(4, range.Start.Character);
+                    Assert.Equal(6, range.End.Line);
+                    Assert.Equal(5, range.End.Character);
+
+                    Assert.Equal("Run tests", codeLens.Command.Title);
+                },
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(2, range.Start.Line);
+                    Assert.Equal(4, range.Start.Character);
+                    Assert.Equal(6, range.End.Line);
+                    Assert.Equal(5, range.End.Character);
+
+                    Assert.Equal("Debug tests", codeLens.Command.Title);
+                },
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(3, range.Start.Line);
+                    Assert.Equal(8, range.Start.Character);
+                    Assert.Equal(5, range.End.Line);
+                    Assert.Equal(9, range.End.Character);
+
+                    Assert.Equal("Run test", codeLens.Command.Title);
+                },
+                codeLens =>
+                {
+                    Range range = codeLens.Range;
+
+                    Assert.Equal(3, range.Start.Line);
+                    Assert.Equal(8, range.Start.Character);
+                    Assert.Equal(5, range.End.Line);
+                    Assert.Equal(9, range.End.Character);
+
+                    Assert.Equal("Debug test", codeLens.Command.Title);
                 });
         }
 

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             var logger = NullLogger.Instance;
             powerShellContext = PowerShellContextFactory.Create(logger);
             workspace = new WorkspaceService(NullLoggerFactory.Instance);
-            symbolsService = new SymbolsService(NullLoggerFactory.Instance, powerShellContext, workspace);
+            symbolsService = new SymbolsService(NullLoggerFactory.Instance, powerShellContext, workspace, new ConfigurationService());
             completionHandler = new CompletionHandler(NullLoggerFactory.Instance, powerShellContext, workspace);
         }
 


### PR DESCRIPTION
This shows the lense on every Describe \ Context and It. 

To test this you need Pester v5 ( branch `filter-by-lines` or once merged `v5.0`), you will also need the updated extension from vscode-powershell repo (branch same as here). Once your VSCode is started with the new version (after running the extension by F5), open a .Tests.ps1 file and load Pester v5.

```powershell
Get-Module Pester | Remove-Module ; Import-Module Projects/Pester/Pester.psd1
```

~WIP:~
~Once merged this will show the menu for all versions of Pester are we able to somehow figure out the version of Pester beforehand and only use the new approach when Pester v5 is loaded?~

~If not, should we add opt-in setting? Pester v5 is still far from ready, but I want to use this with beta which will be soon available 🙂~

Ready:
Added opt-in setting for Pester5 that will enable the code lens for all items, otherwise it will use the standard Describe-only lense. This old lense works for both Pester v4 and v5, it just does not take full potential of v5. l used an option, instead of trying to detect which Pester version would be loaded because I don't want to guess, and I also want to force loading of Pester v5 when the code lense for it is specified. Using the existion VSCode configuration infrastructure this can be enabled per workspace. 



