### PR TITLE
Refactor GetCommandSynopsisAsync method make sure cmdlets with module prefixes work

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -76,36 +76,36 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             CommandInfo commandInfo,
             PowerShellContextService powerShellContext)
         {
+            Validate.IsNotNull(nameof(commandInfo), commandInfo);
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
-            string synopsisString = string.Empty;
-
-            if (commandInfo != null &&
-                (commandInfo.CommandType == CommandTypes.Cmdlet ||
-                 commandInfo.CommandType == CommandTypes.Function ||
-                 commandInfo.CommandType == CommandTypes.Filter))
+            // A small optimization to not run Get-Help on things like DSC resources.
+            if (commandInfo.CommandType != CommandTypes.Cmdlet &&
+                commandInfo.CommandType != CommandTypes.Function &&
+                commandInfo.CommandType != CommandTypes.Filter)
             {
-                PSCommand command = new PSCommand();
-                command.AddCommand(@"Microsoft.PowerShell.Core\Get-Help");
-                command.AddArgument(commandInfo);
-                command.AddParameter("ErrorAction", "Ignore");
+                return string.Empty;
+            }
 
-                var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false);
-                PSObject helpObject = results.FirstOrDefault();
+            PSCommand command = new PSCommand()
+                .AddCommand(@"Microsoft.PowerShell.Core\Get-Help")
+                // We use .Name here instead of just passing in commandInfo because
+                // CommandInfo.ToString() duplicates the Prefix if one exists.
+                .AddArgument(commandInfo.Name)
+                .AddParameter("ErrorAction", "Ignore");
 
-                if (helpObject != null)
-                {
-                    // Extract the synopsis string from the object
-                    synopsisString =
-                        (string)helpObject.Properties["synopsis"].Value ??
-                        string.Empty;
+            var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false);
+            PSObject helpObject = results.FirstOrDefault();
 
-                    // Ignore the placeholder value for this field
-                    if (string.Equals(synopsisString, "SHORT DESCRIPTION", System.StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        synopsisString = string.Empty;
-                    }
-                }
+            // Extract the synopsis string from the object
+            string synopsisString =
+                (string)helpObject?.Properties["synopsis"].Value ??
+                string.Empty;
+
+            // Ignore the placeholder value for this field
+            if (string.Equals(synopsisString, "SHORT DESCRIPTION", System.StringComparison.CurrentCultureIgnoreCase))
+            {
+                return string.Empty;
             }
 
             return synopsisString;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 .AddCommand(@"Microsoft.PowerShell.Core\Get-Help")
                 // We use .Name here instead of just passing in commandInfo because
                 // CommandInfo.ToString() duplicates the Prefix if one exists.
-                .AddArgument(commandInfo.Name)
+                .AddParameter("Name", commandInfo.Name)
                 .AddParameter("ErrorAction", "Ignore");
 
             var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false);

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -826,15 +826,14 @@ CanSendReferencesCodeLensRequest
         }
 
         [Fact]
-        public async Task CanSGetHelpCompletionResolveWithPrefixRequest()
+        public async Task CanSendCompletionResolveWithModulePrefixRequest()
         {
-            EvaluateResponseBody evaluateResponseBody =
-                await LanguageClient.SendRequest<EvaluateResponseBody>(
-                    "evaluate",
-                    new EvaluateRequestArguments
-                    {
-                        Expression = "Import-Module Microsoft.PowerShell.Archive -Prefix Slow"
-                    });
+            await LanguageClient.SendRequest<EvaluateResponseBody>(
+                "evaluate",
+                new EvaluateRequestArguments
+                {
+                    Expression = "Import-Module Microsoft.PowerShell.Archive -Prefix Slow"
+                });
 
             string filePath = NewTestFile("Expand-SlowArch");
 

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -826,6 +826,32 @@ CanSendReferencesCodeLensRequest
         }
 
         [Fact]
+        public async Task CanSGetHelpCompletionResolveWithPrefixRequest()
+        {
+            EvaluateResponseBody evaluateResponseBody =
+                await LanguageClient.SendRequest<EvaluateResponseBody>(
+                    "evaluate",
+                    new EvaluateRequestArguments
+                    {
+                        Expression = "Import-Module Microsoft.PowerShell.Archive -Prefix Slow"
+                    });
+
+            string filePath = NewTestFile("Expand-SlowArch");
+
+            CompletionList completionItems = await LanguageClient.TextDocument.Completions(
+                filePath, line: 0, column: 15);
+
+            CompletionItem completionItem = Assert.Single(completionItems,
+                completionItem1 => completionItem1.Label == "Expand-SlowArchive");
+
+            CompletionItem updatedCompletionItem = await LanguageClient.SendRequest<CompletionItem>(
+                "completionItem/resolve",
+                completionItem);
+
+            Assert.Contains("Extracts files from a specified archive", updatedCompletionItem.Documentation.String);
+        }
+
+        [Fact]
         public async Task CanSendHoverRequest()
         {
             string filePath = NewTestFile("Write-Host");


### PR DESCRIPTION
Fixes #1242 
Fixes https://github.com/PowerShell/vscode-powershell/issues/2584

This method needed a good refactor... The main change here is:

```
.AddParameter("Name", commandInfo.Name)
```
instead of
```
.AddArgument(commandInfo)
```

because `commandInfo.ToString()` gives you duplicate Prefixes... I'll link that PowerShell/PowerShell issue here when the original filer opens it.