### PR TITLE
Ensure log directory is created

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -298,14 +298,17 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
         private string GetLogDirPath()
         {
-            if (!string.IsNullOrEmpty(LogPath))
+            string logDir = !string.IsNullOrEmpty(LogPath)
+                ? Path.GetDirectoryName(LogPath)
+                : Path.GetDirectoryName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+            // Ensure logDir exists
+            if (!Directory.Exists(logDir))
             {
-                return Path.GetDirectoryName(LogPath);
+                Directory.CreateDirectory(logDir);
             }
 
-            return Path.GetDirectoryName(
-                Path.GetDirectoryName(
-                    Assembly.GetExecutingAssembly().Location));
+            return logDir;
         }
 
         private void RemovePSReadLineForStartup()

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -303,10 +303,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 : Path.GetDirectoryName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 
             // Ensure logDir exists
-            if (!Directory.Exists(logDir))
-            {
-                Directory.CreateDirectory(logDir);
-            }
+            Directory.CreateDirectory(logDir);
 
             return logDir;
         }


### PR DESCRIPTION
The vim extension ran into this issue where because it didn't create the log dir, PSES wouldn't startup properly.

This makes PSES more resilient.