### PR TITLE
Release `v2.4.5` signed patch update

### DIFF
--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -21,6 +21,7 @@ steps:
     alwaysCopy: true # So publishing works
     certificateId: 'CP-230012' # Authenticode certificate
     useMinimatch: true # This enables the use of globbing
+    shouldSign: true # We always want to sign
     pattern: |
       # PowerShellEditorServices Script
       PowerShellEditorServices/*.{ps1,psd1,psm1,ps1xml}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PowerShell Editor Services Release History
 
+## v2.4.5
+### Wednesday, June 23, 2021
+
+- Fix signing of files in release.
+
 ## v2.4.4
 ### Wednesday, June 16, 2021
 

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.4.4</VersionPrefix>
+    <VersionPrefix>2.4.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation.</Copyright>

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -19,7 +19,7 @@ RootModule = if ($PSEdition -eq 'Core')
     }
 
 # Version number of this module.
-ModuleVersion = '2.4.4'
+ModuleVersion = '2.4.5'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/2536.

We *only* run builds on ADO with the intent to release, therefore we need to
just always sign them. Otherwise the compliance script's default behavior is to
sign when the build is manually triggered, which is not our workflow. We push a
release branch and expect that automatic build to result in signing.