### PR TITLE
Allow formatting when ScriptAnalysis is off

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -265,9 +265,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void EnsureEngineSettingsCurrent()
         {
-            if (_analysisEngineLazy == null ||
-                    (_pssaSettingsFilePath != null
-                    && !File.Exists(_pssaSettingsFilePath)))
+            if (_analysisEngineLazy == null
+                    || (_pssaSettingsFilePath != null
+                        && !File.Exists(_pssaSettingsFilePath)))
             {
                 InitializeAnalysisEngineToCurrentSettings();
             }

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 _settingsParameter = settingsPath;
                 return this;
             }
-            
+
             /// <summary>
             /// Uses a settings hashtable for PSSA rule configuration.
             /// </summary>
@@ -176,7 +176,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             // Invoke-Formatter throws a ParameterBinderValidationException if the ScriptDefinition is an empty string.
             if (string.IsNullOrEmpty(scriptDefinition))
             {
-                return null;
+                _logger.LogDebug("Script Definition was: " + scriptDefinition == null ? "null" : "empty string");
+                return scriptDefinition;
             }
 
             var psCommand = new PSCommand()
@@ -194,7 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             if (result == null)
             {
                 _logger.LogError("Formatter returned null result");
-                return null;
+                return scriptDefinition;
             }
 
             if (result.HasErrors)
@@ -205,7 +206,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                     errorBuilder.Append(err).Append(s_indentJoin);
                 }
                 _logger.LogWarning($"Errors found while formatting file: {errorBuilder}");
-                return null;
+                return scriptDefinition;
             }
 
             foreach (PSObject resultObj in result.Output)
@@ -216,7 +217,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 }
             }
 
-            return null;
+            _logger.LogError("Couldn't get result from output. Returning original script.");
+            return scriptDefinition;
         }
 
         /// <summary>


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2543

With ScriptAnalysis turned off...
```
"powershell.scriptAnalysis.enable": false,
```

this disables PSScriptAnalyzer capabilities in the extension including:
* "Problems" in your open editor file
* Formatting

Since that was off, formatting wasn't working for users (and would throw a weird null ref due to returning `null` instead of `Task.FromResult(null)`).

With that said, I don't see _why_ this needs to be the case. You should be able to run the formatter and have "Problems" turned off. This PR pushes the ScriptAnalysis enabled test up a layer while allowing the Formatting path to trigger the creation of the `AnalysisEngine`.