### PR TITLE
Return null when Hover request is cancelled or no symbol details

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             if (cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("Hover request canceled for file: {0}", request.TextDocument.Uri);
-                return new Hover();
+                return null;
             }
 
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (symbolDetails == null)
             {
-                return new Hover();
+                return null;
             }
 
             List<MarkedString> symbolInfo = new List<MarkedString>();


### PR DESCRIPTION
Previously we returned a new **Hover** instance without initializing the `Contents` or `Range` members. At least in VS Code, this will result in the LSP client attempting to access `null` properties. As we're not returning any **Hover** data, the correct response is to simply return `null`. See the [Hover Request (Response)](https://microsoft.github.io/language-server-protocol/specification#textDocument_hover) section in the LSP spec.

To reproduce the issue in VS Code:
1. Ensure the PowerShell extension is installed and open a PowerShell script.
2. Switch the _Output_ console to _Log (Extension Host)_ or _Log (Window)_ (it seems to differ sometimes?).
3. Hover over some text with no expected hover content (e.g. a word in a string).
4. An exception is thrown on reading the uninitialized `Contents` property of the **Hover** instance.