### PR TITLE
Move Member to Property

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -123,9 +123,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return SemanticTokenType.Type;
             }
 
+            // This represents keys in hashtables and also properties like `Foo` in `$myVar.Foo`
             if ((token.TokenFlags & TokenFlags.MemberName) != 0)
             {
-                return SemanticTokenType.Member;
+                return SemanticTokenType.Property;
             }
 
             // Only check token kind after checking flags

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -113,7 +113,7 @@ Get-A*A
         }
 
         [Fact]
-        public async Task RecognizesArrayMemberInExpandableString()
+        public async Task RecognizesArrayPropertyInExpandableString()
         {
             string text = "\"$(@($Array).Count) OtherText\"";
             ScriptFile scriptFile = new ScriptFile(
@@ -131,7 +131,7 @@ Get-A*A
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Variable == sToken.Type);
                         break;
                     case "Count":
-                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Member == sToken.Type);
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Property == sToken.Type);
                         break;
                 }
             }
@@ -179,7 +179,7 @@ enum MyEnum{
                     case "one":
                     case "two":
                     case "three":
-                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Member == sToken.Type);
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Property == sToken.Type);
                         break;
                 }
             }


### PR DESCRIPTION
Property seems to be the better pick here... I imagine less languages use "member" and just use "property" instead.

Goes with https://github.com/PowerShell/vscode-powershell/pull/2844

![image](https://user-images.githubusercontent.com/2644648/88994938-515df800-d29e-11ea-87d1-bb76a1b85287.png)
before and after

![image](https://user-images.githubusercontent.com/2644648/88994983-6e92c680-d29e-11ea-80b1-41bde1b492bc.png)
before and after

![image](https://user-images.githubusercontent.com/2644648/88995022-866a4a80-d29e-11ea-86c4-25fa21bb69c4.png)
before and after

ISE:
![image](https://user-images.githubusercontent.com/2644648/88995109-b74a7f80-d29e-11ea-8f2d-dcf62eea4186.png)
