### PR TITLE
Update PackageManagement

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -118,7 +118,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         writeOutputToHost: true,
                         addToHistory: true).ConfigureAwait(false);
 
-                    // There were errors installing PackageManagement.
                     if (errors.Length == 0)
                     {
                         _languageServer.Window.ShowMessage(new ShowMessageParams
@@ -129,10 +128,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     }
                     else
                     {
+                        // There were errors installing PackageManagement.
                         _languageServer.Window.ShowMessage(new ShowMessageParams
                         {
                             Type = MessageType.Error,
-                            Message = "PackageManagement update failed. Please run the following command in a Windows PowerShell prompt and restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`"
+                            Message = "PackageManagement update failed. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`"
                         });
                     }
                 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -4,23 +4,41 @@
 //
 
 using System;
+using System.Management.Automation;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using Microsoft.PowerShell.EditorServices.Utility;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class GetVersionHandler : IGetVersionHandler
     {
-        private readonly ILogger<GetVersionHandler> _logger;
+        private static readonly Version s_desiredPackageManagementVersion = new Version(1, 4, 6);
 
-        public GetVersionHandler(ILoggerFactory factory)
+        private readonly ILogger<GetVersionHandler> _logger;
+        private readonly PowerShellContextService _powerShellContextService;
+        private readonly ILanguageServer _languageServer;
+        private readonly ConfigurationService _configurationService;
+
+        public GetVersionHandler(
+            ILoggerFactory factory,
+            PowerShellContextService powerShellContextService,
+            ILanguageServer languageServer,
+            ConfigurationService configurationService)
         {
             _logger = factory.CreateLogger<GetVersionHandler>();
+            _powerShellContextService = powerShellContextService;
+            _languageServer = languageServer;
+            _configurationService = configurationService;
         }
 
-        public Task<PowerShellVersion> Handle(GetVersionParams request, CancellationToken cancellationToken)
+        public async Task<PowerShellVersion> Handle(GetVersionParams request, CancellationToken cancellationToken)
         {
             var architecture = PowerShellProcessArchitecture.Unknown;
             // This should be changed to using a .NET call sometime in the future... but it's just for logging purposes.
@@ -37,13 +55,18 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            return Task.FromResult(new PowerShellVersion
+            if (VersionUtils.IsPS5 && _configurationService.CurrentSettings.PromptToUpdatePackageManagement)
+            {
+                await CheckPackageManagement().ConfigureAwait(false);
+            }
+
+            return new PowerShellVersion
             {
                 Version = VersionUtils.PSVersionString,
                 Edition = VersionUtils.PSEdition,
                 DisplayVersion = VersionUtils.PSVersion.ToString(2),
                 Architecture = architecture.ToString()
-            });
+            };
         }
 
         private enum PowerShellProcessArchitecture
@@ -51,6 +74,69 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             Unknown,
             X86,
             X64
+        }
+
+        private async Task CheckPackageManagement()
+        {
+            PSCommand getModule = new PSCommand().AddCommand("Get-Module").AddParameter("ListAvailable").AddParameter("Name", "PackageManagement");
+            foreach (PSModuleInfo module in await _powerShellContextService.ExecuteCommandAsync<PSModuleInfo>(getModule))
+            {
+                // The user has a good enough version of PackageManagement
+                if(module.Version >= s_desiredPackageManagementVersion)
+                {
+                    break;
+                }
+
+                _logger.LogDebug("Old version of PackageManagement detected. Attempting to update.");
+
+                var takeActionText = "Yes";
+                MessageActionItem messageAction = await _languageServer.Window.ShowMessage(new ShowMessageRequestParams
+                {
+                    Message = "You have an older version of PackageManagement known to cause issues with the PowerShell extension. Would you like to update PackageManagement (You will need to restart the PowerShell extension after)?",
+                    Type = MessageType.Warning,
+                    Actions = new []
+                    {
+                        new MessageActionItem
+                        {
+                            Title = takeActionText
+                        },
+                        new MessageActionItem
+                        {
+                            Title = "Not now"
+                        }
+                    }
+                });
+
+                // If the user chose "Not now" ignore it for the rest of the session.
+                if (messageAction?.Title == takeActionText)
+                {
+                    StringBuilder errors = new StringBuilder();
+                    await _powerShellContextService.ExecuteScriptStringAsync(
+                        "powershell.exe -NoLogo -NoProfile -Command 'Install-Module -Name PackageManagement -Force -MinimumVersion 1.4.6 -Scope CurrentUser -AllowClobber'",
+                        errors,
+                        writeInputToHost: true,
+                        writeOutputToHost: true,
+                        addToHistory: true).ConfigureAwait(false);
+
+                    // There were errors installing PackageManagement.
+                    if (errors.Length == 0)
+                    {
+                        _languageServer.Window.ShowMessage(new ShowMessageParams
+                        {
+                            Type = MessageType.Info,
+                            Message = "PackageManagement updated, If you already had PackageManagement loaded in your session, please restart the PowerShell extension."
+                        });
+                    }
+                    else
+                    {
+                        _languageServer.Window.ShowMessage(new ShowMessageParams
+                        {
+                            Type = MessageType.Error,
+                            Message = "PackageManagement update failed. Please run the following command in a Windows PowerShell prompt and restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`"
+                        });
+                    }
+                }
+            }
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -20,6 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         private readonly object updateLock = new object();
         public bool EnableProfileLoading { get; set; }
 
+        public bool PromptToUpdatePackageManagement { get; set; }
+
         public ScriptAnalysisSettings ScriptAnalysis { get; set; }
 
         public CodeFormattingSettings CodeFormatting { get; set; }
@@ -46,6 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                 lock (updateLock)
                 {
                     this.EnableProfileLoading = settings.EnableProfileLoading;
+                    this.PromptToUpdatePackageManagement = settings.PromptToUpdatePackageManagement;
                     this.ScriptAnalysis.Update(
                         settings.ScriptAnalysis,
                         workspaceRootPath,


### PR DESCRIPTION
I don't really want this at startup... but it's the best place for it, unfortunately.

This adds a feature to update the users version of PackageManagement if they have a bad version.

vscode-powershell settings PR: https://github.com/PowerShell/vscode-powershell/pull/2651