### PR TITLE
Ensure that errors are written to the console when debugging

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -837,6 +837,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 if (executionOptions.WriteErrorsToHost)
                 {
                     // Write the error to the host
+                    // We must await this after the runspace handle has been released or we will deadlock
                     writeErrorsToConsoleTask = this.WriteExceptionToHostAsync(e);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2534.

The PowerShell thread writing errors was never awaited and was being starved it seems. We now wait for the error writing to finish