### PR TITLE
Improve Task usage

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -288,7 +288,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _messageQueue = new BlockingCollection<string>();
 
             // Start writer listening to queue
-            _writerTask = Task.Run(RunWriter);
+            _writerTask = Task.Factory.StartNew(
+                RunWriter,
+                CancellationToken.None, // Inner method will manage cancellation
+                TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default);
         }
 
         public void OnCompleted()

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
@@ -37,11 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             await _readKeyHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                return
-                    _bufferedKey.HasValue
-                        ? _bufferedKey.Value
-                        : await Task.Factory.StartNew(
-                            () => (_bufferedKey = System.Console.ReadKey(intercept)).Value);
+                return _bufferedKey ?? await Task.Run(() => (_bufferedKey = System.Console.ReadKey(intercept)).Value).ConfigureAwait(false);
             }
             finally
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
@@ -37,7 +37,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             await _readKeyHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                return _bufferedKey ?? await Task.Run(() => (_bufferedKey = System.Console.ReadKey(intercept)).Value).ConfigureAwait(false);
+                if (_bufferedKey == null)
+                {
+                    _bufferedKey = await Task.Run(() => Console.ReadKey(intercept)).ConfigureAwait(false);
+                }
+
+                return _bufferedKey.Value;
             }
             finally
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -152,11 +152,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             if (this.commandLoopCancellationToken == null)
             {
                 this.commandLoopCancellationToken = new CancellationTokenSource();
-
-                var commandLoopThreadTask = Task.Factory.StartNew(() =>
-                    {
-                        return this.StartReplLoopAsync(this.commandLoopCancellationToken.Token);
-                    });
+                Task.Run(() => this.StartReplLoopAsync(this.commandLoopCancellationToken.Token));
             }
             else
             {


### PR DESCRIPTION
Makes the following changes:

- Changes `Task.Factory.StartNew` invocations to `Task.Run` to simplify the child attach semantics (invoking tasks won't hang around for new threads to finish now, since in the places where we use it, it seems we really wanted to kick off a new thread)
- Removes `async`/`await` from methods that just do some setup and run another task
- Adds a `TaskOptions.LongRunning` hint to the logger thread so that it's less likely to impact the thread pool. The other option here is to use a new `Thread` and bypass the thread pool altogether. Happy to do either (but this one represents a smaller change).