### PR TITLE
Make sure ErrorRecords go to Error stream

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -47,15 +47,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
         [SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "cctor needed for version specific initialization")]
         static PowerShellContextService()
         {
-            // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection
+            // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection.
             if (!VersionUtils.IsNetCore || VersionUtils.IsPS7OrGreater)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
                 s_runspaceApartmentStateSetter = (Action<Runspace, ApartmentState>)setter;
 
-                // Used to write Error Views to
-                s_writeStreamProperty = typeof(PSObject).GetProperty("WriteStream", BindingFlags.Instance | BindingFlags.NonPublic);
+                // Used to write ErrorRecords to the Error stream. Using Public and NonPublic because the plan is to make this property
+                // public in 7.0.1
+                s_writeStreamProperty = typeof(PSObject).GetProperty("WriteStream", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
                 Type writeStreamType = typeof(PSObject).Assembly.GetType("System.Management.Automation.WriteStreamType");
                 s_errorStreamValue = Enum.Parse(writeStreamType, "Error");
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1946,7 +1946,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
             else
             {
-                var note = new PSNoteProperty("WriteErrorStream", true);
+                var note = new PSNoteProperty("writeErrorStream", true);
                 psObject.Properties.Add(note);
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1946,7 +1946,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
             else
             {
-                var note = new PSNoteProperty("writeErrorStream", true);
+                var note = new PSNoteProperty("WriteErrorStream", true);
                 psObject.Properties.Add(note);
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -573,6 +573,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="value"></param>
         public override void WriteErrorLine(string value)
         {
+            // PowerShell's ConsoleHost also skips over empty lines:
+            // https://github.com/PowerShell/PowerShell/blob/8e683972284a5a7f773ea6d027d9aac14d7e7524/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs#L1334-L1337
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
             this.WriteOutput(
                 value,
                 true,


### PR DESCRIPTION
@daxian-dbw found a strange behavior in the Console's PSHost [where empty lines are skipped](https://github.com/PowerShell/PowerShell/blob/8e683972284a5a7f773ea6d027d9aac14d7e7524/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs#L1334-L1337) in `WriteErrorLine`.

He also discovered that errors were not going into the Error stream unless they have the `WriteStream` property set to `Error`.. which sadly can only be done via reflection.

This leverages that so that errors are printed out correctly instead of with this ugly line:
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/2644648/74889054-a3d0db00-5334-11ea-915d-040e2a9dbb43.png)

Also actually uses PowerShell to format parse errors correctly.
