### PR TITLE
Leverage internal HostUI for VT100 check

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -67,12 +67,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         #region Properties
 
-#if !PowerShellv3 && !PowerShellv4 && !PowerShellv5r1 // Only available in Windows 10 Update 1 or higher
         /// <summary>
         /// Returns true if the host supports VT100 output codes.
         /// </summary>
-        public override bool SupportsVirtualTerminal => true;
-#endif
+        public override bool SupportsVirtualTerminal => false;
 
         /// <summary>
         /// Returns true if a native application is currently running.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -66,6 +66,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         #endregion
 
         /// <summary>
+        /// Returns true if the host supports VT100 output codes.
+        /// </summary>
+        public override bool SupportsVirtualTerminal => internalHostUI.SupportsVirtualTerminal;
+
+        /// <summary>
         /// Gets a value indicating whether writing progress is supported.
         /// </summary>
         internal protected override bool SupportsWriteProgress => true;


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2637
Fixes https://github.com/PowerShell/vscode-powershell/issues/2640

A user can be using PowerShell 5.1 or greater on Windows Server 2012 R2.

We can leverage the internal host to get the value already computed by ConsoleHost.

I haven't tested this... I'd need to break out a 2012 R2 VM 😢