### PR TITLE
Move PSRL decision option to be in Hosting

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -183,14 +183,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             var logger = factory.CreateLogger<PowerShellContextService>();
 
-            // We should only use PSReadLine if we specificied that we want a console repl
-            // and we have not explicitly said to use the legacy ReadLine.
-            // We also want it if we are either:
-            // * On Windows on any version OR
-            // * On Linux or macOS on any version greater than or equal to 7
             bool shouldUsePSReadLine = hostStartupInfo.ConsoleReplEnabled
-                && !hostStartupInfo.UsesLegacyReadLine
-                && (VersionUtils.IsWindows || !VersionUtils.IsPS6);
+                && !hostStartupInfo.UsesLegacyReadLine;
 
             var powerShellContext = new PowerShellContextService(
                 logger,


### PR DESCRIPTION
When you're on macOS or Linux using PS6, we default to using the Legacy Console experience.

However, this exposed a bug where the PSRL static constructor was still being run in debug sessions because the check for non-Windows PS6 was happening later.

This moves that logic up so that it's correct when debug sessions are created.