### PR TITLE
Optimize when we run GetCommandInfoAsync

### DIFF
--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -349,7 +349,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // need to continue because we won't be able to get the
             // CommandInfo object.
             if (foundSymbol?.SymbolType != SymbolType.Function
-            && foundSymbol?.SymbolType != SymbolType.Unknown)
+                && foundSymbol?.SymbolType != SymbolType.Unknown)
             {
                 return null;
             }
@@ -467,8 +467,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // look for it in the builtin commands but only if the symbol
             // we are looking at is possibly a Function.
             if (foundDefinition == null
-            && (foundSymbol.SymbolType == SymbolType.Function
-            || foundSymbol.SymbolType == SymbolType.Unknown))
+                && (foundSymbol.SymbolType == SymbolType.Function
+                    || foundSymbol.SymbolType == SymbolType.Unknown))
             {
                 CommandInfo cmdInfo =
                     await CommandHelpers.GetCommandInfoAsync(

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -345,7 +345,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     lineNumber,
                     columnNumber);
 
-            if (foundSymbol == null)
+            // If we are not possibly looking at a Function, we don't
+            // need to continue because we won't be able to get the
+            // CommandInfo object.
+            if (foundSymbol?.SymbolType != SymbolType.Function
+            && foundSymbol?.SymbolType != SymbolType.Unknown)
             {
                 return null;
             }
@@ -459,9 +463,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
             }
 
-            // if definition is not found in file in the workspace
-            // look for it in the builtin commands
-            if (foundDefinition == null)
+            // if the definition is not found in a file in the workspace
+            // look for it in the builtin commands but only if the symbol
+            // we are looking at is possibly a Function.
+            if (foundDefinition == null
+            && (foundSymbol.SymbolType == SymbolType.Function
+            || foundSymbol.SymbolType == SymbolType.Unknown))
             {
                 CommandInfo cmdInfo =
                     await CommandHelpers.GetCommandInfoAsync(


### PR DESCRIPTION
Now we are certain that `GetCommandInfoAsync` will only run when we have a Function. I included Unknown as well just in case, but I could take that out.

We should no longer see these in logs:

```
2020-03-13 12:37:12.884 -07:00 [ERR] Execution of the following command(s) completed with errors:

    Microsoft.PowerShell.Core\Get-Command -Name -ErrorAction Ignore

```
^ *Explanation*: `-Name` is being passed in to `Get-Command`.