### PR TITLE
Support ConstrainedLanguage mode

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -274,6 +274,16 @@ task TestE2E {
 
     $env:PWSH_EXE_NAME = if ($IsCoreCLR) { "pwsh" } else { "powershell" }
     exec { & $script:dotnetExe test --logger trx -f $script:NetRuntime.Core (DotNetTestFilter) }
+
+    # Run E2E tests in ConstrainedLanguage mode.
+    if (!$script:IsUnix) {
+        try {
+            [System.Environment]::SetEnvironmentVariable("__PSLockdownPolicy", "0x80000007", [System.EnvironmentVariableTarget]::Machine);
+            exec { & $script:dotnetExe test --logger trx -f $script:NetRuntime.Core (DotNetTestFilter) }
+        } finally {
+            [System.Environment]::SetEnvironmentVariable("__PSLockdownPolicy", $null, [System.EnvironmentVariableTarget]::Machine);
+        }
+    }
 }
 
 task LayoutModule -After Build {

--- a/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
@@ -10,7 +10,9 @@ function Clear-Host {
     param()
 
     __clearhost
-    $psEditor.Window.Terminal.Clear()
+    if ($host.Runspace.LanguageMode -eq [System.Management.Automation.PSLanguageMode]::FullLanguage) {
+        $psEditor.Window.Terminal.Clear()
+    }
 }
 
 if (!$IsMacOS -or $IsLinux) {

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
 using SMA = System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using Microsoft.PowerShell.EditorServices.Hosting;
 using System.Globalization;
 using System.Collections;
@@ -358,6 +359,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 AdditionalModules = AdditionalModules,
                 LanguageServiceTransport = GetLanguageServiceTransport(),
                 DebugServiceTransport = GetDebugServiceTransport(),
+                LanguageMode = Runspace.DefaultRunspace.SessionStateProxy.LanguageMode,
                 ProfilePaths = new ProfilePathConfig
                 {
                     AllUsersAllHosts = GetProfilePathFromProfileObject(profile, ProfileUserKind.AllUsers, ProfileHostKind.AllHosts),

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -113,7 +113,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public ProfilePathConfig ProfilePaths { get; set; }
 
         /// <summary>
-        /// The language mode of the original runspace that we will inherit from.
+        /// The language mode inherited from the orginal PowerShell process.
+        /// This will be used when creating runspaces so that we honor the same language mode.
         /// </summary>
         public PSLanguageMode LanguageMode { get; internal set; }
 

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -4,6 +4,7 @@
 //
 
 using System.Collections.Generic;
+using System.Management.Automation;
 using System.Management.Automation.Host;
 
 namespace Microsoft.PowerShell.EditorServices.Hosting
@@ -110,6 +111,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// If none are provided, these will be generated from the hosting PowerShell's profile paths.
         /// </summary>
         public ProfilePathConfig ProfilePaths { get; set; }
+
+        /// <summary>
+        /// The language mode of the original runspace that we will inherit from.
+        /// </summary>
+        public PSLanguageMode LanguageMode { get; internal set; }
 
         public string StartupBanner { get; set; } = @"
 

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -190,8 +190,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // Make sure the .NET Framework version supports .NET Standard 2.0
             CheckNetFxVersion();
 #endif
-            // Ensure the language mode allows us to run
-            CheckLanguageMode();
 
             // Add the bundled modules to the PSModulePath
             UpdatePSModulePath();
@@ -249,19 +247,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             }
         }
 #endif
-
-        /// <summary>
-        /// PSES currently does not work in Constrained Language Mode, because PSReadLine script invocations won't work in it.
-        /// Ideally we can find a better way so that PSES will work in CLM.
-        /// </summary>
-        private void CheckLanguageMode()
-        {
-            _logger.Log(PsesLogLevel.Diagnostic, "Checking that PSES is running in FullLanguage mode");
-            if (Runspace.DefaultRunspace.SessionStateProxy.LanguageMode != PSLanguageMode.FullLanguage)
-            {
-                throw new InvalidOperationException("Cannot start PowerShell Editor Services in Constrained Language Mode");
-            }
-        }
 
         private void UpdatePSModulePath()
         {

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -332,7 +332,7 @@ PID: {System.Diagnostics.Process.GetCurrentProcess().Id}
         {
             using (var pwsh = SMA.PowerShell.Create())
             {
-                return pwsh.AddScript("$OutputEncoding.EncodingName").Invoke<string>()[0];
+                return pwsh.AddScript("$OutputEncoding.EncodingName", useLocalScope: true).Invoke<string>()[0];
             }
         }
 

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -237,8 +237,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 profilePaths,
                 _config.FeatureFlags,
                 _config.AdditionalModules,
-                _config.LogPath,
                 _config.LanguageMode,
+                _config.LogPath,
                 (int)_config.LogLevel,
                 consoleReplEnabled: _config.ConsoleRepl != ConsoleReplKind.None,
                 usesLegacyReadLine: _config.ConsoleRepl == ConsoleReplKind.LegacyReadLine);

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -238,6 +238,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 _config.FeatureFlags,
                 _config.AdditionalModules,
                 _config.LogPath,
+                _config.LanguageMode,
                 (int)_config.LogLevel,
                 consoleReplEnabled: _config.ConsoleRepl != ConsoleReplKind.None,
                 usesLegacyReadLine: _config.ConsoleRepl == ConsoleReplKind.LegacyReadLine);

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Management.Automation;
 using System.Management.Automation.Host;
 
 namespace Microsoft.PowerShell.EditorServices.Hosting
@@ -90,6 +91,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public string LogPath { get; }
 
         /// <summary>
+        /// The language mode of the original runspace that we will inherit from.
+        /// </summary>
+        public PSLanguageMode LanguageMode { get; }
+
+        /// <summary>
         /// The minimum log level of log events to be logged.
         /// </summary>
         public int LogLevel { get; }
@@ -130,6 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             IReadOnlyList<string> featureFlags,
             IReadOnlyList<string> additionalModules,
             string logPath,
+            PSLanguageMode languageMode,
             int logLevel,
             bool consoleReplEnabled,
             bool usesLegacyReadLine)
@@ -142,6 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             FeatureFlags = featureFlags ?? Array.Empty<string>();
             AdditionalModules = additionalModules ?? Array.Empty<string>();
             LogPath = logPath;
+            LanguageMode = languageMode;
             LogLevel = logLevel;
             ConsoleReplEnabled = consoleReplEnabled;
             UsesLegacyReadLine = usesLegacyReadLine;

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -91,7 +91,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public string LogPath { get; }
 
         /// <summary>
-        /// The language mode of the original runspace that we will inherit from.
+        /// The language mode inherited from the orginal PowerShell process.
+        /// This will be used when creating runspaces so that we honor the same language mode.
         /// </summary>
         public PSLanguageMode LanguageMode { get; }
 
@@ -123,6 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="currentUsersProfilePath">The path to the user specific profile.</param>
         /// <param name="featureFlags">Flags of features to enable.</param>
         /// <param name="additionalModules">Names or paths of additional modules to import.</param>
+        /// <param name="languageMode">The language mode inherited from the orginal PowerShell process. This will be used when creating runspaces so that we honor the same language mode.</param>
         /// <param name="logPath">The path to log to.</param>
         /// <param name="logLevel">The minimum log event level.</param>
         /// <param name="consoleReplEnabled">Enable console if true.</param>
@@ -135,8 +137,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ProfilePathInfo profilePaths,
             IReadOnlyList<string> featureFlags,
             IReadOnlyList<string> additionalModules,
-            string logPath,
             PSLanguageMode languageMode,
+            string logPath,
             int logLevel,
             bool consoleReplEnabled,
             bool usesLegacyReadLine)
@@ -148,8 +150,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ProfilePaths = profilePaths;
             FeatureFlags = featureFlags ?? Array.Empty<string>();
             AdditionalModules = additionalModules ?? Array.Empty<string>();
-            LogPath = logPath;
             LanguageMode = languageMode;
+            LogPath = logPath;
             LogLevel = logLevel;
             ConsoleReplEnabled = consoleReplEnabled;
             UsesLegacyReadLine = usesLegacyReadLine;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -597,7 +597,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // cancelled prompt when it's called again.
             if (executionOptions.AddToHistory)
             {
-                this.PromptContext.AddToHistory(psCommand.Commands[0].CommandText);
+                this.PromptContext.AddToHistory(executionOptions.InputString ?? psCommand.Commands[0].CommandText);
             }
 
             bool hadErrors = false;
@@ -686,7 +686,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 if (executionOptions.WriteInputToHost)
                 {
                     this.WriteOutput(
-                        psCommand.Commands[0].CommandText,
+                        executionOptions.InputString ?? psCommand.Commands[0].CommandText,
                         includeNewLine: true);
                 }
 
@@ -1161,7 +1161,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             using (PowerShell pwsh = PowerShell.Create())
             {
                 pwsh.Runspace = runspace;
-                IEnumerable<TResult> results = pwsh.AddScript(scriptToExecute).Invoke<TResult>();
+                IEnumerable<TResult> results = pwsh.AddScript(scriptToExecute, useLocalScope: true).Invoke<TResult>();
                 return results.DefaultIfEmpty(defaultValue).First();
             }
         }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -213,7 +213,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     hostUserInterface,
                     logger);
 
-            Runspace initialRunspace = PowerShellContextService.CreateRunspace(psHost);
+            Runspace initialRunspace = PowerShellContextService.CreateRunspace(psHost, hostStartupInfo.LanguageMode);
             powerShellContext.Initialize(hostStartupInfo.ProfilePaths, initialRunspace, true, hostUserInterface);
 
             powerShellContext.ImportCommandsModuleAsync();
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var psHost = new EditorServicesPSHost(powerShellContext, hostDetails, hostUserInterface, logger);
             powerShellContext.ConsoleWriter = hostUserInterface;
             powerShellContext.ConsoleReader = hostUserInterface;
-            return CreateRunspace(psHost);
+            return CreateRunspace(psHost, hostDetails.LanguageMode);
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="psHost"></param>
         /// <returns></returns>
-        public static Runspace CreateRunspace(PSHost psHost)
+        public static Runspace CreateRunspace(PSHost psHost, PSLanguageMode languageMode)
         {
             InitialSessionState initialSessionState;
             if (Environment.GetEnvironmentVariable("PSES_TEST_USE_CREATE_DEFAULT") == "1") {
@@ -276,6 +276,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             } else {
                 initialSessionState = InitialSessionState.CreateDefault2();
             }
+
+            // Create and initialize a new Runspace while honoring the LanguageMode.
+            Console.WriteLine(languageMode);
+            initialSessionState.LanguageMode = languageMode;
 
             Runspace runspace = RunspaceFactory.CreateRunspace(psHost, initialSessionState);
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1162,12 +1162,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 cancellationToken).ConfigureAwait(false);
         }
 
-        internal static TResult ExecuteScriptAndGetItem<TResult>(string scriptToExecute, Runspace runspace, TResult defaultValue = default)
+        internal static TResult ExecuteScriptAndGetItem<TResult>(
+            string scriptToExecute,
+            Runspace runspace,
+            TResult defaultValue = default,
+            bool useLocalScope = false)
         {
             using (PowerShell pwsh = PowerShell.Create())
             {
                 pwsh.Runspace = runspace;
-                IEnumerable<TResult> results = pwsh.AddScript(scriptToExecute, useLocalScope: true).Invoke<TResult>();
+                IEnumerable<TResult> results = pwsh.AddScript(scriptToExecute, useLocalScope).Invoke<TResult>();
                 return results.DefaultIfEmpty(defaultValue).First();
             }
         }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -244,9 +244,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="hostDetails"></param>
         /// <param name="powerShellContext"></param>
-        /// <param name="hostUserInterface">
-        /// The EditorServicesPSHostUserInterface to use for this instance.
-        /// </param>
+        /// <param name="hostUserInterface">The EditorServicesPSHostUserInterface to use for this instance.</param>
         /// <param name="logger">An ILogger implementation to use for this instance.</param>
         /// <returns></returns>
         public static Runspace CreateRunspace(
@@ -266,7 +264,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <summary>
         ///
         /// </summary>
-        /// <param name="psHost"></param>
+        /// <param name="psHost">The PSHost that will be used for this Runspace.</param>
+        /// <param name="languageMode">The language mode inherited from the orginal PowerShell process. This will be used when creating runspaces so that we honor the same language mode.</param>
         /// <returns></returns>
         public static Runspace CreateRunspace(PSHost psHost, PSLanguageMode languageMode)
         {
@@ -277,8 +276,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 initialSessionState = InitialSessionState.CreateDefault2();
             }
 
-            // Create and initialize a new Runspace while honoring the LanguageMode.
-            Console.WriteLine(languageMode);
+            // Create and initialize a new Runspace while honoring the LanguageMode of the original runspace
+            // that started PowerShell Editor Services. This is because the PowerShell Integrated Console
+            // should have the same LanguageMode of whatever is set by the system.
             initialSessionState.LanguageMode = languageMode;
 
             Runspace runspace = RunspaceFactory.CreateRunspace(psHost, initialSessionState);
@@ -414,6 +414,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (powerShellVersion.Major >= 5 &&
                 this.isPSReadLineEnabled &&
+                // TODO: Figure out why PSReadLine isn't working in ConstrainedLanguage mode.
+                initialRunspace.SessionStateProxy.LanguageMode == PSLanguageMode.FullLanguage &&
                 PSReadLinePromptContext.TryGetPSReadLineProxy(logger, initialRunspace, out PSReadLineProxy proxy))
             {
                 this.PromptContext = new PSReadLinePromptContext(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
@@ -121,14 +121,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         runspaceDetails.AddCapability(capability);
 
                         powerShell.Commands.Clear();
-                        powerShell.AddScript("Write-Host \"Gathering DSC resource paths, this may take a while...\"");
-                        powerShell.Invoke();
+                        powerShell
+                            .AddCommand("Microsoft.PowerShell.Utility\\Write-Host")
+                            .AddArgument("Gathering DSC resource paths, this may take a while...")
+                            .Invoke();
 
                         // Get the list of DSC resource paths
                         powerShell.Commands.Clear();
-                        powerShell.AddCommand("Get-DscResource");
-                        powerShell.AddCommand("Select-Object");
-                        powerShell.AddParameter("ExpandProperty", "ParentPath");
+                        powerShell
+                            .AddCommand("Get-DscResource")
+                            .AddCommand("Select-Object")
+                            .AddParameter("ExpandProperty", "ParentPath");
 
                         Collection<PSObject> resourcePaths = null;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionOptions.cs
@@ -47,6 +47,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public bool WriteInputToHost { get; set; }
 
         /// <summary>
+        /// If this is set, we will use this string for history and writing to the host
+        /// instead of grabbing the command from the PSCommand.
+        /// </summary>
+        public string InputString { get; set; }
+
+        /// <summary>
+        /// If this is set, we will use this string for history and writing to the host
+        /// instead of grabbing the command from the PSCommand.
+        /// </summary>
+        public bool UseNewScope { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the command to
         /// be executed is a console input prompt, such as the
         /// PSConsoleHostReadLine function.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
                 pwsh.Runspace = runspace;
                 var psReadLineType = pwsh
-                    .AddScript(ReadLineInitScript)
+                    .AddScript(ReadLineInitScript, useLocalScope: true)
                     .Invoke<Type>()
                     .FirstOrDefault();
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             try
             {
-                var psVersionTable = PowerShellContextService.ExecuteScriptAndGetItem<Hashtable>("$PSVersionTable", runspace);
+                var psVersionTable = PowerShellContextService.ExecuteScriptAndGetItem<Hashtable>("$PSVersionTable", runspace, useLocalScope: true);
                 if (psVersionTable != null)
                 {
                     var edition = psVersionTable["PSEdition"] as string;
@@ -134,7 +134,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         versionString = powerShellVersion.ToString();
                     }
 
-                    var arch = PowerShellContextService.ExecuteScriptAndGetItem<string>("$env:PROCESSOR_ARCHITECTURE", runspace);
+                    var arch = PowerShellContextService.ExecuteScriptAndGetItem<string>("$env:PROCESSOR_ARCHITECTURE", runspace, useLocalScope: true);
                     if (arch != null)
                     {
                         if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
@@ -223,7 +223,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         PowerShellContextService.ExecuteScriptAndGetItem<string>(
                             "$Host.Name",
                             runspace,
-                            defaultValue: string.Empty);
+                            defaultValue: string.Empty,
+                            useLocalScope: true);
 
                 // hostname is 'ServerRemoteHost' when the user enters a session.
                 // ex. Enter-PSSession

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
@@ -56,7 +56,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             PSCommand infoCommand = new PSCommand();
             infoCommand.AddScript(
-                "@{ 'computerName' = if ([Environment]::MachineName) {[Environment]::MachineName}  else {'localhost'}; 'processId' = $PID; 'instanceId' = $host.InstanceId }");
+                "@{ 'computerName' = if ([Environment]::MachineName) {[Environment]::MachineName}  else {'localhost'}; 'processId' = $PID; 'instanceId' = $host.InstanceId }",
+                useLocalScope: true);
 
             return infoCommand;
         }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -135,9 +135,13 @@ function CanSendWorkspaceSymbolRequest {
             Assert.Equal("CanSendWorkspaceSymbolRequest { }", symbol.Name);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanReceiveDiagnosticsFromFileOpen()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             NewTestFile("$a = 4");
             await WaitForDiagnostics();
 
@@ -154,9 +158,13 @@ function CanSendWorkspaceSymbolRequest {
             Assert.Empty(Diagnostics);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanReceiveDiagnosticsFromFileChanged()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             string filePath = NewTestFile("$a = 4");
             await WaitForDiagnostics();
             Diagnostics.Clear();
@@ -191,9 +199,13 @@ function CanSendWorkspaceSymbolRequest {
             Assert.Equal("PSUseDeclaredVarsMoreThanAssignments", diagnostic.Code);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanReceiveDiagnosticsFromConfigurationChange()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             NewTestFile("gci | % { $_ }");
             await WaitForDiagnostics();
 
@@ -275,9 +287,13 @@ $_
                 });
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendFormattingRequest()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             string scriptPath = NewTestFile(@"
 gci | % {
 Get-Process
@@ -306,9 +322,13 @@ Get-Process
             Assert.Contains("\t", textEdit.NewText);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendRangeFormattingRequest()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             string scriptPath = NewTestFile(@"
 gci | % {
 Get-Process
@@ -756,9 +776,13 @@ CanSendReferencesCodeLensRequest
             Assert.Equal("1 reference", codeLensResolveResult.Command.Title);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendCodeActionRequest()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             string filePath = NewTestFile("gci");
             await WaitForDiagnostics();
 
@@ -929,9 +953,11 @@ CanSendDefinitionRequest
             Assert.Equal(33, locationOrLocationLink.Location.Range.End.Character);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendGetProjectTemplatesRequest()
         {
+            Skip.If(TestsFixture.RunningInConstainedLanguageMode, "Plaster doesn't work in ConstrainedLanguage mode.");
+
             GetProjectTemplatesResponse getProjectTemplatesResponse =
                 await LanguageClient.SendRequest<GetProjectTemplatesResponse>(
                     "powerShell/getProjectTemplates",
@@ -951,9 +977,13 @@ CanSendDefinitionRequest
                 });
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendGetCommentHelpRequest()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode && TestsFixture.IsWindowsPowerShell,
+                "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
+
             string scriptPath = NewTestFile(@"
 function CanSendGetCommentHelpRequest {
     param(
@@ -1012,9 +1042,13 @@ function CanSendGetCommentHelpRequest {
             Assert.True(pSCommandMessages.Count > 20);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CanSendExpandAliasRequest()
         {
+            Skip.If(
+                TestsFixture.RunningInConstainedLanguageMode,
+                "This feature currently doesn't support ConstrainedLanguage Mode.");
+
             ExpandAliasResult expandAliasResult =
                 await LanguageClient.SendRequest<ExpandAliasResult>(
                     "powerShell/expandAlias",

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.16.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PowerShellEditorServices.Test.E2E/TestsFixture.cs
+++ b/test/PowerShellEditorServices.Test.E2E/TestsFixture.cs
@@ -5,10 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
-using OmniSharp.Extensions.LanguageServer.Client;
 using OmniSharp.Extensions.LanguageServer.Client.Processes;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
 namespace PowerShellEditorServices.Test.E2E
@@ -41,6 +38,10 @@ namespace PowerShellEditorServices.Test.E2E
         protected StdioServerProcess _psesProcess;
 
         public static string PwshExe { get; } = Environment.GetEnvironmentVariable("PWSH_EXE_NAME") ?? "pwsh";
+
+        public static bool IsWindowsPowerShell { get; } = PwshExe.Contains("powershell");
+        public static bool RunningInConstainedLanguageMode { get; } =
+            Environment.GetEnvironmentVariable("__PSLockdownPolicy", EnvironmentVariableTarget.Machine) != null;
 
         public virtual bool IsDebugAdapterTests { get; set; }
 

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -46,8 +46,8 @@ namespace Microsoft.PowerShell.EditorServices.Test
                 TestProfilePaths,
                 new List<string>(),
                 new List<string>(),
-                null,
                 PSLanguageMode.FullLanguage,
+                null,
                 0,
                 consoleReplEnabled: false,
                 usesLegacyReadLine: false);

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -12,6 +12,7 @@ using Microsoft.PowerShell.EditorServices.Test.Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -46,6 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
                 new List<string>(),
                 new List<string>(),
                 null,
+                PSLanguageMode.FullLanguage,
                 0,
                 consoleReplEnabled: false,
                 usesLegacyReadLine: false);


### PR DESCRIPTION
With this PR, we have some support of `ConstrainedLanguage` mode. The `LanguageMode` is inherited from the initial runspace that starts `Start-EditorServices`

Windows PowerShell is started without PSRL and it is working... but there's more work that will need to be done here. Here are notes I've made from this:

* [x] Custom `Clear-Host` doesn't work... probably because `$psEditor` doesn't work
    * Fixed by only calling `$psEditor.....Clear()` on FullLanguage
* [x] `$psEditor` doesn't work because of method invoking
    * ISE has same problem... aka by-design
* [x] Diagnostics aren't showing up (on Windows PowerShell, but show up on PSCore probably because of different definitions of "Trusted")
    * PSSA is being loaded with ConstrainedLanguage mode in Windows PowerShell to this proves my theory.
* [x] Windows PowerShell is started without PSRL (this is also happening in a console outside of VS Code)
    * NOTE: idk why but PSReadLine doesn't show up in `Get-Module -list` in Windows PowerShell
    * Since we won't offer PSRL for ConstrainedLanguage mode initially, this isn't a problem atm
* [x] PS 6.2+ loads PSRL... and it seems to work (syntax highlighting, readline all works)... but it emits a `System.NotSupportedException: Cannot dot-source this command because it was defined in a different language mode...` over and over and over so not sure if it's PSRL's fault or PSES's yet...
    * For now, I'm offering the legacy readline for ConstrainedLanguage mode.
* [x] debugging does not work
    * The file is run, but the setting of breakpoints fails silently. I think this is ok for now... ideally we put up a warning... but that's hard to do from the DebugServer.
* [x] Expand Alias doesn't work
    * waiting on https://github.com/PowerShell/PowerShellEditorServices/pull/1199