### PR TITLE
Fire and forget evaluate

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/EvaluateHandler.cs
@@ -21,19 +21,19 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _powerShellContextService = powerShellContextService;
         }
 
-        public async Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
+        public Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
         {
-            await _powerShellContextService.ExecuteScriptStringAsync(
+            _powerShellContextService.ExecuteScriptStringAsync(
                 request.Expression,
                 writeInputToHost: true,
                 writeOutputToHost: true,
-                addToHistory: true).ConfigureAwait(false);
+                addToHistory: true);
 
-            return new EvaluateResponseBody
+            return Task.FromResult(new EvaluateResponseBody
             {
                 Result = "",
                 VariablesReference = 0
-            };
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2424

When you hit F8 in an interactive session that kicked the debugger on and stopped at a breakpoint, F8 would no longer work. This is because we were waiting for the original F8 to finish.

This changes the evaluate message to fire and forget which allows F8 to be run after the breakpoint is stopped.