### PR TITLE
Fix CommentHelp for when a function has other problems with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   Fix intellisense and `F5` not working after debugging.
 - 🐛🧰 [vscode-PowerShell #2495](https://github.com/PowerShell/PowerShellEditorServices/pull/1211) -
   Fix PowerShellEditorServices.Commands module commands not working due to types being moved.
+- 🐛👮 [vscode-PowerShell #2516](https://github.com/PowerShell/PowerShellEditorServices/pull/1216) -
+  Fix CommentHelp for when a function has other problems with it.
 
 ## v2.0.0-preview.9
 ### Thursday, February 20, 2020

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -490,8 +490,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         { "BlockComment", forBlockComment },
                         { "VSCodeSnippetCorrection", true },
                         { "Placement", helpLocation }}
-                    }}
-                }};
+                    }}},
+                { "IncludeRules", "PSProvideCommentHelp" }};
         }
 
         #region IDisposable Support
@@ -505,7 +505,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     if (_analysisEngineLazy != null
                         && _analysisEngineLazy.IsValueCreated)
-                    { 
+                    {
                         _analysisEngineLazy.Value.Dispose();
                     }
 

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -809,9 +809,13 @@ CanSendDefinitionRequest
             string scriptPath = NewTestFile(@"
 function CanSendGetCommentHelpRequest {
     param(
-        [string]
-        $myParam
+        $myParam,
+        $myOtherParam,
+        $yetAnotherParam
     )
+
+    # Include other problematic code to make sure this still works
+    gci
 }
 ");
 


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2516

We weren't specifically telling PSSA to only run the one rule so other diagnostics were coming back. I would guess that this fix would also have some perf impact as well which is nice.

an example bad function that works with this change:
```pwsh
function CanSendGetCommentHelpRequest {
    param(
        $myParam,
        $myOtherParam,
        $yetAnotherParam
    )

    # Include other problematic code to make sure this still works
    gci
}
```
The test change failed before the code change and passed after the code change.