### PR TITLE
Fix untitled file references

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -150,20 +150,20 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// Creates a new ScriptFile instance by reading file contents from
         /// the given TextReader.
         /// </summary>
-        /// <param name="filePath">The path at which the script file resides.</param>
-        /// <param name="clientFilePath">The path which the client uses to identify the file.</param>
+        /// <param name="fileUri">The System.Uri of the file.</param>
         /// <param name="textReader">The TextReader to use for reading the file's contents.</param>
         /// <param name="powerShellVersion">The version of PowerShell for which the script is being parsed.</param>
         public ScriptFile(
-            string filePath,
-            string clientFilePath,
+            Uri fileUri,
             TextReader textReader,
             Version powerShellVersion)
         {
-            this.FilePath = filePath;
-            this.ClientFilePath = clientFilePath;
+            this.FilePath = fileUri.IsFile
+                ? fileUri.LocalPath
+                : fileUri.OriginalString;
+            this.ClientFilePath = fileUri.OriginalString;
             this.IsAnalysisEnabled = true;
-            this.IsInMemory = WorkspaceService.IsPathInMemory(filePath);
+            this.IsInMemory = !fileUri.IsFile;
             this.powerShellVersion = powerShellVersion;
 
             // SetFileContents() calls ParseFileContents() which initializes the rest of the properties.
@@ -173,37 +173,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// Creates a new ScriptFile instance with the specified file contents.
         /// </summary>
-        /// <param name="filePath">The path at which the script file resides.</param>
-        /// <param name="clientFilePath">The path which the client uses to identify the file.</param>
+        /// <param name="fileUri">The System.Uri of the file.</param>
         /// <param name="initialBuffer">The initial contents of the script file.</param>
         /// <param name="powerShellVersion">The version of PowerShell for which the script is being parsed.</param>
         public ScriptFile(
-            string filePath,
-            string clientFilePath,
+            Uri fileUri,
             string initialBuffer,
             Version powerShellVersion)
             : this(
-                  filePath,
-                  clientFilePath,
+                  fileUri,
                   new StringReader(initialBuffer),
-                  powerShellVersion)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new ScriptFile instance with the specified filepath.
-        /// </summary>
-        /// <param name="filePath">The path at which the script file resides.</param>
-        /// <param name="clientFilePath">The path which the client uses to identify the file.</param>
-        /// <param name="powerShellVersion">The version of PowerShell for which the script is being parsed.</param>
-        public ScriptFile(
-            string filePath,
-            string clientFilePath,
-            Version powerShellVersion)
-            : this(
-                  filePath,
-                  clientFilePath,
-                  File.ReadAllText(filePath),
                   powerShellVersion)
         {
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -158,6 +158,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             TextReader textReader,
             Version powerShellVersion)
         {
+            // For non-files, use their URI representation instead
+            // so that other operations know it's untitled/in-memory
+            // and don't think that it's a relative path
+            // on the file system.
             this.FilePath = fileUri.IsFile
                 ? fileUri.LocalPath
                 : fileUri.OriginalString;

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -294,10 +294,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // add original file so it's not searched for, then find all file references
             referencedScriptFiles.Add(scriptFile.Id, scriptFile);
-            if (!scriptFile.IsInMemory)
-            {
-                RecursivelyFindReferences(scriptFile, referencedScriptFiles);
-            }
+            RecursivelyFindReferences(scriptFile, referencedScriptFiles);
 
             // remove original file from referened file and add it as the first element of the
             // expanded referenced list to maintain order so the original file is always first in the list
@@ -400,9 +397,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             Dictionary<string, ScriptFile> referencedScriptFiles)
         {
             // Get the base path of the current script for use in resolving relative paths
-            string baseFilePath =
-                GetBaseFilePath(
-                    scriptFile.FilePath);
+            string baseFilePath = scriptFile.IsInMemory
+                ? WorkspacePath
+                : Path.GetDirectoryName(scriptFile.FilePath);
 
             foreach (string referencedFileName in scriptFile.ReferencedFiles)
             {
@@ -436,31 +433,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     }
                 }
             }
-        }
-
-        internal string ResolveFilePath(string filePath)
-        {
-            if (!IsPathInMemory(filePath))
-            {
-                if (filePath.StartsWith(@"file://"))
-                {
-                    filePath = WorkspaceService.UnescapeDriveColon(filePath);
-                    // Client sent the path in URI format, extract the local path
-                    filePath = new Uri(filePath).LocalPath;
-                }
-
-                // Clients could specify paths with escaped space, [ and ] characters which .NET APIs
-                // will not handle.  These paths will get appropriately escaped just before being passed
-                // into the PowerShell engine.
-                //filePath = PowerShellContext.UnescapeWildcardEscapedPath(filePath);
-
-                // Get the absolute file path
-                filePath = Path.GetFullPath(filePath);
-            }
-
-            this.logger.LogDebug("Resolved path: " + filePath);
-
-            return filePath;
         }
 
         internal Uri ResolveFileUri(Uri fileUri)
@@ -510,27 +482,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return isInMemory;
         }
 
-        private string GetBaseFilePath(string filePath)
-        {
-            if (IsPathInMemory(filePath))
-            {
-                // If the file is in memory, use the workspace path
-                return this.WorkspacePath;
-            }
-
-            if (!Path.IsPathRooted(filePath))
-            {
-                // TODO: Assert instead?
-                throw new InvalidOperationException(
-                    string.Format(
-                        "Must provide a full path for originalScriptPath: {0}",
-                        filePath));
-            }
-
-            // Get the directory of the file path
-            return Path.GetDirectoryName(filePath);
-        }
-
         internal string ResolveRelativeScriptPath(string baseFilePath, string relativePath)
         {
             string combinedPath = null;
@@ -577,39 +528,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             return combinedPath;
-        }
-
-        /// <summary>
-        /// Takes a file-scheme URI with an escaped colon after the drive letter and unescapes only the colon.
-        /// VSCode sends escaped colons after drive letters, but System.Uri expects unescaped.
-        /// </summary>
-        /// <param name="fileUri">The fully-escaped file-scheme URI string.</param>
-        /// <returns>A file-scheme URI string with the drive colon unescaped.</returns>
-        private static string UnescapeDriveColon(string fileUri)
-        {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return fileUri;
-            }
-
-            // Check here that we have something like "file:///C%3A/" as a prefix (caller must check the file:// part)
-            if (!(fileUri[7] == '/' &&
-                  char.IsLetter(fileUri[8]) &&
-                  fileUri[9] == '%' &&
-                  fileUri[10] == '3' &&
-                  fileUri[11] == 'A' &&
-                  fileUri[12] == '/'))
-            {
-                return fileUri;
-            }
-
-            var sb = new StringBuilder(fileUri.Length - 2); // We lost "%3A" and gained ":", so length - 2
-            sb.Append("file:///");
-            sb.Append(fileUri[8]); // The drive letter
-            sb.Append(':');
-            sb.Append(fileUri.Substring(12)); // The rest of the URI after the colon
-
-            return sb.ToString();
         }
 
         private static Uri UnescapeDriveColon(Uri fileUri)

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -142,8 +142,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     scriptFile =
                         new ScriptFile(
-                            resolvedFileUri.LocalPath,
-                            resolvedFileUri.OriginalString,
+                            resolvedFileUri,
                             streamReader,
                             this.powerShellVersion);
 
@@ -249,8 +248,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 scriptFile =
                     new ScriptFile(
-                        resolvedFileUri.LocalPath,
-                        resolvedFileUri.OriginalString,
+                        resolvedFileUri,
                         initialBuffer,
                         this.powerShellVersion);
 
@@ -296,7 +294,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // add original file so it's not searched for, then find all file references
             referencedScriptFiles.Add(scriptFile.Id, scriptFile);
-            RecursivelyFindReferences(scriptFile, referencedScriptFiles);
+            if (!scriptFile.IsInMemory)
+            {
+                RecursivelyFindReferences(scriptFile, referencedScriptFiles);
+            }
 
             // remove original file from referened file and add it as the first element of the
             // expanded referenced list to maintain order so the original file is always first in the list


### PR DESCRIPTION
This optimizes the `ScriptFile` constructor and also fixed an issue where in-memory files wouldn't be able to get CodeLens.

I want to get to a point where `DocumentUri` on the `ScriptFile` class is a reference to `System.Uri` but I'm gonna call that out of scope due to time constraints.

I believe this change is needed for #1119 as well