### PR TITLE
switch to string.empty

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -310,9 +310,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 {
                     psObjectDict.Add(
                         keyValuePair.Key,
-                        keyValuePair.Value != null
-                            ? PSObject.AsPSObject(keyValuePair.Value)
-                            : string.Empty);
+                        PSObject.AsPSObject(keyValuePair.Value ?? string.Empty));
                 }
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -312,7 +312,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         keyValuePair.Key,
                         keyValuePair.Value != null
                             ? PSObject.AsPSObject(keyValuePair.Value)
-                            : null);
+                            : string.Empty);
                 }
             }
 


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/1790

Changes the default to `string.Empty` to be constant with ConsoleHost.

This also means that `Read-Host` and `Read-Host -Prompt` have the same behavior when the user just hits `<ENTER>` on a prompt.