### PR TITLE
Updated Semantic Handler to work with new LSP 

### DIFF
--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.4" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.17.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.2" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.3" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.17.2" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.9.0" />

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 if (_powerShellContextService.CurrentRunspace.Runspace.SessionStateProxy.LanguageMode != PSLanguageMode.FullLanguage)
                 {
-                    _languageServer.Window.ShowWarning("You have an older version of PackageManagement known to cause issues with the PowerShell extension. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`");
+                    _languageServer.Window.LogWarning("You have an older version of PackageManagement known to cause issues with the PowerShell extension. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`");
                     return;
                 }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 if (_powerShellContextService.CurrentRunspace.Runspace.SessionStateProxy.LanguageMode != PSLanguageMode.FullLanguage)
                 {
-                    _languageServer.Window.LogWarning("You have an older version of PackageManagement known to cause issues with the PowerShell extension. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`");
+                    _languageServer.Window.ShowWarning("You have an older version of PackageManagement known to cause issues with the PowerShell extension. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`");
                     return;
                 }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -12,7 +12,7 @@ using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -25,7 +25,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             DocumentSelector = LspUtils.PowerShellDocumentSelector,
             Legend = new SemanticTokensLegend(),
-            Full = new SemanticTokensCapabilityRequestFull() {
+            Full = new SemanticTokensCapabilityRequestFull
+            {
                 Delta = true
             },
             Range = true

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -12,26 +12,23 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
-using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document.Proposals;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesSemanticTokensHandler : SemanticTokensHandler
+    internal class PsesSemanticTokensHandler : SemanticTokensHandlerBase
     {
         private static readonly SemanticTokensRegistrationOptions s_registrationOptions = new SemanticTokensRegistrationOptions
         {
             DocumentSelector = LspUtils.PowerShellDocumentSelector,
             Legend = new SemanticTokensLegend(),
-            DocumentProvider = new Supports<SemanticTokensDocumentProviderOptions>(
-                isSupported: true,
-                new SemanticTokensDocumentProviderOptions
-                {
-                    Edits = true
-                }),
-            RangeProvider = true
+            Full = new SemanticTokensCapabilityRequestFull() {
+                Delta = true
+            },
+            Range = true
         };
 
         private readonly ILogger _logger;

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1147,7 +1147,7 @@ function CanSendGetCommentHelpRequest {
             SemanticTokens result =
                 await PsesLanguageClient
                     .SendRequest<SemanticTokensParams>(
-                        "textDocument/semanticTokens",
+                        "textDocument/semanticTokens/full",
                         new SemanticTokensParams
                         {
                             TextDocument = new TextDocumentIdentifier
@@ -1162,7 +1162,7 @@ function CanSendGetCommentHelpRequest {
             var expectedArr = new int[5]
                 {
                     // line, index, token length, token type, token modifiers
-                    0, 0, scriptContent.Length, 2, 0 //function token: line 0, index 0, length, type 2 = keyword, no modifiers
+                    0, 0, 8, 1, 0 //function token: line 0, index 0, length 8, type 1 = keyword, no modifiers
                 };
 
             Assert.Equal(expectedArr, result.Data.ToArray());

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1162,7 +1162,7 @@ function CanSendGetCommentHelpRequest {
             var expectedArr = new int[5]
                 {
                     // line, index, token length, token type, token modifiers
-                    0, 0, 8, 1, 0 //function token: line 0, index 0, length 8, type 1 = keyword, no modifiers
+                    0, 0, scriptContent.Length, 1, 0 //function token: line 0, index 0, length of script, type 1 = keyword, no modifiers
                 };
 
             Assert.Equal(expectedArr, result.Data.ToArray());

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.2" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.17.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
PsesSemanticTokensHandler was not compatible with the Omnisharp.Extensions.LanguageServer update to 0.17.3 following the new LSP spect (v3.18). This PR fixes those issues.

Also see: https://github.com/PowerShell/vscode-powershell/pull/2861