### PR TITLE
No warning about module being imported

### DIFF
--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -76,11 +76,7 @@ Copyright = '(c) 2017 Microsoft. All rights reserved.'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @(
-    'Start-EditorServices',
-    '__Invoke-ReadLineForEditorServices',
-    '__Invoke-ReadLineConstructor'
-)
+CmdletsToExport = @('Start-EditorServices')
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
@@ -12,7 +12,6 @@ namespace Microsoft.PowerShell.EditorServices.Commands
     /// <summary>
     /// The Start-EditorServices command, the conventional entrypoint for PowerShell Editor Services.
     /// </summary>
-    [Cmdlet("__Invoke", "ReadLineConstructor")]
     public sealed class InvokeReadLineConstructorCommand : PSCmdlet
     {
         protected override void EndProcessing()

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerShell.EditorServices.Commands
     /// <summary>
     /// The Start-EditorServices command, the conventional entrypoint for PowerShell Editor Services.
     /// </summary>
-    [Cmdlet("__Invoke", "ReadLineForEditorServices")]
     public sealed class InvokeReadLineForEditorServicesCommand : PSCmdlet
     {
         private delegate string ReadLineInvoker(

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -29,8 +29,11 @@ namespace Microsoft.PowerShell.EditorServices.Server
         /// </summary>
         private static int s_hasRunPsrlStaticCtor = 0;
 
-        private static readonly Lazy<Type> s_lazyReadLineCmdletType = new Lazy<Type>(() =>
-            Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineConstructorCommand, Microsoft.PowerShell.EditorServices.Hosting"));
+        private static readonly Lazy<CmdletInfo> s_lazyInvokeReadLineConstructorCmdletInfo = new Lazy<CmdletInfo>(() =>
+        {
+            var type = Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineConstructorCommand, Microsoft.PowerShell.EditorServices.Hosting");
+            return new CmdletInfo("__Invoke-ReadLineConstructor", type);
+        });
 
         private readonly Stream _inputStream;
         private readonly Stream _outputStream;
@@ -85,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 if (_usePSReadLine && _useTempSession && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
                 {
                     var command = new PSCommand()
-                        .AddCommand(new CmdletInfo("__Invoke-ReadLineConstructor", s_lazyReadLineCmdletType.Value));
+                        .AddCommand(s_lazyInvokeReadLineConstructorCmdletInfo.Value);
 
                     // This must be run synchronously to ensure debugging works
                     _powerShellContextService

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -740,7 +740,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
 
                 PowerShell shell = this.PromptNest.GetPowerShell(executionOptions.IsReadLine);
-                shell.Commands = psCommand;
+
+                // Due to the following PowerShell bug, we can't just assign shell.Commands to psCommand
+                // because PowerShell strips out CommandInfo:
+                // https://github.com/PowerShell/PowerShell/issues/12297
+                shell.Commands.Clear();
+                foreach (Command command in psCommand.Commands)
+                {
+                    shell.Commands.AddCommand(command);
+                }
 
                 // Don't change our SessionState for ReadLine.
                 if (!executionOptions.IsReadLine)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -3,18 +3,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
+using System.Management.Automation.Runspaces;
 using System.Threading;
 using System.Threading.Tasks;
-using System;
-using System.Management.Automation.Runspaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {
-    using System.Collections.Generic;
     using System.Management.Automation;
-    using Microsoft.Extensions.Logging;
 
     internal class PSReadLinePromptContext : IPromptContext
     {
@@ -43,6 +43,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             AddToHistory = false,
             IsReadLine = true,
         };
+
+        private static readonly Lazy<Type> s_lazyReadLineCmdletType = new Lazy<Type>(() =>
+            Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineForEditorServicesCommand, Microsoft.PowerShell.EditorServices.Hosting"));
 
         private readonly PowerShellContextService _powerShellContext;
 
@@ -129,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             var readLineCommand = new PSCommand()
-                .AddCommand("__Invoke-ReadLineForEditorServices")
+                .AddCommand(new CmdletInfo("__Invoke-ReadLineForEditorServices", s_lazyReadLineCmdletType.Value))
                 .AddParameter("CancellationToken", _readLineCancellationSource.Token);
 
             IEnumerable<string> readLineResults = await _powerShellContext.ExecuteCommandAsync<string>(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -35,6 +35,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 return [Microsoft.PowerShell.PSConsoleReadLine]
             }";
 
+        private static readonly Lazy<CmdletInfo> s_lazyInvokeReadLineForEditorServicesCmdletInfo = new Lazy<CmdletInfo>(() =>
+        {
+            var type = Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineForEditorServicesCommand, Microsoft.PowerShell.EditorServices.Hosting");
+            return new CmdletInfo("__Invoke-ReadLineForEditorServices", type);
+        });
+
         private static ExecutionOptions s_psrlExecutionOptions = new ExecutionOptions
         {
             WriteErrorsToHost = false,
@@ -43,12 +49,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             AddToHistory = false,
             IsReadLine = true,
         };
-
-        private static readonly Lazy<CmdletInfo> s_lazyInvokeReadLineForEditorServicesCmdletInfo = new Lazy<CmdletInfo>(() =>
-        {
-            var type = Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineForEditorServicesCommand, Microsoft.PowerShell.EditorServices.Hosting");
-            return new CmdletInfo("__Invoke-ReadLineForEditorServices", type);
-        });
 
         private readonly PowerShellContextService _powerShellContext;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -44,8 +44,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             IsReadLine = true,
         };
 
-        private static readonly Lazy<Type> s_lazyReadLineCmdletType = new Lazy<Type>(() =>
-            Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineForEditorServicesCommand, Microsoft.PowerShell.EditorServices.Hosting"));
+        private static readonly Lazy<CmdletInfo> s_lazyInvokeReadLineForEditorServicesCmdletInfo = new Lazy<CmdletInfo>(() =>
+        {
+            var type = Type.GetType("Microsoft.PowerShell.EditorServices.Commands.InvokeReadLineForEditorServicesCommand, Microsoft.PowerShell.EditorServices.Hosting");
+            return new CmdletInfo("__Invoke-ReadLineForEditorServices", type);
+        });
 
         private readonly PowerShellContextService _powerShellContext;
 
@@ -132,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             var readLineCommand = new PSCommand()
-                .AddCommand(new CmdletInfo("__Invoke-ReadLineForEditorServices", s_lazyReadLineCmdletType.Value))
+                .AddCommand(s_lazyInvokeReadLineForEditorServicesCmdletInfo.Value)
                 .AddParameter("CancellationToken", _readLineCancellationSource.Token);
 
             IEnumerable<string> readLineResults = await _powerShellContext.ExecuteCommandAsync<string>(

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
+using System.Linq.Expressions;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
@@ -11,21 +13,31 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 {
     internal static class PSCommandExtensions
     {
-        private static ConstructorInfo s_commandCtor =
-            typeof(Command).GetConstructor(
+
+        private static readonly Func<CommandInfo, Command> s_commandCtor;
+
+        static PSCommandExtensions()
+        {
+            var ctor = typeof(Command).GetConstructor(
                 BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
                 binder: null,
                 new[] { typeof(CommandInfo) },
                 modifiers: null);
+
+            ParameterExpression commandInfo = Expression.Parameter(typeof(CommandInfo), nameof(commandInfo));
+
+            s_commandCtor = Expression.Lambda<Func<CommandInfo, Command>>(
+                Expression.New(ctor, commandInfo),
+                new[] { commandInfo })
+                .Compile();
+        }
 
         // PowerShell's missing an API for us to AddCommand using a CommandInfo.
         // An issue was filed here: https://github.com/PowerShell/PowerShell/issues/12295
         // This works around this by creating a `Command` and passing it into PSCommand.AddCommand(Command command)
         internal static PSCommand AddCommand(this PSCommand command, CommandInfo commandInfo)
         {
-            var rsCommand = (Command) s_commandCtor
-                .Invoke(new object[] { commandInfo });
-
+            var rsCommand = s_commandCtor(commandInfo);
             return command.AddCommand(rsCommand);
         }
     }

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -13,7 +13,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 {
     internal static class PSCommandExtensions
     {
-
         private static readonly Func<CommandInfo, Command> s_commandCtor;
 
         static PSCommandExtensions()

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Reflection;
+
+namespace Microsoft.PowerShell.EditorServices.Utility
+{
+    internal static class PSCommandExtensions
+    {
+        private static ConstructorInfo s_commandCtor =
+            typeof(Command).GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                binder: null,
+                new[] { typeof(CommandInfo) },
+                modifiers: null);
+
+        internal static PSCommand AddCommand(this PSCommand command, CommandInfo commandInfo)
+        {
+            var rsCommand = (Command) s_commandCtor
+                .Invoke(new object[] { commandInfo });
+
+            return command.AddCommand(rsCommand);
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -18,6 +18,9 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 new[] { typeof(CommandInfo) },
                 modifiers: null);
 
+        // PowerShell's missing an API for us to AddCommand using a CommandInfo.
+        // An issue was filed here: https://github.com/PowerShell/PowerShell/issues/12295
+        // This works around this by creating a `Command` and passing it into PSCommand.AddCommand(Command command)
         internal static PSCommand AddCommand(this PSCommand command, CommandInfo commandInfo)
         {
             var rsCommand = (Command) s_commandCtor


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2626

This no longer exposes the cmdlets and instead creates a `CmdletInfo` object with the implementing type.

Unfortunately, we have to work around 2 PowerShell issues:
https://github.com/PowerShell/PowerShell/issues/12295
https://github.com/PowerShell/PowerShell/issues/12297