### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"postCreateCommand": "dotnet restore",
 
 	"extensions": [
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "ms-vscode.powershell-preview",
         "davidanson.vscode-markdownlint",
         "editorconfig.editorconfig"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "ms-vscode.powershell",
         "davidanson.vscode-markdownlint",
         "editorconfig.editorconfig"


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)