### PR TITLE
Fix bad context state after debugging

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1240,6 +1240,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.PromptNest.GetPowerShell(isReadLine: false).BeginStop(null, null);
             }
 
+            // TODO:
+            // This lock and state reset are a temporary fix at best.
+            // We need to investigate how the debugger should be interacting
+            // with PowerShell in this cancellation scenario.
             this.sessionStateLock.Wait();
             try
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1225,14 +1225,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (this.PromptNest.IsInDebugger)
             {
+                this.versionSpecificOperations.StopCommandInDebugger(this);
                 if (shouldAbortDebugSession)
                 {
-                    this.versionSpecificOperations.StopCommandInDebugger(this);
                     this.ResumeDebugger(DebuggerResumeAction.Stop);
-                }
-                else
-                {
-                    this.versionSpecificOperations.StopCommandInDebugger(this);
                 }
             }
             else

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -744,7 +744,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // Don't change our SessionState for ReadLine.
                 if (!executionOptions.IsReadLine)
                 {
-                    await this.sessionStateLock.WaitAsync();
+                    await this.sessionStateLock.WaitAsync().ConfigureAwait(false);
                     shell.InvocationStateChanged += PowerShell_InvocationStateChanged;
                 }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -22,10 +22,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Management.Automation;
-    using System.Runtime.InteropServices;
     using Microsoft.PowerShell.EditorServices.Handlers;
     using Microsoft.PowerShell.EditorServices.Hosting;
-    using Microsoft.PowerShell.EditorServices.Logging;
     using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 
     /// <summary>
@@ -1240,19 +1238,21 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // This lock and state reset are a temporary fix at best.
             // We need to investigate how the debugger should be interacting
             // with PowerShell in this cancellation scenario.
-            this.sessionStateLock.Wait();
-            try
+            if (this.sessionStateLock.Wait(0))
             {
-                this.SessionState = PowerShellContextState.Aborting;
-                this.OnExecutionStatusChanged(
-                    ExecutionStatus.Aborted,
-                    null,
-                    false);
-            }
-            finally
-            {
-                this.SessionState = PowerShellContextState.Ready;
-                this.sessionStateLock.Release();
+                try
+                {
+                    this.SessionState = PowerShellContextState.Aborting;
+                    this.OnExecutionStatusChanged(
+                        ExecutionStatus.Aborted,
+                        null,
+                        false);
+                }
+                finally
+                {
+                    this.SessionState = PowerShellContextState.Ready;
+                    this.sessionStateLock.Release();
+                }
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1238,6 +1238,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // This lock and state reset are a temporary fix at best.
             // We need to investigate how the debugger should be interacting
             // with PowerShell in this cancellation scenario.
+            //
+            // Currently we try to acquire a lock on the execution status changed event.
+            // If we can't, it's because a command is executing, so we shouldn't change the status.
+            // If we can, we own the status and should fire the event.
             if (this.sessionStateLock.Wait(0))
             {
                 try


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2364.
Fixes https://github.com/PowerShell/vscode-powershell/issues/2488.
May fix https://github.com/PowerShell/vscode-powershell/issues/2396.

After debugging is stopped, the PowerShellContextService was being marked as being in session state aborted. Now we set the state to ready.

This fix isn't ideal, since it's made without a full understanding of the conceptual state machine of the PowerShellContextService, but it does fix the issues for the coming release while we sift through the actual architectural cause of the problem (and ideally fix it down the line)