### PR TITLE
Add '$' as trigger character for completion

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 DocumentSelector = LspUtils.PowerShellDocumentSelector,
                 ResolveProvider = true,
-                TriggerCharacters = new[] { ".", "-", ":", "\\" }
+                TriggerCharacters = new[] { ".", "-", ":", "\\", "$" }
             };
         }
 


### PR DESCRIPTION
Fixes https://github.com/PowerShell/PowerShellEditorServices/issues/1176 so IntelliSense gets triggered automatically when writing variables.