### PR TITLE
Use Assembly.LoadFile in WinPS

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -406,28 +406,5 @@ PID: {System.Diagnostics.Process.GetCurrentProcess().Id}
                 throw new ArgumentNullException(nameof(_hostConfig.PSHost));
             }
         }
-
-#if !CoreCLR
-        private static void LoadAllAssembliesInDirectory(HostLogger logger, string directoryPath)
-        {
-            foreach (string asmPath in Directory.GetFiles(directoryPath, "*.dll"))
-            {
-                Assembly result = null;
-                try
-                {
-                    result = Assembly.LoadFile(asmPath);
-                }
-                catch (Exception e)
-                {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Exception trying to load '{asmPath}':\n{e}");
-                }
-
-                if (result == null)
-                {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Loading assembly '{asmPath}' returned null");
-                }
-            }
-        }
-#endif
     }
 }

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 string baseDirAsmPath = Path.Combine(s_psesBaseDirPath, dllName);
                 if (File.Exists(baseDirAsmPath))
                 {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES base dir into LoadFrom context");
+                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES base dir into LoadFile context");
                     return Assembly.LoadFile(baseDirAsmPath);
                 }
 
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 string asmPath = Path.Combine(s_psesDependencyDirPath, dllName);
                 if (File.Exists(asmPath))
                 {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES dependency dir into LoadFrom context");
+                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES dependency dir into LoadFile context");
                     return Assembly.LoadFile(asmPath);
                 }
 


### PR DESCRIPTION
Switch over to using `Assembly.LoadFile()` instead of `Assembly.LoadFrom()` to load dependency assemblies in WinPS to avoid clobbering module dependencies.

Fixes https://github.com/PowerShell/vscode-powershell/issues/2397
Fixes https://github.com/PowerShell/vscode-powershell/issues/2545