### PR TITLE
Update `.editorconfig` to prevent unintentional whitespace changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,8 @@ insert_final_newline = true
 [*.{cs}]
 indent_size = 4
 trim_trailing_whitespace = true
+csharp_space_before_open_square_brackets = true
+csharp_space_after_keywords_in_control_flow_statements = false
 
 [*.{json}]
 indent_size = 2


### PR DESCRIPTION
Added 
csharp_space_before_open_square_brackets = true
csharp_space_after_keywords_in_control_flow_statements = false
to enforce the existing convention and prevent unintentional changes.