### PR TITLE
Fix crash on paste

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -45,6 +45,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 return [Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]
             }";
 
+        private static ExecutionOptions s_psrlExecutionOptions = new ExecutionOptions
+        {
+            WriteErrorsToHost = false,
+            WriteOutputToHost = false,
+            InterruptCommandPrompt = false,
+            AddToHistory = false,
+            IsReadLine = true,
+        };
+
         private readonly PowerShellContextService _powerShellContext;
 
         private readonly PromptNest _promptNest;
@@ -133,19 +142,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 .AddScript(ReadLineScript)
                 .AddArgument(_readLineCancellationSource.Token);
 
-            var executionOptions = new ExecutionOptions
-            {
-                WriteErrorsToHost = false,
-                WriteOutputToHost = false,
-                InterruptCommandPrompt = false,
-                AddToHistory = false,
-                IsReadLine = isCommandLine,
-            };
-
             IEnumerable<string> readLineResults = await _powerShellContext.ExecuteCommandAsync<string>(
                 readLineCommand,
                 errorMessages: null,
-                executionOptions).ConfigureAwait(false);
+                s_psrlExecutionOptions).ConfigureAwait(false);
 
             string line = readLineResults.FirstOrDefault();
 


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2420.

As @daxian-dbw explained, PSReadLine fires off its ReadKey call on a different thread to be asynchronous. This means the PSReadLine call can return before the ReadKey delegate has been called, leading to a condition where the `finally` block had set the cancellation token to `null` but our `ReadKey` delegate hadn't been run yet.

It turns out we don't need to set the cancellation token source to null; it will get reset on the next call anyway.