### PR TITLE
Allow progress colors to be settable and gettable from the internal host

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -804,8 +804,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         internal ConsoleColor VerboseForegroundColor { get; set; } = ConsoleColor.Yellow;
         internal ConsoleColor VerboseBackgroundColor { get; set; } = BackgroundColor;
 
-        internal ConsoleColor ProgressForegroundColor { get; set; } = ConsoleColor.Yellow;
-        internal ConsoleColor ProgressBackgroundColor { get; set; } = ConsoleColor.DarkCyan;
+        internal virtual ConsoleColor ProgressForegroundColor { get; set; } = ConsoleColor.Yellow;
+        internal virtual ConsoleColor ProgressBackgroundColor { get; set; } = ConsoleColor.DarkCyan;
 
         private async Task StartReplLoopAsync(CancellationToken cancellationToken)
         {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         #region Private Fields
 
         private readonly PSHostUserInterface internalHostUI;
+        private readonly PSObject _privateData;
         private ConsoleReadLine consoleReadLine;
 
         #endregion
@@ -45,6 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 logger)
         {
             this.internalHostUI = internalHost.UI;
+            _privateData = internalHost.PrivateData;
             this.consoleReadLine = new ConsoleReadLine(powerShellContext);
 
             // Set the output encoding to UTF-8 so that special
@@ -69,6 +71,36 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// Gets a value indicating whether writing progress is supported.
         /// </summary>
         internal protected override bool SupportsWriteProgress => true;
+
+        /// <summary>
+        /// Gets and sets the value of progress foreground from the internal host since Progress is handled there.
+        /// </summary>
+        internal override ConsoleColor ProgressForegroundColor
+        {
+            get
+            {
+                return (ConsoleColor) _privateData.Properties["ProgressForegroundColor"].Value;
+            }
+            set
+            {
+                _privateData.Properties["ProgressForegroundColor"].Value = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the value of progress background from the internal host since Progress is handled there.
+        /// </summary>
+        internal override ConsoleColor ProgressBackgroundColor
+        {
+            get
+            {
+                return (ConsoleColor) _privateData.Properties["ProgressBackgroundColor"].Value;
+            }
+            set
+            {
+                _privateData.Properties["ProgressBackgroundColor"].Value = value;
+            }
+        }
 
         /// <summary>
         /// Requests that the HostUI implementation read a command line

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private readonly PSHostUserInterface _internalHostUI;
         private readonly PSObject _internalHostPrivateData;
-        private ConsoleReadLine _consoleReadLine;
+        private readonly ConsoleReadLine _consoleReadLine;
 
         #endregion
 
@@ -77,14 +77,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal override ConsoleColor ProgressForegroundColor
         {
-            get
-            {
-                return (ConsoleColor) _internalHostPrivateData.Properties["ProgressForegroundColor"].Value;
-            }
-            set
-            {
-                _internalHostPrivateData.Properties["ProgressForegroundColor"].Value = value;
-            }
+            get => (ConsoleColor)_privateData.Properties["ProgressForegroundColor"].Value;
+            set => _privateData.Properties["ProgressForegroundColor"].Value = value;
         }
 
         /// <summary>
@@ -92,14 +86,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal override ConsoleColor ProgressBackgroundColor
         {
-            get
-            {
-                return (ConsoleColor) _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value;
-            }
-            set
-            {
-                _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value = value;
-            }
+            get => (ConsoleColor)_internalHostPrivateData.Properties["ProgressBackgroundColor"].Value;
+            set => _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value = value;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         #region Private Fields
 
         private readonly PSHostUserInterface _internalHostUI;
-        private readonly PSObject _privateData;
+        private readonly PSObject _internalHostPrivateData;
         private ConsoleReadLine _consoleReadLine;
 
         #endregion
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 logger)
         {
             _internalHostUI = internalHost.UI;
-            _privateData = internalHost.PrivateData;
+            _internalHostPrivateData = internalHost.PrivateData;
             _consoleReadLine = new ConsoleReadLine(powerShellContext);
 
             // Set the output encoding to UTF-8 so that special
@@ -79,11 +79,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             get
             {
-                return (ConsoleColor) _privateData.Properties["ProgressForegroundColor"].Value;
+                return (ConsoleColor) _internalHostPrivateData.Properties["ProgressForegroundColor"].Value;
             }
             set
             {
-                _privateData.Properties["ProgressForegroundColor"].Value = value;
+                _internalHostPrivateData.Properties["ProgressForegroundColor"].Value = value;
             }
         }
 
@@ -94,11 +94,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             get
             {
-                return (ConsoleColor) _privateData.Properties["ProgressBackgroundColor"].Value;
+                return (ConsoleColor) _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value;
             }
             set
             {
-                _privateData.Properties["ProgressBackgroundColor"].Value = value;
+                _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value = value;
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -21,9 +21,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
     {
         #region Private Fields
 
-        private readonly PSHostUserInterface internalHostUI;
+        private readonly PSHostUserInterface _internalHostUI;
         private readonly PSObject _privateData;
-        private ConsoleReadLine consoleReadLine;
+        private ConsoleReadLine _consoleReadLine;
 
         #endregion
 
@@ -45,9 +45,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 new TerminalPSHostRawUserInterface(logger, internalHost),
                 logger)
         {
-            this.internalHostUI = internalHost.UI;
+            _internalHostUI = internalHost.UI;
             _privateData = internalHost.PrivateData;
-            this.consoleReadLine = new ConsoleReadLine(powerShellContext);
+            _consoleReadLine = new ConsoleReadLine(powerShellContext);
 
             // Set the output encoding to UTF-8 so that special
             // characters are written to the console correctly
@@ -56,11 +56,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             System.Console.CancelKeyPress +=
                 (obj, args) =>
                 {
-                    if (!this.IsNativeApplicationRunning)
+                    if (!IsNativeApplicationRunning)
                     {
                         // We'll handle Ctrl+C
                         args.Cancel = true;
-                        this.SendControlC();
+                        SendControlC();
                     }
                 };
         }
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <returns>A Task that can be awaited for the resulting input string.</returns>
         protected override Task<string> ReadCommandLineAsync(CancellationToken cancellationToken)
         {
-            return this.consoleReadLine.ReadCommandLineAsync(cancellationToken);
+            return _consoleReadLine.ReadCommandLineAsync(cancellationToken);
         }
 
         /// <summary>
@@ -124,9 +124,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         protected override InputPromptHandler OnCreateInputPromptHandler()
         {
             return new TerminalInputPromptHandler(
-                this.consoleReadLine,
+                _consoleReadLine,
                 this,
-                this.Logger);
+                Logger);
         }
 
         /// <summary>
@@ -137,9 +137,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         protected override ChoicePromptHandler OnCreateChoicePromptHandler()
         {
             return new TerminalChoicePromptHandler(
-                this.consoleReadLine,
+                _consoleReadLine,
                 this,
-                this.Logger);
+                Logger);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         protected override void WriteProgressImpl(long sourceId, ProgressRecord record)
         {
-            this.internalHostUI.WriteProgress(sourceId, record);
+            _internalHostUI.WriteProgress(sourceId, record);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -77,8 +77,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal override ConsoleColor ProgressForegroundColor
         {
-            get => (ConsoleColor)_privateData.Properties["ProgressForegroundColor"].Value;
-            set => _privateData.Properties["ProgressForegroundColor"].Value = value;
+            get => (ConsoleColor)_internalHostPrivateData.Properties["ProgressForegroundColor"].Value;
+            set => _internalHostPrivateData.Properties["ProgressForegroundColor"].Value = value;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
     {
         #region Private Fields
 
-        private readonly PSHostUserInterface _internalHostUI;
+        private readonly PSHostUserInterface internalHostUI;
         private readonly PSObject _internalHostPrivateData;
         private readonly ConsoleReadLine _consoleReadLine;
 
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 new TerminalPSHostRawUserInterface(logger, internalHost),
                 logger)
         {
-            _internalHostUI = internalHost.UI;
+            internalHostUI = internalHost.UI;
             _internalHostPrivateData = internalHost.PrivateData;
             _consoleReadLine = new ConsoleReadLine(powerShellContext);
 
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         protected override void WriteProgressImpl(long sourceId, ProgressRecord record)
         {
-            _internalHostUI.WriteProgress(sourceId, record);
+            internalHostUI.WriteProgress(sourceId, record);
         }
 
         /// <summary>


### PR DESCRIPTION
If you look at the first commit, you'll see that it allows us to inherit the setting and getting of the Progress colors from the internal host.

The second+ commits are purely cosmetic since I was touching the file.