### PR TITLE
Remove "All Rights Reserved" from copyright notices

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,5 @@
-#-------------------------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
-#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1.802
 

--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -30,10 +30,8 @@
 	"Copyright header": {
 		"prefix": "CopyrightHeader",
 		"body": [
-			"//",
-			"// Copyright (c) Microsoft. All rights reserved.",
-			"// Licensed under the MIT license. See LICENSE file in the project root for full license information.",
-			"//"
+			"// Copyright (c) Microsoft Corporation.",
+			"// Licensed under the MIT License."
 		],
 		"description": "Copyright header"
 	}

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -3,7 +3,7 @@
     <VersionPrefix>2.4.1</VersionPrefix>
     <VersionSuffix>preview.1</VersionSuffix>
     <Company>Microsoft</Company>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation.</Copyright>
     <LangVersion>9.0</LangVersion>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/PowerShell/PowerShellEditorServices/master/LICENSE</PackageLicenseUrl>

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 param(
     [ValidateSet("Debug", "Release")]

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,8 @@
 #!/usr/bin/env pwsh
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param(
     [Parameter()]
     [switch]

--- a/docs/template/conceptual.html.primary.tmpl
+++ b/docs/template/conceptual.html.primary.tmpl
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 {{!include(/^styles/.*/)}}
 {{!include(/^fonts/.*/)}}
 {{!include(favicon.ico)}}

--- a/docs/template/partials/class.tmpl.partial
+++ b/docs/template/partials/class.tmpl.partial
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 
 {{^_disableContribution}}
 {{#docurl}}<a href="{{docurl}}" class="pull-right mobile-hide"><span class="fa fa-github"></span>{{__global.improveThisDoc}}</a>{{/docurl}}

--- a/docs/template/partials/footer.tmpl.partial
+++ b/docs/template/partials/footer.tmpl.partial
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 
 <footer>
   <div class="inner-footer">

--- a/docs/template/partials/head.tmpl.partial
+++ b/docs/template/partials/head.tmpl.partial
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 
 <head>
   <meta charset="utf-8">

--- a/docs/template/partials/namespace.tmpl.partial
+++ b/docs/template/partials/namespace.tmpl.partial
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 
 {{^_disableContribution}}
 {{#docurl}}

--- a/docs/template/partials/navbar.tmpl.partial
+++ b/docs/template/partials/navbar.tmpl.partial
@@ -1,4 +1,4 @@
-{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{!Copyright (c) Microsoft Corporation. Licensed under the MIT License.}}
 
 <nav class="navbar navbar-inverse">
      <div class="container">

--- a/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psd1
+++ b/module/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.psd1
@@ -27,7 +27,7 @@ Author = 'Microsoft'
 CompanyName = 'Microsoft'
 
 # Copyright statement for this module
-Copyright = '(c) 2017 Microsoft. All rights reserved.'
+Copyright = '(c) 2021 Microsoft Corporation.'
 
 # Description of the functionality provided by this module
 Description = 'Provides added functionality to PowerShell Editor Services for the Visual Studio Code editor.'

--- a/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
+++ b/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psd1
@@ -24,7 +24,7 @@ Author = 'Microsoft'
 CompanyName = 'Microsoft'
 
 # Copyright statement for this module
-Copyright = '(c) 2017 Microsoft. All rights reserved.'
+Copyright = '(c) 2021 Microsoft Corporation.'
 
 # Description of the functionality provided by this module
 Description = 'Provides internal commands for PowerShell Editor Services that only work in an editor session.'

--- a/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psm1
+++ b/module/PowerShellEditorServices/Commands/PowerShellEditorServices.Commands.psm1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 Microsoft.PowerShell.Utility\Import-LocalizedData -BindingVariable Strings -FileName Strings -ErrorAction Ignore
 

--- a/module/PowerShellEditorServices/Commands/Private/BuiltInCommands.ps1
+++ b/module/PowerShellEditorServices/Commands/Private/BuiltInCommands.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Register-EditorCommand `
     -Name 'PowerShellEditorServices.OpenEditorProfile' `
     -DisplayName 'Open Editor Profile' `

--- a/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 Microsoft.PowerShell.Management\Get-Item function:Clear-Host | Microsoft.PowerShell.Management\Set-Item function:__clearhost
 

--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -1,7 +1,5 @@
-﻿#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 <#
 .EXTERNALHELP ..\PowerShellEditorServices.Commands-help.xml

--- a/module/PowerShellEditorServices/Commands/Public/ConvertFrom-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/ConvertFrom-ScriptExtent.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function ConvertFrom-ScriptExtent {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/ConvertTo-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/ConvertTo-ScriptExtent.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function ConvertTo-ScriptExtent {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Find-Ast.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Find-Ast.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Find-Ast {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Get-Token.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Get-Token.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Get-Token {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Import-EditorCommand.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Import-EditorCommand {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Join-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Join-ScriptExtent.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Join-ScriptExtent {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Out-CurrentFile.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Out-CurrentFile.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Out-CurrentFile {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Set-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Set-ScriptExtent.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Set-ScriptExtent {
     <#

--- a/module/PowerShellEditorServices/Commands/Public/Test-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Test-ScriptExtent.ps1
@@ -1,7 +1,5 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 function Test-ScriptExtent {
     <#

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Starts the language and debug services from the PowerShellEditorServices module.

--- a/scripts/AddCopyrightHeaders.ps1
+++ b/scripts/AddCopyrightHeaders.ps1
@@ -21,7 +21,7 @@ function Add-CopyrightHeaders($basePath)
 		if ($fileContent.StartsWith($copyrightHeaderString) -eq $false)
 		{
 			# Add the copyright header to the file
-			Set-Content $sourceFile.FullName ($copyrightHeaderString + "`r`n`r`n" + $fileContent)
+			Set-Content $sourceFile.FullName ($copyrightHeaderString + [Environment]::NewLine + [Environment]::NewLine + $fileContent)
 			Write-Output ("Updated {0}" -f (Resolve-Path $sourceFile.FullName -Relative))
 			$global:updateCount++
 		}

--- a/scripts/AddCopyrightHeaders.ps1
+++ b/scripts/AddCopyrightHeaders.ps1
@@ -1,14 +1,10 @@
-#
-# Copyright (c) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 $copyrightHeaderString =
 @'
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 '@
 
 $global:updateCount = 0;

--- a/scripts/BuildDocs.ps1
+++ b/scripts/BuildDocs.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param([switch]$Serve, [switch]$Clean, [switch]$Publish)
 
 $toolsPath = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\tools")

--- a/scripts/FetchLatestBuild.ps1
+++ b/scripts/FetchLatestBuild.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param($buildVersion = $null)
 
 $releasePath = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\release")

--- a/scripts/PackageSignedBinaries.ps1
+++ b/scripts/PackageSignedBinaries.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 # This script assumes the FetchBuildBinaries.ps1 has been run and
 # the binaries in 'release\BinariesToSign' have been signed and
 # replaced.

--- a/scripts/PublishPackages.ps1
+++ b/scripts/PublishPackages.ps1
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 $releasePath = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\release")
 $finalPackagePath = [System.IO.Path]::GetFullPath("$releasePath\FinalPackages")
@@ -15,7 +17,7 @@ foreach ($package in $packages) {
     }
     else
     {
-        Write-Output "Pushed package $package.FullName"   
+        Write-Output "Pushed package $package.FullName"
     }
 }
 

--- a/scripts/azurePipelinesBuild.ps1
+++ b/scripts/azurePipelinesBuild.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 $ErrorActionPreference = 'Stop'
 
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineConstructorCommand.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.Commands;
 using System;

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostInfo.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostInfo.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/PowerShellEditorServices.Hosting/GlobalSuppressions.cs
+++ b/src/PowerShellEditorServices.Hosting/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Server;
 using System;

--- a/src/PowerShellEditorServices.Hosting/Internal/NamedPipeUtils.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/NamedPipeUtils.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices.Hosting/Internal/PsesLoadContext.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/PsesLoadContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/PowerShellEditorServices.VSCode/Cmdlets/VSCodeHtmlContentViewCommands.cs
+++ b/src/PowerShellEditorServices.VSCode/Cmdlets/VSCodeHtmlContentViewCommands.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewFeature.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewType.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewType.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
 {

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
 {

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewMessages.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Extensions.Services;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/ICustomView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/ICustomView.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentView.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/IHtmlContentViews.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices.VSCode/CustomViews/ViewColumn.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/ViewColumn.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Extensions/Api/DocumentSymbolService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/DocumentSymbolService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Extensions/Api/EditorContextService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorContextService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq.Expressions;

--- a/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Extensions/Api/ExtensionCommandService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/ExtensionCommandService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services;
 using System;

--- a/src/PowerShellEditorServices/Extensions/Api/LanguageServerService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/LanguageServerService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;

--- a/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using System;

--- a/src/PowerShellEditorServices/Extensions/EditorCommand.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorCommand.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 

--- a/src/PowerShellEditorServices/Extensions/EditorCommandAttribute.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorCommandAttribute.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 
 namespace Microsoft.PowerShell.EditorServices.Extensions

--- a/src/PowerShellEditorServices/Extensions/EditorContext.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Handlers;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Reflection;

--- a/src/PowerShellEditorServices/Extensions/EditorRequests.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorRequests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Extensions/EditorTerminal.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorTerminal.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Extensions
 {

--- a/src/PowerShellEditorServices/Extensions/EditorWindow.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWindow.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Extensions
 {

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading.Tasks;
 

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/src/PowerShellEditorServices/GlobalSuppressions.cs
+++ b/src/PowerShellEditorServices/GlobalSuppressions.cs
@@ -1,4 +1,7 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/src/PowerShellEditorServices/Hosting/EditorServicesLoading.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesLoading.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Hosting
 {

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
+++ b/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/src/PowerShellEditorServices/Logging/LoggerExtensions.cs
+++ b/src/PowerShellEditorServices/Logging/LoggerExtensions.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
+++ b/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.IO;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
+++ b/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/src/PowerShellEditorServices/Services/CodeLens/CodeLensData.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/CodeLensData.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.CodeLenses
 {

--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using Microsoft.PowerShell.EditorServices.Services;

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 using Microsoft.Extensions.Logging;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetailsBase.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetailsBase.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using Microsoft.PowerShell.EditorServices.Utility;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/InvalidPowerShellExpressionException.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/InvalidPowerShellExpressionException.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableContainerDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableContainerDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetailsBase.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Utility;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableScope.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableScope.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebuggerActionHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebuggerActionHandlers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Linq;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SetVariableHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SetVariableHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SourceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SourceHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoiceDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoiceDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Host;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/CollectionFieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/CollectionFieldDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleChoicePromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Linq;
 using Microsoft.Extensions.Logging;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleInputPromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/CredentialFieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/CredentialFieldDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/FieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/FieldDetails.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Utility;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/IConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/IConsoleOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/InputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/InputPromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/PromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/PromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalChoicePromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalInputPromptHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Security;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Handlers;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/EvaluateHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Linq;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IEvaluateHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.PowerShellContext;
 using MediatR;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IInvokeExtensionCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IInvokeExtensionCommandHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using MediatR;
 using OmniSharp.Extensions.JsonRpc;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/InvokeExtensionCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/InvokeExtensionCommandHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation.Runspaces;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/TemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/TemplateHandlers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Extensions;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionOptions.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionStatus.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionStatus.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionStatusChangedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionStatusChangedEventArgs.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionTarget.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ExecutionTarget.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Hosting;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/IHostInput.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/IHostInput.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/IHostOutput.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/IHostOutput.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptEvents.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptEvents.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/SimplePSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/SimplePSHostRawUserInterface.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Host;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Host;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/IPromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/IPromptContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/IRunspaceCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/IRunspaceCapability.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/IVersionSpecificOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/IVersionSpecificOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/LegacyReadLineContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/LegacyReadLineContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/OutputType.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/OutputType.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/OutputWrittenEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/OutputWrittenEventArgs.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLineProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLineProxy.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Reflection;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PipelineExecutionRequest.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PipelineExecutionRequest.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShell5Operations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShell5Operations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellContextState.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellContextState.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellExecutionResult.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellExecutionResult.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ProgressDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ProgressDetails.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrame.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrame.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrameType.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrameType.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceChangedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceChangedEventArgs.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Utility;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.CSharp.RuntimeBinder;
 using System;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceHandle.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceHandle.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Host;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionStateChangedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionStateChangedEventArgs.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/TemplateService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/TemplateService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Handlers;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/IDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/IDocumentSymbolProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/src/PowerShellEditorServices/Services/Symbols/ParameterSetSignatures.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ParameterSetSignatures.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/PsdDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PsdDocumentSymbolProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/ScriptExtent.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ScriptExtent.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolReference.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolReference.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolType.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolType.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 {

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindCommandVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindCommandVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Linq;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDotSourcedVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDotSourcedVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation.Language;
 

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor2.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor2.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/TextDocument/BufferPosition.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/BufferPosition.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Diagnostics;
 

--- a/src/PowerShellEditorServices/Services/TextDocument/BufferRange.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/BufferRange.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;

--- a/src/PowerShellEditorServices/Services/TextDocument/CompletionResults.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/CompletionResults.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/FileChange.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/FileChange.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 {

--- a/src/PowerShellEditorServices/Services/TextDocument/FilePosition.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/FilePosition.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 {

--- a/src/PowerShellEditorServices/Services/TextDocument/FoldingReference.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/FoldingReference.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation;

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptRegion.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptRegion.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation.Language;

--- a/src/PowerShellEditorServices/Services/Workspace/ConfigurationService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/ConfigurationService.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.Configuration;
 

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceFileSystemWrapper.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceFileSystemWrapper.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/src/PowerShellEditorServices/Utility/AsyncLock.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncLock.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading;

--- a/src/PowerShellEditorServices/Utility/AsyncQueue.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncQueue.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/PowerShellEditorServices/Utility/AsyncUtils.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncUtils.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 

--- a/src/PowerShellEditorServices/Utility/Extensions.cs
+++ b/src/PowerShellEditorServices/Utility/Extensions.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq;

--- a/src/PowerShellEditorServices/Utility/IScriptExtentExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/IScriptExtentExtensions.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Management.Automation.Language;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;

--- a/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Utility/LspUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspUtils.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Linq.Expressions;

--- a/src/PowerShellEditorServices/Utility/PathUtils.cs
+++ b/src/PowerShellEditorServices/Utility/PathUtils.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.IO;
 using System.Runtime.InteropServices;

--- a/src/PowerShellEditorServices/Utility/Validate.cs
+++ b/src/PowerShellEditorServices/Utility/Validate.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
@@ -28,7 +26,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         }
 
         /// <summary>
-        /// Throws ArgumentOutOfRangeException if the value is outside 
+        /// Throws ArgumentOutOfRangeException if the value is outside
         /// of the given lower and upper limits.
         /// </summary>
         /// <param name="parameterName">The name of the parameter being validated.</param>
@@ -38,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static void IsWithinRange(
             string parameterName,
             int valueToCheck,
-            int lowerLimit, 
+            int lowerLimit,
             int upperLimit)
         {
             // TODO: Debug assert here if lowerLimit >= upperLimit
@@ -56,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         }
 
         /// <summary>
-        /// Throws ArgumentOutOfRangeException if the value is greater than or equal 
+        /// Throws ArgumentOutOfRangeException if the value is greater than or equal
         /// to the given upper limit.
         /// </summary>
         /// <param name="parameterName">The name of the parameter being validated.</param>
@@ -79,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         }
 
         /// <summary>
-        /// Throws ArgumentOutOfRangeException if the value is less than or equal 
+        /// Throws ArgumentOutOfRangeException if the value is less than or equal
         /// to the given lower limit.
         /// </summary>
         /// <param name="parameterName">The name of the parameter being validated.</param>
@@ -102,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         }
 
         /// <summary>
-        /// Throws ArgumentException if the value is equal to the undesired value. 
+        /// Throws ArgumentException if the value is equal to the undesired value.
         /// </summary>
         /// <typeparam name="TValue">The type of value to be validated.</typeparam>
         /// <param name="parameterName">The name of the parameter being validated.</param>

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Reflection;

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/PowerShellEditorServices.Test.E2E/Processes/ServerProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/ServerProcess.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.IO;
 using System.Reactive.Subjects;

--- a/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteAttributeValue.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteAttributeValue.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteFilePath.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteFilePath.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteNamespace.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteNamespace.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteTypeName.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteTypeName.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteVariableInFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteVariableInFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsDotSourcedFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsDotSourcedFile.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinition.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinition.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionInDotSourceReference.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionInDotSourceReference.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionInWorkspace.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionInWorkspace.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsVariableDefinition.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsVariableDefinition.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Occurrences/FindOccurrencesOnParameter.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Occurrences/FindOccurrencesOnParameter.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Occurrences/FindsOccurrencesOnFunction.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Occurrences/FindsOccurrencesOnFunction.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/ParameterHints/FindsParameterSetsOnCommand.cs
+++ b/test/PowerShellEditorServices.Test.Shared/ParameterHints/FindsParameterSetsOnCommand.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/ParameterHints/FindsParameterSetsOnCommandWithSpaces.cs
+++ b/test/PowerShellEditorServices.Test.Shared/ParameterHints/FindsParameterSetsOnCommandWithSpaces.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnBuiltInCommandWithAlias.cs
+++ b/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnBuiltInCommandWithAlias.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnFunction.cs
+++ b/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnFunction.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnFunctionMultiFileDotSource.cs
+++ b/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnFunctionMultiFileDotSource.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesonVariable.cs
+++ b/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesonVariable.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/SymbolDetails/FindsDetailsForBuiltInCommand.cs
+++ b/test/PowerShellEditorServices.Test.Shared/SymbolDetails/FindsDetailsForBuiltInCommand.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInMultiSymbolFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInMultiSymbolFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInNoSymbolsFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInNoSymbolsFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPSDFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPSDFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPesterFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPesterFile.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 

--- a/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
+++ b/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/test/PowerShellEditorServices.Test/AssemblyInfo.cs
+++ b/test/PowerShellEditorServices.Test/AssemblyInfo.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Xunit;
 

--- a/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/InputPromptHandlerTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -1,9 +1,7 @@
-// TODO: Fix these tests which cause the test runner to stop responding...
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
-// //
-// // Copyright (c) Microsoft. All rights reserved.
-// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// //
+// TODO: Fix these tests which cause the test runner to stop responding...
 
 // using Microsoft.PowerShell.EditorServices.Utility;
 // using Microsoft.PowerShell.EditorServices.Test.Shared;

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerShell.EditorServices.Extensions;

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Management.Automation;

--- a/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using Xunit;
 using System.IO;
 using Microsoft.PowerShell.EditorServices.Services;

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerShell.EditorServices.Services;

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.IO;

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -1,7 +1,5 @@
-﻿//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;

--- a/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Utility;
 using System;

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Utility;
 using System.Collections.Concurrent;

--- a/test/PowerShellEditorServices.Test/Utility/VersionUtilsTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/VersionUtilsTests.cs
@@ -1,7 +1,5 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 using Microsoft.PowerShell.EditorServices.Utility;
 using Xunit;

--- a/tools/PsesLogAnalyzer/Analyze.ps1
+++ b/tools/PsesLogAnalyzer/Analyze.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Gets LSP notification messages sent from either server to the client or vice-versa.

--- a/tools/PsesLogAnalyzer/Parse-PsesLog.ps1
+++ b/tools/PsesLogAnalyzer/Parse-PsesLog.ps1
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 $peekBuf = $null
 $currentLineNum = 0

--- a/tools/PsesLogAnalyzer/PsesLogAnalyzer.psd1
+++ b/tools/PsesLogAnalyzer/PsesLogAnalyzer.psd1
@@ -27,7 +27,7 @@ Author = 'Microsoft'
 CompanyName = 'Microsoft'
 
 # Copyright statement for this module
-Copyright = '(c) 2018 Microsoft. All rights reserved.'
+Copyright = '(c) 2021 Microsoft Corporation.'
 
 # Description of the functionality provided by this module
 Description = 'PowerShellEditorServices log file parser and analysis commands.'

--- a/tools/PsesLogAnalyzer/Types.ps1
+++ b/tools/PsesLogAnalyzer/Types.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 enum PsesLogLevel {
     Diagnostic
     Verbose
@@ -72,7 +75,7 @@ class PsesNotificationMessage {
         if (($this.Name -eq '$/cancelRequest') -and ($this.Data -ne $null)) {
             return "Name: $($this.Name) Source: $($this.Source), Id: $($this.Data.params.id)"
         }
-    
+
         return "Name: $($this.Name) Source: $($this.Source), DataSize: $($this.DataSize)"
     }
 }


### PR DESCRIPTION
Per Microsoft policy at:
https://docs.opensource.microsoft.com/content/releasing/copyright-headers.html

All copyright notices no longer include "All Rights Reserved" and the comment style has been updated to be consistent with policy.

Resolves #1465 

Also double-checked that all `*.cs` and `*.ps1` files have a copyright notice.