### PR TITLE
mitigate prompt issue

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             EditorServicesPSHostUserInterface hostUserInterface =
                 hostStartupInfo.ConsoleReplEnabled
-                    ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, hostStartupInfo.PSHost, shouldUsePSReadLine, logger)
+                    ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, hostStartupInfo.PSHost, logger)
                     : new ProtocolPSHostUserInterface(languageServer, powerShellContext, logger);
 
             EditorServicesPSHost psHost =

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -852,12 +852,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 }
                 finally
                 {
-                    // This supplies the newline in the Legacy ReadLine when executing code in the terminal via hitting the ENTER key.
-                    // Without this, hitting ENTER with a no input looks like it does nothing (no new prompt is written)
+                    // This supplies the newline in the Legacy ReadLine when executing code in the terminal via hitting the ENTER key
+                    // or Ctrl+C. Without this, hitting ENTER with a no input looks like it does nothing (no new prompt is written)
                     // and also the output would show up on the same line as the code you wanted to execute (the prompt line).
-                    // Since PSReadLine handles ENTER internally to itself, we only want to do this when using the Legacy ReadLine.
-                    if (!_isPSReadLineEnabled &&
-                        !cancellationToken.IsCancellationRequested &&
+                    // This is AlSO applied to PSReadLine for the Ctrl+C scenario which appears like it does nothing...
+                    // TODO: This still gives an extra newline when you hit ENTER in the PSReadLine experience. We should figure
+                    // out if there's any way to avoid that... but unfortunately, in both scenarios, we only see that empty
+                    // string is returned.
+                    if (!cancellationToken.IsCancellationRequested &&
                         originalCursorTop == await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false))
                     {
                         this.WriteLine();

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -809,7 +809,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             while (!cancellationToken.IsCancellationRequested)
             {
                 string commandString = null;
-                int originalCursorTop = 0;
 
                 try
                 {
@@ -822,7 +821,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
                 try
                 {
-                    originalCursorTop = await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false);
                     commandString = await this.ReadCommandLineAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch (PipelineStoppedException)
@@ -856,8 +854,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     // TODO: This still gives an extra newline when you hit ENTER in the PSReadLine experience. We should figure
                     // out if there's any way to avoid that... but unfortunately, in both scenarios, we only see that empty
                     // string is returned.
-                    if (!cancellationToken.IsCancellationRequested &&
-                        originalCursorTop == await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false))
+                    if (!cancellationToken.IsCancellationRequested)
                     {
                         this.WriteLine();
                     }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -35,7 +35,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private readonly ConcurrentDictionary<ProgressKey, object> currentProgressMessages =
             new ConcurrentDictionary<ProgressKey, object>();
 
-        private readonly bool _isPSReadLineEnabled;
         private PromptHandler activePromptHandler;
         private PSHostRawUserInterface rawUserInterface;
         private CancellationTokenSource commandLoopCancellationToken;
@@ -106,13 +105,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public EditorServicesPSHostUserInterface(
             PowerShellContextService powerShellContext,
             PSHostRawUserInterface rawUserInterface,
-            bool isPSReadLineEnabled,
             ILogger logger)
         {
             this.Logger = logger;
             this.powerShellContext = powerShellContext;
             this.rawUserInterface = rawUserInterface;
-            _isPSReadLineEnabled = isPSReadLineEnabled;
 
             this.powerShellContext.DebuggerStop += PowerShellContext_DebuggerStop;
             this.powerShellContext.DebuggerResumed += PowerShellContext_DebuggerResumed;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
@@ -33,7 +33,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             : base (
                 powerShellContext,
                 new SimplePSHostRawUserInterface(logger),
-                isPSReadLineEnabled: false,
                 logger)
         {
             _languageServer = languageServer;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -38,12 +38,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public TerminalPSHostUserInterface(
             PowerShellContextService powerShellContext,
             PSHost internalHost,
-            bool isPSReadLineEnabled,
             ILogger logger)
             : base (
                 powerShellContext,
                 new TerminalPSHostRawUserInterface(logger, internalHost),
-                isPSReadLineEnabled,
                 logger)
         {
             this.internalHostUI = internalHost.UI;


### PR DESCRIPTION
I needed to remove the check of PSReadLine because in the PSRL experience, whether you used ENTER or Ctrl-C, we'd still only get empty string...

This means that it would work with ENTER as ENTER would cause the cursor to go down... but Ctrl-C didn't.

I'm not sure if this is a PSRL bug that only we are exposing or actually our bug... but this makes it less ugly for sure.

The downside is that once the screen starts scrolling, an extra new line shows up.

cc @daxian-dbw if you're curious.