### PR TITLE
Fix when no CommandInfo comes back

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 .FirstOrDefault();
 
             // Only cache CmdletInfos since they're exposed in binaries they are likely to not change throughout the session.
-            if (commandInfo.CommandType == CommandTypes.Cmdlet)
+            if (commandInfo?.CommandType == CommandTypes.Cmdlet)
             {
                 s_commandInfoCache.TryAdd(commandName, commandInfo);
             }


### PR DESCRIPTION
Before this PSES drops an exception in the log. It's "handled" so the extension doesn't break down... but we don't want the stacktrace in the log.

The behavior is still the same, this just prevents when `Get-Command` returns nothing.