### PR TITLE
Signaturehelp cancellation and some caching

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 .OfType<CommandInfo>()
                 .FirstOrDefault();
 
-            // Only cache CmdletInfos since they're exposed in binaries and can never change throughout the session.
+            // Only cache CmdletInfos since they're exposed in binaries they are likely to not change throughout the session.
             if (commandInfo.CommandType == CommandTypes.Cmdlet)
             {
                 s_commandInfoCache.TryAdd(commandName, commandInfo);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -108,6 +108,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             // If we have a synopsis cached, return that.
+            // NOTE: If the user runs Update-Help, it's possible that this synopsis will be out of date.
+            // Given the perf increase of doing this, and the simple workaround of restarting the extension,
+            // this seems worth it.
             if (s_synopsisCache.TryGetValue(commandInfo.Name, out string synopsis))
             {
                 return synopsis;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 return cmdInfo;
             }
 
-            // Make sure the command's noun isn't blacklisted.  This is
+            // Make sure the command's noun isn't in the exclusion list.  This is
             // currently necessary to make sure that Get-Command doesn't
             // load PackageManagement or PowerShellGet because they cause
             // a major slowdown in IntelliSense.

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -22,20 +22,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-        private readonly PowerShellContextService _powerShellContextService;
 
         private HoverCapability _capability;
 
         public HoverHandler(
             ILoggerFactory factory,
             SymbolsService symbolsService,
-            WorkspaceService workspaceService,
-            PowerShellContextService powerShellContextService)
+            WorkspaceService workspaceService)
         {
             _logger = factory.CreateLogger<HoverHandler>();
             _symbolsService = symbolsService;
             _workspaceService = workspaceService;
-            _powerShellContextService = powerShellContextService;
         }
 
         public HoverRegistrationOptions GetRegistrationOptions()

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -20,7 +20,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class SignatureHelpHandler : ISignatureHelpHandler
     {
-        private static readonly SignatureInformation[] s_emptySignatureResult = Array.Empty<SignatureInformation>();
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
@@ -52,6 +51,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<SignatureHelp> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("SignatureHelp request canceled for file: {0}", request.TextDocument.Uri);
+                return new SignatureHelp();
+            }
+
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             ParameterSetSignatures parameterSets =
@@ -61,28 +66,28 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     (int) request.Position.Character + 1,
                     _powerShellContextService).ConfigureAwait(false);
 
-            SignatureInformation[] signatures = s_emptySignatureResult;
-
-            if (parameterSets != null)
+            if (parameterSets == null)
             {
-                signatures = new SignatureInformation[parameterSets.Signatures.Length];
-                for (int i = 0; i < signatures.Length; i++)
-                {
-                    var parameters = new ParameterInformation[parameterSets.Signatures[i].Parameters.Count()];
-                    int j = 0;
-                    foreach (ParameterInfo param in parameterSets.Signatures[i].Parameters)
-                    {
-                        parameters[j] = CreateParameterInfo(param);
-                        j++;
-                    }
+                return new SignatureHelp();
+            }
 
-                    signatures[i] = new SignatureInformation
-                    {
-                        Label = parameterSets.CommandName + " " + parameterSets.Signatures[i].SignatureText,
-                        Documentation = null,
-                        Parameters = parameters,
-                    };
+            SignatureInformation[] signatures = new SignatureInformation[parameterSets.Signatures.Length];
+            for (int i = 0; i < signatures.Length; i++)
+            {
+                var parameters = new ParameterInformation[parameterSets.Signatures[i].Parameters.Count()];
+                int j = 0;
+                foreach (ParameterInfo param in parameterSets.Signatures[i].Parameters)
+                {
+                    parameters[j] = CreateParameterInfo(param);
+                    j++;
                 }
+
+                signatures[i] = new SignatureInformation
+                {
+                    Label = parameterSets.CommandName + " " + parameterSets.Signatures[i].SignatureText,
+                    Documentation = null,
+                    Parameters = parameters,
+                };
             }
 
             return new SignatureHelp

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -3,8 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -71,15 +70,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return new SignatureHelp();
             }
 
-            SignatureInformation[] signatures = new SignatureInformation[parameterSets.Signatures.Length];
+            var signatures = new SignatureInformation[parameterSets.Signatures.Length];
             for (int i = 0; i < signatures.Length; i++)
             {
-                var parameters = new ParameterInformation[parameterSets.Signatures[i].Parameters.Count()];
-                int j = 0;
+                var parameters = new List<ParameterInformation>();
                 foreach (ParameterInfo param in parameterSets.Signatures[i].Parameters)
                 {
-                    parameters[j] = CreateParameterInfo(param);
-                    j++;
+                    parameters.Add(CreateParameterInfo(param));
                 }
 
                 signatures[i] = new SignatureInformation


### PR DESCRIPTION
* SignatureHelp request is now cancellable - I saw this request a bunch in a user's log
* SignatureHelp request cleaned up a bit
* Cache `CmdletInfo`'s and synopsis' of `CmdletInfo`s.
* Renamed `NounExclusionList` to `s_nounExclusionList`