### PR TITLE
Fix startup in AllSigned execution policy

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -367,11 +367,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     powerShellVersion.ToString());
             }
 
-            if (VersionUtils.IsWindows)
-            {
-                this.SetExecutionPolicy();
-            }
-
             // Set up the runspace
             this.ConfigureRunspace(this.CurrentRunspace);
 
@@ -427,6 +422,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
             else
             {
                 this.PromptContext = new LegacyReadLineContext(this);
+            }
+
+            if (VersionUtils.IsWindows)
+            {
+                this.SetExecutionPolicy();
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2102,25 +2102,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // - Process
             // - CurrentUser
             // - LocalMachine
-            // This is the order of precedence we want to follow, skipping the Process scope
+            // We want to ignore policy settings, since we'll already have those anyway.
+            // Then we need to look at the CurrentUser setting, and then the LocalMachine setting.
             //
             // Get-ExecutionPolicy -List emits PSObjects with Scope and ExecutionPolicy note properties
             // set to expected values, so we must sift through those.
+
             ExecutionPolicy policyToSet = ExecutionPolicy.Bypass;
-            for (int i = policies.Count - 1; i >= 0; i--)
+            var currentUserPolicy = (ExecutionPolicy)policies[policies.Count - 2].Members["ExecutionPolicy"].Value;
+            if (currentUserPolicy != ExecutionPolicy.Undefined)
             {
-                PSObject policyObject = policies[i];
-
-                if ((ExecutionPolicyScope)policyObject.Members["Scope"].Value == ExecutionPolicyScope.Process)
+                policyToSet = currentUserPolicy
+            }
+            else
+            {
+                var localMachinePolicy = (ExecutionPolicy)policies[policies.Count - 1].Members["ExecutionPolicy"].Value;
+                if (localMachinePolicy != ExecutionPolicy.Undefined)
                 {
-                    break;
-                }
-
-                var executionPolicy = (ExecutionPolicy)policyObject.Members["ExecutionPolicy"].Value;
-                if (executionPolicy != ExecutionPolicy.Undefined)
-                {
-                    policyToSet = executionPolicy;
-                    break;
+                    policyToSet = localMachinePolicy;
                 }
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -2112,7 +2112,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var currentUserPolicy = (ExecutionPolicy)policies[policies.Count - 2].Members["ExecutionPolicy"].Value;
             if (currentUserPolicy != ExecutionPolicy.Undefined)
             {
-                policyToSet = currentUserPolicy
+                policyToSet = currentUserPolicy;
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2504.

We were setting the execution policy before importing PSReadLine. Now we set it afterward.

Not sure what happens with PSSA here.

Ideally we could solve this by linking against those libraries rather than importing them as modules.

EDIT: It also turns out that Execution Policy scope order wasn't what we thought it would be, so we were setting a lower scope first. We now set the CurrentUser scope ahead of the LocalMachine scope.