### PR TITLE
Fix references on Windows due to slashes

### DIFF
--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -406,7 +406,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var fileMatchResult = matcher.Execute(fsFactory.RootDirectory);
             foreach (FilePatternMatch item in fileMatchResult.Files)
             {
-                yield return Path.Combine(WorkspacePath, item.Path);
+                // item.Path always contains forward slashes in paths when it should be backslashes on Windows.
+                // Since we're returning strings here, it's important to use the correct directory separator.
+                var path = VersionUtils.IsWindows ? item.Path.Replace('/', Path.DirectorySeparatorChar) : item.Path;
+                yield return Path.Combine(WorkspacePath, path);
             }
         }
 

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -103,19 +103,19 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 // suggest it should be find the '.ps1xml' files because we search for the pattern '*.ps1'
                 // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
                 Assert.Equal(4, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/donotfind.ps1", fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psm1", fileList[2]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[3]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList[0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList[2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[3]);
             }
             else
             {
                 Assert.Equal(5, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/donotfind.ps1", fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psm1", fileList[2]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"other") + "/other.ps1xml", fileList[3]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[4]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList[0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList[2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "other", "other.ps1xml"), fileList[3]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[4]);
             }
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             );
 
             Assert.Equal(1, fileList.Count);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[0]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[0]);
         }
 
         [Fact]
@@ -150,8 +150,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             );
 
             Assert.Equal(2, fileList.Count);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath,"nested") + "/nestedmodule.psd1", fileList[0]);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath,"rootfile.ps1"), fileList[1]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[0]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[1]);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2810

So item.Path always contains forward slashes... this means that the paths returned on Windows will be mixed:

C:\\Foo/Bar/baz.ps1

This result is used in counting references in CodeLens and `C:\\Foo/Bar/baz.ps1` was being treated differently from `C:\\Foo\\Bar\\baz.ps1` because they're just strings... https://github.com/PowerShell/PowerShellEditorServices/blob/master/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs#L200 

this fixes the issue by fixing the directory separator... 




... though in the future, it might be worth using FileInfo or something else in that ordered dictionary...