### PR TITLE
run profile paths together

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1161,12 +1161,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (this.profilePaths != null)
             {
                 // Load any of the profile paths that exist
+                var command = new PSCommand();
                 foreach (var profilePath in GetLoadableProfilePaths(this.profilePaths))
                 {
-                    PSCommand command = new PSCommand();
-                    command.AddCommand(profilePath, false);
-                    await this.ExecuteCommandAsync<object>(command, sendOutputToHost: true, sendErrorToHost: true).ConfigureAwait(false);
+                    command.AddCommand(profilePath, false).AddStatement();
                 }
+                await ExecuteCommandAsync<object>(command, sendOutputToHost: true, sendErrorToHost: true).ConfigureAwait(false);
 
                 // Gather the session details (particularly the prompt) after
                 // loading the user's profiles.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     command.AddCommand(profilePath, false).AddStatement();
                 }
-                await ExecuteCommandAsync<object>(command, sendOutputToHost: true, sendErrorToHost: true).ConfigureAwait(false);
+                await ExecuteCommandAsync<object>(command, sendOutputToHost: true).ConfigureAwait(false);
 
                 // Gather the session details (particularly the prompt) after
                 // loading the user's profiles.


### PR DESCRIPTION
There was a race condition where the fact that we'd execute each profile individually would be too fast for the PowerShell runspace and would throw this hideous error:

```
2020-01-27 15:18:50.254 -08:00 [FTL] Failed to handle request workspace/didChangeConfiguration
System.InvalidOperationException: A PowerShell object cannot be created that uses the current runspace because there is no current runspace available.  The current runspace might be starting, such as when it is created with an Initial Session State.
   at System.Management.Automation.PowerShell.Create(RunspaceMode runspace)
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.<>c.<GetSessionDetailsInNestedPipeline>b__153_0(PSCommand command) in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 2228
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.GetSessionDetails(Func`2 invokeAction) in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 2154
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.GetSessionDetailsInNestedPipeline() in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 2225
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.ExecuteCommandAsync[TResult](PSCommand psCommand, StringBuilder errorMessages, ExecutionOptions executionOptions) in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 883
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.ExecuteCommandAsync[TResult](PSCommand psCommand, Boolean sendOutputToHost, Boolean sendErrorToHost) in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 526
   at Microsoft.PowerShell.EditorServices.Services.PowerShellContextService.LoadHostProfilesAsync() in D:\a\1\s\src\PowerShellEditorServices\Services\PowerShellContext\PowerShellContextService.cs:line 1163
   at Microsoft.PowerShell.EditorServices.Handlers.ConfigurationHandler.Handle(DidChangeConfigurationParams request, CancellationToken cancellationToken) in D:\a\1\s\src\PowerShellEditorServices\Services\Workspace\Handlers\ConfigurationHandler.cs:line 74
   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteNotification(TDescriptor descriptor, Notification notification, CancellationToken token)
```

With this change we run all of the profiles (separated as statements of course) in one invocation.