### PR TITLE
Only run diagnostics on PowerShell files

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -410,7 +410,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void PublishScriptDiagnostics(ScriptFile scriptFile, IReadOnlyList<ScriptFileMarker> markers)
         {
-            var diagnostics = new Diagnostic[scriptFile.DiagnosticMarkers.Count];
+            var diagnostics = new Diagnostic[markers.Count];
 
             CorrectionTableEntry fileCorrections = _mostRecentCorrectionsByFile.GetOrAdd(
                 scriptFile,

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             };
         }
 
-        public async Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
+        public Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            return new LocationContainer(locations);
+            return Task.FromResult(new LocationContainer(locations));
         }
 
         public void SetCapability(ReferencesCapability capability)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     class TextDocumentHandler : ITextDocumentSyncHandler
     {
+        private static readonly Uri s_fakeUri = new Uri("Untitled:fake");
 
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
@@ -85,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             if (LspUtils.PowerShellDocumentSelector.IsMatch(new TextDocumentAttributes(
                 // We use a fake Uri because we only want to test the LanguageId here and not if the
                 // file ends in ps*1.
-                new Uri("Untitled:file"),
+                s_fakeUri,
                 notification.TextDocument.LanguageId)))
             {
                 // Kick off script diagnostics if we got a PowerShell file without blocking the response

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -82,10 +82,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     notification.TextDocument.Uri,
                     notification.TextDocument.Text);
 
-            // Kick off script diagnostics if we got a PowerShell file without blocking the response
-            // TODO: Get all recently edited files in the workspace
-            if (notification.TextDocument.LanguageId == "powershell")
+            if (LspUtils.PowerShellDocumentSelector.IsMatch(new TextDocumentAttributes(
+                // We use null because we only want to test the LanguageId here and not if the
+                // file ends in ps*1.
+                null,
+                notification.TextDocument.LanguageId)))
             {
+                // Kick off script diagnostics if we got a PowerShell file without blocking the response
+                // TODO: Get all recently edited files in the workspace
                 _analysisService.RunScriptDiagnostics(new ScriptFile[] { openedFile }, token);
             }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -83,9 +83,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     notification.TextDocument.Text);
 
             if (LspUtils.PowerShellDocumentSelector.IsMatch(new TextDocumentAttributes(
-                // We use null because we only want to test the LanguageId here and not if the
+                // We use a fake Uri because we only want to test the LanguageId here and not if the
                 // file ends in ps*1.
-                null,
+                new Uri("Untitled:file"),
                 notification.TextDocument.LanguageId)))
             {
                 // Kick off script diagnostics if we got a PowerShell file without blocking the response

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -82,9 +82,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     notification.TextDocument.Uri,
                     notification.TextDocument.Text);
 
-            // Kick off script diagnostics without blocking the response
+            // Kick off script diagnostics if we got a PowerShell file without blocking the response
             // TODO: Get all recently edited files in the workspace
-            _analysisService.RunScriptDiagnostics(new ScriptFile[] { openedFile }, token);
+            if (notification.TextDocument.LanguageId == "powershell")
+            {
+                _analysisService.RunScriptDiagnostics(new ScriptFile[] { openedFile }, token);
+            }
 
             _logger.LogTrace("Finished opening document.");
             return Unit.Task;

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -59,7 +59,7 @@ namespace PowerShellEditorServices.Test.E2E
             Diagnostics.Clear();
         }
 
-        private string NewTestFile(string script, bool isPester = false)
+        private string NewTestFile(string script, bool isPester = false, string languageId = "powershell")
         {
             string fileExt = isPester ? ".Tests.ps1" : ".ps1";
             string filePath = Path.Combine(s_binDir, Path.GetRandomFileName() + fileExt);
@@ -69,7 +69,7 @@ namespace PowerShellEditorServices.Test.E2E
             {
                 TextDocument = new TextDocumentItem
                 {
-                    LanguageId = "powershell",
+                    LanguageId = languageId,
                     Version = 0,
                     Text = script,
                     Uri = new Uri(filePath)
@@ -143,6 +143,15 @@ function CanSendWorkspaceSymbolRequest {
 
             Diagnostic diagnostic = Assert.Single(Diagnostics);
             Assert.Equal("PSUseDeclaredVarsMoreThanAssignments", diagnostic.Code);
+        }
+
+        [Fact]
+        public async Task WontReceiveDiagnosticsFromFileOpenThatIsNotPowerShell()
+        {
+            NewTestFile("$a = 4", languageId: "plaintext");
+            await Task.Delay(2000);
+
+            Assert.Empty(Diagnostics);
         }
 
         [Fact]


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2572

We need to not run script diagnostics if the file we get isn't a PowerShell file in VS Code but is a PowerShell file on the file system.