### PR TITLE
Refactor GetCommandHandler to not use dynamic

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -62,14 +62,29 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 foreach (CommandInfo command in result)
                 {
-                    // Get the default ParameterSet
+                    // Some info objects have a quicker way to get the DefaultParameterSet. These
+                    // are also the most likely to show up so win-win.
                     string defaultParameterSet = null;
-                    foreach (CommandParameterSetInfo parameterSetInfo in command.ParameterSets)
+                    switch (command)
                     {
-                        if (parameterSetInfo.IsDefault)
-                        {
-                            defaultParameterSet = parameterSetInfo.Name;
+                        case CmdletInfo info:
+                            defaultParameterSet = info.DefaultParameterSet;
                             break;
+                        case FunctionInfo info:
+                            defaultParameterSet = info.DefaultParameterSet;
+                            break;
+                    }
+
+                    if (defaultParameterSet == null)
+                    {
+                        // Try to get the default ParameterSet if it isn't streamlined (ExternalScriptInfo for example)
+                        foreach (CommandParameterSetInfo parameterSetInfo in command.ParameterSets)
+                        {
+                            if (parameterSetInfo.IsDefault)
+                            {
+                                defaultParameterSet = parameterSetInfo.Name;
+                                break;
+                            }
                         }
                     }
 

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1004,8 +1004,8 @@ function CanSendGetCommentHelpRequest {
         [Fact]
         public async Task CanSendGetCommandRequest()
         {
-            List<PSCommandMessage> pSCommandMessages =
-                await LanguageClient.SendRequest<List<PSCommandMessage>>("powerShell/getCommand", new GetCommandParams());
+            List<object> pSCommandMessages =
+                await LanguageClient.SendRequest<List<object>>("powerShell/getCommand", new GetCommandParams());
 
             Assert.NotEmpty(pSCommandMessages);
             // There should be at least 20 commands or so.


### PR DESCRIPTION
Refactor GetCommandHandler to not use dynamic.

This includes a test change that was needed because a PowerShell type didn't serialize correctly.

cc @corbob 