### PR TITLE
Fix how we set execution policy

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -41,16 +41,27 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 "../../Commands/PowerShellEditorServices.Commands.psd1"));
 
         private static readonly Action<Runspace, ApartmentState> s_runspaceApartmentStateSetter;
+        private static readonly PropertyInfo s_writeStreamProperty;
+        private static readonly object s_errorStreamValue;
 
         [SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "cctor needed for version specific initialization")]
         static PowerShellContextService()
         {
-            // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection
+            // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection.
             if (!VersionUtils.IsNetCore || VersionUtils.IsPS7OrGreater)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
                 s_runspaceApartmentStateSetter = (Action<Runspace, ApartmentState>)setter;
+            }
+
+            if (VersionUtils.IsPS7OrGreater)
+            {
+                // Used to write ErrorRecords to the Error stream. Using Public and NonPublic because the plan is to make this property
+                // public in 7.0.1
+                s_writeStreamProperty = typeof(PSObject).GetProperty("WriteStream", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                Type writeStreamType = typeof(PSObject).Assembly.GetType("System.Management.Automation.WriteStreamType");
+                s_errorStreamValue = Enum.Parse(writeStreamType, "Error");
             }
         }
 
@@ -1924,43 +1935,22 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        private void WriteExceptionToHost(Exception e)
+        private void WriteExceptionToHost(RuntimeException e)
         {
-            const string ExceptionFormat =
-                "{0}\r\n{1}\r\n    + CategoryInfo          : {2}\r\n    + FullyQualifiedErrorId : {3}";
+            var psObject = PSObject.AsPSObject(e.ErrorRecord);
 
-            if (!(e is IContainsErrorRecord containsErrorRecord) ||
-                containsErrorRecord.ErrorRecord == null)
+            // Used to write ErrorRecords to the Error stream so they are rendered in the console correctly.
+            if (VersionUtils.IsPS7OrGreater)
             {
-                this.WriteError(e.Message, null, 0, 0);
-                return;
+                s_writeStreamProperty.SetValue(psObject, s_errorStreamValue);
+            }
+            else
+            {
+                var note = new PSNoteProperty("writeErrorStream", true);
+                psObject.Properties.Add(note);
             }
 
-            ErrorRecord errorRecord = containsErrorRecord.ErrorRecord;
-            if (errorRecord.InvocationInfo == null)
-            {
-                this.WriteError(errorRecord.ToString(), String.Empty, 0, 0);
-                return;
-            }
-
-            string errorRecordString = errorRecord.ToString();
-            if ((errorRecord.InvocationInfo.PositionMessage != null) &&
-                errorRecordString.IndexOf(errorRecord.InvocationInfo.PositionMessage, StringComparison.Ordinal) != -1)
-            {
-                this.WriteError(errorRecordString);
-                return;
-            }
-
-            string message =
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    ExceptionFormat,
-                    errorRecord.ToString(),
-                    errorRecord.InvocationInfo.PositionMessage,
-                    errorRecord.CategoryInfo,
-                    errorRecord.FullyQualifiedErrorId);
-
-            this.WriteError(message);
+            ExecuteCommandAsync(new PSCommand().AddCommand("Microsoft.PowerShell.Core\\Out-Default").AddParameter("InputObject", psObject));
         }
 
         private void WriteError(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2089,7 +2089,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             // We want to get the list hierarchy of execution policies
             // Calling the cmdlet is the simplest way to do that
-            IEnumerable<PSObject> policies = this.powerShell
+            IReadOnlyList<PSObject> policies = this.powerShell
                 .AddCommand("Get-ExecutionPolicy")
                     .AddParameter("-List")
                 .Invoke();
@@ -2107,17 +2107,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Get-ExecutionPolicy -List emits PSObjects with Scope and ExecutionPolicy note properties
             // set to expected values, so we must sift through those.
             ExecutionPolicy policyToSet = ExecutionPolicy.Bypass;
-            foreach (PSObject policy in policies)
+            for (int i = policies.Count; i >= 0; i--)
             {
-                if ((ExecutionPolicyScope)policy.Members["Scope"].Value == ExecutionPolicyScope.Process)
+                PSObject policyObject = policies[i];
+
+                if ((ExecutionPolicyScope)policyObject.Members["Scope"].Value == ExecutionPolicyScope.Process)
                 {
                     continue;
                 }
 
-                var executionPolicy = (ExecutionPolicy)policy.Members["ExecutionPolicy"].Value;
+                var executionPolicy = (ExecutionPolicy)policyObject.Members["ExecutionPolicy"].Value;
                 if (executionPolicy != ExecutionPolicy.Undefined)
                 {
                     policyToSet = executionPolicy;
+                    break;
                 }
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2113,7 +2113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 if ((ExecutionPolicyScope)policyObject.Members["Scope"].Value == ExecutionPolicyScope.Process)
                 {
-                    continue;
+                    break;
                 }
 
                 var executionPolicy = (ExecutionPolicy)policyObject.Members["ExecutionPolicy"].Value;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2107,7 +2107,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Get-ExecutionPolicy -List emits PSObjects with Scope and ExecutionPolicy note properties
             // set to expected values, so we must sift through those.
             ExecutionPolicy policyToSet = ExecutionPolicy.Bypass;
-            for (int i = policies.Count; i >= 0; i--)
+            for (int i = policies.Count - 1; i >= 0; i--)
             {
                 PSObject policyObject = policies[i];
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation.Host;
@@ -23,6 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Management.Automation;
+    using System.Runtime.InteropServices;
     using Microsoft.PowerShell.EditorServices.Handlers;
     using Microsoft.PowerShell.EditorServices.Hosting;
     using Microsoft.PowerShell.EditorServices.Logging;
@@ -367,10 +367,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     powerShellVersion.ToString());
             }
 
-            if (this.LocalPowerShellVersion.Edition != "Linux")
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // TODO: Should this be configurable?
-                this.SetExecutionPolicy(ExecutionPolicy.RemoteSigned);
+                this.SetExecutionPolicy();
             }
 
             // Set up the runspace
@@ -2086,56 +2086,67 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return stringBuilder.ToString();
         }
 
-        private void SetExecutionPolicy(ExecutionPolicy desiredExecutionPolicy)
+        private void SetExecutionPolicy()
         {
-            var currentPolicy = ExecutionPolicy.Undefined;
+            // We want to get the list hierarchy of execution policies
+            // Calling the cmdlet is the simplest way to do that
+            IEnumerable<PSObject> policies = this.powerShell
+                .AddCommand("Get-ExecutionPolicy")
+                    .AddParameter("-List")
+                .Invoke();
 
-            // Get the current execution policy so that we don't set it higher than it already is
-            this.powerShell.Commands.AddCommand("Get-ExecutionPolicy");
+            this.powerShell.Commands.Clear();
 
-            var result = this.powerShell.Invoke<ExecutionPolicy>();
-            if (result.Count > 0)
+            // The policies come out in the following order:
+            // - MachinePolicy
+            // - UserPolicy
+            // - Process
+            // - CurrentUser
+            // - LocalMachine
+            // This is the order of precedence we want to follow, skipping the Process scope
+            //
+            // Get-ExecutionPolicy -List emits PSObjects with Scope and ExecutionPolicy note properties
+            // set to expected values, so we must sift through those.
+            ExecutionPolicy policyToSet = ExecutionPolicy.Bypass;
+            foreach (PSObject policy in policies)
             {
-                currentPolicy = result.FirstOrDefault();
+                if ((ExecutionPolicyScope)policy.Members["Scope"].Value == ExecutionPolicyScope.Process)
+                {
+                    continue;
+                }
+
+                var executionPolicy = (ExecutionPolicy)policy.Members["ExecutionPolicy"].Value;
+                if (executionPolicy != ExecutionPolicy.Undefined)
+                {
+                    policyToSet = executionPolicy;
+                }
             }
 
-            if (desiredExecutionPolicy < currentPolicy ||
-                desiredExecutionPolicy == ExecutionPolicy.Bypass ||
-                currentPolicy == ExecutionPolicy.Undefined)
+            // If there's nothing to do, save ourselves a PowerShell invocation
+            if (policyToSet == ExecutionPolicy.Bypass)
             {
-                this.logger.LogTrace(
-                    string.Format(
-                        "Setting execution policy:\r\n    Current = ExecutionPolicy.{0}\r\n    Desired = ExecutionPolicy.{1}",
-                        currentPolicy,
-                        desiredExecutionPolicy));
+                this.logger.LogTrace("Execution policy already set to Bypass. Skipping execution policy set");
+                return;
+            }
 
-                this.powerShell.Commands.Clear();
+            // Finally set the inherited execution policy
+            this.logger.LogTrace("Setting execution policy to {Policy}", policyToSet);
+            try
+            {
                 this.powerShell
                     .AddCommand("Set-ExecutionPolicy")
-                    .AddParameter("ExecutionPolicy", desiredExecutionPolicy)
                     .AddParameter("Scope", ExecutionPolicyScope.Process)
-                    .AddParameter("Force");
-
-                try
-                {
-                    this.powerShell.Invoke();
-                }
-                catch (CmdletInvocationException e)
-                {
-                    this.logger.LogException(
-                        $"An error occurred while calling Set-ExecutionPolicy, the desired policy of {desiredExecutionPolicy} may not be set.",
-                        e);
-                }
-
-                this.powerShell.Commands.Clear();
+                    .AddParameter("ExecutionPolicy", policyToSet)
+                    .AddParameter("Force")
+                    .Invoke();
             }
-            else
+            catch (CmdletInvocationException e)
             {
-                this.logger.LogTrace(
-                    string.Format(
-                        "Current execution policy: ExecutionPolicy.{0}",
-                        currentPolicy));
-
+                this.logger.LogError(e, "Error occurred calling 'Set-ExecutionPolicy -Scope Process -ExecutionPolicy {Policy} -Force'", policyToSet);
+            }
+            finally
+            {
+                this.powerShell.Commands.Clear();
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     powerShellVersion.ToString());
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (VersionUtils.IsWindows)
             {
                 this.SetExecutionPolicy();
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -369,7 +369,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                // TODO: Should this be configurable?
                 this.SetExecutionPolicy();
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -573,6 +573,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="value"></param>
         public override void WriteErrorLine(string value)
         {
+            // PowerShell's ConsoleHost also skips over empty lines:
+            // https://github.com/PowerShell/PowerShell/blob/8e683972284a5a7f773ea6d027d9aac14d7e7524/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs#L1334-L1337
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
             this.WriteOutput(
                 value,
                 true,


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2404.

Now, on startup, we do our best to inherit the correct execution policy.