### PR TITLE
Fix Read-Host behavior which mangles input

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -76,7 +76,8 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 _powerShellContextService.IsDebugServerActive = true;
 
                 // Needed to make sure PSReadLine's static properties are initialized in the pipeline thread.
-                if (_usePSReadLine && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
+                // This is only needed for Temp sessions who only have a debug server.
+                if (_usePSReadLine && _useTempSession && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
                 {
                     // This must be run synchronously to ensure debugging works
                     _powerShellContextService


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2291

So this class constructor is needed to run for temp sessions but it's not needed for regular sessions.

I confirmed the following worked properly:

* Temp session with script: "Read-Host"
* Regular session with script: "Read-Host"
* Regular session with script: "'hi'"
Temp session with script: "'hi'"

Eventually we want to get rid of this `ExecuteScriptStringAsync` for Constrained language mode support but this change gets us the expected behavior.