### PR TITLE
Upgrade to GitHub-Native Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-
-# update_schedule: live is only supported on javascript, ruby:bundler, python, php:composer, dotnet:nuget, rust:cargo, elixir:hex
-
-update_configs:
-  # Looks at the sln file in the root
-  - package_manager: "dotnet:nuget"
-    directory: "/"
-    update_schedule: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "05:00"
+    timezone: America/Los_Angeles
+  assignees:
+    - "andschwa"


### PR DESCRIPTION
Manually create GitHub-Native Dependabot configuration. Resolves #1462. I had to do this manually because the Dependabot website continued to fail to create the PR, and GitHub support has been unable to resolve it.

The configuration is the same as used in the extension's repository: https://github.com/PowerShell/vscode-powershell/pull/3310