### PR TITLE
Move PSReadLine logic to cmdlets

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -76,7 +76,11 @@ Copyright = '(c) 2017 Microsoft. All rights reserved.'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @('Start-EditorServices')
+CmdletsToExport = @(
+    'Start-EditorServices',
+    '__Invoke-ReadLineForEditorServices',
+    '__Invoke-ReadLineConstructor'
+)
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
@@ -1,0 +1,24 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Management.Automation;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.PowerShell.EditorServices.Commands
+{
+    /// <summary>
+    /// The Start-EditorServices command, the conventional entrypoint for PowerShell Editor Services.
+    /// </summary>
+    [Cmdlet("__Invoke", "ReadLineConstructor")]
+    public sealed class InvokeReadLineConstructorCommand : PSCmdlet
+    {
+        protected override void EndProcessing()
+        {
+            Type type = Type.GetType("Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2");
+            RuntimeHelpers.RunClassConstructor(type.TypeHandle);
+        }
+    }
+}

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
@@ -1,0 +1,46 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.PowerShell.EditorServices.Commands
+{
+    /// <summary>
+    /// The Start-EditorServices command, the conventional entrypoint for PowerShell Editor Services.
+    /// </summary>
+    [Cmdlet("__Invoke", "ReadLineForEditorServices")]
+    public sealed class InvokeReadLineForEditorServicesCommand : PSCmdlet
+    {
+        private static Lazy<MethodInfo> s_readLine = new Lazy<MethodInfo>(() =>
+        {
+            Type type = Type.GetType("Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2");
+            return type.GetMethod("ReadLine", new [] { typeof(Runspace), typeof(EngineIntrinsics), typeof(CancellationToken)});
+        });
+
+        /// <summary>
+        /// The ID to give to the host's profile.
+        /// </summary>
+        [Parameter(Mandatory = true)]
+        [ValidateNotNullOrEmpty]
+        public CancellationToken CancellationToken { get; set; }
+
+        protected override void EndProcessing()
+        {
+            // This returns a string.
+            object result = s_readLine.Value.Invoke(null, new object []
+                {
+                    Runspace.DefaultRunspace,
+                    SessionState.PSVariable.Get("ExecutionContext").Value,
+                    CancellationToken
+                });
+
+            WriteObject(result);
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,8 +81,9 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 if (_usePSReadLine && _useTempSession && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
                 {
                     // This must be run synchronously to ensure debugging works
+                    var command = new PSCommand().AddCommand("__Invoke-ReadLineConstructor");
                     _powerShellContextService
-                        .ExecuteScriptStringAsync("[System.Runtime.CompilerServices.RuntimeHelpers]::RunClassConstructor([Microsoft.PowerShell.PSConsoleReadLine].TypeHandle)")
+                        .ExecuteCommandAsync<object>(command, sendOutputToHost: true, sendErrorToHost: true)
                         .GetAwaiter()
                         .GetResult();
                 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -18,15 +18,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
     internal class PSReadLinePromptContext : IPromptContext
     {
-        private const string ReadLineScript = @"
-            [System.Diagnostics.DebuggerHidden()]
-            [System.Diagnostics.DebuggerStepThrough()]
-            param()
-            return [Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]::ReadLine(
-                $Host.Runspace,
-                $ExecutionContext,
-                $args[0])";
-
         private const string ReadLineInitScript = @"
             [System.Diagnostics.DebuggerHidden()]
             [System.Diagnostics.DebuggerStepThrough()]
@@ -41,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 }
 
                 Import-Module -ModuleInfo $module
-                return [Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]
+                return [Microsoft.PowerShell.PSConsoleReadLine]
             }";
 
         private static ExecutionOptions s_psrlExecutionOptions = new ExecutionOptions
@@ -138,8 +129,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             var readLineCommand = new PSCommand()
-                .AddScript(ReadLineScript)
-                .AddArgument(_readLineCancellationSource.Token);
+                .AddCommand("__Invoke-ReadLineForEditorServices")
+                .AddParameter("CancellationToken", _readLineCancellationSource.Token);
 
             IEnumerable<string> readLineResults = await _powerShellContext.ExecuteCommandAsync<string>(
                 readLineCommand,


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2623

This _should_ enable the ability to _start up_ with ConstrainedLanguage mode (though I didn't remove the check because I wasn't sure if I could set it on non-Windows). There are features that won't work though - expand alias, remoting, Command explorer, etc.