### PR TITLE
Hook up Telemetry LSP event and add telemetry event when users opt-out/in to features

### DIFF
--- a/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
+++ b/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.PowerShell.EditorServices.Logging
+{
+    // This inheirits from Dictionary so that it can be passed in to SendTelemetryEvent()
+    // which takes in an IDictionary<string, JToken>
+    // However, I wanted creation to be easy so you can do
+    // new PsesTelemetryEvent { EventName = "eventName", Data = data }
+    internal class PsesTelemetryEvent : Dictionary<string, JToken>
+    {
+        public string EventName
+        {
+            get
+            {
+                return this["EventName"].ToString() ?? "PsesEvent";
+            }
+            set
+            {
+                this["EventName"] = value;
+            }
+        }
+
+        public JObject Data
+        {
+            get
+            {
+                return this["Data"] as JObject ?? new JObject();
+            }
+            set
+            {
+                this["Data"] = value;
+            }
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -14,7 +14,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    [Serial, Method("powerShell/getCommand")]
+    [Serial, Method("powerShell/getCommand", Direction.ClientToServer)]
     internal interface IGetCommandHandler : IJsonRpcRequestHandler<GetCommandParams, List<PSCommandMessage>> { }
 
     internal class GetCommandParams : IRequest<List<PSCommandMessage>> { }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
@@ -8,10 +8,12 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    [Serial, Method("powerShell/getProjectTemplates")]
+    [Serial]
+    [Method("powerShell/getProjectTemplates", Direction.ClientToServer)]
     internal interface IGetProjectTemplatesHandler : IJsonRpcRequestHandler<GetProjectTemplatesRequest, GetProjectTemplatesResponse> { }
 
-    [Serial, Method("powerShell/newProjectFromTemplate")]
+    [Serial]
+    [Method("powerShell/newProjectFromTemplate", Direction.ClientToServer)]
     internal interface INewProjectFromTemplateHandler : IJsonRpcRequestHandler<NewProjectFromTemplateRequest, NewProjectFromTemplateResponse> { }
 
     internal class GetProjectTemplatesRequest : IRequest<GetProjectTemplatesResponse>

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -5,16 +5,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Configuration;
-using MediatR;
+using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
-using System.IO;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
@@ -24,6 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly WorkspaceService _workspaceService;
         private readonly ConfigurationService _configurationService;
         private readonly PowerShellContextService _powerShellContextService;
+        private readonly ILanguageServerFacade _languageServer;
         private DidChangeConfigurationCapability _capability;
         private bool _profilesLoaded;
         private bool _consoleReplStarted;
@@ -34,13 +39,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             WorkspaceService workspaceService,
             AnalysisService analysisService,
             ConfigurationService configurationService,
-            PowerShellContextService powerShellContextService)
+            PowerShellContextService powerShellContextService,
+            ILanguageServerFacade languageServer)
         {
             _logger = factory.CreateLogger<PsesConfigurationHandler>();
             _workspaceService = workspaceService;
             _configurationService = configurationService;
             _powerShellContextService = powerShellContextService;
-
+            _languageServer = languageServer;
             ConfigurationUpdated += analysisService.OnConfigurationUpdated;
         }
 
@@ -56,6 +62,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 return await Unit.Task.ConfigureAwait(false);
             }
+
+            SendFeatureChangesTelemetry(incomingSettings);
 
             bool oldLoadProfiles = _configurationService.CurrentSettings.EnableProfileLoading;
             bool oldScriptAnalysisEnabled =
@@ -139,6 +147,52 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             return await Unit.Task.ConfigureAwait(false);
+        }
+
+        private void SendFeatureChangesTelemetry(LanguageServerSettingsWrapper incomingSettings)
+        {
+            Dictionary<string, bool> configChanges = new Dictionary<string, bool>();
+            if (incomingSettings.Powershell.ScriptAnalysis.Enable != null &&
+                _configurationService.CurrentSettings.ScriptAnalysis.Enable != incomingSettings.Powershell.ScriptAnalysis.Enable)
+            {
+                configChanges["ScriptAnalysis"] = incomingSettings.Powershell.ScriptAnalysis.Enable ?? false;
+            }
+
+            if (_configurationService.CurrentSettings.CodeFolding.Enable != incomingSettings.Powershell.CodeFolding.Enable)
+            {
+                configChanges["CodeFolding"] = incomingSettings.Powershell.CodeFolding.Enable;
+            }
+
+            if (_configurationService.CurrentSettings.PromptToUpdatePackageManagement != incomingSettings.Powershell.PromptToUpdatePackageManagement)
+            {
+                configChanges["PromptToUpdatePackageManagement"] = incomingSettings.Powershell.PromptToUpdatePackageManagement;
+            }
+
+            if (_configurationService.CurrentSettings.EnableProfileLoading != incomingSettings.Powershell.EnableProfileLoading)
+            {
+                configChanges["ProfileLoading"] = incomingSettings.Powershell.EnableProfileLoading;
+            }
+
+            if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens != incomingSettings.Powershell.Pester.UseLegacyCodeLens)
+            {
+                // From our perspective we want to see how many people are opting in to this so we flip the value
+                configChanges["Pester5CodeLens"] = !incomingSettings.Powershell.Pester.UseLegacyCodeLens;
+            }
+
+            // No need to send any telemetry since nothing changed
+            if (configChanges.Count == 0)
+            {
+                return;
+            }
+
+            _languageServer.Window.SendTelemetryEvent(new TelemetryEventParams
+            {
+                Data = new PsesTelemetryEvent
+                {
+                    EventName = "EnabledPsesFeatures",
+                    Data = JObject.FromObject(configChanges)
+                }
+            });
         }
 
         public void SetCapability(DidChangeConfigurationCapability capability)

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -152,28 +152,37 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private void SendFeatureChangesTelemetry(LanguageServerSettingsWrapper incomingSettings)
         {
             Dictionary<string, bool> configChanges = new Dictionary<string, bool>();
-            if (incomingSettings.Powershell.ScriptAnalysis.Enable != null &&
+            // Send telemetry if the user opted-out of ScriptAnalysis
+            if (incomingSettings.Powershell.ScriptAnalysis.Enable == false &&
                 _configurationService.CurrentSettings.ScriptAnalysis.Enable != incomingSettings.Powershell.ScriptAnalysis.Enable)
             {
                 configChanges["ScriptAnalysis"] = incomingSettings.Powershell.ScriptAnalysis.Enable ?? false;
             }
 
-            if (_configurationService.CurrentSettings.CodeFolding.Enable != incomingSettings.Powershell.CodeFolding.Enable)
+            // Send telemetry if the user opted-out of CodeFolding
+            if (!incomingSettings.Powershell.CodeFolding.Enable &&
+                _configurationService.CurrentSettings.CodeFolding.Enable != incomingSettings.Powershell.CodeFolding.Enable)
             {
                 configChanges["CodeFolding"] = incomingSettings.Powershell.CodeFolding.Enable;
             }
 
-            if (_configurationService.CurrentSettings.PromptToUpdatePackageManagement != incomingSettings.Powershell.PromptToUpdatePackageManagement)
+            // Send telemetry if the user opted-out of the prompt to update PackageManagement
+            if (!incomingSettings.Powershell.PromptToUpdatePackageManagement &&
+                _configurationService.CurrentSettings.PromptToUpdatePackageManagement != incomingSettings.Powershell.PromptToUpdatePackageManagement)
             {
                 configChanges["PromptToUpdatePackageManagement"] = incomingSettings.Powershell.PromptToUpdatePackageManagement;
             }
 
-            if (_configurationService.CurrentSettings.EnableProfileLoading != incomingSettings.Powershell.EnableProfileLoading)
+            // Send telemetry if the user opted-out of Profile loading
+            if (!incomingSettings.Powershell.EnableProfileLoading &&
+                _configurationService.CurrentSettings.EnableProfileLoading != incomingSettings.Powershell.EnableProfileLoading)
             {
                 configChanges["ProfileLoading"] = incomingSettings.Powershell.EnableProfileLoading;
             }
 
-            if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens != incomingSettings.Powershell.Pester.UseLegacyCodeLens)
+            // Send telemetry if the user opted-in to Pester 5+ CodeLens
+            if (!incomingSettings.Powershell.Pester.UseLegacyCodeLens &&
+                _configurationService.CurrentSettings.Pester.UseLegacyCodeLens != incomingSettings.Powershell.Pester.UseLegacyCodeLens)
             {
                 // From our perspective we want to see how many people are opting in to this so we flip the value
                 configChanges["Pester5CodeLens"] = !incomingSettings.Powershell.Pester.UseLegacyCodeLens;
@@ -189,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 Data = new PsesTelemetryEvent
                 {
-                    EventName = "EnabledPsesFeatures",
+                    EventName = "NonDefaultPsesFeatureConfiguration",
                     Data = JObject.FromObject(configChanges)
                 }
             });

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private void SendFeatureChangesTelemetry(LanguageServerSettingsWrapper incomingSettings)
         {
-            Dictionary<string, bool> configChanges = new Dictionary<string, bool>();
+            var configChanges = new Dictionary<string, bool>();
             // Send telemetry if the user opted-out of ScriptAnalysis
             if (incomingSettings.Powershell.ScriptAnalysis.Enable == false &&
                 _configurationService.CurrentSettings.ScriptAnalysis.Enable != incomingSettings.Powershell.ScriptAnalysis.Enable)

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -18,9 +18,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
     internal class LanguageServerSettings
     {
         private readonly object updateLock = new object();
-        public bool EnableProfileLoading { get; set; }
 
-        public bool PromptToUpdatePackageManagement { get; set; }
+        public bool EnableProfileLoading { get; set; } = true;
+
+        public bool PromptToUpdatePackageManagement { get; set; } = true;
 
         public ScriptAnalysisSettings ScriptAnalysis { get; set; }
 


### PR DESCRIPTION
needs https://github.com/PowerShell/vscode-powershell/pull/3053 for the full flow.

The LSP has a message called [telemetry event](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#telemetry_event). The omnisharp lib gives us a mechanism for sending this so this PR hooks that up.
It's important to note that this doesn't make any requests besides sending a message to the client (aka vscode) to do the work of sending a telemetry event off the box. This way PSES doesn't have to depend on any AppInsights dll or something like that.

The event that this adds is an event called `NonDefaultPsesFeatureConfiguration` that has the body of settings that have been switched off/on from the default value. For example, if the user turns off the PackageManagement prompt (which defaults to on... aka true) then an event is fired with payload: `{ PromptToUpdatePackageManagement: false }` where false is the _new_ value it is being set to aka the non-default value.

This also modifies the E2E test to check to see if telemetry is sent when PSSA is turned off.

I also fixed a couple build warnings by adding Async to the end of all the test methods while I was touching it (sorry it makes the diff more annoying :( )
