### PR TITLE
Expose new rule PSAvoidUsingDoubleQuotesForConstantString added in PSSA 1.19.1

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
     "PSScriptAnalyzer":{
-        "MinimumVersion":"1.19.0",
+        "MinimumVersion":"1.19.1",
         "MaximumVersion":"1.99"
     },
     "Plaster":{

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -216,6 +216,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
         public bool AddWhitespaceAroundPipe { get; set; }
         public bool AutoCorrectAliases { get; set; }
+        public bool UseConstantStrings { get; set; }
         public CodeFormattingPreset Preset { get; set; }
         public bool OpenBraceOnSameLine { get; set; }
         public bool NewLineAfterOpenBrace { get; set; }
@@ -315,6 +316,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                 { "PSUseCorrectCasing", new Hashtable {
                     { "Enable", UseCorrectCasing }
                 }},
+                { "PSAvoidUsingDoubleQuotesForConstantString", new Hashtable {
+                    { "Enable", UseConstantStrings }
+                }},
             };
 
             if (AutoCorrectAliases)
@@ -331,7 +335,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                         "PSPlaceOpenBrace",
                         "PSUseConsistentWhitespace",
                         "PSUseConsistentIndentation",
-                        "PSAlignAssignmentStatement"
+                        "PSAlignAssignmentStatement",
+                        "PSAvoidUsingDoubleQuotesForConstantString",
                 }},
                 {
                     "Rules", ruleConfigurations


### PR DESCRIPTION
This is related to https://github.com/PowerShell/vscode-powershell/pull/2831