### PR TITLE
Fix cancellation for completions and add Hover cancellation

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             if (cancellationToken.IsCancellationRequested)
             {
+                _logger.LogDebug("CodeAction request canceled at range: {0}", request.Range);
                 return Array.Empty<CommandOrCodeAction>();
             }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             if (cancellationToken.IsCancellationRequested)
             {
+                _logger.LogDebug("FoldingRange request canceled for file: {0}", request.TextDocument.Uri);
                 return Task.FromResult(new Container<FoldingRange>());
             }
 


### PR DESCRIPTION
* adds some logging for a couple handlers
* adds cancellation support for the `textDocument/hover` request
* adds lock to `completionItem/resolve` handler which prevents deadlock
