### PR TITLE
Fix unintentional module import

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -117,6 +117,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return request;
             }
 
+            // No details means the module hasn't been imported yet and Intellisense shouldn't import the module to get this info.
+            if (request.Detail is null)
+            {
+                return request;
+            }
+
             try
             {
                 await _completionResolveLock.WaitAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/715 by not getting command documentation unless the module has already been imported.

This should greatly help with the command IntelliSense experience