### PR TITLE
Include PSReadLine 2.1.0+ prereleases in PSReadLine filter

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -33,8 +33,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             param()
             end {
                 $module = Get-Module -ListAvailable PSReadLine |
-                    Where-Object Version -ge '2.0.0' |
-                    Where-Object { -not $_.PrivateData.PSData.Prerelease } |
+                    Where-Object { $_.Version -gt '2.0.0' -or ($_.Version -eq '2.0.0' -and -not $_.PrivateData.PSData.Prerelease) } |
                     Sort-Object -Descending Version |
                     Select-Object -First 1
                 if (-not $module) {


### PR DESCRIPTION
Today, we don't allow PSReadLine prereleases due to our filter logic... This permits prereleases but only if the version is greater than 2.0.0. We do this because 2.0.0 was the first _stable_ version of PSReadLine that supported PSES.