### PR TITLE
Needed changes for Notebook UI Support

### DIFF
--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -115,9 +115,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 
                     DocumentUri uri = DocumentUri.From(foundReference.FilePath);
                     // For any vscode-notebook-cell, we need to ignore the backing file on disk.
-                    if (scriptFile.DocumentUri.Scheme == "vscode-notebook-cell" &&
-                        uri.Path == scriptFile.DocumentUri.Path &&
-                        uri.Scheme == "file")
+                    if (uri.Scheme == "file" &&
+                        scriptFile.DocumentUri.Scheme == "vscode-notebook-cell" &&
+                        uri.Path == scriptFile.DocumentUri.Path)
                     {
                         continue;
                     }

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -113,9 +113,18 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                         continue;
                     }
 
+                    DocumentUri uri = DocumentUri.From(foundReference.FilePath);
+                    // For any vscode-notebook-cell, we need to ignore the backing file on disk.
+                    if (scriptFile.DocumentUri.Scheme == "vscode-notebook-cell" &&
+                        uri.Path == scriptFile.DocumentUri.Path &&
+                        uri.Scheme == "file")
+                    {
+                        continue;
+                    }
+
                     acc.Add(new Location
                     {
-                        Uri = DocumentUri.From(foundReference.FilePath),
+                        Uri = uri,
                         Range = foundReference.ScriptRegion.ToRange()
                     });
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -217,8 +217,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         internal static bool IsUntitledPath(string path)
         {
             Validate.IsNotNull(nameof(path), path);
-
-            return path.ToLower().StartsWith("untitled:") || path.StartsWith("vscode-notebook:");
+            return DocumentUri.From(path).Scheme.ToLower() != Uri.UriSchemeFile;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -217,7 +217,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         internal static bool IsUntitledPath(string path)
         {
             Validate.IsNotNull(nameof(path), path);
-            return DocumentUri.From(path).Scheme.ToLower() != Uri.UriSchemeFile;
+            return string.Equals(
+                DocumentUri.From(path).Scheme,
+                Uri.UriSchemeFile,
+                StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -218,7 +218,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         {
             Validate.IsNotNull(nameof(path), path);
 
-            return path.ToLower().StartsWith("untitled:");
+            return path.ToLower().StartsWith("untitled:") || path.StartsWith("vscode-notebook:");
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -195,6 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // List supported schemes here
                 case "file":
                 case "untitled":
+                case "vscode-notebook":
                     break;
 
                 default:

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // List supported schemes here
                 case "file":
                 case "untitled":
-                case "vscode-notebook":
+                case "vscode-notebook-cell":
                     break;
 
                 default:


### PR DESCRIPTION
I wanted to make changes to PSES as small as possible because Notebook UI is a vscode feature, but some things had to be done.

1. For CodeLens inside of a Notebook Cell, we need to ignore any results from the actual backing file because CodeLens looks at the file system. That would be counting duplicates.
2. Had to add vscode-notebook-cell to our list of supporting schemes
3. Made the Untitled path check more robust.