### PR TITLE
Fix  .NET installation

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -70,7 +70,7 @@ function Install-Dotnet {
     $installScriptPath = Join-Path ([System.IO.Path]::GetTempPath()) $installScript
     Invoke-WebRequest "https://dot.net/v1/$installScript" -OutFile $installScriptPath
 
-    # Download and install the different .NET channels in parallel
+    # Download and install the different .NET channels
     foreach ($dotnetChannel in $Channel)
     {
         Write-Host "`n### Installing .NET CLI $Version...`n"

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -60,7 +60,7 @@ function Install-Dotnet {
 
     $env:DOTNET_INSTALL_DIR = "$PSScriptRoot/.dotnet"
 
-    Write-Information "Installing .NET channels $Channel"
+    Write-Host "Installing .NET channels $Channel" -ForegroundColor Green
 
     # The install script is platform-specific
     $installScriptExt = if ($script:IsUnix) { "sh" } else { "ps1" }
@@ -73,7 +73,7 @@ function Install-Dotnet {
     # Download and install the different .NET channels in parallel
     foreach ($dotnetChannel in $Channel)
     {
-        Write-Information "`n### Installing .NET CLI $Version...`n"
+        Write-Host "`n### Installing .NET CLI $Version...`n"
 
         if ($script:IsUnix) {
             chmod +x $installScriptPath
@@ -95,12 +95,12 @@ function Install-Dotnet {
 
         & $installScriptPath @params
 
-        Write-Information "`n### Installation complete for version $Version."
+        Write-Host "`n### Installation complete for version $Version."
     }
 
     $env:PATH = $env:DOTNET_INSTALL_DIR + [System.IO.Path]::PathSeparator + $env:PATH
 
-    Write-Information '.NET installation complete'
+    Write-Host '.NET installation complete' -ForegroundColor Green
 }
 
 task SetupDotNet -Before Clean, Build, TestHost, TestServerWinPS, TestServerPS7, TestServerPS71, TestE2E {


### PR DESCRIPTION
.NET install script was failing on my machine because of whitespace in the path.

I got rid of the `iex` and replaced it with some splatting.

~~Also moved the three downloads into jobs in an attempt to parallelise them a bit, although not sure what kind of speedup there is.~~ Not reliable, back to serial

Tested this on Windows and macOS, but worth another test.