### PR TITLE
Centralize module loading

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,33 @@ trim_trailing_whitespace = true
 csharp_space_before_open_square_brackets = true
 csharp_space_after_keywords_in_control_flow_statements = true
 
+# CS0168: The variable 'var' is declared but never used
+dotnet_diagnostic.CS0168.severity = error
+# CS0169: The private field 'class member' is never used
+dotnet_diagnostic.CS0169.severity = error
+# CS0219: The variable 'variable' is assigned but its value is never used
+dotnet_diagnostic.CS0219.severity = error
+# CS0414: The private field 'field' is assigned but its value is never used
+dotnet_diagnostic.CS0414.severity = error
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.CA1068.severity = error
+# CA1822: Mark members as static
+dotnet_diagnostic.CA1822.severity = error
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = error
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = error
+# CA2016: Forward the CancellationToken parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = error
+# All maintainability issues (dead code etc.)
+# See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/maintainability-warnings
+dotnet_analyzer_diagnostic.category-Maintainability.severity = error
+# VSTHRD002: Synchronously waiting on tasks or awaiters may cause deadlocks
+# TODO: Fix all of these issues and explicitly ignore the intentional ones.
+dotnet_diagnostic.VSTHRD002.severity = silent
+# VSTHRD200: Use "Async" suffix for awaitable methods
+dotnet_diagnostic.VSTHRD200.severity = silent
+
 [*.{json}]
 indent_size = 2
 trim_trailing_whitespace = true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 
 # Global reviewers
-* @tylerl0706 @rjmholt
+* @andschwa @rjmholt
 
 # Area: Analysis & Formatting
 src/PowerShellEditorServices/Analysis/                 @rjmholt

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Build
       shell: pwsh
-      run: scripts/azurePipelinesBuild.ps1
+      run: tools/azurePipelinesBuild.ps1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -9,58 +9,49 @@ variables:
     value: 'true'
 
 trigger:
-  batch: true
   branches:
     include:
       - master
-      - legacy/1.x
-  paths:
-    exclude:
-      - /.dependabot/*
-      - /.poshchan/*
-      - /.github/**/*
-      - /.vscode/**/*
-      - /.vsts-ci/misc-analysis.yml
-      - /tools/**/*
-      - .editorconfig
-      - .gitattributes
-      - .gitignore
-      - /docs/**/*
-      - /CHANGELOG.md
-      - /CONTRIBUTING.md
-      - /README.md
-      - /LICENSE
-      - /CODE_OF_CONDUCT.md
 
-# TODO: Setup matrix of image support.
+pr:
+- master
+
 jobs:
-- job: 'PS51_Win10'
-  displayName: PowerShell 5.1 | Windows 10
+- job: PS51_Win2016
+  displayName: PowerShell 5.1 - Windows Server 2016
   pool:
-    # TODO: Update this image.
-    vmImage: 'vs2017-win2016'
+    vmImage: vs2017-win2016
   steps:
   - template: templates/ci-general.yml
     parameters:
       pwsh: false
 
-- job: 'PS7_Win10'
-  displayName: PowerShell 7 | Windows 10
+- job: PS51_Win2019
+  displayName: PowerShell 5.1 - Windows Server 2019
   pool:
-    vmImage: 'windows-2019'
+    vmImage: windows-2019
+  steps:
+  - template: templates/ci-general.yml
+    parameters:
+      pwsh: false
+
+- job: PS7_Win2019
+  displayName: PowerShell 7 - Windows Server 2019
+  pool:
+    vmImage: windows-2019
   steps:
   - template: templates/ci-general.yml
 
-- job: 'PS7_macOS'
-  displayName: PowerShell 7 | macOS
+- job: PS7_macOS
+  displayName: PowerShell 7 - macOS 10.15
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: macOS-10.15
   steps:
   - template: templates/ci-general.yml
 
-- job: 'PS7_Ubuntu'
-  displayName: PowerShell 7 | Ubuntu
+- job: PS7_Ubuntu
+  displayName: PowerShell 7 - Ubuntu 20.04
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: ubuntu-20.04
   steps:
   - template: templates/ci-general.yml

--- a/.vsts-ci/azure-pipelines-release.yml
+++ b/.vsts-ci/azure-pipelines-release.yml
@@ -1,3 +1,5 @@
+name: Release-$(Build.SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rr)
+
 variables:
   # Don't download unneeded packages
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
@@ -9,33 +11,51 @@ variables:
 trigger:
   branches:
     include:
-      - release/*
-  tags:
-    include:
-    - v*
+      - release
 
 resources:
   repositories:
   - repository: ComplianceRepo
     type: github
-    endpoint: ComplianceGHRepo
+    endpoint: GitHub
     name: PowerShell/compliance
+  - repository: vscode-powershell
+    type: git
+    name: vscode-powershell
 
-jobs:
-- job: 'ReleaseBuild'
-  displayName: 'Build release'
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - template: templates/ci-general.yml
+stages:
+- stage: Build
+  displayName: Build the release
+  jobs:
+  - job: Build
+    pool:
+      vmImage: windows-2019
+    steps:
+    - template: templates/ci-general.yml
 
-- job: 'SignBuild'
-  displayName: Signing Build
-  dependsOn: 'ReleaseBuild'
-  pool:
-    name: '1ES'
-    demands: ImageOverride -equals MMS2019
-  variables:
-  - group: ESRP
-  steps:
-  - template: templates/release-general.yml
+- stage: Sign
+  displayName: Sign the release
+  jobs:
+  - job: Sign
+    pool:
+      name: 1ES
+      demands: ImageOverride -equals MMS2019
+    variables:
+    - group: ESRP
+    steps:
+    - template: templates/release-general.yml
+
+- stage: Publish
+  displayName: Publish the draft release
+  jobs:
+  - deployment: Publish
+    environment: PowerShellEditorServices
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+    - group: Publish
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - template: templates/publish-general.yml

--- a/.vsts-ci/misc-analysis.yml
+++ b/.vsts-ci/misc-analysis.yml
@@ -1,31 +1,25 @@
 name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+
 trigger:
-  # Batch merge builds together while a merge build is running
-  batch: true
   branches:
     include:
     - master
 
 pr:
-  branches:
-    include:
-    - master
-    - legacy/1.x
+- master
 
 resources:
   repositories:
   - repository: ComplianceRepo
     type: github
-    endpoint: ComplianceGHRepo
+    endpoint: GitHub
     name: PowerShell/compliance
 
 jobs:
-- job: Compliance_Job
+- job: Compliance
   pool:
     vmImage: windows-latest
   steps:
   - checkout: self
-    clean: true
   - checkout: ComplianceRepo
-    clean: true
   - template: ci-compliance.yml@ComplianceRepo

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -1,43 +1,36 @@
 parameters:
-  pwsh: true
+- name: pwsh
+  type: boolean
+  default: true
 
 steps:
-  - powershell: |
-      Write-Host "Installing PowerShell Daily..."
+- pwsh: $PSVersionTable
+  displayName: PowerShell version
 
-      # Use `AGENT_TEMPDIRECTORY` to make sure the downloaded PowerShell is cleaned up.
-      $powerShellPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'powershell'
-      Invoke-WebRequest -Uri https://aka.ms/install-powershell.ps1 -OutFile ./install-powershell.ps1
+- task: PowerShell@2
+  displayName: Build and test
+  inputs:
+    filePath: tools/azurePipelinesBuild.ps1
+    pwsh: ${{ parameters.pwsh }}
 
-      ./install-powershell.ps1 -Destination $powerShellPath -Daily
+# NOTE: We zip the artifacts because they're ~20 MB compressed, but ~300 MB raw,
+# and we have limited pipeline artifact storage space.
+- task: ArchiveFiles@2
+  displayName: Zip pipeline artifacts
+  inputs:
+    rootFolderOrFile: module
+    includeRootFolder: false
+    archiveType: zip
+    archiveFile: PowerShellEditorServices-Build.zip
+    verbose: true
 
-      # Using `prependpath` to update the PATH just for this build.
-      Write-Host "##vso[task.prependpath]$powerShellPath"
-    displayName: Install PowerShell Daily
-    continueOnError: true
+- publish: PowerShellEditorServices-Build.zip
+  artifact: PowerShellEditorServices-Build-$(System.JobId)
+  displayName: Publish unsigned pipeline artifacts
 
-  - pwsh: '$PSVersionTable'
-    displayName: Display PowerShell version information
-
-  - pwsh: Write-Host "##vso[build.updatebuildnumber]$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhmmss"))"
-    displayName: Set Build Name for Non-PR
-    condition: ne(variables['Build.Reason'], 'PullRequest')
-  - task: PowerShell@2
-    inputs:
-      filePath: scripts/azurePipelinesBuild.ps1
-      pwsh: ${{ parameters.pwsh }}
-  - task: PublishTestResults@2
-    inputs:
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-    condition: succeededOrFailed()
-  - task: PublishTestResults@2
-    inputs:
-      testRunner: NUnit
-      testResultsFiles: '**/TestResults.xml'
-    condition: succeededOrFailed()
-  - task: PublishBuildArtifacts@1
-    inputs:
-      ArtifactName: PowerShellEditorServices-CI
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    condition: succeededOrFailed()
+- task: PublishTestResults@2
+  displayName: Publish test results
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '**/*.trx'
+  condition: succeededOrFailed()

--- a/.vsts-ci/templates/publish-general.yml
+++ b/.vsts-ci/templates/publish-general.yml
@@ -1,0 +1,12 @@
+steps:
+- checkout: self
+- checkout: vscode-powershell
+
+- download: current
+  artifact: PowerShellEditorServices
+  displayName: Download signed pipeline artifacts
+
+- pwsh: |
+    $(Build.SourcesDirectory)/vscode-powershell/tools/setupReleaseTools.ps1 -Token $(GitHubToken)
+    New-DraftRelease -RepositoryName PowerShellEditorServices -Assets $(Pipeline.Workspace)/PowerShellEditorServices/PowerShellEditorServices.zip
+  displayName: Drafting a GitHub Release

--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -1,27 +1,26 @@
 steps:
-
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download Build Artifacts'
-  inputs:
-    downloadType: specific
+- download: current
+  displayName: Download unsigned pipeline artifacts
 
 - task: ExtractFiles@1
-  displayName: 'Extract Build Zip'
+  displayName: Extract unsigned artifacts
   inputs:
-    archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/PowerShellEditorServices-CI/PowerShellEditorServices*.zip'
-    destinationFolder: '$(Build.ArtifactStagingDirectory)/PowerShellEditorServices'
+    archiveFilePatterns: $(Pipeline.Workspace)/PowerShellEditorServices-Build-*/PowerShellEditorServices-Build.zip
+    destinationFolder: $(Pipeline.Workspace)/Unsigned
+    cleanDestinationFolder: true
 
 - checkout: ComplianceRepo
-  displayName: 'Checkout the ComplianceRepo'
 
+# NOTE: The signing templates explicitly copy everything along as they run, so
+# the last output path has every signed (and intentionally unsigned) file.
 - template: EsrpSign.yml@ComplianceRepo
   parameters:
-    buildOutputPath: '$(Build.ArtifactStagingDirectory)/PowerShellEditorServices'
-    signOutputPath: '$(Build.ArtifactStagingDirectory)/FirstPartySigned'
-    alwaysCopy: true # So publishing works
-    certificateId: 'CP-230012' # Authenticode certificate
-    useMinimatch: true # This enables the use of globbing
+    buildOutputPath: $(Pipeline.Workspace)/Unsigned
+    signOutputPath: $(Pipeline.Workspace)/FirstPartySigned
+    alwaysCopy: true
+    certificateId: CP-230012 # Authenticode certificate
     shouldSign: true # We always want to sign
+    useMinimatch: true # This enables the use of globbing
     pattern: |
       # PowerShellEditorServices Script
       PowerShellEditorServices/*.{ps1,psd1,psm1,ps1xml}
@@ -35,12 +34,12 @@ steps:
 
 - template: EsrpSign.yml@ComplianceRepo
   parameters:
-    buildOutputPath: '$(Build.ArtifactStagingDirectory)/FirstPartySigned'
-    signOutputPath: '$(Build.ArtifactStagingDirectory)/ThirdPartySigned'
-    alwaysCopy: true # So publishing works
-    certificateId: 'CP-231522' # Third-party certificate
-    useMinimatch: true # This enables the use of globbing
+    buildOutputPath: $(Pipeline.Workspace)/FirstPartySigned
+    signOutputPath: $(Pipeline.Workspace)/ThirdPartySigned
+    alwaysCopy: true
+    certificateId: CP-231522 # Third-party certificate
     shouldSign: true # We always want to sign
+    useMinimatch: true # This enables the use of globbing
     pattern: |
       **/MediatR.dll
       **/Nerdbank.Streams.dll
@@ -49,27 +48,37 @@ steps:
       **/Serilog*.dll
       **/UnixConsoleEcho.dll
 
-- publish: $(Build.ArtifactStagingDirectory)/ThirdPartySigned
-  artifact: PowerShellEditorServices
-  displayName: 'Publish signed (and unsigned) artifacts'
+- task: ArchiveFiles@2
+  displayName: Zip signed artifacts
+  inputs:
+    rootFolderOrFile: $(Pipeline.Workspace)/ThirdPartySigned
+    includeRootFolder: false
+    archiveType: zip
+    archiveFile: PowerShellEditorServices.zip
+    replaceExistingArchive: true
+    verbose: true
 
 - checkout: self
 
 - template: assembly-module-compliance.yml@ComplianceRepo
   parameters:
     # binskim
-    AnalyzeTarget: '$(Build.ArtifactStagingDirectory)/*.dll'
+    AnalyzeTarget: $(Pipeline.Workspace)/*.dll
     AnalyzeSymPath: 'SRV*'
     # component-governance
-    sourceScanPath: '$(Build.SourcesDirectory)/PowerShellEditorServices'
+    sourceScanPath: $(Build.SourcesDirectory)/PowerShellEditorServices
     # credscan
     suppressionsFile: ''
     # TermCheck AKA PoliCheck
-    targetArgument: '$(Build.SourcesDirectory)/PowerShellEditorServices'
-    optionsUEPATH: '$(Build.SourcesDirectory)/PowerShellEditorServices/tools/terms/UserExclusions.xml'
+    targetArgument: $(Build.SourcesDirectory)/PowerShellEditorServices
+    optionsUEPATH: $(Build.SourcesDirectory)/PowerShellEditorServices/tools/terms/UserExclusions.xml
     optionsRulesDBPath: ''
-    optionsFTPath: '$(Build.SourcesDirectory)/PowerShellEditorServices/tools/terms/FileTypeSet.xml'
+    optionsFTPath: $(Build.SourcesDirectory)/PowerShellEditorServices/tools/terms/FileTypeSet.xml
     # tsa-upload
-    codeBaseName: 'PowerShell_PowerShellEditorServices_20210201'
-    # selections
+    codeBaseName: PowerShell_PowerShellEditorServices_20210201
+    # We don't use any Windows APIs directly, so we don't need API scan
     APIScan: false
+
+- publish: PowerShellEditorServices.zip
+  artifact: PowerShellEditorServices
+  displayName: Publish signed pipeline artifacts

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -11,5 +11,8 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PowerShell/PowerShellEditorServices</RepositoryUrl>
     <DebugType>portable</DebugType>
+    <!-- See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <!-- TODO: Enable `EnforceCodeStyleInBuild` -->
   </PropertyGroup>
 </Project>

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
@@ -24,7 +25,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             Type type = Type.GetType("Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2");
             MethodInfo method = type?.GetMethod(
                 "ReadLine",
-                new[] { typeof(Runspace), typeof(EngineIntrinsics), typeof(CancellationToken) });
+                new [] { typeof(Runspace), typeof(EngineIntrinsics), typeof(CancellationToken) });
 
             // TODO: Handle method being null here. This shouldn't ever happen.
 

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -93,7 +94,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext defaultLoadContext, AssemblyName asmName) =>
             {
+#if DEBUG
+                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}. Stacktrace:\n{new StackTrace()}");
+#else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}");
+#endif
 
                 // We only want the Editor Services DLL; the new ALC will lazily load its dependencies automatically
                 if (!string.Equals(asmName.Name, "Microsoft.PowerShell.EditorServices", StringComparison.Ordinal))
@@ -124,7 +129,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // Unlike in .NET Core, we need to be look for all dependencies in .NET Framework, not just PSES.dll
             AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) =>
             {
+#if DEBUG
+                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}. Stacktrace:\n{new StackTrace()}");
+#else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}");
+#endif
 
                 var asmName = new AssemblyName(args.Name);
                 var dllName = $"{asmName.Name}.dll";
@@ -217,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // This is not high priority, since the PSES process shouldn't be reused
         }
 
-        private void LoadEditorServices()
+        private static void LoadEditorServices()
         {
             // This must be in its own method, since the actual load happens when the calling method is called
             // The call within this method is therefore a total no-op
@@ -308,7 +317,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             LogOperatingSystemDetails();
         }
 
-        private string GetPSOutputEncoding()
+        private static string GetPSOutputEncoding()
         {
             using (var pwsh = SMA.PowerShell.Create())
             {
@@ -337,7 +346,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 ");
         }
 
-        private string GetOSArchitecture()
+        private static string GetOSArchitecture()
         {
 #if CoreCLR
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)

--- a/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
+++ b/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
@@ -31,10 +31,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PowerShellEditorServices\PowerShellEditorServices.csproj" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewBase.cs
@@ -28,40 +28,31 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
             this.languageServer = languageServer;
         }
 
-        internal async Task CreateAsync()
-        {
-            await languageServer.SendRequestAsync(
+        internal Task CreateAsync() =>
+            languageServer.SendRequestAsync(
                 NewCustomViewRequest.Method,
                 new NewCustomViewRequest
                 {
                     Id = this.Id,
                     Title = this.Title,
                     ViewType = this.ViewType,
-                }
-            );
-        }
+                });
 
-        public async Task Show(ViewColumn viewColumn)
-        {
-            await languageServer.SendRequestAsync(
+        public Task Show(ViewColumn viewColumn) =>
+            languageServer.SendRequestAsync(
                 ShowCustomViewRequest.Method,
                 new ShowCustomViewRequest
                 {
                     Id = this.Id,
                     ViewColumn = viewColumn
-                }
-            );
-        }
+                });
 
-        public async Task Close()
-        {
-            await languageServer.SendRequestAsync(
+        public Task Close() =>
+            languageServer.SendRequestAsync(
                 CloseCustomViewRequest.Method,
                 new CloseCustomViewRequest
                 {
                     Id = this.Id,
-                }
-            );
-        }
+                });
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
@@ -21,9 +21,8 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         {
         }
 
-        public async Task SetContentAsync(string htmlBodyContent)
-        {
-            await languageServer.SendRequestAsync(
+        public Task SetContentAsync(string htmlBodyContent) =>
+            languageServer.SendRequestAsync(
                 SetHtmlContentViewRequest.Method,
                 new SetHtmlContentViewRequest
                 {
@@ -31,31 +30,24 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     HtmlContent = new HtmlContent { BodyContent = htmlBodyContent }
                 }
             );
-        }
 
-        public async Task SetContentAsync(HtmlContent htmlContent)
-        {
-            HtmlContent validatedContent =
-                new HtmlContent()
-                {
-                    BodyContent = htmlContent.BodyContent,
-                    JavaScriptPaths = this.GetUriPaths(htmlContent.JavaScriptPaths),
-                    StyleSheetPaths = this.GetUriPaths(htmlContent.StyleSheetPaths)
-                };
-
-            await languageServer.SendRequestAsync(
+        public Task SetContentAsync(HtmlContent htmlContent) =>
+            languageServer.SendRequestAsync(
                 SetHtmlContentViewRequest.Method,
                 new SetHtmlContentViewRequest
                 {
                     Id = this.Id,
-                    HtmlContent = validatedContent
+                    HtmlContent = new HtmlContent()
+                    {
+                        BodyContent = htmlContent.BodyContent,
+                        JavaScriptPaths = HtmlContentView.GetUriPaths(htmlContent.JavaScriptPaths),
+                        StyleSheetPaths = HtmlContentView.GetUriPaths(htmlContent.StyleSheetPaths)
+                    }
                 }
             );
-        }
 
-        public async Task AppendContentAsync(string appendedHtmlBodyContent)
-        {
-            await languageServer.SendRequestAsync(
+        public Task AppendContentAsync(string appendedHtmlBodyContent) =>
+            languageServer.SendRequestAsync(
                 AppendHtmlContentViewRequest.Method,
                 new AppendHtmlContentViewRequest
                 {
@@ -63,9 +55,8 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     AppendedHtmlBodyContent = appendedHtmlBodyContent
                 }
             );
-        }
 
-        private string[] GetUriPaths(string[] filePaths)
+        private static string[] GetUriPaths(string[] filePaths)
         {
             return
                 filePaths?

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentViewsFeature.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
                     viewTitle,
                     languageServer);
 
-            await htmlView.CreateAsync();
+            await htmlView.CreateAsync().ConfigureAwait(false);
             this.AddView(htmlView);
 
             return htmlView;

--- a/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// In .NET Framework, this returns null.
         /// </summary>
         /// <returns>The assembly load context used for loading PSES, or null in .NET Framework.</returns>
-        public object GetPsesAssemblyLoadContext()
+        public static object GetPsesAssemblyLoadContext()
         {
             if (!VersionUtils.IsNetCore)
             {
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// </summary>
         /// <param name="assemblyPath">The absolute path of the assembly to load.</param>
         /// <returns>The loaded assembly object.</returns>
-        public Assembly LoadAssemblyInPsesLoadContext(string assemblyPath)
+        public static Assembly LoadAssemblyInPsesLoadContext(string assemblyPath)
         {
             if (!VersionUtils.IsNetCore)
             {

--- a/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                 new ShowInputPromptRequest
                 {
                     Name = message,
-                }).Returning<ShowInputPromptResponse>(CancellationToken.None);
+                }).Returning<ShowInputPromptResponse>(CancellationToken.None).ConfigureAwait(false);
 
             if (response.PromptCancelled)
             {
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Message = message,
                     Choices = choiceDetails,
                     DefaultChoices = defaultChoiceIndexes?.ToArray(),
-                }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
+                }).Returning<ShowChoicePromptResponse>(CancellationToken.None).ConfigureAwait(false);
 
             if (response.PromptCancelled)
             {
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Message = message,
                     Choices = choiceDetails,
                     DefaultChoices = defaultChoiceIndex > -1 ? new[] { defaultChoiceIndex } : null,
-                }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
+                }).Returning<ShowChoicePromptResponse>(CancellationToken.None).ConfigureAwait(false);
 
             if (response.PromptCancelled)
             {

--- a/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             return files.AsReadOnly();
         }
 
-        private IEditorScriptFile GetEditorFileFromScriptFile(ScriptFile file)
+        private static IEditorScriptFile GetEditorFileFromScriptFile(ScriptFile file)
         {
             return new EditorScriptFile(file);
         }

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -362,7 +362,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// </summary>
         /// <param name="powershell">The PowerShell instance to execute.</param>
         /// <returns>The output of PowerShell execution.</returns>
-        private Collection<PSObject> InvokePowerShellWithModulePathPreservation(System.Management.Automation.PowerShell powershell)
+        private static Collection<PSObject> InvokePowerShellWithModulePathPreservation(System.Management.Automation.PowerShell powershell)
         {
             using (PSModulePathPreserver.Take())
             {

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="pesterSymbol">The Pester symbol to get CodeLenses for.</param>
         /// <param name="scriptFile">The script file the Pester symbol comes from.</param>
         /// <returns>All CodeLenses for the given Pester symbol.</returns>
-        private CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
+        private static CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
         {
             string word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
             var codeLensResults = new CodeLens[]

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             ScriptFile[] references = _workspaceService.ExpandScriptReferences(
                 scriptFile);
 
-            SymbolReference foundSymbol = _symbolsService.FindFunctionDefinitionAtLocation(
+            SymbolReference foundSymbol = SymbolsService.FindFunctionDefinitionAtLocation(
                 scriptFile,
                 codeLens.Range.Start.Line + 1,
                 codeLens.Range.Start.Character + 1);

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Legacy behavior
             PSCommand psCommand = new PSCommand();
             psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
-            IEnumerable<Breakpoint> breakpoints = await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
+            IEnumerable<Breakpoint> breakpoints = await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
             return breakpoints.ToList();
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (psCommand != null)
             {
                 IEnumerable<Breakpoint> setBreakpoints =
-                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
+                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
                 configuredBreakpoints.AddRange(
                     setBreakpoints.Select(BreakpointDetails.Create));
             }
@@ -210,7 +210,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             if (psCommand != null)
             {
                 IEnumerable<Breakpoint> setBreakpoints =
-                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
+                    await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
                 configuredBreakpoints.AddRange(
                     setBreakpoints.Select(CommandBreakpointDetails.Create));
             }
@@ -301,7 +301,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Remove-PSBreakpoint");
                 psCommand.AddParameter("Id", breakpoints.Select(b => b.Id).ToArray());
 
-                await _powerShellContextService.ExecuteCommandAsync<object>(psCommand);
+                await _powerShellContextService.ExecuteCommandAsync<object>(psCommand).ConfigureAwait(false);
             }
         }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
 #pragma warning disable CS4014
             // Trigger the clean up of the debugger. No need to wait for it.
-            Task.Run(_psesDebugServer.OnSessionEnded);
+            Task.Run(_psesDebugServer.OnSessionEnded, cancellationToken);
 #pragma warning restore CS4014
 
             return new DisconnectResponse();

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -264,7 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 await _powerShellContextService.ExecuteScriptStringAsync(
                     $"Enter-PSHostProcess -Id {processId}",
-                    errorMessages);
+                    errorMessages).ConfigureAwait(false);
 
                 if (errorMessages.Length > 0)
                 {
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 await _powerShellContextService.ExecuteScriptStringAsync(
                     $"Enter-PSHostProcess -CustomPipeName {request.CustomPipeName}",
-                    errorMessages);
+                    errorMessages).ConfigureAwait(false);
 
                 if (errorMessages.Length > 0)
                 {
@@ -307,7 +307,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     .AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace")
                     .AddParameter("Name", request.RunspaceName)
                     .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
-                    .AddParameter("ExpandProperty", "Id"));
+                    .AddParameter("ExpandProperty", "Id")).ConfigureAwait(false);
                 foreach (var id in ids)
                 {
                     _debugStateService.RunspaceId = id;
@@ -396,12 +396,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                {
                    try
                    {
-                       await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSHostProcess");
+                       await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSHostProcess").ConfigureAwait(false);
 
                        if (_debugStateService.IsRemoteAttach &&
                            _powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
                        {
-                           await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSSession");
+                           await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSSession").ConfigureAwait(false);
                        }
                    }
                    catch (Exception e)

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public Task<StackTraceResponse> Handle(StackTraceArguments request, CancellationToken cancellationToken)
         {
             StackFrameDetails[] stackFrameDetails =
-                _debugService.GetStackFrames();
+                _debugService.GetStackFrames(cancellationToken);
 
             // Handle a rare race condition where the adapter requests stack frames before they've
             // begun building.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 throw new TaskCanceledException(task);
                             }
 
-                            return this.GetSingleResult(task.GetAwaiter().GetResult());
+                            return ChoicePromptHandler.GetSingleResult(task.GetAwaiter().GetResult());
                         }));
         }
 
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         #region Private Methods
 
-        private int GetSingleResult(int[] choiceArray)
+        private static int GetSingleResult(int[] choiceArray)
         {
             return
                 choiceArray != null

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             return this.ReadLineAsync(false, cancellationToken);
         }
 
-        public async Task<SecureString> ReadSecureLineAsync(CancellationToken cancellationToken)
+        public async static Task<SecureString> ReadSecureLineAsync(CancellationToken cancellationToken)
         {
             SecureString secureString = new SecureString();
 
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             }
                             else
                             {
-                                using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandleAsync().ConfigureAwait(false))
+                                using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandleAsync(cancellationToken) .ConfigureAwait(false))
                                 using (PowerShell powerShell = PowerShell.Create())
                                 {
                                     powerShell.Runspace = runspaceHandle.Runspace;
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         if (completion != null)
                         {
                             currentCursorIndex =
-                                this.InsertInput(
+                                ConsoleReadLine.InsertInput(
                                     inputLine,
                                     promptStartCol,
                                     promptStartRow,
@@ -271,7 +271,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         if (currentCursorIndex > 0)
                         {
                             currentCursorIndex =
-                                this.MoveCursorToIndex(
+                                ConsoleReadLine.MoveCursorToIndex(
                                     promptStartCol,
                                     promptStartRow,
                                     consoleWidth,
@@ -283,7 +283,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         currentCompletion = null;
 
                         currentCursorIndex =
-                            this.MoveCursorToIndex(
+                            ConsoleReadLine.MoveCursorToIndex(
                                 promptStartCol,
                                 promptStartRow,
                                 consoleWidth,
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         if (currentCursorIndex < inputLine.Length)
                         {
                             currentCursorIndex =
-                                this.MoveCursorToIndex(
+                                ConsoleReadLine.MoveCursorToIndex(
                                     promptStartCol,
                                     promptStartRow,
                                     consoleWidth,
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         currentCompletion = null;
 
                         currentCursorIndex =
-                            this.MoveCursorToIndex(
+                            ConsoleReadLine.MoveCursorToIndex(
                                 promptStartCol,
                                 promptStartRow,
                                 consoleWidth,
@@ -342,7 +342,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             historyIndex--;
 
                             currentCursorIndex =
-                                this.InsertInput(
+                                ConsoleReadLine.InsertInput(
                                     inputLine,
                                     promptStartCol,
                                     promptStartRow,
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             if (historyIndex < currentHistory.Count)
                             {
                                 currentCursorIndex =
-                                    this.InsertInput(
+                                    ConsoleReadLine.InsertInput(
                                         inputLine,
                                         promptStartCol,
                                         promptStartRow,
@@ -379,7 +379,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             else if (historyIndex == currentHistory.Count)
                             {
                                 currentCursorIndex =
-                                    this.InsertInput(
+                                    ConsoleReadLine.InsertInput(
                                         inputLine,
                                         promptStartCol,
                                         promptStartRow,
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         historyIndex = currentHistory != null ? currentHistory.Count : -1;
 
                         currentCursorIndex =
-                            this.InsertInput(
+                            ConsoleReadLine.InsertInput(
                                 inputLine,
                                 promptStartCol,
                                 promptStartRow,
@@ -412,7 +412,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         if (currentCursorIndex > 0)
                         {
                             currentCursorIndex =
-                                this.InsertInput(
+                                ConsoleReadLine.InsertInput(
                                     inputLine,
                                     promptStartCol,
                                     promptStartRow,
@@ -430,7 +430,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         if (currentCursorIndex < inputLine.Length)
                         {
                             currentCursorIndex =
-                                this.InsertInput(
+                                ConsoleReadLine.InsertInput(
                                     inputLine,
                                     promptStartCol,
                                     promptStartRow,
@@ -471,7 +471,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         currentCompletion = null;
 
                         currentCursorIndex =
-                            this.InsertInput(
+                            ConsoleReadLine.InsertInput(
                                 inputLine,
                                 promptStartCol,
                                 promptStartRow,
@@ -490,7 +490,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         }
 
         // TODO: Is this used?
-        private int CalculateIndexFromCursor(
+        private static int CalculateIndexFromCursor(
             int promptStartCol,
             int promptStartRow,
             int consoleWidth)
@@ -500,7 +500,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 ConsoleProxy.GetCursorLeft() - promptStartCol;
         }
 
-        private void CalculateCursorFromIndex(
+        private static void CalculateCursorFromIndex(
             int promptStartCol,
             int promptStartRow,
             int consoleWidth,
@@ -513,7 +513,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             cursorCol = cursorCol % consoleWidth;
         }
 
-        private int InsertInput(
+        private static int InsertInput(
             StringBuilder inputLine,
             int promptStartCol,
             int promptStartRow,
@@ -532,7 +532,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             // Move the cursor to the new insertion point
-            this.MoveCursorToIndex(
+            ConsoleReadLine.MoveCursorToIndex(
                 promptStartCol,
                 promptStartRow,
                 consoleWidth,
@@ -581,7 +581,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
                 // Move the cursor to the final position
                 return
-                    this.MoveCursorToIndex(
+                    ConsoleReadLine.MoveCursorToIndex(
                         promptStartCol,
                         promptStartRow,
                         consoleWidth,
@@ -593,13 +593,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
         }
 
-        private int MoveCursorToIndex(
+        private static int MoveCursorToIndex(
             int promptStartCol,
             int promptStartRow,
             int consoleWidth,
             int newCursorIndex)
         {
-            this.CalculateCursorFromIndex(
+            ConsoleReadLine.CalculateCursorFromIndex(
                 promptStartCol,
                 promptStartRow,
                 consoleWidth,

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/TerminalInputPromptHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <returns>A Task that can be awaited to get the user's response.</returns>
         protected override async Task<SecureString> ReadSecureStringAsync(CancellationToken cancellationToken)
         {
-            SecureString secureString = await this.consoleReadLine.ReadSecureLineAsync(cancellationToken).ConfigureAwait(false);
+            SecureString secureString = await ConsoleReadLine.ReadSecureLineAsync(cancellationToken).ConfigureAwait(false);
             this.hostOutput.WriteOutput(string.Empty);
 
             return secureString;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             return false;
         }
 
-        private bool SpinUntilKeyAvailable(int millisecondsTimeout, CancellationToken cancellationToken)
+        private static bool SpinUntilKeyAvailable(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             return SpinWait.SpinUntil(
                 () =>
@@ -254,7 +254,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 millisecondsTimeout);
         }
 
-        private Task<bool> SpinUntilKeyAvailableAsync(int millisecondsTimeout, CancellationToken cancellationToken)
+        private static Task<bool> SpinUntilKeyAvailableAsync(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             return Task<bool>.Factory.StartNew(
                 () => SpinWait.SpinUntil(
@@ -264,10 +264,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         s_waitHandle.Wait(ShortWaitForKeySpinUntilSleepTime, cancellationToken);
                         return IsKeyAvailable(cancellationToken);
                     },
-                    millisecondsTimeout));
+                    millisecondsTimeout), cancellationToken);
         }
 
-        private bool IsKeyAvailable(CancellationToken cancellationToken)
+        private static bool IsKeyAvailable(CancellationToken cancellationToken)
         {
             s_stdInHandle.Wait(cancellationToken);
             try
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
         }
 
-        private async Task<bool> IsKeyAvailableAsync(CancellationToken cancellationToken)
+        private async static Task<bool> IsKeyAvailableAsync(CancellationToken cancellationToken)
         {
             await s_stdInHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             int triggerLine = request.TriggerPosition.Line + 1;
 
-            FunctionDefinitionAst functionDefinitionAst = _symbolsService.GetFunctionDefinitionForHelpComment(
+            FunctionDefinitionAst functionDefinitionAst = SymbolsService.GetFunctionDefinitionForHelpComment(
                 scriptFile,
                 triggerLine,
                 out string helpLocation);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private async Task CheckPackageManagement()
         {
             PSCommand getModule = new PSCommand().AddCommand("Get-Module").AddParameter("ListAvailable").AddParameter("Name", "PackageManagement");
-            foreach (PSModuleInfo module in await _powerShellContextService.ExecuteCommandAsync<PSModuleInfo>(getModule))
+            foreach (PSModuleInfo module in await _powerShellContextService.ExecuteCommandAsync<PSModuleInfo>(getModule).ConfigureAwait(false))
             {
                 // The user has a good enough version of PackageManagement
                 if (module.Version >= s_desiredPackageManagementVersion)
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                             Title = "Not now"
                         }
                     }
-                });
+                }).ConfigureAwait(false);
 
                 // If the user chose "Not now" ignore it for the rest of the session.
                 if (messageAction?.Title == takeActionText)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
@@ -319,7 +319,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                             if (fileContent != null)
                             {
-                                this.StoreRemoteFile(localFilePath, fileContent, pathMappings);
+                                RemoteFileManagerService.StoreRemoteFile(localFilePath, fileContent, pathMappings);
                             }
                             else
                             {
@@ -475,7 +475,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             RemotePathMappings pathMappings = this.GetPathMappings(runspaceDetails);
             string localFilePath = pathMappings.GetMappedPath(remoteFilePath);
 
-            this.StoreRemoteFile(
+            RemoteFileManagerService.StoreRemoteFile(
                 localFilePath,
                 fileContent,
                 pathMappings);
@@ -483,7 +483,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return localFilePath;
         }
 
-        private void StoreRemoteFile(
+        private static void StoreRemoteFile(
             string localFilePath,
             byte[] fileContent,
             RemotePathMappings pathMappings)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             internal ConsoleColorProxy(EditorServicesPSHostUserInterface hostUserInterface)
             {
-                if (hostUserInterface == null) throw new ArgumentNullException("hostUserInterface");
+                if (hostUserInterface == null) throw new ArgumentNullException(nameof(hostUserInterface));
                 _hostUserInterface = hostUserInterface;
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             var request = new InvocationRequest(pwsh =>
             {
-                using (_promptNest.GetRunspaceHandle(CancellationToken.None, isReadLine: false))
+                using (_promptNest.GetRunspaceHandle(isReadLine: false, CancellationToken.None))
                 {
                     pwsh.Runspace = _runspace;
                     invocationAction(pwsh);
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             CreateInvocationSubscriber();
         }
 
-        private void SetSubscriberExecutionThreadWithReflection(PSEventSubscriber subscriber)
+        private static void SetSubscriberExecutionThreadWithReflection(PSEventSubscriber subscriber)
         {
             // We need to create the PowerShell object in the same thread so we can get a nested
             // PowerShell.  This is the only way to consistently take control of the pipeline.  The

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         /// <param name="isReadLine">Indicates whether this is for a PSReadLine command.</param>
         /// <returns>The <see cref="RunspaceHandle" /> for the current frame.</returns>
-        internal RunspaceHandle GetRunspaceHandle(CancellationToken cancellationToken, bool isReadLine)
+        internal RunspaceHandle GetRunspaceHandle(bool isReadLine, CancellationToken cancellationToken)
         {
             if (_isDisposed)
             {
@@ -264,10 +264,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // is in process.
             if (isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
-                GetRunspaceHandleImpl(cancellationToken, isReadLine: false);
+                GetRunspaceHandleImpl(isReadLine: false, cancellationToken);
             }
 
-            return GetRunspaceHandleImpl(cancellationToken, isReadLine);
+            return GetRunspaceHandleImpl(isReadLine, cancellationToken);
         }
 
 
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// The <see cref="Task{RunspaceHandle}.Result" /> property will return the
         /// <see cref="RunspaceHandle" /> for the current frame.
         /// </returns>
-        internal async Task<RunspaceHandle> GetRunspaceHandleAsync(CancellationToken cancellationToken, bool isReadLine)
+        internal async Task<RunspaceHandle> GetRunspaceHandleAsync(bool isReadLine, CancellationToken cancellationToken)
         {
             if (_isDisposed)
             {
@@ -295,10 +295,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // is in process.
             if (isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
-                await GetRunspaceHandleImplAsync(cancellationToken, isReadLine: false).ConfigureAwait(false);
+                await GetRunspaceHandleImplAsync(isReadLine: false, cancellationToken).ConfigureAwait(false);
             }
 
-            return await GetRunspaceHandleImplAsync(cancellationToken, isReadLine).ConfigureAwait(false);
+            return await GetRunspaceHandleImplAsync(isReadLine, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -517,7 +517,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             return queue;
         }
 
-        private RunspaceHandle GetRunspaceHandleImpl(CancellationToken cancellationToken, bool isReadLine)
+        private RunspaceHandle GetRunspaceHandleImpl(bool isReadLine, CancellationToken cancellationToken)
         {
             if (isReadLine)
             {
@@ -527,7 +527,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             return CurrentFrame.Queue.Dequeue(cancellationToken);
         }
 
-        private async Task<RunspaceHandle> GetRunspaceHandleImplAsync(CancellationToken cancellationToken, bool isReadLine)
+        private async Task<RunspaceHandle> GetRunspaceHandleImplAsync(bool isReadLine, CancellationToken cancellationToken)
         {
             if (isReadLine)
             {

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>A SymbolReference of the symbol found at the given location
         /// or null if there is no symbol at that location
         /// </returns>
-        public SymbolReference FindSymbolAtLocation(
+        public static SymbolReference FindSymbolAtLocation(
             ScriptFile scriptFile,
             int lineNumber,
             int columnNumber)
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="symbolLineNumber">The line number of the cursor for the given script</param>
         /// <param name="symbolColumnNumber">The coulumn number of the cursor for the given script</param>
         /// <returns>FindOccurrencesResult</returns>
-        public IReadOnlyList<SymbolReference> FindOccurrencesInFile(
+        public static IReadOnlyList<SymbolReference> FindOccurrencesInFile(
             ScriptFile file,
             int symbolLineNumber,
             int symbolColumnNumber)
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>A SymbolReference of the symbol found at the given location
         /// or null if there is no symbol at that location
         /// </returns>
-        public SymbolReference FindFunctionDefinitionAtLocation(
+        public static SymbolReference FindFunctionDefinitionAtLocation(
             ScriptFile scriptFile,
             int lineNumber,
             int columnNumber)
@@ -573,7 +573,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="lineNumber">The 1 based line on which to look for function definition.</param>
         /// <param name="helpLocation"></param>
         /// <returns>If found, returns the function definition, otherwise, returns null.</returns>
-        public FunctionDefinitionAst GetFunctionDefinitionForHelpComment(
+        public static FunctionDefinitionAst GetFunctionDefinitionForHelpComment(
             ScriptFile scriptFile,
             int lineNumber,
             out string helpLocation)
@@ -647,7 +647,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="scriptFile">Open script file.</param>
         /// <param name="lineNumber">The 1 based line on which to look for function definition.</param>
         /// <returns>If found, returns the function definition on the given line. Otherwise, returns null.</returns>
-        public FunctionDefinitionAst GetFunctionDefinitionAtLine(
+        public static FunctionDefinitionAst GetFunctionDefinitionAtLine(
             ScriptFile scriptFile,
             int lineNumber)
         {

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            if (!s_completionHandle.Wait(0))
+            if (!s_completionHandle.Wait(0, cancellationToken))
             {
                 return null;
             }

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             return AstVisitAction.Continue;
         }
 
-        private bool IsAssignedAtScriptScope(VariableExpressionAst variableExpressionAst)
+        private static bool IsAssignedAtScriptScope(VariableExpressionAst variableExpressionAst)
         {
             Ast parent = variableExpressionAst.Parent;
             if (!(parent is AssignmentStatementAst))

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
         }
 
-        public bool CanResolve(CompletionItem value)
+        public static bool CanResolve(CompletionItem value)
         {
             return value.Kind == CompletionItemKind.Function;
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolReference foundSymbol =
-                _symbolsService.FindSymbolAtLocation(
+                SymbolsService.FindSymbolAtLocation(
                     scriptFile,
                     request.Position.Line + 1,
                     request.Position.Character + 1);

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
-            IReadOnlyList<SymbolReference> symbolOccurrences = _symbolsService.FindOccurrencesInFile(
+            IReadOnlyList<SymbolReference> symbolOccurrences = SymbolsService.FindOccurrencesInFile(
                 scriptFile,
                 request.Position.Line + 1,
                 request.Position.Character + 1);

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolReference foundSymbol =
-                _symbolsService.FindSymbolAtLocation(
+                SymbolsService.FindSymbolAtLocation(
                     scriptFile,
                     request.Position.Line + 1,
                     request.Position.Character + 1);

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly WorkspaceService _workspaceService;
         private readonly RemoteFileManagerService _remoteFileManagerService;
 
-        public TextDocumentSyncKind Change => TextDocumentSyncKind.Incremental;
+        public static TextDocumentSyncKind Change => TextDocumentSyncKind.Incremental;
 
         public PsesTextDocumentHandler(
             ILoggerFactory factory,

--- a/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
@@ -14,9 +14,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
     /// </summary>
     internal static class TokenOperations
     {
-        // Region kinds to align with VSCode's region kinds
-        private const string RegionKindComment = "comment";
-        private const string RegionKindRegion = "region";
         private static readonly FoldingRangeKind? RegionKindNone = null;
 
         // These regular expressions are used to match lines which mark the start and end of region comment in a PowerShell

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         #region private Methods
 
-        private bool IsQueryMatch(string query, string symbolName)
+        private static bool IsQueryMatch(string query, string symbolName)
         {
             return symbolName.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -41,7 +41,7 @@ namespace PowerShellEditorServices.Test.E2E
         {
             var factory = new LoggerFactory();
             _psesProcess = new PsesStdioProcess(factory, true);
-            await _psesProcess.Start();
+            await _psesProcess.Start().ConfigureAwait(false);
 
             var initialized = new TaskCompletionSource<bool>();
             PsesDebugAdapterClient = DebugAdapterClient.Create(options =>
@@ -99,7 +99,7 @@ namespace PowerShellEditorServices.Test.E2E
             }
         }
 
-        private string NewTestFile(string script, bool isPester = false)
+        private static string NewTestFile(string script, bool isPester = false)
         {
             string fileExt = isPester ? ".Tests.ps1" : ".ps1";
             string filePath = Path.Combine(s_binDir, Path.GetRandomFileName() + fileExt);
@@ -128,7 +128,7 @@ namespace PowerShellEditorServices.Test.E2E
             return builder.ToString();
         }
 
-        private string[] GetLog()
+        private static string[] GetLog()
         {
             return File.ReadLines(s_testOutputPath).ToArray();
         }

--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -43,7 +43,7 @@ namespace PowerShellEditorServices.Test.E2E
         {
             var factory = new LoggerFactory();
             _psesProcess = new PsesStdioProcess(factory, IsDebugAdapterTests);
-            await _psesProcess.Start();
+            await _psesProcess.Start().ConfigureAwait(false);
 
             Diagnostics = new List<Diagnostic>();
             TelemetryEvents = new List<PsesTelemetryEvent>();

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -35,8 +35,6 @@ namespace PowerShellEditorServices.Test.E2E
         private readonly static string s_binDir =
             Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-        private static bool s_registeredOnLogMessage;
-
         private readonly ILanguageClient PsesLanguageClient;
         private readonly List<Diagnostic> Diagnostics;
         private readonly List<PsesTelemetryEvent> TelemetryEvents;
@@ -94,7 +92,7 @@ namespace PowerShellEditorServices.Test.E2E
                     throw new InvalidDataException("No diagnostics showed up after 20s.");
                 }
 
-                await Task.Delay(2000);
+                await Task.Delay(2000).ConfigureAwait(false);
                 i++;
             }
         }
@@ -110,7 +108,7 @@ namespace PowerShellEditorServices.Test.E2E
                     throw new InvalidDataException("No telemetry events showed up after 20s.");
                 }
 
-                await Task.Delay(2000);
+                await Task.Delay(2000).ConfigureAwait(false);
                 i++;
             }
         }
@@ -122,7 +120,7 @@ namespace PowerShellEditorServices.Test.E2E
             PowerShellVersion details
                 = await PsesLanguageClient
                     .SendRequest<GetVersionParams>("powerShell/getVersion", new GetVersionParams())
-                    .Returning<PowerShellVersion>(CancellationToken.None);
+                    .Returning<PowerShellVersion>(CancellationToken.None).ConfigureAwait(false);
 
             if(PwshExe == "powershell")
             {
@@ -152,7 +150,7 @@ function CanSendWorkspaceSymbolRequest {
                     {
                         Query = "CanSendWorkspaceSymbolRequest"
                     })
-                .Returning<Container<SymbolInformation>>(CancellationToken.None);
+                .Returning<Container<SymbolInformation>>(CancellationToken.None).ConfigureAwait(false);
 
             SymbolInformation symbol = Assert.Single(symbols);
             Assert.Equal("CanSendWorkspaceSymbolRequest { }", symbol.Name);
@@ -167,7 +165,7 @@ function CanSendWorkspaceSymbolRequest {
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             NewTestFile("$a = 4");
-            await WaitForDiagnosticsAsync();
+            await WaitForDiagnosticsAsync().ConfigureAwait(false);
 
             Diagnostic diagnostic = Assert.Single(Diagnostics);
             Assert.Equal("PSUseDeclaredVarsMoreThanAssignments", diagnostic.Code);
@@ -178,7 +176,7 @@ function CanSendWorkspaceSymbolRequest {
         public async Task WontReceiveDiagnosticsFromFileOpenThatIsNotPowerShellAsync()
         {
             NewTestFile("$a = 4", languageId: "plaintext");
-            await Task.Delay(2000);
+            await Task.Delay(2000).ConfigureAwait(false);
 
             Assert.Empty(Diagnostics);
         }
@@ -192,7 +190,7 @@ function CanSendWorkspaceSymbolRequest {
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string filePath = NewTestFile("$a = 4");
-            await WaitForDiagnosticsAsync();
+            await WaitForDiagnosticsAsync().ConfigureAwait(false);
             Diagnostics.Clear();
 
             PsesLanguageClient.SendNotification("textDocument/didChange", new DidChangeTextDocumentParams
@@ -220,7 +218,7 @@ function CanSendWorkspaceSymbolRequest {
                 }
             });
 
-            await WaitForDiagnosticsAsync();
+            await WaitForDiagnosticsAsync().ConfigureAwait(false);
             if (Diagnostics.Count > 1)
             {
                 StringBuilder errorBuilder = new StringBuilder().AppendLine("Multiple diagnostics found when there should be only 1:");
@@ -245,7 +243,7 @@ function CanSendWorkspaceSymbolRequest {
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             NewTestFile("gci | % { $_ }");
-            await WaitForDiagnosticsAsync();
+            await WaitForDiagnosticsAsync().ConfigureAwait(false);
 
             // NewTestFile doesn't clear diagnostic notifications so we need to do that for this test.
             Diagnostics.Clear();
@@ -292,7 +290,7 @@ function CanSendWorkspaceSymbolRequest {
                 });
 
             // Wait a bit to make sure no telemetry events came through
-            await Task.Delay(2000);
+            await Task.Delay(2000).ConfigureAwait(false);
             // Since we have default settings we should not get any telemetry events about
             Assert.Empty(TelemetryEvents.Where(e => e.EventName == "NonDefaultPsesFeatureConfiguration"));
         }
@@ -320,7 +318,7 @@ $_
                                 Uri = new Uri(scriptPath)
                             }
                         })
-                    .Returning<Container<FoldingRange>>(CancellationToken.None);
+                    .Returning<Container<FoldingRange>>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(foldingRanges.OrderBy(f => f.StartLine),
                 range1 =>
@@ -369,7 +367,7 @@ Get-Process
                             InsertSpaces = false
                         }
                     })
-                .Returning<TextEditContainer>(CancellationToken.None);
+                .Returning<TextEditContainer>(CancellationToken.None).ConfigureAwait(false);
 
             TextEdit textEdit = Assert.Single(textEdits);
 
@@ -420,7 +418,7 @@ Get-Process
                             InsertSpaces = false
                         }
                     })
-                .Returning<TextEditContainer>(CancellationToken.None);
+                .Returning<TextEditContainer>(CancellationToken.None).ConfigureAwait(false);
 
             TextEdit textEdit = Assert.Single(textEdits);
 
@@ -451,7 +449,7 @@ CanSendDocumentSymbolRequest
                                 Uri = new Uri(scriptPath)
                             }
                         })
-                    .Returning<SymbolInformationOrDocumentSymbolContainer>(CancellationToken.None);
+                    .Returning<SymbolInformationOrDocumentSymbolContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(symbolInformationOrDocumentSymbols,
                 symInfoOrDocSym => {
@@ -495,7 +493,7 @@ CanSendReferencesRequest
                             IncludeDeclaration = false
                         }
                     })
-                .Returning<LocationContainer>(CancellationToken.None);
+                .Returning<LocationContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(locations,
                 location1 =>
@@ -543,7 +541,7 @@ Write-Host 'Goodbye'
                                 Character = 1
                             }
                         })
-                    .Returning<DocumentHighlightContainer>(CancellationToken.None);
+                    .Returning<DocumentHighlightContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(documentHighlights,
                 documentHighlight1 =>
@@ -596,7 +594,7 @@ Write-Host 'Goodbye'
                         .SendRequest<GetPSHostProcesssesParams>(
                             "powerShell/getPSHostProcesses",
                             new GetPSHostProcesssesParams { })
-                        .Returning<PSHostProcessResponse[]>(CancellationToken.None);
+                        .Returning<PSHostProcessResponse[]>(CancellationToken.None).ConfigureAwait(false);
             }
             finally
             {
@@ -640,7 +638,7 @@ Write-Host 'Goodbye'
                             {
                                 ProcessId = $"{process.Id}"
                             })
-                        .Returning<RunspaceResponse[]>(CancellationToken.None);
+                        .Returning<RunspaceResponse[]>(CancellationToken.None).ConfigureAwait(false);
             }
             finally
             {
@@ -690,7 +688,7 @@ Describe 'DescribeName' {
                             Uri = new Uri(filePath)
                         }
                     })
-                .Returning<CodeLensContainer>(CancellationToken.None);
+                .Returning<CodeLensContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(codeLenses,
                 codeLens1 =>
@@ -756,7 +754,7 @@ Describe 'DescribeName' {
                             Uri = new Uri(filePath)
                         }
                     })
-                .Returning<CodeLensContainer>(CancellationToken.None);
+                .Returning<CodeLensContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(codeLenses,
                 codeLens =>
@@ -849,7 +847,7 @@ CanSendReferencesCodeLensRequest
                             Uri = new Uri(filePath)
                         }
                     })
-                .Returning<CodeLensContainer>(CancellationToken.None);
+                .Returning<CodeLensContainer>(CancellationToken.None).ConfigureAwait(false);
 
             CodeLens codeLens = Assert.Single(codeLenses);
 
@@ -861,7 +859,7 @@ CanSendReferencesCodeLensRequest
 
             CodeLens codeLensResolveResult = await PsesLanguageClient
                 .SendRequest<CodeLens>("codeLens/resolve", codeLens)
-                .Returning<CodeLens>(CancellationToken.None);
+                .Returning<CodeLens>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal("1 reference", codeLensResolveResult.Command.Title);
         }
@@ -875,7 +873,7 @@ CanSendReferencesCodeLensRequest
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string filePath = NewTestFile("gci");
-            await WaitForDiagnosticsAsync();
+            await WaitForDiagnosticsAsync().ConfigureAwait(false);
 
             CommandOrCodeActionContainer commandOrCodeActions =
                 await PsesLanguageClient
@@ -903,7 +901,7 @@ CanSendReferencesCodeLensRequest
                                 Diagnostics = new Container<Diagnostic>(Diagnostics)
                             }
                         })
-                    .Returning<CommandOrCodeActionContainer>(CancellationToken.None);
+                    .Returning<CommandOrCodeActionContainer>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(commandOrCodeActions,
                 command =>
@@ -946,7 +944,7 @@ CanSendReferencesCodeLensRequest
 
             CompletionItem updatedCompletionItem = await PsesLanguageClient
                 .SendRequest<CompletionItem>("completionItem/resolve", completionItem)
-                .Returning<CompletionItem>(CancellationToken.None);
+                .Returning<CompletionItem>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Contains("Writes customized output to a host", updatedCompletionItem.Documentation.String);
         }
@@ -962,7 +960,7 @@ CanSendReferencesCodeLensRequest
                     {
                         Expression = "Import-Module Microsoft.PowerShell.Archive -Prefix Slow"
                     })
-                .ReturningVoid(CancellationToken.None);
+                .ReturningVoid(CancellationToken.None).ConfigureAwait(false);
 
             string filePath = NewTestFile("Expand-SlowArch");
 
@@ -981,7 +979,7 @@ CanSendReferencesCodeLensRequest
 
             CompletionItem updatedCompletionItem = await PsesLanguageClient
                 .SendRequest<CompletionItem>("completionItem/resolve", completionItem)
-                .Returning<CompletionItem>(CancellationToken.None);
+                .Returning<CompletionItem>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Contains("Extracts files from a specified archive", updatedCompletionItem.Documentation.String);
         }
@@ -1001,7 +999,7 @@ CanSendReferencesCodeLensRequest
                         Uri = DocumentUri.FromFileSystemPath(filePath)
                     },
                     Position = new Position(line: 0, character: 1)
-                });
+                }).ConfigureAwait(false);
 
             Assert.True(hover.Contents.HasMarkedStrings);
             Assert.Collection(hover.Contents.MarkedStrings,
@@ -1037,7 +1035,7 @@ CanSendReferencesCodeLensRequest
                             Character = 9
                         }
                     })
-                .Returning<SignatureHelp>(CancellationToken.None);
+                .Returning<SignatureHelp>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Contains("Get-Date", signatureHelp.Signatures.First().Label);
         }
@@ -1070,7 +1068,7 @@ CanSendDefinitionRequest
                                 Character = 2
                             }
                         })
-                    .Returning<LocationOrLocationLinks>(CancellationToken.None);
+                    .Returning<LocationOrLocationLinks>(CancellationToken.None).ConfigureAwait(false);
 
             LocationOrLocationLink locationOrLocationLink =
                     Assert.Single(locationOrLocationLinks);
@@ -1095,7 +1093,7 @@ CanSendDefinitionRequest
                         {
                             IncludeInstalledModules = true
                         })
-                    .Returning<GetProjectTemplatesResponse>(CancellationToken.None);
+                    .Returning<GetProjectTemplatesResponse>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Collection(getProjectTemplatesResponse.Templates.OrderBy(t => t.Title),
                 template1 =>
@@ -1143,7 +1141,7 @@ function CanSendGetCommentHelpRequest {
                                 Character = 0
                             }
                         })
-                    .Returning<CommentHelpRequestResult>(CancellationToken.None);
+                    .Returning<CommentHelpRequestResult>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.NotEmpty(commentHelpRequestResult.Content);
             Assert.Contains("myParam", commentHelpRequestResult.Content[7]);
@@ -1161,7 +1159,7 @@ function CanSendGetCommentHelpRequest {
                         {
                             Expression = "Get-ChildItem"
                         })
-                    .Returning<EvaluateResponseBody>(CancellationToken.None);
+                    .Returning<EvaluateResponseBody>(CancellationToken.None).ConfigureAwait(false);
 
             // These always gets returned so this test really just makes sure we get _any_ response.
             Assert.Equal("", evaluateResponseBody.Result);
@@ -1175,7 +1173,7 @@ function CanSendGetCommentHelpRequest {
             List<object> pSCommandMessages =
                 await PsesLanguageClient
                     .SendRequest<GetCommandParams>("powerShell/getCommand", new GetCommandParams())
-                    .Returning<List<object>>(CancellationToken.None);
+                    .Returning<List<object>>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.NotEmpty(pSCommandMessages);
             // There should be at least 20 commands or so.
@@ -1198,7 +1196,7 @@ function CanSendGetCommentHelpRequest {
                         {
                             Text = "gci"
                         })
-                    .Returning<ExpandAliasResult>(CancellationToken.None);
+                    .Returning<ExpandAliasResult>(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal("Get-ChildItem", expandAliasResult.Text);
         }
@@ -1221,7 +1219,7 @@ function CanSendGetCommentHelpRequest {
                                 Uri = new Uri(scriptPath)
                             }
                         })
-                    .Returning<SemanticTokens>(CancellationToken.None);
+                    .Returning<SemanticTokens>(CancellationToken.None).ConfigureAwait(false);
 
             // More information about how this data is generated can be found at
             // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.2" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
@@ -123,7 +123,7 @@ namespace PowerShellEditorServices.Test.E2E
                 serverProcess.Kill();
             }
 
-            await ServerExitCompletion.Task;
+            await ServerExitCompletion.Task.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
+++ b/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
@@ -14,8 +14,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared
     /// </summary>
     public static class TestUtilities
     {
-        private static readonly char[] s_unixPathSeparators = new [] { '/' };
-
         private static readonly char[] s_unixNewlines = new [] { '\n' };
 
         /// <summary>

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteCommandInFile.SourceDetails);
+                    CompleteCommandInFile.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteCommandFromModule.SourceDetails);
+                    CompleteCommandFromModule.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
 
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteTypeName.SourceDetails);
+                    CompleteTypeName.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
 
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteNamespace.SourceDetails);
+                    CompleteNamespace.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
 
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteVariableInFile.SourceDetails);
+                    CompleteVariableInFile.SourceDetails).ConfigureAwait(false);
 
             Assert.Single(completionResults.Completions);
             Assert.Equal(
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteAttributeValue.SourceDetails);
+                    CompleteAttributeValue.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             CompletionResults completionResults =
                 await this.GetCompletionResults(
-                    CompleteFilePath.SourceDetails);
+                    CompleteFilePath.SourceDetails).ConfigureAwait(false);
 
             Assert.NotEmpty(completionResults.Completions);
             // TODO: Since this is a path completion, this test will need to be
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             ParameterSetSignatures paramSignatures =
                 await this.GetParamSetSignatures(
-                    FindsParameterSetsOnCommand.SourceDetails);
+                    FindsParameterSetsOnCommand.SourceDetails).ConfigureAwait(false);
 
             Assert.NotNull(paramSignatures);
             Assert.Equal("Get-Process", paramSignatures.CommandName);
@@ -213,7 +213,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             ParameterSetSignatures paramSignatures =
                 await this.GetParamSetSignatures(
-                    FindsParameterSetsOnCommandWithSpaces.SourceDetails);
+                    FindsParameterSetsOnCommandWithSpaces.SourceDetails).ConfigureAwait(false);
 
             Assert.NotNull(paramSignatures);
             Assert.Equal("Write-Host", paramSignatures.CommandName);
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             SymbolReference definitionResult =
                 await this.GetDefinition(
-                    FindsFunctionDefinition.SourceDetails);
+                    FindsFunctionDefinition.SourceDetails).ConfigureAwait(false);
 
             Assert.Equal(1, definitionResult.ScriptRegion.StartLineNumber);
             Assert.Equal(10, definitionResult.ScriptRegion.StartColumnNumber);
@@ -239,7 +239,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             SymbolReference definitionResult =
                 await this.GetDefinition(
-                    FindsFunctionDefinitionInDotSourceReference.SourceDetails);
+                    FindsFunctionDefinitionInDotSourceReference.SourceDetails).ConfigureAwait(false);
 
             Assert.True(
                 definitionResult.FilePath.EndsWith(
@@ -256,7 +256,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             SymbolReference definitionResult =
                 await this.GetDefinition(
-                    FindsDotSourcedFile.SourceDetails);
+                    FindsDotSourcedFile.SourceDetails).ConfigureAwait(false);
 
             Assert.True(
                 definitionResult.FilePath.EndsWith(
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             SymbolReference definitionResult =
                 await this.GetDefinition(
-                    FindsFunctionDefinitionInWorkspace.SourceDetails);
+                    FindsFunctionDefinitionInWorkspace.SourceDetails).ConfigureAwait(false);
             Assert.EndsWith("ReferenceFileE.ps1", definitionResult.FilePath);
             Assert.Equal("My-FunctionInFileE", definitionResult.SymbolName);
         }
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         {
             SymbolReference definitionResult =
                 await this.GetDefinition(
-                    FindsVariableDefinition.SourceDetails);
+                    FindsVariableDefinition.SourceDetails).ConfigureAwait(false);
 
             Assert.Equal(6, definitionResult.ScriptRegion.StartLineNumber);
             Assert.Equal(1, definitionResult.ScriptRegion.StartColumnNumber);
@@ -373,7 +373,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.symbolsService.FindSymbolDetailsAtLocationAsync(
                     this.GetScriptFile(FindsDetailsForBuiltInCommand.SourceDetails),
                     FindsDetailsForBuiltInCommand.SourceDetails.StartLineNumber,
-                    FindsDetailsForBuiltInCommand.SourceDetails.StartColumnNumber);
+                    FindsDetailsForBuiltInCommand.SourceDetails.StartColumnNumber).ConfigureAwait(false);
 
             Assert.NotNull(symbolDetails.Documentation);
             Assert.NotEqual("", symbolDetails.Documentation);
@@ -460,7 +460,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 await this.completionHandler.GetCompletionsInFileAsync(
                     GetScriptFile(scriptRegion),
                     scriptRegion.StartLineNumber,
-                    scriptRegion.StartColumnNumber);
+                    scriptRegion.StartColumnNumber).ConfigureAwait(false);
         }
 
         private async Task<ParameterSetSignatures> GetParamSetSignatures(ScriptRegion scriptRegion)
@@ -470,7 +470,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                     GetScriptFile(scriptRegion),
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber,
-                    powerShellContext);
+                    powerShellContext).ConfigureAwait(false);
         }
 
         private async Task<SymbolReference> GetDefinition(ScriptRegion scriptRegion)
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             ScriptFile scriptFile = GetScriptFile(scriptRegion);
 
             SymbolReference symbolReference =
-                this.symbolsService.FindSymbolAtLocation(
+                SymbolsService.FindSymbolAtLocation(
                     scriptFile,
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber);
@@ -488,7 +488,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             return
                 await this.symbolsService.GetDefinitionOfSymbolAsync(
                     scriptFile,
-                    symbolReference);
+                    symbolReference).ConfigureAwait(false);
         }
 
         private List<SymbolReference> GetReferences(ScriptRegion scriptRegion)
@@ -496,7 +496,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             ScriptFile scriptFile = GetScriptFile(scriptRegion);
 
             SymbolReference symbolReference =
-                this.symbolsService.FindSymbolAtLocation(
+                SymbolsService.FindSymbolAtLocation(
                     scriptFile,
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber);
@@ -513,7 +513,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         private IReadOnlyList<SymbolReference> GetOccurrences(ScriptRegion scriptRegion)
         {
             return
-                this.symbolsService.FindOccurrencesInFile(
+                SymbolsService.FindOccurrencesInFile(
                     GetScriptFile(scriptRegion),
                     scriptRegion.StartLineNumber,
                     scriptRegion.StartColumnNumber);

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         /// <summary>
         /// Helper method to create a stub script file and then call FoldableRegions
         /// </summary>
-        private FoldingReference[] GetRegions(string text) {
+        private static FoldingReference[] GetRegions(string text) {
             ScriptFile scriptFile = new ScriptFile(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
@@ -153,7 +153,7 @@ $foo = 'bar'
         /// <summary>
         /// Assertion helper to compare two FoldingReference arrays.
         /// </summary>
-        private void AssertFoldingReferenceArrays(
+        private static void AssertFoldingReferenceArrays(
             FoldingReference[] expected,
             FoldingReference[] actual)
         {

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -25,7 +25,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplySingleLineInsert()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 "This is a test.",
                 "This is a working test.",
                 new FileChange
@@ -42,7 +42,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplySingleLineReplace()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 "This is a potentially broken test.",
                 "This is a working test.",
                 new FileChange
@@ -59,7 +59,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplySingleLineDelete()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 "This is a test of the emergency broadcasting system.",
                 "This is a test.",
                 new FileChange
@@ -76,7 +76,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplyMultiLineInsert()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("first\nsecond\nfifth"),
                 TestUtilities.NormalizeNewlines("first\nsecond\nthird\nfourth\nfifth"),
                 new FileChange
@@ -93,7 +93,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplyMultiLineReplace()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("first\nsecoXX\nXXfth"),
                 TestUtilities.NormalizeNewlines("first\nsecond\nthird\nfourth\nfifth"),
                 new FileChange
@@ -110,7 +110,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplyMultiLineReplaceWithRemovedLines()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("first\nsecoXX\nREMOVE\nTHESE\nLINES\nXXfth"),
                 TestUtilities.NormalizeNewlines("first\nsecond\nthird\nfourth\nfifth"),
                 new FileChange
@@ -127,7 +127,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplyMultiLineDelete()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("first\nsecond\nREMOVE\nTHESE\nLINES\nthird"),
                 TestUtilities.NormalizeNewlines("first\nsecond\nthird"),
                 new FileChange
@@ -144,7 +144,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanApplyEditsToEndOfFile()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("line1\nline2\nline3\n\n"),
                 TestUtilities.NormalizeNewlines("line1\nline2\nline3\n\n\n\n"),
                 new FileChange
@@ -161,7 +161,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanAppendToEndOfFile()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("line1\nline2\nline3"),
                 TestUtilities.NormalizeNewlines("line1\nline2\nline3\nline4\nline5"),
                 new FileChange
@@ -208,7 +208,7 @@ namespace PSLanguageService.Test
             Assert.Throws<ArgumentOutOfRangeException>(
                 () =>
                 {
-                    this.AssertFileChange(
+                    AssertFileChange(
                         TestUtilities.NormalizeNewlines("first\nsecond\nREMOVE\nTHESE\nLINES\nthird"),
                         TestUtilities.NormalizeNewlines("first\nsecond\nthird"),
                         new FileChange
@@ -226,7 +226,7 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanDeleteFromEndOfFile()
         {
-            this.AssertFileChange(
+            AssertFileChange(
                 TestUtilities.NormalizeNewlines("line1\nline2\nline3\nline4"),
                 TestUtilities.NormalizeNewlines("line1\nline2"),
                 new FileChange
@@ -256,7 +256,7 @@ namespace PSLanguageService.Test
             }
         }
 
-        private void AssertFileChange(
+        private static void AssertFileChange(
             string initialString,
             string expectedString,
             FileChange fileChange)

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -14,8 +14,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
 {
     public class WorkspaceTests
     {
-        private static readonly Version PowerShellVersion = new Version("5.0");
-
         private static readonly Lazy<string> s_lazyDriveLetter = new Lazy<string>(() => Path.GetFullPath("\\").Substring(0, 1));
 
         public static string CurrentDriveLetter => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncLockTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             Assert.Equal(TaskStatus.WaitingForActivation, lockTwo.Status);
             lockOne.Result.Dispose();
 
-            await lockTwo;
+            await lockTwo.ConfigureAwait(false);
             Assert.Equal(TaskStatus.RanToCompletion, lockTwo.Status);
         }
 
@@ -45,4 +45,3 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
         }
     }
 }
-

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -33,16 +33,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
                         async () =>
                         {
                             // Wait for a bit and then add more items to the queue
-                            await Task.Delay(250);
+                            await Task.Delay(250).ConfigureAwait(false);
 
                             foreach (var i in Enumerable.Range(100, 200))
                             {
-                                await inputQueue.EnqueueAsync(i);
+                                await inputQueue.EnqueueAsync(i).ConfigureAwait(false);
                             }
 
                             // Cancel the waiters
                             cancellationTokenSource.Cancel();
-                        }));
+                        })).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
 
             // Cancel the first task and then enqueue a number
             cancellationSource.Cancel();
-            await inputQueue.EnqueueAsync(1);
+            await inputQueue.EnqueueAsync(1).ConfigureAwait(false);
 
             // Wait for things to propegate.
             await Task.Delay(1000).ConfigureAwait(false);
@@ -77,17 +77,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             Assert.Equal(1, taskTwo.Result);
         }
 
-        private async Task ConsumeItemsAsync(
+        private static async Task ConsumeItemsAsync(
             AsyncQueue<int> inputQueue,
             ConcurrentBag<int> outputItems,
             CancellationToken cancellationToken)
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                int consumedItem = await inputQueue.DequeueAsync(cancellationToken);
+                int consumedItem = await inputQueue.DequeueAsync(cancellationToken).ConfigureAwait(false);
                 outputItems.Add(consumedItem);
             }
         }
     }
 }
-

--- a/tools/azurePipelinesBuild.ps1
+++ b/tools/azurePipelinesBuild.ps1
@@ -6,9 +6,9 @@ $ErrorActionPreference = 'Stop'
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
 if ($IsWindows -or $PSVersionTable.PSVersion.Major -lt 6) {
     # We rely on PowerShellGet's -AllowPrerelease which is in PowerShellGet 1.6 so we need to update PowerShellGet.
-    Get-Module PowerShellGet,PackageManagement | Remove-Module -Force -Verbose
-    powershell -Command { Install-Module -Name PowerShellGet -MinimumVersion 1.6 -Force -Confirm:$false -Verbose }
-    powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force -Confirm:$false -Verbose }
+    Get-Module PowerShellGet,PackageManagement | Remove-Module -Force
+    powershell -Command { Install-Module -Name PowerShellGet -MinimumVersion 1.6 -Force }
+    powershell -Command { Install-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force }
     Import-Module -Name PowerShellGet -MinimumVersion 1.6 -Force
     Import-Module -Name PackageManagement -MinimumVersion 1.1.7.0 -Force
 }
@@ -17,7 +17,7 @@ if ($IsWindows -or $PSVersionTable.PSVersion.Major -lt 6) {
 Update-Help -Force -ErrorAction SilentlyContinue
 
 # Needed for build and docs gen.
-Install-Module InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser
-Install-Module PlatyPS -RequiredVersion 0.9.0 -Scope CurrentUser
+Install-Module -Name InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force
+Install-Module -Name PlatyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force
 
 Invoke-Build -Configuration Release


### PR DESCRIPTION
This builds on top of https://github.com/PowerShell/PowerShellEditorServices/pull/1514 and is a pre-requisite for 

https://github.com/PowerShell/PowerShellEditorServices/pull/1516 and https://github.com/PowerShell/PowerShellEditorServices/pull/1507

By centralizing all module loading into PowerShellContextService.cs, we can more easily honor the -BundledModulesPath parameter as we aren't building the relative path to our modules folder in multiple locations. Additionally, since we have all the information we need in PowerShellContextService to determine which modules will be necessary, we can load them all using a method compatible with the runspace, as Import-Module isn't always available and sometimes you need to use initialSessionState.ImportPSModuleFromPath
