### PR TITLE
Show tooltip for comparison operators

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -266,6 +266,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     {
                         detailString = matches[0].Groups[1].Value;
                     }
+                    // The comparison operators (-eq, -not, -gt, etc) are unfortunately fall into ParameterName
+                    // but they don't have a type associated to them. This allows those tooltips to show up.
+                    else if (!string.IsNullOrEmpty(completionDetails.ToolTipText))
+                    {
+                        detailString = completionDetails.ToolTipText;
+                    }
                     break;
                 case CompletionType.Command:
                     // For Commands, let's extract the resolved command or the path for an exe


### PR DESCRIPTION
fixes https://github.com/PowerShell/vscode-powershell/issues/2706

The comparison operators (-eq, -not, -gt, etc) unfortunately fall into the `CompletionType` `ParameterName` (thanks PowerShell) but they don't have a type associated to them like actual parameters so nothing was being stored.