### PR TITLE
move to omnisharp 0.17.0

### DIFF
--- a/src/PowerShellEditorServices/Extensions/Api/EditorContextService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorContextService.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Handlers;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -94,16 +95,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         public async Task<ILspCurrentFileContext> GetCurrentLspFileContextAsync()
         {
             ClientEditorContext clientContext =
-                await _languageServer.SendRequest<GetEditorContextRequest, ClientEditorContext>(
+                await _languageServer.SendRequest<GetEditorContextRequest>(
                     "editor/getEditorContext",
-                    new GetEditorContextRequest()).ConfigureAwait(false);
+                    new GetEditorContextRequest())
+                .Returning<ClientEditorContext>(CancellationToken.None)
+                .ConfigureAwait(false);
 
             return new LspCurrentFileContext(clientContext);
         }
 
         public Task OpenNewUntitledFileAsync()
         {
-            return _languageServer.SendRequest<string>("editor/newFile", null);
+            return _languageServer.SendRequest<string>("editor/newFile", null).ReturningVoid(CancellationToken.None);
         }
 
         public Task OpenFileAsync(Uri fileUri) => OpenFileAsync(fileUri, preview: false);
@@ -114,12 +117,12 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             {
                 FilePath = fileUri.LocalPath,
                 Preview = preview,
-            });
+            }).ReturningVoid(CancellationToken.None);
         }
 
         public Task CloseFileAsync(Uri fileUri)
         {
-            return _languageServer.SendRequest("editor/closeFile", fileUri.LocalPath);
+            return _languageServer.SendRequest("editor/closeFile", fileUri.LocalPath).ReturningVoid(CancellationToken.None);
         }
 
         public Task SaveFileAsync(Uri fileUri) => SaveFileAsync(fileUri, null);
@@ -130,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             {
                 FilePath = oldFileUri.LocalPath,
                 NewPath = newFileUri?.LocalPath,
-            });
+            }).ReturningVoid(CancellationToken.None);
         }
 
         public Task SetSelectionAsync(ILspFileRange range)
@@ -138,7 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             return _languageServer.SendRequest("editor/setSelection", new SetSelectionRequest
             {
                 SelectionRange = range.ToOmnisharpRange()
-            });
+            }).ReturningVoid(CancellationToken.None);
         }
 
         public Task InsertTextAsync(Uri fileUri, string text, ILspFileRange range)
@@ -148,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                 FilePath = fileUri.LocalPath,
                 InsertText = text,
                 InsertRange = range.ToOmnisharpRange(),
-            });
+            }).ReturningVoid(CancellationToken.None);
         }
     }
 }

--- a/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
@@ -112,12 +113,12 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         public async Task<string> PromptInputAsync(string message)
         {
             // The VSCode client currently doesn't use the Label field, so we ignore it
-            ShowInputPromptResponse response = await _languageServer.SendRequest<ShowInputPromptRequest, ShowInputPromptResponse>(
+            ShowInputPromptResponse response = await _languageServer.SendRequest<ShowInputPromptRequest>(
                 "powerShell/showInputPrompt",
                 new ShowInputPromptRequest
                 {
                     Name = message,
-                });
+                }).Returning<ShowInputPromptResponse>(CancellationToken.None);
 
             if (response.PromptCancelled)
             {
@@ -134,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         {
             ChoiceDetails[] choiceDetails = GetChoiceDetails(choices);
 
-            ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest, ShowChoicePromptResponse>(
+            ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest>(
                 "powerShell/showChoicePrompt",
                 new ShowChoicePromptRequest
                 {
@@ -143,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Message = message,
                     Choices = choiceDetails,
                     DefaultChoices = defaultChoiceIndexes?.ToArray(),
-                });
+                }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
 
             if (response.PromptCancelled)
             {
@@ -160,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         {
             ChoiceDetails[] choiceDetails = GetChoiceDetails(choices);
 
-            ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest, ShowChoicePromptResponse>(
+            ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest>(
                 "powerShell/showChoicePrompt",
                 new ShowChoicePromptRequest
                 {
@@ -169,7 +170,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Message = message,
                     Choices = choiceDetails,
                     DefaultChoices = defaultChoiceIndex > -1 ? new[] { defaultChoiceIndex } : null,
-                });
+                }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
 
             if (response.PromptCancelled)
             {

--- a/src/PowerShellEditorServices/Extensions/Api/LanguageServerService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/LanguageServerService.cs
@@ -5,6 +5,7 @@
 
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Extensions.Services
@@ -89,27 +90,27 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         public Task SendRequestAsync(string method)
         {
-            return _languageServer.SendRequest<Unit>(method);
+            return _languageServer.SendRequest(method).ReturningVoid(CancellationToken.None);
         }
 
         public Task SendRequestAsync<T>(string method, T parameters)
         {
-            return _languageServer.SendRequest<T, Unit>(method, parameters);
+            return _languageServer.SendRequest<T>(method, parameters).ReturningVoid(CancellationToken.None);
         }
 
         public Task<TResponse> SendRequestAsync<TResponse>(string method)
         {
-            return _languageServer.SendRequest<TResponse>(method);
+            return _languageServer.SendRequest(method).Returning<TResponse>(CancellationToken.None);
         }
 
         public Task<TResponse> SendRequestAsync<T, TResponse>(string method, T parameters)
         {
-            return _languageServer.SendRequest<T, TResponse>(method, parameters);
+            return _languageServer.SendRequest<T>(method, parameters).Returning<TResponse>(CancellationToken.None);
         }
 
         public Task<object> SendRequestAsync(string method, object parameters)
         {
-            return _languageServer.SendRequest<object, object>(method, parameters);
+            return _languageServer.SendRequest<object>(method, parameters).Returning<object>(CancellationToken.None);
         }
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
@@ -204,12 +204,12 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// The line index of the position within the file.
         /// </summary>
-        long Line { get; }
+        int Line { get; }
 
         /// <summary>
         /// The character offset from the line of the position.
         /// </summary>
-        long Character { get; }
+        int Character { get; }
     }
 
     /// <summary>
@@ -260,9 +260,9 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             _position = position;
         }
 
-        public long Line => _position.Line;
+        public int Line => _position.Line;
 
-        public long Character => _position.Character;
+        public int Character => _position.Character;
 
         public bool Equals(OmnisharpLspPosition other)
         {
@@ -350,15 +350,15 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
     /// </summary>
     public class LspFilePosition : ILspFilePosition
     {
-        public LspFilePosition(long line, long column)
+        public LspFilePosition(int line, int column)
         {
             Line = line;
             Character = column;
         }
 
-        public long Line { get; }
+        public int Line { get; }
 
-        public long Character { get; }
+        public int Character { get; }
     }
 
     /// <summary>
@@ -455,7 +455,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <returns>An equivalent 1-based file position.</returns>
         public static IFilePosition ToFilePosition(this ILspFilePosition position)
         {
-            return new FilePosition((int)position.Line + 1, (int)position.Character + 1);
+            return new FilePosition(position.Line + 1, position.Character + 1);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.16.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="1.0.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
@@ -49,7 +49,7 @@
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Include="UnixConsoleEcho" Version="0.1.0" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.16.0" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="1.0.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.0-*" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
@@ -49,7 +49,7 @@
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Include="UnixConsoleEcho" Version="0.1.0" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="1.0.0" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.17.0-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services.Analysis;
 using Microsoft.PowerShell.EditorServices.Services.Configuration;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
@@ -41,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var sb = new StringBuilder(256)
             .Append(diagnostic.Source ?? "?")
             .Append("_")
-            .Append(diagnostic.Code.IsString ? diagnostic.Code.String : diagnostic.Code.Long.ToString())
+            .Append(diagnostic.Code?.IsString ?? true ? diagnostic.Code?.String : diagnostic.Code?.Long.ToString())
             .Append("_")
             .Append(diagnostic.Severity?.ToString() ?? "?")
             .Append("_")
@@ -421,7 +422,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             _languageServer.Document.PublishDiagnostics(new PublishDiagnosticsParams
             {
-                Uri = new Uri(scriptFile.DocumentUri),
+                Uri = DocumentUri.From(scriptFile.DocumentUri),
                 Diagnostics = new Container<Diagnostic>(diagnostics)
             });
         }

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -88,8 +88,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 
             SymbolReference foundSymbol = _symbolsService.FindFunctionDefinitionAtLocation(
                 scriptFile,
-                (int)codeLens.Range.Start.Line + 1,
-                (int)codeLens.Range.Start.Character + 1);
+                codeLens.Range.Start.Line + 1,
+                codeLens.Range.Start.Character + 1);
 
             List<SymbolReference> referencesResult = _symbolsService.FindReferencesOfSymbol(
                 foundSymbol,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -181,8 +181,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             BreakpointDetails[] breakpointDetails = request.Breakpoints
                 .Select((srcBreakpoint) => BreakpointDetails.Create(
                     scriptFile.FilePath,
-                    (int)srcBreakpoint.Line,
-                    (int?)srcBreakpoint.Column,
+                    srcBreakpoint.Line,
+                    srcBreakpoint.Column,
                     srcBreakpoint.Condition,
                     srcBreakpoint.HitCondition,
                     srcBreakpoint.LogMessage))

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public async Task<ConfigurationDoneResponse> Handle(ConfigurationDoneArguments request, CancellationToken cancellationToken)
+        public Task<ConfigurationDoneResponse> Handle(ConfigurationDoneArguments request, CancellationToken cancellationToken)
         {
             _debugService.IsClientAttached = true;
 
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            return new ConfigurationDoneResponse();
+            return Task.FromResult(new ConfigurationDoneResponse());
         }
 
         private async Task LaunchScriptAsync(string scriptToLaunch)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Handlers;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Services
@@ -38,9 +39,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
             };
 
             ClientEditorContext clientContext =
-                await _languageServer.SendRequest<GetEditorContextRequest, ClientEditorContext>(
+                await _languageServer.SendRequest<GetEditorContextRequest>(
                     "editor/getEditorContext",
-                    new GetEditorContextRequest()).ConfigureAwait(false);
+                    new GetEditorContextRequest())
+                .Returning<ClientEditorContext>(CancellationToken.None)
+                .ConfigureAwait(false);
 
             return this.ConvertClientEditorContext(clientContext);
         }
@@ -70,7 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             Character = insertRange.End.Column - 1
                         }
                     }
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task SetSelectionAsync(BufferRange selectionRange)
@@ -96,7 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             Character = selectionRange.End.Column - 1
                         }
                     }
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public EditorContext ConvertClientEditorContext(
@@ -111,13 +114,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     this,
                     scriptFile,
                     new BufferPosition(
-                        (int) clientContext.CursorPosition.Line + 1,
-                        (int) clientContext.CursorPosition.Character + 1),
+                        clientContext.CursorPosition.Line + 1,
+                        clientContext.CursorPosition.Character + 1),
                     new BufferRange(
-                        (int) clientContext.SelectionRange.Start.Line + 1,
-                        (int) clientContext.SelectionRange.Start.Character + 1,
-                        (int) clientContext.SelectionRange.End.Line + 1,
-                        (int) clientContext.SelectionRange.End.Character + 1),
+                        clientContext.SelectionRange.Start.Line + 1,
+                        clientContext.SelectionRange.Start.Character + 1,
+                        clientContext.SelectionRange.End.Line + 1,
+                        clientContext.SelectionRange.End.Character + 1),
                     clientContext.CurrentFileLanguage);
         }
 
@@ -128,7 +131,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return;
             };
 
-            await _languageServer.SendRequest<string>("editor/newFile", null).ConfigureAwait(false);
+            await _languageServer.SendRequest<string>("editor/newFile", null)
+                .ReturningVoid(CancellationToken.None)
+                .ConfigureAwait(false);
         }
 
         public async Task OpenFileAsync(string filePath)
@@ -142,7 +147,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 FilePath = filePath,
                 Preview = DefaultPreviewSetting
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task OpenFileAsync(string filePath, bool preview)
@@ -156,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 FilePath = filePath,
                 Preview = preview
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task CloseFileAsync(string filePath)
@@ -166,7 +171,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return;
             };
 
-            await _languageServer.SendRequest("editor/closeFile", filePath).ConfigureAwait(false);
+            await _languageServer.SendRequest("editor/closeFile", filePath)
+                .ReturningVoid(CancellationToken.None)
+                .ConfigureAwait(false);
         }
 
         public Task SaveFileAsync(string filePath)
@@ -185,7 +192,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 FilePath = currentPath,
                 NewPath = newSavePath
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public string GetWorkspacePath()
@@ -205,7 +212,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return;
             };
 
-            await _languageServer.SendRequest("editor/showInformationMessage", message).ConfigureAwait(false);
+            await _languageServer.SendRequest("editor/showInformationMessage", message)
+                .ReturningVoid(CancellationToken.None)
+                .ConfigureAwait(false);
         }
 
         public async Task ShowErrorMessageAsync(string message)
@@ -215,7 +224,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return;
             };
 
-            await _languageServer.SendRequest("editor/showErrorMessage", message).ConfigureAwait(false);
+            await _languageServer.SendRequest("editor/showErrorMessage", message)
+                .ReturningVoid(CancellationToken.None)
+                .ConfigureAwait(false);
         }
 
         public async Task ShowWarningMessageAsync(string message)
@@ -225,7 +236,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return;
             };
 
-            await _languageServer.SendRequest("editor/showWarningMessage", message).ConfigureAwait(false);
+            await _languageServer.SendRequest("editor/showWarningMessage", message)
+                .ReturningVoid(CancellationToken.None)
+                .ConfigureAwait(false);
         }
 
         public async Task SetStatusBarMessageAsync(string message, int? timeout)
@@ -239,7 +252,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 Message = message,
                 Timeout = timeout
-            }).ConfigureAwait(false);
+            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
         public void ClearTerminal()

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return result;
             }
 
-            int triggerLine = (int) request.TriggerPosition.Line + 1;
+            int triggerLine = request.TriggerPosition.Line + 1;
 
             FunctionDefinitionAst functionDefinitionAst = _symbolsService.GetFunctionDefinitionForHelpComment(
                 scriptFile,

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             base.ShowPrompt(promptStyle);
 
-            _languageServer.SendRequest<ShowChoicePromptRequest, ShowChoicePromptResponse>(
+            _languageServer.SendRequest<ShowChoicePromptRequest>(
                 "powerShell/showChoicePrompt",
                 new ShowChoicePromptRequest
                 {
@@ -44,6 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     Choices = this.Choices,
                     DefaultChoices = this.DefaultChoices
                 })
+                .Returning<ShowChoicePromptResponse>(CancellationToken.None)
                 .ContinueWith(HandlePromptResponse)
                 .ConfigureAwait(false);
         }
@@ -115,13 +116,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             base.ShowFieldPrompt(fieldDetails);
 
-            _languageServer.SendRequest<ShowInputPromptRequest, ShowInputPromptResponse>(
+            _languageServer.SendRequest<ShowInputPromptRequest>(
                 "powerShell/showInputPrompt",
                 new ShowInputPromptRequest
                 {
                     Name = fieldDetails.Name,
                     Label = fieldDetails.Label
-                }).ContinueWith(HandlePromptResponse)
+                }).Returning<ShowInputPromptResponse>(CancellationToken.None)
+                .ContinueWith(HandlePromptResponse)
                 .ConfigureAwait(false);
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // If there are any code fixes, send these commands first so they appear at top of "Code Fix" menu in the client UI.
             foreach (Diagnostic diagnostic in request.Context.Diagnostics)
             {
-                if (string.IsNullOrEmpty(diagnostic.Code.String))
+                if (string.IsNullOrEmpty(diagnostic.Code?.String))
                 {
                     _logger.LogWarning(
                         $"textDocument/codeAction skipping diagnostic with empty Code field: {diagnostic.Source} {diagnostic.Message}");
@@ -118,13 +118,19 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             var ruleNamesProcessed = new HashSet<string>();
             foreach (Diagnostic diagnostic in request.Context.Diagnostics)
             {
-                if (!diagnostic.Code.IsString || string.IsNullOrEmpty(diagnostic.Code.String)) { continue; }
+                if (
+                    !diagnostic.Code.HasValue ||
+                    !diagnostic.Code.Value.IsString ||
+                    string.IsNullOrEmpty(diagnostic.Code?.String))
+                {
+                    continue;
+                }
 
                 if (string.Equals(diagnostic.Source, "PSScriptAnalyzer", StringComparison.OrdinalIgnoreCase) &&
-                    !ruleNamesProcessed.Contains(diagnostic.Code.String))
+                    !ruleNamesProcessed.Contains(diagnostic.Code?.String))
                 {
-                    ruleNamesProcessed.Add(diagnostic.Code.String);
-                    var title = $"Show documentation for: {diagnostic.Code.String}";
+                    ruleNamesProcessed.Add(diagnostic.Code?.String);
+                    var title = $"Show documentation for: {diagnostic.Code?.String}";
                     codeActions.Add(new CodeAction
                     {
                         Title = title,
@@ -136,7 +142,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         {
                             Title = title,
                             Name = "PowerShell.ShowCodeActionDocumentation",
-                            Arguments = JArray.FromObject(new[] { diagnostic.Code.String })
+                            Arguments = JArray.FromObject(new[] { diagnostic.Code?.String })
                         }
                     });
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -63,8 +63,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
         {
-            int cursorLine = (int) request.Position.Line + 1;
-            int cursorColumn = (int) request.Position.Character + 1;
+            int cursorLine = request.Position.Line + 1;
+            int cursorColumn = request.Position.Character + 1;
 
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -50,8 +50,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             SymbolReference foundSymbol =
                 _symbolsService.FindSymbolAtLocation(
                     scriptFile,
-                    (int) request.Position.Line + 1,
-                    (int) request.Position.Character + 1);
+                    request.Position.Line + 1,
+                    request.Position.Character + 1);
 
             List<LocationOrLocationLink> definitionLocations = new List<LocationOrLocationLink>();
             if (foundSymbol != null)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -56,8 +56,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             IReadOnlyList<SymbolReference> symbolOccurrences = _symbolsService.FindOccurrencesInFile(
                 scriptFile,
-                (int)request.Position.Line + 1,
-                (int)request.Position.Character + 1);
+                request.Position.Line + 1,
+                request.Position.Character + 1);
 
             if (symbolOccurrences == null)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -127,10 +127,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             Range range = request.Range;
             var rangeList = range == null ? null : new int[]
             {
-                (int)range.Start.Line + 1,
-                (int)range.Start.Character + 1,
-                (int)range.End.Line + 1,
-                (int)range.End.Character + 1
+                range.Start.Line + 1,
+                range.Start.Character + 1,
+                range.End.Line + 1,
+                range.End.Character + 1
             };
 
             formattedScript = await _analysisService.FormatAsync(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -56,8 +56,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             SymbolDetails symbolDetails =
                 await _symbolsService.FindSymbolDetailsAtLocationAsync(
                         scriptFile,
-                        (int) request.Position.Line + 1,
-                        (int) request.Position.Character + 1).ConfigureAwait(false);
+                        request.Position.Line + 1,
+                        request.Position.Character + 1).ConfigureAwait(false);
 
             if (symbolDetails == null)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -46,8 +46,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             SymbolReference foundSymbol =
                 _symbolsService.FindSymbolAtLocation(
                     scriptFile,
-                    (int)request.Position.Line + 1,
-                    (int)request.Position.Character + 1);
+                    request.Position.Line + 1,
+                    request.Position.Character + 1);
 
             List<SymbolReference> referencesResult =
                 _symbolsService.FindReferencesOfSymbol(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -61,8 +61,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ParameterSetSignatures parameterSets =
                 await _symbolsService.FindParameterSetsInFileAsync(
                     scriptFile,
-                    (int) request.Position.Line + 1,
-                    (int) request.Position.Character + 1,
+                    request.Position.Line + 1,
+                    request.Position.Character + 1,
                     _powerShellContextService).ConfigureAwait(false);
 
             if (parameterSets == null)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 IncludeText = true
             };
         }
-        public TextDocumentAttributes GetTextDocumentAttributes(Uri uri)
+        public TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri)
         {
             return new TextDocumentAttributes(uri, "powershell");
         }
@@ -157,10 +157,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return new FileChange
             {
                 InsertString = insertString,
-                Line = (int)(changeRange.Start.Line + 1),
-                Offset = (int)(changeRange.Start.Character + 1),
-                EndLine = (int)(changeRange.End.Line + 1),
-                EndOffset = (int)(changeRange.End.Character + 1),
+                Line = changeRange.Start.Line + 1,
+                Offset = changeRange.Start.Character + 1,
+                EndLine = changeRange.End.Line + 1,
+                EndOffset = changeRange.End.Character + 1,
                 IsReload = false
             };
         }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -831,8 +831,8 @@ CanSendReferencesCodeLensRequest
                         "Replace gci with Get-ChildItem",
                         command.CodeAction.Title);
                     Assert.Equal(
-                        CodeActionKind.QuickFix.Kind,
-                        command.CodeAction.Kind.Kind);
+                        CodeActionKind.QuickFix,
+                        command.CodeAction.Kind);
                     Assert.Single(command.CodeAction.Edit.DocumentChanges);
                 },
                 command =>

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.16.0" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.17.0-*" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.8" />

--- a/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
@@ -64,8 +64,8 @@ function
             int positionsIndex = 0;
             foreach (SymbolReference reference in references)
             {
-                Assert.Equal((int)positions[positionsIndex].Line, reference.ScriptRegion.StartLineNumber);
-                Assert.Equal((int)positions[positionsIndex].Character, reference.ScriptRegion.StartColumnNumber);
+                Assert.Equal(positions[positionsIndex].Line, reference.ScriptRegion.StartLineNumber);
+                Assert.Equal(positions[positionsIndex].Character, reference.ScriptRegion.StartColumnNumber);
 
                 positionsIndex++;
             }


### PR DESCRIPTION
main changes:

`Uri` -> `DocumentUri`
`long`s -> `int`s

and requests now have a `.Returning<resultType>(CancellationToken)` and `.ReturningNull(CancellationToken)` instead of doing like `SendRequest<Params,Result>(....)`

~Just waiting on https://github.com/OmniSharp/csharp-language-server-protocol/pull/237~ done