### PR TITLE
Update mac Image to 10.14 in CI as 10.13 is going to be deprecated in March

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -52,7 +52,7 @@ jobs:
 - job: 'PS6_macOS'
   displayName: PowerShell 6 | macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
   - template: templates/ci-general.yml
 


### PR DESCRIPTION
https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/


Note that Azure DevOps recently added 10.15 as well, so an alternative would be to use `macOS-latest` or both images
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops