### PR TITLE
Startup task tweaks

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -21,11 +21,8 @@ using System.Runtime.InteropServices;
 #endif
 
 #if DEBUG
-using System.Diagnostics;
-using System.Threading;
-
 using Debugger = System.Diagnostics.Debugger;
-using System.Threading.Tasks;
+using System.Threading;
 #endif
 
 namespace Microsoft.PowerShell.EditorServices.Commands

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -21,9 +21,10 @@ using System.Runtime.InteropServices;
 #endif
 
 #if DEBUG
-using Debugger = System.Diagnostics.Debugger;
 using System.Diagnostics;
 using System.Threading;
+
+using Debugger = System.Diagnostics.Debugger;
 #endif
 
 namespace Microsoft.PowerShell.EditorServices.Commands

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using System.Threading;
 
 using Debugger = System.Diagnostics.Debugger;
+using System.Threading.Tasks;
 #endif
 
 namespace Microsoft.PowerShell.EditorServices.Commands
@@ -238,7 +239,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 using (var psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, sessionFileWriter, _loggerUnsubscribers))
                 {
                     _logger.Log(PsesLogLevel.Verbose, "Loading EditorServices");
-                    psesLoader.LoadAndRunEditorServicesAsync().Wait();
+                    psesLoader.LoadAndRunEditorServicesAsync().GetAwaiter().GetResult();
                 }
             }
             catch (Exception e)

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -433,20 +433,20 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
             if (Stdio)
             {
-                return new StdioTransportConfig();
+                return new StdioTransportConfig(_logger);
             }
 
             if (LanguageServiceInPipeName != null && LanguageServiceOutPipeName != null)
             {
-                return SimplexNamedPipeTransportConfig.Create(LanguageServiceInPipeName, LanguageServiceOutPipeName);
+                return SimplexNamedPipeTransportConfig.Create(_logger, LanguageServiceInPipeName, LanguageServiceOutPipeName);
             }
 
             if (SplitInOutPipes)
             {
-                return SimplexNamedPipeTransportConfig.Create(LanguageServicePipeName);
+                return SimplexNamedPipeTransportConfig.Create(_logger, LanguageServicePipeName);
             }
 
-            return DuplexNamedPipeTransportConfig.Create(LanguageServicePipeName);
+            return DuplexNamedPipeTransportConfig.Create(_logger, LanguageServicePipeName);
         }
 
         private ITransportConfig GetDebugServiceTransport()
@@ -457,7 +457,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             {
                 if (DebugServiceOnly)
                 {
-                    return new StdioTransportConfig();
+                    return new StdioTransportConfig(_logger);
                 }
 
                 _logger.Log(PsesLogLevel.Diagnostic, "No debug transport: Transport is Stdio with debug disabled");
@@ -466,15 +466,15 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
             if (DebugServiceInPipeName != null && DebugServiceOutPipeName != null)
             {
-                return SimplexNamedPipeTransportConfig.Create(DebugServiceInPipeName, DebugServiceOutPipeName);
+                return SimplexNamedPipeTransportConfig.Create(_logger, DebugServiceInPipeName, DebugServiceOutPipeName);
             }
 
             if (SplitInOutPipes)
             {
-                return SimplexNamedPipeTransportConfig.Create(DebugServicePipeName);
+                return SimplexNamedPipeTransportConfig.Create(_logger, DebugServicePipeName);
             }
 
-            return DuplexNamedPipeTransportConfig.Create(DebugServicePipeName);
+            return DuplexNamedPipeTransportConfig.Create(_logger, DebugServicePipeName);
         }
 
         private enum ProfileHostKind

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -22,6 +22,7 @@ using System.Runtime.InteropServices;
 
 #if DEBUG
 using Debugger = System.Diagnostics.Debugger;
+using System.Diagnostics;
 using System.Threading;
 #endif
 
@@ -236,6 +237,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 using (var psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, sessionFileWriter, _loggerUnsubscribers))
                 {
                     _logger.Log(PsesLogLevel.Verbose, "Loading EditorServices");
+                    // Start editor services and wait here until it shuts down
                     psesLoader.LoadAndRunEditorServicesAsync().GetAwaiter().GetResult();
                 }
             }

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -363,7 +363,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                     _fileWriter.WriteLine(logMessage);
                 }
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
             }
         }

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -206,7 +206,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _editorServicesRunner = new EditorServicesRunner(_logger, _hostConfig, _sessionFileWriter, _loggersToUnsubscribe);
 
             // The trigger method for Editor Services
-            // We will wait here until Editor Services shuts down
             return Task.Run(_editorServicesRunner.RunUntilShutdown);
         }
 

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public void Dispose()
         {
-            _editorServicesRunner.Dispose();
+            _editorServicesRunner?.Dispose();
 
             // TODO:
             // Remove assembly resolve events

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -220,6 +220,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private void LoadEditorServices()
         {
+            // This must be in its own method, since the actual load happens when the calling method is called
+            // The call within this method is therefore a total no-op
             EditorServicesLoading.LoadEditorServicesForHost();
         }
 

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -211,6 +211,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public void Dispose()
         {
+            _logger.Log(PsesLogLevel.Diagnostic, "Loader disposed");
             _editorServicesRunner?.Dispose();
 
             // TODO:

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _sessionFileWriter.WriteSessionStarted(_config.LanguageServiceTransport, _config.DebugServiceTransport);
 
             // Finally, wait for Editor Services to shut down
+            _logger.Log(PsesLogLevel.Diagnostic, "Waiting on PSES run/shutdown");
             return runAndAwaitShutdown;
         }
 
@@ -73,6 +74,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             try
             {
+                _logger.Log(PsesLogLevel.Diagnostic, "Creating/running editor services");
+
                 bool creatingLanguageServer = _config.LanguageServiceTransport != null;
                 bool creatingDebugServer = _config.DebugServiceTransport != null;
                 bool isTempDebugSession = creatingDebugServer && !creatingLanguageServer;

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// Start and run Editor Services and then wait for shutdown.
         /// </summary>
         /// <returns>A task that ends when Editor Services shuts down.</returns>
-        public async Task RunUntilShutdown()
+        public Task RunUntilShutdown()
         {
             // Start Editor Services
             Task runAndAwaitShutdown = CreateEditorServicesAndRunUntilShutdown();
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _sessionFileWriter.WriteSessionStarted(_config.LanguageServiceTransport, _config.DebugServiceTransport);
 
             // Finally, wait for Editor Services to shut down
-            await runAndAwaitShutdown.ConfigureAwait(false);
+            return runAndAwaitShutdown;
         }
 
         public void Dispose()


### PR DESCRIPTION
- Makes disposal logic simpler
- Passes tasks through rather than awaiting them internally
- Fixes a bug where the logger was catching the wrong exception type
- Always kick the PSES start logic onto a new thread