### PR TITLE
Update to use OmniSharp 0.19.0

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -4,6 +4,7 @@
     <VersionSuffix>preview.1</VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <LangVersion>9.0</LangVersion>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/PowerShell/PowerShellEditorServices/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
+++ b/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices.Hosting</AssemblyName>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
+++ b/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PowerShellEditorServices\PowerShellEditorServices.csproj" />
-    <PackageReference Include="PowerShellStandard.Library" Version="5.1.0">
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
+++ b/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
@@ -9,10 +9,10 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.PowerShell.EditorServices.Logging
 {
     // This inheirits from Dictionary so that it can be passed in to SendTelemetryEvent()
-    // which takes in an IDictionary<string, JToken>
+    // which takes in an IDictionary<string, object>
     // However, I wanted creation to be easy so you can do
     // new PsesTelemetryEvent { EventName = "eventName", Data = data }
-    internal class PsesTelemetryEvent : Dictionary<string, JToken>
+    internal class PsesTelemetryEvent : Dictionary<string, object>
     {
         public string EventName
         {

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -7,17 +7,7 @@
     <Description>Provides common PowerShell editor capabilities as a .NET library.</Description>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices</AssemblyName>
-    <LangVersion>Latest</LangVersion>
     <Configurations>Debug;Release</Configurations>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <LangVersion>latest</LangVersion>
-    <CheckForOverflowUnderflow></CheckForOverflowUnderflow>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.19.0" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.18.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -94,6 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     .WithHandler<ExpandAliasHandler>()
                     .WithHandler<PsesSemanticTokensHandler>()
                     .OnInitialize(
+                        // TODO: Either fix or ignore "method lacks 'await'" warning.
                         async (languageServer, request, cancellationToken) =>
                         {
                             var serviceProvider = languageServer.Services;

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                         .AddPsesLanguageServices(_hostDetails))
                     .ConfigureLogging(builder => builder
                         .AddSerilog(Log.Logger)
-                        .AddLanguageProtocolLogging(_minimumLogLevel)
+                        .AddLanguageProtocolLogging()
                         .SetMinimumLevel(_minimumLogLevel))
                     .WithHandler<PsesWorkspaceSymbolsHandler>()
                     .WithHandler<PsesTextDocumentHandler>()

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     Data = JToken.FromObject(new {
                         Uri = scriptFile.DocumentUri,
                         ProviderId = nameof(PesterCodeLensProvider)
-                    }, Serializer.Instance.JsonSerializer),
+                    }, LspSerializer.Instance.JsonSerializer),
                     Command = new Command()
                     {
                         Name = "PowerShell.RunPesterTests",
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                             false /* No debug */,
                             pesterSymbol.TestName,
                             pesterSymbol.ScriptRegion?.StartLineNumber
-                        }, Serializer.Instance.JsonSerializer)
+                        }, LspSerializer.Instance.JsonSerializer)
                     }
                 },
 
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     Data = JToken.FromObject(new {
                         Uri = scriptFile.DocumentUri,
                         ProviderId = nameof(PesterCodeLensProvider)
-                    }, Serializer.Instance.JsonSerializer),
+                    }, LspSerializer.Instance.JsonSerializer),
                     Command = new Command()
                     {
                         Name = "PowerShell.RunPesterTests",
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                             pesterSymbol.TestName,
                             pesterSymbol.ScriptRegion?.StartLineNumber
                         },
-                        Serializer.Instance.JsonSerializer)
+                        LspSerializer.Instance.JsonSerializer)
                     }
                 }
             };

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                         {
                             Uri = scriptFile.DocumentUri,
                             ProviderId = nameof(ReferencesCodeLensProvider)
-                        }, Serializer.Instance.JsonSerializer),
+                        }, LspSerializer.Instance.JsonSerializer),
                         Range = sym.ScriptRegion.ToRange()
                     });
                 }
@@ -145,7 +145,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                         codeLens.Range.Start,
                         referenceLocations
                     },
-                    Serializer.Instance.JsonSerializer)
+                    LspSerializer.Instance.JsonSerializer)
                 }
             };
         }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -146,7 +146,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     break;
             }
 
-            OmniSharp.Extensions.DebugAdapter.Protocol.Models.Breakpoint breakpoint;
+            var breakpoint = new OmniSharp.Extensions.DebugAdapter.Protocol.Models.Breakpoint
+            {
+                Verified = e.UpdateType != BreakpointUpdateType.Disabled
+            };
+
             if (e.Breakpoint is LineBreakpoint)
             {
                 breakpoint = LspDebugUtils.CreateBreakpoint(BreakpointDetails.Create(e.Breakpoint));
@@ -161,8 +165,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 _logger.LogError($"Unrecognized breakpoint type {e.Breakpoint.GetType().FullName}");
                 return;
             }
-
-            breakpoint.Verified = e.UpdateType != BreakpointUpdateType.Disabled;
 
             _debugAdapterServer.SendNotification(EventNames.Breakpoint,
                 new BreakpointEvent

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebuggerActionHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebuggerActionHandlers.cs
@@ -13,6 +13,7 @@ using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
+    // TODO: Inherit from ABCs instead of satisfying interfaces.
     internal class DebuggerActionHandlers : IContinueHandler, INextHandler, IPauseHandler, IStepInHandler, IStepOutHandler
     {
         private readonly ILogger _logger;
@@ -22,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ILoggerFactory loggerFactory,
             DebugService debugService)
         {
-            _logger = loggerFactory.CreateLogger<ContinueHandler>();
+            _logger = loggerFactory.CreateLogger<ContinueHandlerBase>();
             _debugService = debugService;
         }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -22,7 +22,7 @@ using OmniSharp.Extensions.DebugAdapter.Protocol.Server;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesLaunchRequestArguments : LaunchRequestArguments
+    internal record PsesLaunchRequestArguments : LaunchRequestArguments
     {
         /// <summary>
         /// Gets or sets the absolute path to the script to debug.
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public Dictionary<string, string> Env { get; set; }
     }
 
-    internal class PsesAttachRequestArguments : AttachRequestArguments
+    internal record PsesAttachRequestArguments : AttachRequestArguments
     {
         public string ComputerName { get; set; }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
@@ -16,13 +16,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             return Task.FromResult(new ThreadsResponse
             {
-                // TODO: What do I do with these?
-                Threads = new Container<OmniSharp.Extensions.DebugAdapter.Protocol.Models.Thread>(
-                    new OmniSharp.Extensions.DebugAdapter.Protocol.Models.Thread
-                    {
-                        Id = 1,
-                        Name = "Main Thread"
-                    })
+                // TODO: This is an empty container of threads...do we need to make a thread?
+                Threads = new Container<System.Threading.Thread>()
             });
         }
     }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             CodeActionKinds = new CodeActionKind[] { CodeActionKind.QuickFix }
         };
 
+        // TODO: Either fix or ignore "method lacks 'await'" warning.
         public override async Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
         {
             // TODO: How on earth do we handle a CodeAction? This is new...

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -19,46 +19,37 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesCodeActionHandler : ICodeActionHandler
+    internal class PsesCodeActionHandler : CodeActionHandlerBase
     {
-        private static readonly CodeActionKind[] s_supportedCodeActions = new[]
-        {
-            CodeActionKind.QuickFix
-        };
-
-        private readonly CodeActionRegistrationOptions _registrationOptions;
-
         private readonly ILogger _logger;
-
         private readonly AnalysisService _analysisService;
-
         private readonly WorkspaceService _workspaceService;
-
-        private CodeActionCapability _capability;
 
         public PsesCodeActionHandler(ILoggerFactory factory, AnalysisService analysisService, WorkspaceService workspaceService)
         {
             _logger = factory.CreateLogger<PsesCodeActionHandler>();
             _analysisService = analysisService;
             _workspaceService = workspaceService;
-            _registrationOptions = new CodeActionRegistrationOptions
+        }
+
+        protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities) => new CodeActionRegistrationOptions
             {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-                CodeActionKinds = s_supportedCodeActions
-            };
-        }
+            // TODO: What do we do with the arguments?
+            DocumentSelector = LspUtils.PowerShellDocumentSelector,
+            CodeActionKinds = new CodeActionKind[] { CodeActionKind.QuickFix }
+        };
 
-        public CodeActionRegistrationOptions GetRegistrationOptions()
+        public override async Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
         {
-            return _registrationOptions;
+            // TODO: How on earth do we handle a CodeAction? This is new...
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("CodeAction request canceled for: {0}", request.Title);
+            }
+            return request;
         }
 
-        public void SetCapability(CodeActionCapability capability)
-        {
-            _capability = capability;
-        }
-
-        public async Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
+        public override async Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -101,7 +92,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                                 new WorkspaceEditDocumentChange(
                                     new TextDocumentEdit
                                     {
-                                        TextDocument = new VersionedTextDocumentIdentifier
+                                        TextDocument = new OptionalVersionedTextDocumentIdentifier
                                         {
                                             Uri = request.TextDocument.Uri
                                         },

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -21,25 +21,22 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
+    // TODO: Use ABCs.
     internal class PsesCompletionHandler : ICompletionHandler, ICompletionResolveHandler
     {
         const int DefaultWaitTimeoutMilliseconds = 5000;
         private readonly SemaphoreSlim _completionLock = AsyncUtils.CreateSimpleLockingSemaphore();
         private readonly SemaphoreSlim _completionResolveLock = AsyncUtils.CreateSimpleLockingSemaphore();
-
         private readonly ILogger _logger;
         private readonly PowerShellContextService _powerShellContextService;
         private readonly WorkspaceService _workspaceService;
-
         private CompletionResults _mostRecentCompletions;
-
         private int _mostRecentRequestLine;
-
         private int _mostRecentRequestOffest;
-
         private string _mostRecentRequestFile;
-
         private CompletionCapability _capability;
+        private readonly Guid _id = Guid.NewGuid();
+        Guid ICanBeIdentifiedHandler.Id => _id;
 
         public PsesCompletionHandler(
             ILoggerFactory factory,
@@ -51,15 +48,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public CompletionRegistrationOptions GetRegistrationOptions()
+        public CompletionRegistrationOptions GetRegistrationOptions(CompletionCapability capability, ClientCapabilities clientCapabilities) => new CompletionRegistrationOptions
         {
-            return new CompletionRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-                ResolveProvider = true,
-                TriggerCharacters = new[] { ".", "-", ":", "\\", "$" }
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector,
+            ResolveProvider = true,
+            TriggerCharacters = new[] { ".", "-", ":", "\\", "$" }
+        };
 
         public async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
         {
@@ -145,10 +139,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 if (commandInfo != null)
                 {
-                    request.Documentation =
-                        await CommandHelpers.GetCommandSynopsisAsync(
-                            commandInfo,
-                            _powerShellContextService).ConfigureAwait(false);
+                    request = request with
+                    {
+                        Documentation = await CommandHelpers.GetCommandSynopsisAsync(commandInfo, _powerShellContextService).ConfigureAwait(false)
+                    };
                 }
 
                 // Send back the updated CompletionItem
@@ -160,7 +154,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
         }
 
-        public void SetCapability(CompletionCapability capability)
+        public void SetCapability(CompletionCapability capability, ClientCapabilities clientCapabilities)
         {
             _capability = capability;
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -18,13 +18,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesDefinitionHandler : IDefinitionHandler
+    internal class PsesDefinitionHandler : DefinitionHandlerBase
     {
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-
-        private DefinitionCapability _capability;
 
         public PsesDefinitionHandler(
             ILoggerFactory factory,
@@ -36,15 +34,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public DefinitionRegistrationOptions GetRegistrationOptions()
+        protected override DefinitionRegistrationOptions CreateRegistrationOptions(DefinitionCapability capability, ClientCapabilities clientCapabilities) => new DefinitionRegistrationOptions
         {
-            return new DefinitionRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public async Task<LocationOrLocationLinks> Handle(DefinitionParams request, CancellationToken cancellationToken)
+        public override async Task<LocationOrLocationLinks> Handle(DefinitionParams request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
@@ -74,11 +69,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             return new LocationOrLocationLinks(definitionLocations);
-        }
-
-        public void SetCapability(DefinitionCapability capability)
-        {
-            _capability = capability;
         }
 
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -17,17 +17,12 @@ using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesDocumentHighlightHandler : IDocumentHighlightHandler
+    internal class PsesDocumentHighlightHandler : DocumentHighlightHandlerBase
     {
         private static readonly DocumentHighlightContainer s_emptyHighlightContainer = new DocumentHighlightContainer();
-
         private readonly ILogger _logger;
-
         private readonly WorkspaceService _workspaceService;
-
         private readonly SymbolsService _symbolsService;
-
-        private DocumentHighlightCapability _capability;
 
         public PsesDocumentHighlightHandler(
             ILoggerFactory loggerFactory,
@@ -40,15 +35,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _logger.LogInformation("highlight handler loaded");
         }
 
-        public DocumentHighlightRegistrationOptions GetRegistrationOptions()
+        protected override DocumentHighlightRegistrationOptions CreateRegistrationOptions(DocumentHighlightCapability capability, ClientCapabilities clientCapabilities) => new DocumentHighlightRegistrationOptions
         {
-            return new DocumentHighlightRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public Task<DocumentHighlightContainer> Handle(
+        public override Task<DocumentHighlightContainer> Handle(
             DocumentHighlightParams request,
             CancellationToken cancellationToken)
         {
@@ -75,11 +67,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             return Task.FromResult(new DocumentHighlightContainer(highlights));
-        }
-
-        public void SetCapability(DocumentHighlightCapability capability)
-        {
-            _capability = capability;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -23,14 +23,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesDocumentSymbolHandler : IDocumentSymbolHandler
+    internal class PsesDocumentSymbolHandler : DocumentSymbolHandlerBase
     {
         private readonly ILogger _logger;
         private readonly WorkspaceService _workspaceService;
-
         private readonly IDocumentSymbolProvider[] _providers;
-
-        private DocumentSymbolCapability _capability;
 
         public PsesDocumentSymbolHandler(ILoggerFactory factory, ConfigurationService configurationService, WorkspaceService workspaceService)
         {
@@ -44,15 +41,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             };
         }
 
-        public DocumentSymbolRegistrationOptions GetRegistrationOptions()
+        protected override DocumentSymbolRegistrationOptions CreateRegistrationOptions(DocumentSymbolCapability capability, ClientCapabilities clientCapabilities) => new DocumentSymbolRegistrationOptions
         {
-            return new DocumentSymbolRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public Task<SymbolInformationOrDocumentSymbolContainer> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
+        public override Task<SymbolInformationOrDocumentSymbolContainer> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
@@ -90,11 +84,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
 
             return Task.FromResult(new SymbolInformationOrDocumentSymbolContainer(symbols));
-        }
-
-        public void SetCapability(DocumentSymbolCapability capability)
-        {
-            _capability = capability;
         }
 
         private IEnumerable<ISymbolReference> ProvideDocumentSymbols(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -16,30 +16,25 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesFoldingRangeHandler : IFoldingRangeHandler
+    internal class PsesFoldingRangeHandler : FoldingRangeHandlerBase
     {
         private readonly ILogger _logger;
         private readonly ConfigurationService _configurationService;
         private readonly WorkspaceService _workspaceService;
 
-        private FoldingRangeCapability _capability;
-
         public PsesFoldingRangeHandler(ILoggerFactory factory, ConfigurationService configurationService, WorkspaceService workspaceService)
         {
-            _logger = factory.CreateLogger<FoldingRangeHandler>();
+            _logger = factory.CreateLogger<PsesFoldingRangeHandler>();
             _configurationService = configurationService;
             _workspaceService = workspaceService;
         }
 
-        public FoldingRangeRegistrationOptions GetRegistrationOptions()
+        protected override FoldingRangeRegistrationOptions CreateRegistrationOptions(FoldingRangeCapability capability, ClientCapabilities clientCapabilities) => new FoldingRangeRegistrationOptions
         {
-            return new FoldingRangeRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public Task<Container<FoldingRange>> Handle(FoldingRangeRequestParam request, CancellationToken cancellationToken)
+        public override Task<Container<FoldingRange>> Handle(FoldingRangeRequestParam request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -74,11 +69,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             return Task.FromResult(new Container<FoldingRange>(result));
-        }
-
-        public void SetCapability(FoldingRangeCapability capability)
-        {
-            _capability = capability;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -17,6 +17,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     // TODO: Add IDocumentOnTypeFormatHandler to support on-type formatting.
+    // TODO: Use ABCs.
     internal class PsesDocumentFormattingHandlers : IDocumentFormattingHandler, IDocumentRangeFormattingHandler
     {
         private readonly ILogger _logger;
@@ -39,21 +40,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public DocumentFormattingRegistrationOptions GetRegistrationOptions()
+        public DocumentFormattingRegistrationOptions GetRegistrationOptions(DocumentFormattingCapability capability, ClientCapabilities clientCapabilities) => new DocumentFormattingRegistrationOptions
         {
-            return new DocumentFormattingRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        DocumentRangeFormattingRegistrationOptions IRegistration<DocumentRangeFormattingRegistrationOptions>.GetRegistrationOptions()
+        public DocumentRangeFormattingRegistrationOptions GetRegistrationOptions(DocumentRangeFormattingCapability capability, ClientCapabilities clientCapabilities) => new DocumentRangeFormattingRegistrationOptions
         {
-            return new DocumentRangeFormattingRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
         public async Task<TextEditContainer> Handle(DocumentFormattingParams request, CancellationToken cancellationToken)
         {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -17,13 +17,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesHoverHandler : IHoverHandler
+    internal class PsesHoverHandler : HoverHandlerBase
     {
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-
-        private HoverCapability _capability;
 
         public PsesHoverHandler(
             ILoggerFactory factory,
@@ -35,15 +33,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public HoverRegistrationOptions GetRegistrationOptions()
+        protected override HoverRegistrationOptions CreateRegistrationOptions(HoverCapability capability, ClientCapabilities clientCapabilities) => new HoverRegistrationOptions
         {
-            return new HoverRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public async Task<Hover> Handle(HoverParams request, CancellationToken cancellationToken)
+        public override async Task<Hover> Handle(HoverParams request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -79,11 +74,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 Contents = new MarkedStringsOrMarkupContent(symbolInfo),
                 Range = symbolRange
             };
-        }
-
-        public void SetCapability(HoverCapability capability)
-        {
-            _capability = capability;
         }
 
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class PsesSemanticTokensHandler : SemanticTokensHandlerBase
     {
-        private static readonly SemanticTokensRegistrationOptions s_registrationOptions = new SemanticTokensRegistrationOptions
+        protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(SemanticTokensCapability capability, ClientCapabilities clientCapabilities) => new SemanticTokensRegistrationOptions
         {
             DocumentSelector = LspUtils.PowerShellDocumentSelector,
             Legend = new SemanticTokensLegend(),
@@ -35,7 +35,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly WorkspaceService _workspaceService;
 
         public PsesSemanticTokensHandler(ILogger<PsesSemanticTokensHandler> logger, WorkspaceService workspaceService)
-            : base(s_registrationOptions)
         {
             _logger = logger;
             _workspaceService = workspaceService;
@@ -160,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ITextDocumentIdentifierParams @params,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult(new SemanticTokensDocument(GetRegistrationOptions().Legend));
+            return Task.FromResult(new SemanticTokensDocument(RegistrationOptions.Legend));
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
@@ -13,9 +13,8 @@ using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
-using OmniSharp.Extensions.LanguageServer.Protocol.Document.Proposals;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -18,12 +18,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    class PsesReferencesHandler : IReferencesHandler
+    class PsesReferencesHandler : ReferencesHandlerBase
     {
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-        private ReferenceCapability _capability;
 
         public PsesReferencesHandler(ILoggerFactory factory, SymbolsService symbolsService, WorkspaceService workspaceService)
         {
@@ -32,15 +31,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspaceService;
         }
 
-        public ReferenceRegistrationOptions GetRegistrationOptions()
+        protected override ReferenceRegistrationOptions CreateRegistrationOptions(ReferenceCapability capability, ClientCapabilities clientCapabilities) => new ReferenceRegistrationOptions
         {
-            return new ReferenceRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector
+        };
 
-        public Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
+        public override Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
@@ -71,11 +67,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             return Task.FromResult(new LocationContainer(locations));
-        }
-
-        public void SetCapability(ReferenceCapability capability)
-        {
-            _capability = capability;
         }
 
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -17,14 +17,12 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesSignatureHelpHandler : ISignatureHelpHandler
+    internal class PsesSignatureHelpHandler : SignatureHelpHandlerBase
     {
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
         private readonly PowerShellContextService _powerShellContextService;
-
-        private SignatureHelpCapability _capability;
 
         public PsesSignatureHelpHandler(
             ILoggerFactory factory,
@@ -38,17 +36,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _powerShellContextService = powerShellContextService;
         }
 
-        public SignatureHelpRegistrationOptions GetRegistrationOptions()
+        protected override SignatureHelpRegistrationOptions CreateRegistrationOptions(SignatureHelpCapability capability, ClientCapabilities clientCapabilities) => new SignatureHelpRegistrationOptions
         {
-            return new SignatureHelpRegistrationOptions
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-                // A sane default of " ". We may be able to include others like "-".
-                TriggerCharacters = new Container<string>(" ")
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector,
+            // A sane default of " ". We may be able to include others like "-".
+            TriggerCharacters = new Container<string>(" ")
+        };
 
-        public async Task<SignatureHelp> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
+        public override async Task<SignatureHelp> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -93,11 +88,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 ActiveParameter = null,
                 ActiveSignature = 0
             };
-        }
-
-        public void SetCapability(SignatureHelpCapability capability)
-        {
-            _capability = capability;
         }
 
         private static ParameterInformation CreateParameterInfo(ParameterInfo parameterInfo)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -19,7 +19,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    class PsesTextDocumentHandler : ITextDocumentSyncHandler
+    class PsesTextDocumentHandler : TextDocumentSyncHandlerBase
     {
         private static readonly Uri s_fakeUri = new Uri("Untitled:fake");
 
@@ -27,7 +27,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly AnalysisService _analysisService;
         private readonly WorkspaceService _workspaceService;
         private readonly RemoteFileManagerService _remoteFileManagerService;
-        private SynchronizationCapability _capability;
 
         public TextDocumentSyncKind Change => TextDocumentSyncKind.Incremental;
 
@@ -43,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _remoteFileManagerService = remoteFileManagerService;
         }
 
-        public Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
+        public override Task<Unit> Handle(DidChangeTextDocumentParams notification, CancellationToken token)
         {
             ScriptFile changedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
@@ -62,21 +61,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return Unit.Task;
         }
 
-        TextDocumentChangeRegistrationOptions IRegistration<TextDocumentChangeRegistrationOptions>.GetRegistrationOptions()
+        protected override TextDocumentSyncRegistrationOptions CreateRegistrationOptions(SynchronizationCapability capability, ClientCapabilities clientCapabilities) => new TextDocumentSyncRegistrationOptions()
         {
-            return new TextDocumentChangeRegistrationOptions()
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-                SyncKind = Change
-            };
-        }
+            DocumentSelector = LspUtils.PowerShellDocumentSelector,
+            Change = Change,
+            Save = new SaveOptions { IncludeText = true }
+        };
 
-        public void SetCapability(SynchronizationCapability capability)
-        {
-            _capability = capability;
-        }
-
-        public Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
+        public override Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
         {
             ScriptFile openedFile =
                 _workspaceService.GetFileBuffer(
@@ -98,15 +90,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return Unit.Task;
         }
 
-        TextDocumentRegistrationOptions IRegistration<TextDocumentRegistrationOptions>.GetRegistrationOptions()
-        {
-            return new TextDocumentRegistrationOptions()
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-            };
-        }
-
-        public Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
+        public override Task<Unit> Handle(DidCloseTextDocumentParams notification, CancellationToken token)
         {
             // Find and close the file in the current session
             var fileToClose = _workspaceService.GetFile(notification.TextDocument.Uri);
@@ -121,7 +105,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return Unit.Task;
         }
 
-        public async Task<Unit> Handle(DidSaveTextDocumentParams notification, CancellationToken token)
+        public override async Task<Unit> Handle(DidSaveTextDocumentParams notification, CancellationToken token)
         {
             ScriptFile savedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
@@ -135,18 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return Unit.Value;
         }
 
-        TextDocumentSaveRegistrationOptions IRegistration<TextDocumentSaveRegistrationOptions>.GetRegistrationOptions()
-        {
-            return new TextDocumentSaveRegistrationOptions()
-            {
-                DocumentSelector = LspUtils.PowerShellDocumentSelector,
-                IncludeText = true
-            };
-        }
-        public TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri)
-        {
-            return new TextDocumentAttributes(uri, "powershell");
-        }
+        public override TextDocumentAttributes GetTextDocumentAttributes(DocumentUri uri) => new TextDocumentAttributes(uri, "powershell");
 
         private static FileChange GetFileChangeDetails(Range changeRange, string insertString)
         {

--- a/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 {

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -22,14 +22,13 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesConfigurationHandler : IDidChangeConfigurationHandler
+    internal class PsesConfigurationHandler : DidChangeConfigurationHandlerBase
     {
         private readonly ILogger _logger;
         private readonly WorkspaceService _workspaceService;
         private readonly ConfigurationService _configurationService;
         private readonly PowerShellContextService _powerShellContextService;
         private readonly ILanguageServerFacade _languageServer;
-        private DidChangeConfigurationCapability _capability;
         private bool _profilesLoaded;
         private bool _consoleReplStarted;
         private bool _cwdSet;
@@ -50,12 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ConfigurationUpdated += analysisService.OnConfigurationUpdated;
         }
 
-        public object GetRegistrationOptions()
-        {
-            return null;
-        }
-
-        public async Task<Unit> Handle(DidChangeConfigurationParams request, CancellationToken cancellationToken)
+        public override async Task<Unit> Handle(DidChangeConfigurationParams request, CancellationToken cancellationToken)
         {
             LanguageServerSettingsWrapper incomingSettings = request.Settings.ToObject<LanguageServerSettingsWrapper>();
             if(incomingSettings == null)
@@ -205,11 +199,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     Data = JObject.FromObject(configChanges)
                 }
             });
-        }
-
-        public void SetCapability(DidChangeConfigurationCapability capability)
-        {
-            _capability = capability;
         }
 
         public event EventHandler<LanguageServerSettings> ConfigurationUpdated;

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -193,7 +193,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             _languageServer.Window.SendTelemetryEvent(new TelemetryEventParams
             {
-                Data = new PsesTelemetryEvent
+                ExtensionData = new PsesTelemetryEvent
                 {
                     EventName = "NonDefaultPsesFeatureConfiguration",
                     Data = JObject.FromObject(configChanges)

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -19,12 +19,11 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
-    internal class PsesWorkspaceSymbolsHandler : IWorkspaceSymbolsHandler
+    internal class PsesWorkspaceSymbolsHandler : WorkspaceSymbolsHandlerBase
     {
         private readonly ILogger _logger;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
-        private WorkspaceSymbolCapability _capability;
 
         public PsesWorkspaceSymbolsHandler(ILoggerFactory loggerFactory, SymbolsService symbols, WorkspaceService workspace) {
             _logger = loggerFactory.CreateLogger<PsesWorkspaceSymbolsHandler>();
@@ -32,12 +31,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _workspaceService = workspace;
         }
 
-        public WorkspaceSymbolRegistrationOptions GetRegistrationOptions()
-        {
-            return new WorkspaceSymbolRegistrationOptions();
-        }
+        protected override WorkspaceSymbolRegistrationOptions CreateRegistrationOptions(WorkspaceSymbolCapability capability, ClientCapabilities clientCapabilities) => new WorkspaceSymbolRegistrationOptions { };
 
-        public Task<Container<SymbolInformation>> Handle(WorkspaceSymbolParams request, CancellationToken cancellationToken)
+        public override Task<Container<SymbolInformation>> Handle(WorkspaceSymbolParams request, CancellationToken cancellationToken)
         {
             var symbols = new List<SymbolInformation>();
 
@@ -75,11 +71,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _logger.LogWarning("Logging in a handler works now.");
 
             return Task.FromResult(new Container<SymbolInformation>(symbols));
-        }
-
-        public void SetCapability(WorkspaceSymbolCapability capability)
-        {
-            _capability = capability;
         }
 
         #region private Methods

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
@@ -4,19 +4,11 @@
 //
 
 using System;
-using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Handlers;
-using Xunit;
 using OmniSharp.Extensions.DebugAdapter.Client;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
 using System.Threading;
-using System.Text;
-using System.Linq;
-using Xunit.Abstractions;
-using Microsoft.Extensions.Logging;
-using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 
 namespace PowerShellEditorServices.Test.E2E
 {
@@ -24,7 +16,7 @@ namespace PowerShellEditorServices.Test.E2E
     {
         public static async Task LaunchScript(this DebugAdapterClient debugAdapterClient, string filePath, TaskCompletionSource<object> started)
         {
-            LaunchResponse launchResponse = await debugAdapterClient.RequestLaunch(new PsesLaunchRequestArguments
+            LaunchResponse launchResponse = await debugAdapterClient.Launch(new PsesLaunchRequestArguments
             {
                 NoDebug = false,
                 Script = filePath,

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -182,7 +182,7 @@ namespace PowerShellEditorServices.Test.E2E
             await PsesDebugAdapterClient.LaunchScript(filePath, Started).ConfigureAwait(false);
 
             // {"command":"setBreakpoints","arguments":{"source":{"name":"dfsdfg.ps1","path":"/Users/tyleonha/Code/PowerShell/Misc/foo/dfsdfg.ps1"},"lines":[2],"breakpoints":[{"line":2}],"sourceModified":false},"type":"request","seq":3}
-            SetBreakpointsResponse setBreakpointsResponse = await PsesDebugAdapterClient.RequestSetBreakpoints(new SetBreakpointsArguments
+            SetBreakpointsResponse setBreakpointsResponse = await PsesDebugAdapterClient.SetBreakpoints(new SetBreakpointsArguments
             {
                 Source = new Source
                 {

--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -63,8 +63,8 @@ namespace PowerShellEditorServices.Test.E2E
                     .OnTelemetryEvent(telemetryEventParams => TelemetryEvents.Add(
                         new PsesTelemetryEvent
                         {
-                            EventName = (string) telemetryEventParams.Data["eventName"],
-                            Data = telemetryEventParams.Data["data"] as JObject
+                            EventName = (string)telemetryEventParams.ExtensionData["eventName"],
+                            Data = telemetryEventParams.ExtensionData["data"] as JObject
                         }));
 
                 // Enable all capabilities this this is for testing.

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -215,7 +215,7 @@ function CanSendWorkspaceSymbolRequest {
                         Text = "$a = 7"
                     }
                 }),
-                TextDocument = new VersionedTextDocumentIdentifier
+                TextDocument = new OptionalVersionedTextDocumentIdentifier
                 {
                     Version = 4,
                     Uri = new Uri(filePath)

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -21,7 +21,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
 using Xunit;
 using Xunit.Abstractions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.0" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.0" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Handlers;
 using OmniSharp.Extensions.LanguageServer.Protocol;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models.Proposals;
 using Xunit;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Language

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Handlers;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Language

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.18.3" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
   </ItemGroup>
   <ItemGroup>

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="xunit" Version="2.4.1-pre.build.4059" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.0" />


### PR DESCRIPTION
This updates our base dependency, OmniSharp, from 0.18.3 to 0.19.0, which included many API changes. The approach taken to reduce code was the replacement of interface-implementations with ABC derivations, providing a few things for free for each of the derived classes, and is more inline with the expectations of the library developers. There are a couple classes that implement multiple interfaces, and have been left TODO for a switch to an ABC implementation. Furthermore, the C# language specification needed to be updated because of OmniSharp's use of new language features (namely `record`s), and I found that our xUnit package was misaligned.