### PR TITLE
AllowPrerelease when building Preview build

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -21,6 +21,8 @@ param(
 $script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
 $script:RequiredSdkVersion = (Get-Content (Join-Path $PSScriptRoot 'global.json') | ConvertFrom-Json).sdk.version
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")
+$script:PsesCommonProps = [xml](Get-Content -Raw "$PSScriptRoot/PowerShellEditorServices.Common.props")
+$script:IsPreview = [bool]($script:PsesCommonProps.Project.PropertyGroup.VersionSuffix)
 
 $script:NetRuntime = @{
     Core = 'netcoreapp2.1'
@@ -361,7 +363,7 @@ task RestorePsesModules -After Build {
             Name = $name
             MinimumVersion = $_.Value.MinimumVersion
             MaximumVersion = $_.Value.MaximumVersion
-            AllowPrerelease = $_.Value.AllowPrerelease
+            AllowPrerelease = $script:IsPreview
             Repository = if ($_.Value.Repository) { $_.Value.Repository } else { $DefaultModuleRepository }
             Path = $submodulePath
         }

--- a/modules.json
+++ b/modules.json
@@ -1,16 +1,13 @@
 {
     "PSScriptAnalyzer":{
         "MinimumVersion":"1.18.3",
-        "MaximumVersion":"1.99",
-        "AllowPrerelease":false
+        "MaximumVersion":"1.99"
     },
     "Plaster":{
         "MinimumVersion":"1.0",
-        "MaximumVersion":"1.99",
-        "AllowPrerelease":false
+        "MaximumVersion":"1.99"
     },
     "PSReadLine":{
-        "MinimumVersion":"2.0.0",
-        "AllowPrerelease":true
+        "MinimumVersion":"2.0.0"
     }
 }


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2637
(well really mitigates...)

Now that we have a stable version of PSReadLine that works with the extension, we should only ship stables in the Stable extension.

This allows for previews in Preview builds and stables in Stable builds.

cc @daxian-dbw 