### PR TITLE
Additional changes to allow PSReadLine to work in CLM

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -406,11 +406,16 @@ task RestorePsesModules -After Build {
 
         $splatParameters = @{
            Name = $moduleName
-           MinimumVersion = $moduleInstallDetails.MinimumVersion
-           MaximumVersion = $moduleInstallDetails.MaximumVersion
            AllowPrerelease = $moduleInstallDetails.AllowPrerelease
            Repository = if ($moduleInstallDetails.Repository) { $moduleInstallDetails.Repository } else { $DefaultModuleRepository }
            Path = $submodulePath
+        }
+
+        # Only add Min and Max version if we're doing a stable release.
+        # This is due to a PSGet issue with AllowPrerelease not installing the latest preview.
+        if (!$moduleInstallDetails.AllowPrerelease) {
+            $splatParameters.MinimumVersion = $moduleInstallDetails.MinimumVersion
+            $splatParameters.MaximumVersion = $moduleInstallDetails.MaximumVersion
         }
 
         Write-Host "`tInstalling module: ${moduleName} with arguments $(ConvertTo-Json $splatParameters)"

--- a/modules.json
+++ b/modules.json
@@ -8,6 +8,6 @@
         "MaximumVersion":"1.99"
     },
     "PSReadLine":{
-        "MinimumVersion":"2.0.0"
+        "MinimumVersion":"2.0.2"
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -415,8 +415,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (powerShellVersion.Major >= 5 &&
                 this.isPSReadLineEnabled &&
-                // TODO: Figure out why PSReadLine isn't working in ConstrainedLanguage mode.
-                initialRunspace.SessionStateProxy.LanguageMode == PSLanguageMode.FullLanguage &&
                 PSReadLinePromptContext.TryGetPSReadLineProxy(logger, initialRunspace, out PSReadLineProxy proxy))
             {
                 this.PromptContext = new PSReadLinePromptContext(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -729,7 +729,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
             }
 
-            PSCommand promptCommand = new PSCommand().AddScript("prompt", useLocalScope: true);
+            PSCommand promptCommand = new PSCommand().AddCommand("prompt");
 
             cancellationToken.ThrowIfCancellationRequested();
             string promptString =

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -729,7 +729,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
             }
 
-            PSCommand promptCommand = new PSCommand().AddScript("prompt");
+            PSCommand promptCommand = new PSCommand().AddScript("prompt", useLocalScope: true);
 
             cancellationToken.ThrowIfCancellationRequested();
             string promptString =

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             param()
             end {{
                 $module = Get-Module -ListAvailable PSReadLine |
-                    Where-Object {{ $_.Version -gt '2.0.0' -or ($_.Version -eq '2.0.0' -and -not $_.PrivateData.PSData.Prerelease) }} |
+                    Where-Object {{ $_.Version -ge '2.0.2' }} |
                     Sort-Object -Descending Version |
                     Select-Object -First 1
                 if (-not $module) {{

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     Sort-Object -Descending Version |
                     Select-Object -First 1
                 if (-not $module) {{
-                    Import-Module {_psReadLineModulePath}
+                    Import-Module '{_psReadLineModulePath.Replace("'", "''")}'
                     return [Microsoft.PowerShell.PSConsoleReadLine]
                 }}
 


### PR DESCRIPTION
This is pending a 2.0.2 release of PSRL that has [a fix for CLM](https://github.com/PowerShell/PSReadLine/pull/1527).

On Windows PowerShell, for some reason... when PSReadLine is not a trusted module, `gmo -list` does not show it. As a workaround, we attempt to load PSRL from our module path.

This ensures PSRL will be loaded when the PSRL feature is used.