### PR TITLE
fix #1393: Always use local help to return Full help

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -139,6 +139,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 // We use .Name here instead of just passing in commandInfo because
                 // CommandInfo.ToString() duplicates the Prefix if one exists.
                 .AddParameter("Name", commandInfo.Name)
+                .AddParameter("Online", false)
                 .AddParameter("ErrorAction", "Ignore");
 
             var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false);


### PR DESCRIPTION
If the user has overridden the Get-Help -Online parameter to always be true, then the ShowHelpHandler will always launch a new browser window to the cmdlet help.
Instead, we want it to return the full cmdlet text as intended.

fixes #1393 
fixes https://github.com/PowerShell/vscode-powershell/issues/3071