### PR TITLE
Fix interpolation in Log points, switch to double quotes

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 StringBuilder builder = new StringBuilder(
                     string.IsNullOrEmpty(logMessage)
                         ? "break"
-                        : $"Microsoft.PowerShell.Utility\\Write-Host \"{logMessage}\"");
+                        : $"Microsoft.PowerShell.Utility\\Write-Host \"{logMessage.Replace("\"","`\"")}\"");
 
                 // If HitCondition specified, parse and verify it.
                 if (!(string.IsNullOrWhiteSpace(hitCondition)))

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 StringBuilder builder = new StringBuilder(
                     string.IsNullOrEmpty(logMessage)
                         ? "break"
-                        : $"Microsoft.PowerShell.Utility\\Write-Host '{logMessage}'");
+                        : $"Microsoft.PowerShell.Utility\\Write-Host \"{logMessage}\"");
 
                 // If HitCondition specified, parse and verify it.
                 if (!(string.IsNullOrWhiteSpace(hitCondition)))


### PR DESCRIPTION
Fix https://github.com/PowerShell/vscode-powershell/issues/2654

When this works you can do some fancy stuff like timing loops:

![image](https://user-images.githubusercontent.com/5177512/80022928-feec8e80-8499-11ea-8052-593ab6c1db2a.png)

This uses messages:
```powershell
Init loop var: $($global:prevTS = Get-Date; $prevTS)
Loop time: $($currTS = Get-Date; ($currTS - $prevTS).TotalMilliseconds; $global:prevTS = $currTS) ms
```