### PR TITLE
Switch to better document selecting

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Utility;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -42,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
             _registrationOptions = new CodeActionRegistrationOptions
             {
-                DocumentSelector = new DocumentSelector(new DocumentFilter() { Language = "powershell" }),
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 CodeActionKinds = s_supportedCodeActions
             };
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -14,6 +14,7 @@ using Microsoft.PowerShell.EditorServices.CodeLenses;
 using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -23,13 +24,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class CodeLensHandlers : ICodeLensHandler, ICodeLensResolveHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -47,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new CodeLensRegistrationOptions
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 ResolveProvider = true
             };
         }
@@ -65,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new CompletionRegistrationOptions
             {
-                DocumentSelector = new DocumentSelector(new DocumentFilter { Language = "powershell" }),
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 ResolveProvider = true,
                 TriggerCharacters = new[] { ".", "-", ":", "\\" }
             };

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -19,13 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class DefinitionHandler : IDefinitionHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -46,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector
+                DocumentSelector = LspUtils.PowerShellDocumentSelector
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _symbolsService = symbolService;
             _registrationOptions = new TextDocumentRegistrationOptions()
             {
-                DocumentSelector = new DocumentSelector(new DocumentFilter() { Language = "powershell" } )
+                DocumentSelector = LspUtils.PowerShellDocumentSelector
             };
             _logger.LogInformation("highlight handler loaded");
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -24,13 +24,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class DocumentSymbolHandler : IDocumentSymbolHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly WorkspaceService _workspaceService;
 
@@ -54,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -17,13 +18,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class FoldingRangeHandler : IFoldingRangeHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly ConfigurationService _configurationService;
         private readonly WorkspaceService _workspaceService;
@@ -40,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions()
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -15,13 +16,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class DocumentFormattingHandler : IDocumentFormattingHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
         private readonly ConfigurationService _configurationService;
@@ -40,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector
+                DocumentSelector = LspUtils.PowerShellDocumentSelector
             };
         }
 
@@ -93,13 +87,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
     internal class DocumentRangeFormattingHandler : IDocumentRangeFormattingHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Pattern = "**/*.ps*1"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
         private readonly ConfigurationService _configurationService;
@@ -118,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector
+                DocumentSelector = LspUtils.PowerShellDocumentSelector
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -18,13 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class HoverHandler : IHoverHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -48,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -19,13 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     class ReferencesHandler : IReferencesHandler
     {
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -42,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions
             {
-                DocumentSelector = _documentSelector
+                DocumentSelector = LspUtils.PowerShellDocumentSelector
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -20,14 +21,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     internal class SignatureHelpHandler : ISignatureHelpHandler
     {
         private static readonly SignatureInformation[] s_emptySignatureResult = Array.Empty<SignatureInformation>();
-
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Language = "powershell"
-            }
-        );
-
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -51,7 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new SignatureHelpRegistrationOptions
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 // A sane default of " ". We may be able to include others like "-".
                 TriggerCharacters = new Container<string>(" ")
             };

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -15,6 +15,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.Capabilities;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
@@ -25,14 +26,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly AnalysisService _analysisService;
         private readonly WorkspaceService _workspaceService;
         private readonly RemoteFileManagerService _remoteFileManagerService;
-
-        private readonly DocumentSelector _documentSelector = new DocumentSelector(
-            new DocumentFilter()
-            {
-                Language = "powershell"
-            }
-        );
-
         private SynchronizationCapability _capability;
 
         public TextDocumentSyncKind Change => TextDocumentSyncKind.Incremental;
@@ -72,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentChangeRegistrationOptions()
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 SyncKind = Change
             };
         }
@@ -101,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentRegistrationOptions()
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
             };
         }
 
@@ -138,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return new TextDocumentSaveRegistrationOptions()
             {
-                DocumentSelector = _documentSelector,
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 IncludeText = true
             };
         }

--- a/src/PowerShellEditorServices/Utility/LspUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspUtils.cs
@@ -1,0 +1,27 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    internal static class LspUtils
+    {
+        public static DocumentSelector PowerShellDocumentSelector => new DocumentSelector(
+            DocumentFilter.ForLanguage("powershell"),
+            DocumentFilter.ForLanguage("pwsh"),
+
+            // The vim extension sets all PowerShell files as language "ps1" so this
+            // makes sure we track those.
+            DocumentFilter.ForLanguage("ps1"),
+            DocumentFilter.ForLanguage("psm1"),
+            DocumentFilter.ForLanguage("psd1"),
+
+            // Also specify the file extensions to be thorough
+            // This won't handle untitled files which is why we have to do the ones above.
+            DocumentFilter.ForPattern("**/*.ps*1")
+        );
+    }
+}


### PR DESCRIPTION
Trying to get the vim extension working, I noticed that the `filetype` for PowerShell files was `ps1` instead of `powershell`.

This adds `ps1` and a few others to our document selector.

I really should get the vim extension using `powershell` but it's harder than it sounds because any vim plugin can change this.