### PR TITLE
Format all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 csharp_space_before_open_square_brackets = true
 csharp_space_after_keywords_in_control_flow_statements = false
+csharp_space_after_cast = false
 
 [*.{json}]
 indent_size = 2

--- a/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/InvokeReadLineForEditorServicesCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             Type type = Type.GetType("Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2");
             MethodInfo method = type?.GetMethod(
                 "ReadLine",
-                new[] { typeof(Runspace), typeof(EngineIntrinsics), typeof(CancellationToken) });
+                new [] { typeof(Runspace), typeof(EngineIntrinsics), typeof(CancellationToken) });
 
             // TODO: Handle method being null here. This shouldn't ever happen.
 

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -155,13 +155,13 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         /// Paths to additional PowerShell modules to be imported at startup.
         /// </summary>
         [Parameter]
-        public string[] AdditionalModules { get; set; }
+        public string [] AdditionalModules { get; set; }
 
         /// <summary>
         /// Any feature flags to enable in EditorServices.
         /// </summary>
         [Parameter]
-        public string[] FeatureFlags { get; set; }
+        public string [] FeatureFlags { get; set; }
 
         /// <summary>
         /// When set, enables the integrated console.
@@ -203,9 +203,9 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         protected override void BeginProcessing()
         {
 #if DEBUG
-            if (WaitForDebugger)
+            if(WaitForDebugger)
             {
-                while (!Debugger.IsAttached)
+                while(!Debugger.IsAttached)
                 {
                     Console.WriteLine($"PID: {Process.GetCurrentProcess().Id}");
                     Thread.Sleep(1000);
@@ -234,19 +234,19 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 var sessionFileWriter = new SessionFileWriter(_logger, SessionDetailsPath);
                 _logger.Log(PsesLogLevel.Diagnostic, "Session file writer created");
 
-                using (var psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, sessionFileWriter, _loggerUnsubscribers))
+                using(var psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, sessionFileWriter, _loggerUnsubscribers))
                 {
                     _logger.Log(PsesLogLevel.Verbose, "Loading EditorServices");
                     // Start editor services and wait here until it shuts down
                     psesLoader.LoadAndRunEditorServicesAsync().GetAwaiter().GetResult();
                 }
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 _logger.LogException("Exception encountered starting EditorServices", e);
 
                 // Give the user a chance to read the message if they have a console
-                if (!Stdio)
+                if(!Stdio)
                 {
                     Host.UI.WriteLine("\n== Press any key to close terminal ==");
                     Console.ReadKey();
@@ -256,7 +256,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             }
             finally
             {
-                foreach (IDisposable disposableResource in _disposableResources)
+                foreach(IDisposable disposableResource in _disposableResources)
                 {
                     disposableResource.Dispose();
                 }
@@ -269,7 +269,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
             // We need to not write log messages to Stdio
             // if it's being used as a protocol transport
-            if (!Stdio)
+            if(!Stdio)
             {
                 var hostLogger = new PSHostLogger(Host.UI);
                 _loggerUnsubscribers.Add(_logger.Subscribe(hostLogger));
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
             // Temp debugging sessions may try to reuse this same path,
             // so we ensure they have a unique path
-            if (File.Exists(logPath))
+            if(File.Exists(logPath))
             {
                 int randomInt = new Random().Next();
                 logPath = Path.Combine(logDirPath, $"StartEditorServices-temp{randomInt.ToString("X", CultureInfo.InvariantCulture.NumberFormat)}.log");
@@ -310,14 +310,14 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         private void RemovePSReadLineForStartup()
         {
             _logger.Log(PsesLogLevel.Verbose, "Removing PSReadLine");
-            using (var pwsh = SMA.PowerShell.Create(RunspaceMode.CurrentRunspace))
+            using(var pwsh = SMA.PowerShell.Create(RunspaceMode.CurrentRunspace))
             {
                 bool hasPSReadLine = pwsh.AddCommand(new CmdletInfo("Microsoft.PowerShell.Core\\Get-Module", typeof(GetModuleCommand)))
                     .AddParameter("Name", "PSReadLine")
                     .Invoke()
                     .Any();
 
-                if (hasPSReadLine)
+                if(hasPSReadLine)
                 {
                     pwsh.Commands.Clear();
 
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             _logger.Log(PsesLogLevel.Diagnostic, "Creating host configuration");
 
             string bundledModulesPath = BundledModulesPath;
-            if (!Path.IsPathRooted(bundledModulesPath))
+            if(!Path.IsPathRooted(bundledModulesPath))
             {
                 // For compatibility, the bundled modules path is relative to the PSES bin directory
                 // Ideally it should be one level up, the PSES module root
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 },
             };
 
-            if (StartupBanner != null)
+            if(StartupBanner != null)
             {
                 editorServicesConfig.StartupBanner = StartupBanner;
             }
@@ -378,13 +378,13 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         private string GetProfilePathFromProfileObject(PSObject profileObject, ProfileUserKind userKind, ProfileHostKind hostKind)
         {
             string profilePathName = $"{userKind}{hostKind}";
-            if (profileObject is null)
+            if(profileObject is null)
             {
                 return null;
             }
-            string pwshProfilePath = (string)profileObject.Properties[profilePathName].Value;
+            string pwshProfilePath = (string)profileObject.Properties [profilePathName].Value;
 
-            if (hostKind == ProfileHostKind.AllHosts)
+            if(hostKind == ProfileHostKind.AllHosts)
             {
                 return pwshProfilePath;
             }
@@ -403,18 +403,18 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         {
             _logger.Log(PsesLogLevel.Diagnostic, "Determining REPL kind");
 
-            if (Stdio || !EnableConsoleRepl)
+            if(Stdio || !EnableConsoleRepl)
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "REPL configured as None");
                 return ConsoleReplKind.None;
             }
 
             // TODO: Remove this when we drop support for PS6.
-            var psVersionTable = (Hashtable) this.SessionState.PSVariable.GetValue("PSVersionTable");
-            dynamic version = psVersionTable["PSVersion"];
-            var majorVersion = (int) version.Major;
+            var psVersionTable = (Hashtable)this.SessionState.PSVariable.GetValue("PSVersionTable");
+            dynamic version = psVersionTable ["PSVersion"];
+            var majorVersion = (int)version.Major;
 
-            if (UseLegacyReadLine || (!s_isWindows && majorVersion == 6))
+            if(UseLegacyReadLine || (!s_isWindows && majorVersion == 6))
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "REPL configured as Legacy");
                 return ConsoleReplKind.LegacyReadLine;
@@ -428,23 +428,23 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         {
             _logger.Log(PsesLogLevel.Diagnostic, "Configuring LSP transport");
 
-            if (DebugServiceOnly)
+            if(DebugServiceOnly)
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "No LSP transport: PSES is debug only");
                 return null;
             }
 
-            if (Stdio)
+            if(Stdio)
             {
                 return new StdioTransportConfig(_logger);
             }
 
-            if (LanguageServiceInPipeName != null && LanguageServiceOutPipeName != null)
+            if(LanguageServiceInPipeName != null && LanguageServiceOutPipeName != null)
             {
                 return SimplexNamedPipeTransportConfig.Create(_logger, LanguageServiceInPipeName, LanguageServiceOutPipeName);
             }
 
-            if (SplitInOutPipes)
+            if(SplitInOutPipes)
             {
                 return SimplexNamedPipeTransportConfig.Create(_logger, LanguageServicePipeName);
             }
@@ -456,9 +456,9 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         {
             _logger.Log(PsesLogLevel.Diagnostic, "Configuring debug transport");
 
-            if (Stdio)
+            if(Stdio)
             {
-                if (DebugServiceOnly)
+                if(DebugServiceOnly)
                 {
                     return new StdioTransportConfig(_logger);
                 }
@@ -467,12 +467,12 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 return null;
             }
 
-            if (DebugServiceInPipeName != null && DebugServiceOutPipeName != null)
+            if(DebugServiceInPipeName != null && DebugServiceOutPipeName != null)
             {
                 return SimplexNamedPipeTransportConfig.Create(_logger, DebugServiceInPipeName, DebugServiceOutPipeName);
             }
 
-            if (SplitInOutPipes)
+            if(SplitInOutPipes)
             {
                 return SimplexNamedPipeTransportConfig.Create(_logger, DebugServicePipeName);
             }

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -118,15 +118,15 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>A disposable unsubscribe object.</returns>
         public IDisposable Subscribe(IObserver<(PsesLogLevel logLevel, string message)> observer)
         {
-            if (observer == null)
+            if(observer == null)
             {
                 throw new ArgumentNullException(nameof(observer));
             }
 
-            _observers[observer] = true;
+            _observers [observer] = true;
 
             // Catch up a late subscriber to messages already logged
-            foreach ((PsesLogLevel logLevel, string message) entry in _logMessages)
+            foreach((PsesLogLevel logLevel, string message) entry in _logMessages)
             {
                 observer.OnNext(entry);
             }
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>A disposable unsubscribe object.</returns>
         public IDisposable Subscribe(IObserver<(int logLevel, string message)> observer)
         {
-            if (observer == null)
+            if(observer == null)
             {
                 throw new ArgumentNullException(nameof(observer));
             }
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public void Log(PsesLogLevel logLevel, string message)
         {
             // Do nothing if the severity is lower than the minimum
-            if (logLevel < _minimumLogLevel)
+            if(logLevel < _minimumLogLevel)
             {
                 return;
             }
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _logMessages.Enqueue((logLevel, message));
 
             // Send this log to all observers
-            foreach (IObserver<(PsesLogLevel logLevel, string message)> observer in _observers.Keys)
+            foreach(IObserver<(PsesLogLevel logLevel, string message)> observer in _observers.Keys)
             {
                 observer.OnNext((logLevel, message));
             }
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public void OnNext((PsesLogLevel logLevel, string message) value)
         {
-            switch (value.logLevel)
+            switch(value.logLevel)
             {
                 case PsesLogLevel.Diagnostic:
                     _ui.WriteDebugLine(value.message);
@@ -304,7 +304,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public void OnCompleted()
         {
             // Ensure we only complete once
-            if (Interlocked.Exchange(ref _hasCompleted, 1) != 0)
+            if(Interlocked.Exchange(ref _hasCompleted, 1) != 0)
             {
                 return;
             }
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public void OnNext((PsesLogLevel logLevel, string message) value)
         {
             string message = null;
-            switch (value.logLevel)
+            switch(value.logLevel)
             {
                 case PsesLogLevel.Diagnostic:
                     message = $"[DBG]: {value.message}";
@@ -369,12 +369,12 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             try
             {
-                foreach (string logMessage in _messageQueue.GetConsumingEnumerable(_cancellationSource.Token))
+                foreach(string logMessage in _messageQueue.GetConsumingEnumerable(_cancellationSource.Token))
                 {
                     _fileWriter.WriteLine(logMessage);
                 }
             }
-            catch (OperationCanceledException)
+            catch(OperationCanceledException)
             {
             }
         }

--- a/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
@@ -69,9 +69,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 { "reason", reason },
             };
 
-            if (details != null)
+            if(details != null)
             {
-                sessionObject["details"] = details;
+                sessionObject ["details"] = details;
             }
 
             WriteSessionObject(sessionObject);
@@ -91,28 +91,28 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 { "status", "started" },
             };
 
-            if (languageServiceTransport != null)
+            if(languageServiceTransport != null)
             {
-                sessionObject["languageServiceTransport"] = languageServiceTransport.SessionFileTransportName;
+                sessionObject ["languageServiceTransport"] = languageServiceTransport.SessionFileTransportName;
 
-                if (languageServiceTransport.SessionFileEntries != null)
+                if(languageServiceTransport.SessionFileEntries != null)
                 {
-                    foreach (KeyValuePair<string, object> sessionEntry in languageServiceTransport.SessionFileEntries)
+                    foreach(KeyValuePair<string, object> sessionEntry in languageServiceTransport.SessionFileEntries)
                     {
-                        sessionObject[$"languageService{sessionEntry.Key}"] = sessionEntry.Value;
+                        sessionObject [$"languageService{sessionEntry.Key}"] = sessionEntry.Value;
                     }
                 }
             }
 
-            if (debugAdapterTransport != null)
+            if(debugAdapterTransport != null)
             {
-                sessionObject["debugServiceTransport"] = debugAdapterTransport.SessionFileTransportName;
+                sessionObject ["debugServiceTransport"] = debugAdapterTransport.SessionFileTransportName;
 
-                if (debugAdapterTransport.SessionFileEntries != null)
+                if(debugAdapterTransport.SessionFileEntries != null)
                 {
-                    foreach (KeyValuePair<string, object> sessionEntry in debugAdapterTransport.SessionFileEntries)
+                    foreach(KeyValuePair<string, object> sessionEntry in debugAdapterTransport.SessionFileEntries)
                     {
-                        sessionObject[$"debugService{sessionEntry.Key}"] = sessionEntry.Value;
+                        sessionObject [$"debugService{sessionEntry.Key}"] = sessionEntry.Value;
                     }
                 }
             }
@@ -128,13 +128,13 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             string psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
             string content = null;
-            using (var pwsh = SMA.PowerShell.Create(RunspaceMode.NewRunspace))
+            using(var pwsh = SMA.PowerShell.Create(RunspaceMode.NewRunspace))
             {
                 content = pwsh.AddCommand("ConvertTo-Json")
                     .AddParameter("InputObject", sessionObject)
                     .AddParameter("Depth", 10)
                     .AddParameter("Compress")
-                    .Invoke<string>()[0];
+                    .Invoke<string>() [0];
 
                 // Runspace creation has a bug where it resets the PSModulePath,
                 // which we must correct for

--- a/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>A new duplex named pipe transport configuration.</returns>
         public static DuplexNamedPipeTransportConfig Create(HostLogger logger, string pipeName)
         {
-            if (pipeName == null)
+            if(pipeName == null)
             {
                 return DuplexNamedPipeTransportConfig.Create(logger);
             }
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             _logger = logger;
             _pipeName = pipeName;
-            SessionFileEntries = new Dictionary<string, object>{ { "PipeName", NamedPipeUtils.GetNamedPipePath(pipeName) } };
+            SessionFileEntries = new Dictionary<string, object> { { "PipeName", NamedPipeUtils.GetNamedPipePath(pipeName) } };
         }
 
         public string EndpointDetails => $"InOut pipe: {_pipeName}";
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>A new simplex named pipe transport config.</returns>
         public static SimplexNamedPipeTransportConfig Create(HostLogger logger)
         {
-            return SimplexNamedPipeTransportConfig.Create(logger, NamedPipeUtils.GenerateValidNamedPipeName(new[] { InPipePrefix, OutPipePrefix }));
+            return SimplexNamedPipeTransportConfig.Create(logger, NamedPipeUtils.GenerateValidNamedPipeName(new [] { InPipePrefix, OutPipePrefix }));
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>A new simplex named pipe transport config.</returns>
         public static SimplexNamedPipeTransportConfig Create(HostLogger logger, string pipeNameBase)
         {
-            if (pipeNameBase == null)
+            if(pipeNameBase == null)
             {
                 return SimplexNamedPipeTransportConfig.Create(logger);
             }

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -65,12 +65,12 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ISessionFileWriter sessionFileWriter,
             IReadOnlyCollection<IDisposable> loggersToUnsubscribe)
         {
-            if (logger == null)
+            if(logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            if (hostConfig == null)
+            if(hostConfig == null)
             {
                 throw new ArgumentNullException(nameof(hostConfig));
             }
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             var psesLoadContext = new PsesLoadContext(s_psesDependencyDirPath);
 
-            if (hostConfig.LogLevel == PsesLogLevel.Diagnostic)
+            if(hostConfig.LogLevel == PsesLogLevel.Diagnostic)
             {
                 AppDomain.CurrentDomain.AssemblyLoad += (object sender, AssemblyLoadEventArgs args) =>
                 {
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}");
 
                 // We only want the Editor Services DLL; the new ALC will lazily load its dependencies automatically
-                if (!string.Equals(asmName.Name, "Microsoft.PowerShell.EditorServices", StringComparison.Ordinal))
+                if(!string.Equals(asmName.Name, "Microsoft.PowerShell.EditorServices", StringComparison.Ordinal))
                 {
                     return null;
                 }
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private void UpdatePSModulePath()
         {
-            if (string.IsNullOrEmpty(_hostConfig.BundledModulePath))
+            if(string.IsNullOrEmpty(_hostConfig.BundledModulePath))
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "BundledModulePath not set, skipping");
                 return;
@@ -310,9 +310,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private string GetPSOutputEncoding()
         {
-            using (var pwsh = SMA.PowerShell.Create())
+            using(var pwsh = SMA.PowerShell.Create())
             {
-                return pwsh.AddScript("$OutputEncoding.EncodingName", useLocalScope: true).Invoke<string>()[0];
+                return pwsh.AddScript("$OutputEncoding.EncodingName", useLocalScope: true).Invoke<string>() [0];
             }
         }
 
@@ -340,14 +340,14 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         private string GetOSArchitecture()
         {
 #if CoreCLR
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            if(Environment.OSVersion.Platform != PlatformID.Win32NT)
             {
                 return RuntimeInformation.OSArchitecture.ToString();
             }
 #endif
 
             // If on win7 (version 6.1.x), avoid System.Runtime.InteropServices.RuntimeInformation
-            if (Environment.OSVersion.Version < new Version(6, 2))
+            if(Environment.OSVersion.Version < new Version(6, 2))
             {
                 return Environment.Is64BitProcess
                     ? "X64"
@@ -366,18 +366,18 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             bool debugUsesStdio = _hostConfig.DebugServiceTransport is StdioTransportConfig;
 
             // Ensure LSP and Debug are not both Stdio
-            if (lspUsesStdio && debugUsesStdio)
+            if(lspUsesStdio && debugUsesStdio)
             {
                 throw new ArgumentException("LSP and Debug transports cannot both use Stdio");
             }
 
-            if (_hostConfig.ConsoleRepl != ConsoleReplKind.None
+            if(_hostConfig.ConsoleRepl != ConsoleReplKind.None
                 && (lspUsesStdio || debugUsesStdio))
             {
                 throw new ArgumentException("Cannot use the REPL with a Stdio protocol transport");
             }
 
-            if (_hostConfig.PSHost == null)
+            if(_hostConfig.PSHost == null)
             {
                 throw new ArgumentNullException(nameof(_hostConfig.PSHost));
             }
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             return typeof(PSObject).Assembly
                 .GetType("System.Management.Automation.PSVersionInfo")
                 .GetMethod("get_PSVersion", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                .Invoke(null, new object[0] /* Cannot use Array.Empty, since it must work in net452 */);
+                .Invoke(null, new object [0] /* Cannot use Array.Empty, since it must work in net452 */);
         }
     }
 }

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 HostStartupInfo hostStartupInfo = CreateHostStartupInfo();
 
                 // If we just want a temp debug session, run that and do nothing else
-                if (isTempDebugSession)
+                if(isTempDebugSession)
                 {
                     await RunTempDebugSessionAsync(hostStartupInfo).ConfigureAwait(false);
                     return;
@@ -153,9 +153,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
                 // Unsubscribe the host logger here so that the integrated console is not polluted with input after the first prompt
                 _logger.Log(PsesLogLevel.Verbose, "Starting server, deregistering host logger and registering shutdown listener");
-                if (_loggersToUnsubscribe != null)
+                if(_loggersToUnsubscribe != null)
                 {
-                    foreach (IDisposable loggerToUnsubscribe in _loggersToUnsubscribe)
+                    foreach(IDisposable loggerToUnsubscribe in _loggersToUnsubscribe)
                     {
                         loggerToUnsubscribe.Dispose();
                     }
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 PsesLanguageServer languageServer = await CreateLanguageServerAsync(hostStartupInfo).ConfigureAwait(false);
 
                 Task<PsesDebugServer> debugServerCreation = null;
-                if (creatingDebugServer)
+                if(creatingDebugServer)
                 {
                     debugServerCreation = CreateDebugServerWithLanguageServerAsync(languageServer, usePSReadLine: _config.ConsoleRepl == ConsoleReplKind.PSReadLine);
                 }
@@ -174,14 +174,14 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 Task languageServerStart = languageServer.StartAsync();
 
                 Task debugServerStart = null;
-                if (creatingDebugServer)
+                if(creatingDebugServer)
                 {
                     // We don't need to wait for this to start, since we instead wait for it to complete later
                     debugServerStart = StartDebugServer(debugServerCreation);
                 }
 
                 await languageServerStart.ConfigureAwait(false);
-                if (debugServerStart != null)
+                if(debugServerStart != null)
                 {
                     await debugServerStart.ConfigureAwait(false);
                 }
@@ -210,7 +210,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             // When the debug server shuts down, we want it to automatically restart
             // To do this, we set an event to allow it to create a new debug server as its session ends
-            if (!_alreadySubscribedDebug)
+            if(!_alreadySubscribedDebug)
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "Subscribing debug server for session ended event");
                 _alreadySubscribedDebug = true;
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _logger.Log(PsesLogLevel.Diagnostic, "Creating startup info object");
 
             ProfilePathInfo profilePaths = null;
-            if (_config.ProfilePaths.AllUsersAllHosts != null
+            if(_config.ProfilePaths.AllUsersAllHosts != null
                 || _config.ProfilePaths.AllUsersCurrentHost != null
                 || _config.ProfilePaths.CurrentUserAllHosts != null
                 || _config.ProfilePaths.CurrentUserCurrentHost != null)
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private void WriteStartupBanner()
         {
-            if (_config.ConsoleRepl == ConsoleReplKind.None)
+            if(_config.ConsoleRepl == ConsoleReplKind.None)
             {
                 return;
             }

--- a/src/PowerShellEditorServices.Hosting/Internal/NamedPipeUtils.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/NamedPipeUtils.cs
@@ -85,9 +85,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 string pipeName = $"PSES_{Path.GetRandomFileName()}";
 
                 // In the simple prefix-less case, just test the pipe name
-                if (prefixes == null)
+                if(prefixes == null)
                 {
-                    if (!IsPipeNameValid(pipeName))
+                    if(!IsPipeNameValid(pipeName))
                     {
                         continue;
                     }
@@ -97,22 +97,22 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
                 // If we have prefixes, test that all prefix/pipename combinations are valid
                 bool allPipeNamesValid = true;
-                foreach (string prefix in prefixes)
+                foreach(string prefix in prefixes)
                 {
                     string prefixedPipeName = $"{prefix}_{pipeName}";
-                    if (!IsPipeNameValid(prefixedPipeName))
+                    if(!IsPipeNameValid(prefixedPipeName))
                     {
                         allPipeNamesValid = false;
                         break;
                     }
                 }
 
-                if (allPipeNamesValid)
+                if(allPipeNamesValid)
                 {
                     return pipeName;
                 }
 
-            } while (tries < 10);
+            } while(tries < 10);
 
             throw new IOException("Unable to create named pipe; no available names");
         }
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <returns>True if the named pipe name is valid, false otherwise.</returns>
         public static bool IsPipeNameValid(string pipeName)
         {
-            if (string.IsNullOrEmpty(pipeName))
+            if(string.IsNullOrEmpty(pipeName))
             {
                 return false;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public static string GetNamedPipePath(string pipeName)
         {
 #if CoreCLR
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return Path.Combine(Path.GetTempPath(), $"CoreFxPipe_{pipeName}");
             }

--- a/src/PowerShellEditorServices.Hosting/Internal/PsesLoadContext.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/PsesLoadContext.cs
@@ -37,13 +37,13 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             // If we find the required assembly in $PSHOME, let another mechanism load the assembly
             string psHomeAsmPath = Path.Join(s_psHome, $"{assemblyName.Name}.dll");
-            if (IsSatisfyingAssembly(assemblyName, psHomeAsmPath))
+            if(IsSatisfyingAssembly(assemblyName, psHomeAsmPath))
             {
                 return null;
             }
 
             string asmPath = Path.Join(_dependencyDirPath, $"{assemblyName.Name}.dll");
-            if (IsSatisfyingAssembly(assemblyName, asmPath))
+            if(IsSatisfyingAssembly(assemblyName, asmPath))
             {
                 return LoadFromAssemblyPath(asmPath);
             }
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                     "_name",
                     BindingFlags.NonPublic | BindingFlags.Instance);
 
-                if (nameBackingField != null)
+                if(nameBackingField != null)
                 {
                     nameBackingField.SetValue(this, name);
                 }
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private static bool IsSatisfyingAssembly(AssemblyName requiredAssemblyName, string assemblyPath)
         {
-            if (!File.Exists(assemblyPath))
+            if(!File.Exists(assemblyPath))
             {
                 return false;
             }

--- a/src/PowerShellEditorServices.VSCode/Cmdlets/VSCodeHtmlContentViewCommands.cs
+++ b/src/PowerShellEditorServices.VSCode/Cmdlets/VSCodeHtmlContentViewCommands.cs
@@ -12,7 +12,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 namespace Microsoft.PowerShell.EditorServices.VSCode
 {
     ///
-    [Cmdlet(VerbsCommon.New,"VSCodeHtmlContentView")]
+    [Cmdlet(VerbsCommon.New, "VSCodeHtmlContentView")]
     [OutputType(typeof(IHtmlContentView))]
     public class NewVSCodeHtmlContentViewCommand : PSCmdlet
     {
@@ -36,9 +36,9 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
         ///
         protected override void BeginProcessing()
         {
-            if (_htmlContentViewsFeature == null)
+            if(_htmlContentViewsFeature == null)
             {
-                if (GetVariableValue("psEditor") is EditorObject psEditor)
+                if(GetVariableValue("psEditor") is EditorObject psEditor)
                 {
                     _htmlContentViewsFeature = new HtmlContentViewsFeature(
                         psEditor.GetExtensionServiceProvider().LanguageServer);
@@ -59,12 +59,13 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
                 .GetAwaiter()
                 .GetResult();
 
-            if (_showInColumn != null) {
+            if(_showInColumn != null)
+            {
                 try
                 {
                     view.Show(_showInColumn.Value).GetAwaiter().GetResult();
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     WriteError(
                         new ErrorRecord(
@@ -82,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
     }
 
     ///
-    [Cmdlet(VerbsCommon.Set,"VSCodeHtmlContentView")]
+    [Cmdlet(VerbsCommon.Set, "VSCodeHtmlContentView")]
     public class SetVSCodeHtmlContentViewCommand : PSCmdlet
     {
         ///
@@ -99,11 +100,11 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
 
         ///
         [Parameter(Position = 2)]
-        public string[] JavaScriptPaths { get; set; }
+        public string [] JavaScriptPaths { get; set; }
 
         ///
         [Parameter(Position = 3)]
-        public string[] StyleSheetPaths { get; set; }
+        public string [] StyleSheetPaths { get; set; }
 
         ///
         protected override void BeginProcessing()
@@ -116,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
             {
                 HtmlContentView.SetContentAsync(htmlContent).GetAwaiter().GetResult();
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 WriteError(
                     new ErrorRecord(
@@ -129,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
     }
 
     ///
-    [Cmdlet(VerbsCommon.Close,"VSCodeHtmlContentView")]
+    [Cmdlet(VerbsCommon.Close, "VSCodeHtmlContentView")]
     public class CloseVSCodeHtmlContentViewCommand : PSCmdlet
     {
         ///
@@ -145,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
             {
                 HtmlContentView.Close().GetAwaiter().GetResult();
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 WriteError(
                     new ErrorRecord(
@@ -158,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
     }
 
     ///
-    [Cmdlet(VerbsCommon.Show,"VSCodeHtmlContentView")]
+    [Cmdlet(VerbsCommon.Show, "VSCodeHtmlContentView")]
     public class ShowVSCodeHtmlContentViewCommand : PSCmdlet
     {
         ///
@@ -180,7 +181,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
             {
                 HtmlContentView.Show(ViewColumn).GetAwaiter().GetResult();
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 WriteError(
                     new ErrorRecord(
@@ -193,7 +194,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
     }
 
     ///
-    [Cmdlet(VerbsCommunications.Write,"VSCodeHtmlContentView")]
+    [Cmdlet(VerbsCommunications.Write, "VSCodeHtmlContentView")]
     public class WriteVSCodeHtmlContentViewCommand : PSCmdlet
     {
         ///
@@ -215,7 +216,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode
             {
                 HtmlContentView.AppendContentAsync(AppendedHtmlBodyContent).GetAwaiter().GetResult();
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 WriteError(
                     new ErrorRecord(

--- a/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/CustomViewMessages.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// <summary>
         /// Gets or sets the view's type.
         /// </summary>
-        public CustomViewType ViewType { get; set;}
+        public CustomViewType ViewType { get; set; }
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContent.cs
@@ -18,12 +18,12 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
         /// Gets or sets the array of JavaScript file paths
         /// to be used in the HTML content.
         /// </summary>
-        public string[] JavaScriptPaths { get; set; }
+        public string [] JavaScriptPaths { get; set; }
 
         /// <summary>
         /// Gets or sets the array of stylesheet (CSS) file
         /// paths to be used in the HTML content.
         /// </summary>
-        public string[] StyleSheetPaths { get; set; }
+        public string [] StyleSheetPaths { get; set; }
     }
 }

--- a/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
+++ b/src/PowerShellEditorServices.VSCode/CustomViews/HtmlContentView.cs
@@ -65,11 +65,12 @@ namespace Microsoft.PowerShell.EditorServices.VSCode.CustomViews
             );
         }
 
-        private string[] GetUriPaths(string[] filePaths)
+        private string [] GetUriPaths(string [] filePaths)
         {
             return
                 filePaths?
-                    .Select(p => {
+                    .Select(p =>
+                    {
                         return
                             new Uri(
                                 Path.GetFullPath(p),

--- a/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
@@ -118,9 +118,9 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         public object GetServiceByAssemblyQualifiedName(string asmQualifiedTypeName)
         {
             Type serviceType;
-            if (VersionUtils.IsNetCore)
+            if(VersionUtils.IsNetCore)
             {
-                using (EnterPsesAlcReflectionContext())
+                using(EnterPsesAlcReflectionContext())
                 {
                     serviceType = s_psesAsm.GetType(asmQualifiedTypeName);
                 }
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// <returns>The assembly load context used for loading PSES, or null in .NET Framework.</returns>
         public object GetPsesAssemblyLoadContext()
         {
-            if (!VersionUtils.IsNetCore)
+            if(!VersionUtils.IsNetCore)
             {
                 return null;
             }
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// <returns>The loaded assembly object.</returns>
         public Assembly LoadAssemblyInPsesLoadContext(string assemblyPath)
         {
-            if (!VersionUtils.IsNetCore)
+            if(!VersionUtils.IsNetCore)
             {
                 return Assembly.LoadFrom(assemblyPath);
             }
@@ -200,14 +200,14 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         private static object GetPsesAsmLoadContext()
         {
-            if (!VersionUtils.IsNetCore)
+            if(!VersionUtils.IsNetCore)
             {
                 return null;
             }
 
             Type alcType = Type.GetType("System.Runtime.Loader.AssemblyLoadContext");
             MethodInfo getAlcMethod = alcType.GetMethod("GetLoadContext", BindingFlags.Public | BindingFlags.Static);
-            return getAlcMethod.Invoke(obj: null, new object[] { s_psesAsm });
+            return getAlcMethod.Invoke(obj: null, new object [] { s_psesAsm });
         }
     }
 }

--- a/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
@@ -23,14 +23,14 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// <param name="helpMessage">The message to display to users.</param>
         public PromptChoiceDetails(string label, string helpMessage)
         {
-            if (label == null)
+            if(label == null)
             {
                 throw new ArgumentNullException(nameof(label));
             }
 
             // Currently VSCode sends back selected labels as a single string concatenated with ','
             // When this is fixed, we'll be able to allow commas in labels
-            if (label.Contains(","))
+            if(label.Contains(","))
             {
                 throw new ArgumentException($"Labels may not contain ','. Label: '{label}'", nameof(label));
             }
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
     internal class EditorUIService : IEditorUIService
     {
-        private static string[] s_choiceResponseLabelSeparators = new[] { ", " };
+        private static string [] s_choiceResponseLabelSeparators = new [] { ", " };
 
         private readonly ILanguageServerFacade _languageServer;
 
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Name = message,
                 }).Returning<ShowInputPromptResponse>(CancellationToken.None);
 
-            if (response.PromptCancelled)
+            if(response.PromptCancelled)
             {
                 return null;
             }
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         public async Task<IReadOnlyList<string>> PromptMultipleSelectionAsync(string message, IReadOnlyList<PromptChoiceDetails> choices, IReadOnlyList<int> defaultChoiceIndexes)
         {
-            ChoiceDetails[] choiceDetails = GetChoiceDetails(choices);
+            ChoiceDetails [] choiceDetails = GetChoiceDetails(choices);
 
             ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest>(
                 "powerShell/showChoicePrompt",
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     DefaultChoices = defaultChoiceIndexes?.ToArray(),
                 }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
 
-            if (response.PromptCancelled)
+            if(response.PromptCancelled)
             {
                 return null;
             }
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         public async Task<string> PromptSelectionAsync(string message, IReadOnlyList<PromptChoiceDetails> choices, int defaultChoiceIndex)
         {
-            ChoiceDetails[] choiceDetails = GetChoiceDetails(choices);
+            ChoiceDetails [] choiceDetails = GetChoiceDetails(choices);
 
             ShowChoicePromptResponse response = await _languageServer.SendRequest<ShowChoicePromptRequest>(
                 "powerShell/showChoicePrompt",
@@ -167,10 +167,10 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Caption = string.Empty,
                     Message = message,
                     Choices = choiceDetails,
-                    DefaultChoices = defaultChoiceIndex > -1 ? new[] { defaultChoiceIndex } : null,
+                    DefaultChoices = defaultChoiceIndex > -1 ? new [] { defaultChoiceIndex } : null,
                 }).Returning<ShowChoicePromptResponse>(CancellationToken.None);
 
-            if (response.PromptCancelled)
+            if(response.PromptCancelled)
             {
                 return null;
             }
@@ -178,19 +178,19 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             return response.ResponseText;
         }
 
-        private static ChoiceDetails[] GetChoiceDetails(IReadOnlyList<PromptChoiceDetails> promptChoiceDetails)
+        private static ChoiceDetails [] GetChoiceDetails(IReadOnlyList<PromptChoiceDetails> promptChoiceDetails)
         {
-            var choices = new ChoiceDetails[promptChoiceDetails.Count];
-            for (int i = 0; i < promptChoiceDetails.Count; i++)
+            var choices = new ChoiceDetails [promptChoiceDetails.Count];
+            for(int i = 0; i < promptChoiceDetails.Count; i++)
             {
-                choices[i] = new ChoiceDetails
+                choices [i] = new ChoiceDetails
                 {
-                    Label           = promptChoiceDetails[i].Label,
-                    HelpMessage     = promptChoiceDetails[i].HelpMessage,
+                    Label = promptChoiceDetails [i].Label,
+                    HelpMessage = promptChoiceDetails [i].HelpMessage,
                     // There were intended to enable hotkey use for choice selections,
                     // but currently VSCode does not do anything with them.
                     // They can be exposed once VSCode supports them.
-                    HotKeyIndex     = -1,
+                    HotKeyIndex = -1,
                     HotKeyCharacter = null,
                 };
             }

--- a/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         public bool TryGetFile(Uri fileUri, out IEditorScriptFile file)
         {
-            if (!_workspaceService.TryGetFile(fileUri.LocalPath, out ScriptFile scriptFile))
+            if(!_workspaceService.TryGetFile(fileUri.LocalPath, out ScriptFile scriptFile))
             {
                 file = null;
                 return false;
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         public IReadOnlyList<IEditorScriptFile> GetOpenedFiles()
         {
             var files = new List<IEditorScriptFile>();
-            foreach (ScriptFile openedFile in _workspaceService.GetOpenedFiles())
+            foreach(ScriptFile openedFile in _workspaceService.GetOpenedFiles())
             {
                 files.Add(GetEditorFileFromScriptFile(openedFile));
             }

--- a/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorFileRanges.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             int offset = 0;
             int currLine = 1;
             string fileText = file.Ast.Extent.Text;
-            while (offset < fileText.Length && currLine < lineNumber)
+            while(offset < fileText.Length && currLine < lineNumber)
             {
                 offset = fileText.IndexOf('\n', offset);
                 currLine++;
@@ -35,15 +35,15 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             int line = 1;
             string fileText = file.Ast.Extent.Text;
 
-            if (offset >= fileText.Length)
+            if(offset >= fileText.Length)
             {
                 throw new ArgumentException(nameof(offset), "Offset greater than file length");
             }
 
             int lastLineOffset = -1;
-            for (int i = 0; i < offset; i++)
+            for(int i = 0; i < offset; i++)
             {
-                if (fileText[i] == '\n')
+                if(fileText [i] == '\n')
                 {
                     lastLineOffset = i;
                     line++;
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         internal FileScriptPosition(FileContext file, int lineNumber, int columnNumber, int offset)
         {
             _file = file;
-            Line = file.GetTextLines()[lineNumber - 1];
+            Line = file.GetTextLines() [lineNumber - 1];
             ColumnNumber = columnNumber;
             LineNumber = lineNumber;
             Offset = offset;

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// Returns all registered EditorCommands.
         /// </summary>
         /// <returns>An Array of all registered EditorCommands.</returns>
-        public EditorCommand[] GetCommands()
+        public EditorCommand [] GetCommands()
         {
             return this._extensionService.GetCommands();
         }

--- a/src/PowerShellEditorServices/Extensions/EditorRequests.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorRequests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
 
 
     internal class GetEditorContextRequest
-    {}
+    { }
 
     internal enum EditorCommandResponse
     {

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
             IEditorOperations editorOperations,
             string language = "Unknown")
         {
-            if (string.IsNullOrWhiteSpace(language))
+            if(string.IsNullOrWhiteSpace(language))
             {
                 language = "Unknown";
             }
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// Gets the complete file content as an array of strings.
         /// </summary>
         /// <returns>An array of strings, each representing a line in the file.</returns>
-        public string[] GetTextLines()
+        public string [] GetTextLines()
         {
             return this.scriptFile.FileLines.ToArray();
         }
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
         /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
-        public string[] GetTextLines(FileRange fileRange)
+        public string [] GetTextLines(FileRange fileRange)
         {
             return this.scriptFile.GetLinesInRange(fileRange.ToBufferRange());
         }
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         public void InsertText(string textToInsert)
         {
             // Is there a selection?
-            if (this.editorContext.SelectedRange.HasRange())
+            if(this.editorContext.SelectedRange.HasRange())
             {
                 this.InsertText(
                     textToInsert,
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
                 newFilePath :
                 System.IO.Path.GetFullPath(System.IO.Path.Combine(System.IO.Path.GetDirectoryName(this.scriptFile.FilePath), newFilePath));
 
-            if (File.Exists(absolutePath))
+            if(File.Exists(absolutePath))
             {
                 throw new IOException(String.Format("The file '{0}' already exists", absolutePath));
             }

--- a/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
+++ b/src/PowerShellEditorServices/Logging/PsesTelemetryEvent.cs
@@ -16,11 +16,11 @@ namespace Microsoft.PowerShell.EditorServices.Logging
         {
             get
             {
-                return this["EventName"].ToString() ?? "PsesEvent";
+                return this ["EventName"].ToString() ?? "PsesEvent";
             }
             set
             {
-                this["EventName"] = value;
+                this ["EventName"] = value;
             }
         }
 
@@ -28,11 +28,11 @@ namespace Microsoft.PowerShell.EditorServices.Logging
         {
             get
             {
-                return this["Data"] as JObject ?? new JObject();
+                return this ["Data"] as JObject ?? new JObject();
             }
             set
             {
-                this["Data"] = value;
+                this ["Data"] = value;
             }
         }
     }

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
 
                 // Needed to make sure PSReadLine's static properties are initialized in the pipeline thread.
                 // This is only needed for Temp sessions who only have a debug server.
-                if (_usePSReadLine && _useTempSession && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
+                if(_usePSReadLine && _useTempSession && Interlocked.Exchange(ref s_hasRunPsrlStaticCtor, 1) == 0)
                 {
                     var command = new PSCommand()
                         .AddCommand(s_lazyInvokeReadLineConstructorCmdletInfo.Value);
@@ -114,14 +114,16 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     .WithHandler<DebugEvaluateHandler>()
                     // The OnInitialize delegate gets run when we first receive the _Initialize_ request:
                     // https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize
-                    .OnInitialize(async (server, request, cancellationToken) => {
+                    .OnInitialize(async (server, request, cancellationToken) =>
+                    {
                         var breakpointService = server.GetService<BreakpointService>();
                         // Clear any existing breakpoints before proceeding
                         await breakpointService.RemoveAllBreakpointsAsync().ConfigureAwait(false);
                     })
                     // The OnInitialized delegate gets run right before the server responds to the _Initialize_ request:
                     // https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize
-                    .OnInitialized((server, request, response, cancellationToken) => {
+                    .OnInitialized((server, request, response, cancellationToken) =>
+                    {
                         response.SupportsConditionalBreakpoints = true;
                         response.SupportsConfigurationDoneRequest = true;
                         response.SupportsFunctionBreakpoints = true;

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -116,15 +116,15 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             var workspaceService = serviceProvider.GetService<WorkspaceService>();
 
                             // Grab the workspace path from the parameters
-                            if (request.RootUri != null)
+                            if(request.RootUri != null)
                             {
                                 workspaceService.WorkspacePath = request.RootUri.GetFileSystemPath();
                             }
-                            else if (request.WorkspaceFolders != null)
+                            else if(request.WorkspaceFolders != null)
                             {
                                 // If RootUri isn't set, try to use the first WorkspaceFolder.
                                 // TODO: Support multi-workspace.
-                                foreach (var workspaceFolder in request.WorkspaceFolders)
+                                foreach(var workspaceFolder in request.WorkspaceFolders)
                                 {
                                     workspaceService.WorkspacePath = workspaceFolder.Uri.GetFileSystemPath();
                                     break;

--- a/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
+++ b/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                 .AddSingleton<BreakpointService>()
                 .AddSingleton<DebugStateService>(new DebugStateService
                 {
-                     OwnsEditorSession = useTempSession
+                    OwnsEditorSession = useTempSession
                 })
                 .AddSingleton<DebugEventHandlerService>();
         }

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Defines the list of Script Analyzer rules to include by default if
         /// no settings file is specified.
         /// </summary>
-        private static readonly string[] s_defaultRules = {
+        private static readonly string [] s_defaultRules = {
             "PSAvoidAssignmentToAutomaticVariable",
             "PSUseToExportFieldsInManifest",
             "PSMisleadingBacktick",
@@ -134,9 +134,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="cancellationToken">A cancellation token to cancel this call with.</param>
         /// <returns>A task that finishes when script diagnostics have been published.</returns>
         public void RunScriptDiagnostics(
-            ScriptFile[] filesToAnalyze)
+            ScriptFile [] filesToAnalyze)
         {
-            if (_configurationService.CurrentSettings.ScriptAnalysis.Enable == false)
+            if(_configurationService.CurrentSettings.ScriptAnalysis.Enable == false)
             {
                 return;
             }
@@ -146,20 +146,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // If there's an existing task, we want to cancel it here;
             var cancellationSource = new CancellationTokenSource();
             CancellationTokenSource oldTaskCancellation = Interlocked.Exchange(ref _diagnosticsCancellationTokenSource, cancellationSource);
-            if (oldTaskCancellation != null)
+            if(oldTaskCancellation != null)
             {
                 try
                 {
                     oldTaskCancellation.Cancel();
                     oldTaskCancellation.Dispose();
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     _logger.LogError(e, "Exception occurred while cancelling analysis task");
                 }
             }
 
-            if (filesToAnalyze.Length == 0)
+            if(filesToAnalyze.Length == 0)
             {
                 return;
             }
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var analysisTask = Task.Run(() => DelayThenInvokeDiagnosticsAsync(filesToAnalyze, _diagnosticsCancellationTokenSource.Token), _diagnosticsCancellationTokenSource.Token);
 
             // Ensure that any next corrections request will wait for this diagnostics publication
-            foreach (ScriptFile file in filesToAnalyze)
+            foreach(ScriptFile file in filesToAnalyze)
             {
                 CorrectionTableEntry fileCorrectionsEntry = _mostRecentCorrectionsByFile.GetOrAdd(
                     file,
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="formatSettings">The settings to use with the formatter.</param>
         /// <param name="formatRange">Optionally, the range that should be formatted.</param>
         /// <returns>The text of the formatted PowerShell script.</returns>
-        public Task<string> FormatAsync(string scriptFileContents, Hashtable formatSettings, int[] formatRange = null)
+        public Task<string> FormatAsync(string scriptFileContents, Hashtable formatSettings, int [] formatRange = null)
         {
             EnsureEngineSettingsCurrent();
             return AnalysisEngine.FormatAsync(scriptFileContents, formatSettings, formatRange);
@@ -199,23 +199,23 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns></returns>
         public async Task<string> GetCommentHelpText(string functionText, string helpLocation, bool forBlockComment)
         {
-            if (AnalysisEngine == null)
+            if(AnalysisEngine == null)
             {
                 return null;
             }
 
             Hashtable commentHelpSettings = AnalysisService.GetCommentHelpRuleSettings(helpLocation, forBlockComment);
 
-            ScriptFileMarker[] analysisResults = await AnalysisEngine.AnalyzeScriptAsync(functionText, commentHelpSettings).ConfigureAwait(false);
+            ScriptFileMarker [] analysisResults = await AnalysisEngine.AnalyzeScriptAsync(functionText, commentHelpSettings).ConfigureAwait(false);
 
-            if (analysisResults.Length == 0
-                || analysisResults[0]?.Correction?.Edits == null
-                || analysisResults[0].Correction.Edits.Count() == 0)
+            if(analysisResults.Length == 0
+                || analysisResults [0]?.Correction?.Edits == null
+                || analysisResults [0].Correction.Edits.Count() == 0)
             {
                 return null;
             }
 
-            return analysisResults[0].Correction.Edits[0].Text;
+            return analysisResults [0].Correction.Edits [0].Text;
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>A threadsafe readonly dictionary of the code actions of the particular file.</returns>
         public async Task<IReadOnlyDictionary<string, MarkerCorrection>> GetMostRecentCodeActionsForFileAsync(DocumentUri uri)
         {
-            if (!_workspaceService.TryGetFile(uri, out ScriptFile file)
+            if(!_workspaceService.TryGetFile(uri, out ScriptFile file)
                 || !_mostRecentCorrectionsByFile.TryGetValue(file, out CorrectionTableEntry corrections))
             {
                 return null;
@@ -254,7 +254,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="settings">The new language server settings.</param>
         public void OnConfigurationUpdated(object sender, LanguageServerSettings settings)
         {
-            if (settings.ScriptAnalysis.Enable ?? true)
+            if(settings.ScriptAnalysis.Enable ?? true)
             {
                 InitializeAnalysisEngineToCurrentSettings();
             }
@@ -262,7 +262,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void EnsureEngineSettingsCurrent()
         {
-            if (_analysisEngineLazy == null
+            if(_analysisEngineLazy == null
                     || (_pssaSettingsFilePath != null
                         && !File.Exists(_pssaSettingsFilePath)))
             {
@@ -274,12 +274,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             // We may be triggered after the lazy factory is set,
             // but before it's been able to instantiate
-            if (_analysisEngineLazy == null)
+            if(_analysisEngineLazy == null)
             {
                 _analysisEngineLazy = new Lazy<PssaCmdletAnalysisEngine>(InstantiateAnalysisEngine);
                 return;
             }
-            else if (!_analysisEngineLazy.IsValueCreated)
+            else if(!_analysisEngineLazy.IsValueCreated)
             {
                 return;
             }
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var pssaCmdletEngineBuilder = new PssaCmdletAnalysisEngine.Builder(_loggerFactory);
 
             // If there's a settings file use that
-            if (TryFindSettingsFile(out string settingsFilePath))
+            if(TryFindSettingsFile(out string settingsFilePath))
             {
                 _logger.LogInformation($"Configuring PSScriptAnalyzer with rules at '{settingsFilePath}'");
                 _pssaSettingsFilePath = settingsFilePath;
@@ -314,7 +314,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private PssaCmdletAnalysisEngine RecreateAnalysisEngine(PssaCmdletAnalysisEngine oldAnalysisEngine)
         {
-            if (TryFindSettingsFile(out string settingsFilePath))
+            if(TryFindSettingsFile(out string settingsFilePath))
             {
                 _logger.LogInformation($"Recreating analysis engine with rules at '{settingsFilePath}'");
                 _pssaSettingsFilePath = settingsFilePath;
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string configuredPath = _configurationService.CurrentSettings.ScriptAnalysis.SettingsPath;
 
-            if (string.IsNullOrEmpty(configuredPath))
+            if(string.IsNullOrEmpty(configuredPath))
             {
                 settingsFilePath = null;
                 return false;
@@ -337,7 +337,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             settingsFilePath = _workspaceService.ResolveWorkspacePath(configuredPath);
 
-            if (settingsFilePath == null
+            if(settingsFilePath == null
                 || !File.Exists(settingsFilePath))
             {
                 _logger.LogInformation($"Unable to find PSSA settings file at '{configuredPath}'. Loading default rules.");
@@ -350,15 +350,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void ClearOpenFileMarkers()
         {
-            foreach (ScriptFile file in _workspaceService.GetOpenedFiles())
+            foreach(ScriptFile file in _workspaceService.GetOpenedFiles())
             {
                 ClearMarkers(file);
             }
         }
 
-        private async Task DelayThenInvokeDiagnosticsAsync(ScriptFile[] filesToAnalyze, CancellationToken cancellationToken)
+        private async Task DelayThenInvokeDiagnosticsAsync(ScriptFile [] filesToAnalyze, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 return;
             }
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 await Task.Delay(_analysisDelayMillis, cancellationToken).ConfigureAwait(false);
             }
-            catch (TaskCanceledException)
+            catch(TaskCanceledException)
             {
                 return;
             }
@@ -379,9 +379,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // on.  It makes sense to send back the results from the first
             // delay period while the second one is ticking away.
 
-            foreach (ScriptFile scriptFile in filesToAnalyze)
+            foreach(ScriptFile scriptFile in filesToAnalyze)
             {
-                ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
+                ScriptFileMarker [] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
 
                 scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
 
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void PublishScriptDiagnostics(ScriptFile scriptFile, IReadOnlyList<ScriptFileMarker> markers)
         {
-            var diagnostics = new Diagnostic[markers.Count];
+            var diagnostics = new Diagnostic [markers.Count];
 
             CorrectionTableEntry fileCorrections = _mostRecentCorrectionsByFile.GetOrAdd(
                 scriptFile,
@@ -401,19 +401,19 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             fileCorrections.Corrections.Clear();
 
-            for (int i = 0; i < markers.Count; i++)
+            for(int i = 0; i < markers.Count; i++)
             {
-                ScriptFileMarker marker = markers[i];
+                ScriptFileMarker marker = markers [i];
 
                 Diagnostic diagnostic = GetDiagnosticFromMarker(marker);
 
-                if (marker.Correction != null)
+                if(marker.Correction != null)
                 {
                     string diagnosticId = GetUniqueIdFromDiagnostic(diagnostic);
-                    fileCorrections.Corrections[diagnosticId] = marker.Correction;
+                    fileCorrections.Corrections [diagnosticId] = marker.Correction;
                 }
 
-                diagnostics[i] = diagnostic;
+                diagnostics [i] = diagnostic;
             }
 
             _languageServer.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
@@ -454,12 +454,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private static DiagnosticSeverity MapDiagnosticSeverity(ScriptFileMarkerLevel markerLevel)
         {
-            switch (markerLevel)
+            switch(markerLevel)
             {
-                case ScriptFileMarkerLevel.Error:       return DiagnosticSeverity.Error;
-                case ScriptFileMarkerLevel.Warning:     return DiagnosticSeverity.Warning;
+                case ScriptFileMarkerLevel.Error: return DiagnosticSeverity.Error;
+                case ScriptFileMarkerLevel.Warning: return DiagnosticSeverity.Warning;
                 case ScriptFileMarkerLevel.Information: return DiagnosticSeverity.Information;
-                default:                                return DiagnosticSeverity.Error;
+                default: return DiagnosticSeverity.Error;
             };
         }
 
@@ -482,11 +482,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if(!disposedValue)
             {
-                if (disposing)
+                if(disposing)
                 {
-                    if (_analysisEngineLazy != null
+                    if(_analysisEngineLazy != null
                         && _analysisEngineLazy.IsValueCreated)
                     {
                         _analysisEngineLazy.Value.Dispose();

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
             private object _settingsParameter;
 
-            private string[] _rules;
+            private string [] _rules;
 
             /// <summary>
             /// Create a builder for PssaCmdletAnalysisEngine construction.
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             /// </summary>
             /// <param name="rules">The rules for PSSA to run.</param>
             /// <returns>The builder for chaining.</returns>
-            public Builder WithIncludedRules(string[] rules)
+            public Builder WithIncludedRules(string [] rules)
             {
                 _rules = rules;
                 return this;
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                     cmdletAnalysisEngine.LogAvailablePssaFeatures();
                     return cmdletAnalysisEngine;
                 }
-                catch (FileNotFoundException e)
+                catch(FileNotFoundException e)
                 {
                     logger.LogError(e, $"Unable to find PSScriptAnalyzer. Disabling script analysis. PSModulePath: '{Environment.GetEnvironmentVariable("PSModulePath")}'");
                     return null;
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         private static readonly IReadOnlyCollection<PSObject> s_emptyDiagnosticResult = new Collection<PSObject>();
 
-        private static readonly ScriptFileMarkerLevel[] s_scriptMarkerLevels = new[]
+        private static readonly ScriptFileMarkerLevel [] s_scriptMarkerLevels = new []
         {
             ScriptFileMarkerLevel.Error,
             ScriptFileMarkerLevel.Warning,
@@ -129,13 +129,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         private readonly object _settingsParameter;
 
-        private readonly string[] _rulesToInclude;
+        private readonly string [] _rulesToInclude;
 
         private PssaCmdletAnalysisEngine(
             ILogger logger,
             RunspacePool analysisRunspacePool,
             PSModuleInfo pssaModuleInfo,
-            string[] rulesToInclude)
+            string [] rulesToInclude)
             : this(logger, analysisRunspacePool, pssaModuleInfo)
         {
             _rulesToInclude = rulesToInclude;
@@ -168,11 +168,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// <param name="formatSettings">The formatter settings to use.</param>
         /// <param name="rangeList">A possible range over which to run the formatter.</param>
         /// <returns></returns>
-        public async Task<string> FormatAsync(string scriptDefinition, Hashtable formatSettings, int[] rangeList)
+        public async Task<string> FormatAsync(string scriptDefinition, Hashtable formatSettings, int [] rangeList)
         {
             // We cannot use Range type therefore this workaround of using -1 default value.
             // Invoke-Formatter throws a ParameterBinderValidationException if the ScriptDefinition is an empty string.
-            if (string.IsNullOrEmpty(scriptDefinition))
+            if(string.IsNullOrEmpty(scriptDefinition))
             {
                 _logger.LogDebug("Script Definition was: " + scriptDefinition == null ? "null" : "empty string");
                 return scriptDefinition;
@@ -183,23 +183,23 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 .AddParameter("ScriptDefinition", scriptDefinition)
                 .AddParameter("Settings", formatSettings);
 
-            if (rangeList != null)
+            if(rangeList != null)
             {
                 psCommand.AddParameter("Range", rangeList);
             }
 
             PowerShellResult result = await InvokePowerShellAsync(psCommand).ConfigureAwait(false);
 
-            if (result == null)
+            if(result == null)
             {
                 _logger.LogError("Formatter returned null result");
                 return scriptDefinition;
             }
 
-            if (result.HasErrors)
+            if(result.HasErrors)
             {
                 var errorBuilder = new StringBuilder().Append(s_indentJoin);
-                foreach (ErrorRecord err in result.Errors)
+                foreach(ErrorRecord err in result.Errors)
                 {
                     errorBuilder.Append(err).Append(s_indentJoin);
                 }
@@ -207,9 +207,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 return scriptDefinition;
             }
 
-            foreach (PSObject resultObj in result.Output)
+            foreach(PSObject resultObj in result.Output)
             {
-                if (resultObj?.BaseObject is string formatResult)
+                if(resultObj?.BaseObject is string formatResult)
                 {
                     return formatResult;
                 }
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// </summary>
         /// <param name="scriptContent">The contents of the script to analyze.</param>
         /// <returns>An array of markers indicating script analysis diagnostics.</returns>
-        public Task<ScriptFileMarker[]> AnalyzeScriptAsync(string scriptContent) => AnalyzeScriptAsync(scriptContent, settings: null);
+        public Task<ScriptFileMarker []> AnalyzeScriptAsync(string scriptContent) => AnalyzeScriptAsync(scriptContent, settings: null);
 
 
         /// <summary>
@@ -233,12 +233,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// <param name="scriptContent">The contents of the script to analyze.</param>
         /// <param name="settings">The settings file to use in this instance of analysis.</param>
         /// <returns>An array of markers indicating script analysis diagnostics.</returns>
-        public Task<ScriptFileMarker[]> AnalyzeScriptAsync(string scriptContent, Hashtable settings)
+        public Task<ScriptFileMarker []> AnalyzeScriptAsync(string scriptContent, Hashtable settings)
         {
             // When a new, empty file is created there are by definition no issues.
             // Furthermore, if you call Invoke-ScriptAnalyzer with an empty ScriptDefinition
             // it will generate a ParameterBindingValidationException.
-            if (string.IsNullOrEmpty(scriptContent))
+            if(string.IsNullOrEmpty(scriptContent))
             {
                 return Task.FromResult(Array.Empty<ScriptFileMarker>());
             }
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 .AddParameter("Severity", s_scriptMarkerLevels);
 
             object settingsValue = settings ?? _settingsParameter;
-            if (settingsValue != null)
+            if(settingsValue != null)
             {
                 command.AddParameter("Settings", settingsValue);
             }
@@ -271,7 +271,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             return new PssaCmdletAnalysisEngine(_logger, _analysisRunspacePool, _pssaModuleInfo, settingsHashtable);
         }
 
-        public PssaCmdletAnalysisEngine RecreateWithRules(string[] rules)
+        public PssaCmdletAnalysisEngine RecreateWithRules(string [] rules)
         {
             return new PssaCmdletAnalysisEngine(_logger, _analysisRunspacePool, _pssaModuleInfo, rules);
         }
@@ -281,9 +281,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if(!disposedValue)
             {
-                if (disposing)
+                if(disposing)
                 {
                     _analysisRunspacePool.Dispose();
                 }
@@ -301,18 +301,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         #endregion
 
-        private async Task<ScriptFileMarker[]> GetSemanticMarkersFromCommandAsync(PSCommand command)
+        private async Task<ScriptFileMarker []> GetSemanticMarkersFromCommandAsync(PSCommand command)
         {
             PowerShellResult result = await InvokePowerShellAsync(command).ConfigureAwait(false);
 
             IReadOnlyCollection<PSObject> diagnosticResults = result?.Output ?? s_emptyDiagnosticResult;
             _logger.LogDebug(String.Format("Found {0} violations", diagnosticResults.Count));
 
-            var scriptMarkers = new ScriptFileMarker[diagnosticResults.Count];
+            var scriptMarkers = new ScriptFileMarker [diagnosticResults.Count];
             int i = 0;
-            foreach (PSObject diagnostic in diagnosticResults)
+            foreach(PSObject diagnostic in diagnosticResults)
             {
-                scriptMarkers[i] = ScriptFileMarker.FromDiagnosticRecord(diagnostic);
+                scriptMarkers [i] = ScriptFileMarker.FromDiagnosticRecord(diagnostic);
                 i++;
             }
 
@@ -326,7 +326,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         private PowerShellResult InvokePowerShell(PSCommand command)
         {
-            using (var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.NewRunspace))
+            using(var powerShell = System.Management.Automation.PowerShell.Create(RunspaceMode.NewRunspace))
             {
                 powerShell.RunspacePool = _analysisRunspacePool;
                 powerShell.Commands = command;
@@ -337,13 +337,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                     PSDataCollection<ErrorRecord> errors = powerShell.Streams.Error;
                     result = new PowerShellResult(output, errors, powerShell.HadErrors);
                 }
-                catch (CommandNotFoundException ex)
+                catch(CommandNotFoundException ex)
                 {
                     // This exception is possible if the module path loaded
                     // is wrong even though PSScriptAnalyzer is available as a module
                     _logger.LogError(ex.Message);
                 }
-                catch (CmdletInvocationException ex)
+                catch(CmdletInvocationException ex)
                 {
                     // We do not want to crash EditorServices for exceptions caused by cmdlet invocation.
                     // Two main reasons that cause the exception are:
@@ -364,7 +364,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// <returns>The output of PowerShell execution.</returns>
         private Collection<PSObject> InvokePowerShellWithModulePathPreservation(System.Management.Automation.PowerShell powershell)
         {
-            using (PSModulePathPreserver.Take())
+            using(PSModulePathPreserver.Take())
             {
                 return powershell.Invoke();
             }
@@ -377,12 +377,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         private void LogAvailablePssaFeatures()
         {
             // Save ourselves some work here
-            if (!_logger.IsEnabled(LogLevel.Debug))
+            if(!_logger.IsEnabled(LogLevel.Debug))
             {
                 return;
             }
 
-            if (_pssaModuleInfo == null)
+            if(_pssaModuleInfo == null)
             {
                 throw new FileNotFoundException("Unable to find loaded PSScriptAnalyzer module for logging");
             }
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
             // Log exported cmdlets
             sb.AppendLine("    Exported Cmdlets:");
-            foreach (string cmdletName in _pssaModuleInfo.ExportedCmdlets.Keys.OrderBy(name => name))
+            foreach(string cmdletName in _pssaModuleInfo.ExportedCmdlets.Keys.OrderBy(name => name))
             {
                 sb.Append("    ");
                 sb.AppendLine(cmdletName);
@@ -404,7 +404,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
             // Log available rules
             sb.AppendLine("    Available Rules:");
-            foreach (string ruleName in GetPSScriptAnalyzerRules())
+            foreach(string ruleName in GetPSScriptAnalyzerRules())
             {
                 sb.Append("        ");
                 sb.AppendLine(ruleName);
@@ -419,16 +419,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         private IEnumerable<string> GetPSScriptAnalyzerRules()
         {
             PowerShellResult getRuleResult = InvokePowerShell(new PSCommand().AddCommand("Get-ScriptAnalyzerRule"));
-            if (getRuleResult == null)
+            if(getRuleResult == null)
             {
                 _logger.LogWarning("Get-ScriptAnalyzerRule returned null result");
                 return Enumerable.Empty<string>();
             }
 
             var ruleNames = new List<string>(getRuleResult.Output.Count);
-            foreach (var rule in getRuleResult.Output)
+            foreach(var rule in getRuleResult.Output)
             {
-                ruleNames.Add((string)rule.Members["RuleName"].Value);
+                ruleNames.Add((string)rule.Members ["RuleName"].Value);
             }
 
             return ruleNames;
@@ -441,7 +441,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// <returns>A runspace pool with PSScriptAnalyzer loaded for running script analysis tasks.</returns>
         private static RunspacePool CreatePssaRunspacePool(out PSModuleInfo pssaModuleInfo)
         {
-            using (var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.NewRunspace))
+            using(var ps = System.Management.Automation.PowerShell.Create(RunspaceMode.NewRunspace))
             {
                 // Run `Get-Module -ListAvailable -Name "PSScriptAnalyzer"`
                 ps.AddCommand("Get-Module")
@@ -450,7 +450,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
                 try
                 {
-                    using (PSModulePathPreserver.Take())
+                    using(PSModulePathPreserver.Take())
                     {
                         // Get the latest version of PSScriptAnalyzer we can find
                         pssaModuleInfo = ps.Invoke<PSModuleInfo>()?
@@ -458,12 +458,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                             .FirstOrDefault();
                     }
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     throw new FileNotFoundException("Unable to find PSScriptAnalyzer module on the module path", e);
                 }
 
-                if (pssaModuleInfo == null)
+                if(pssaModuleInfo == null)
                 {
                     throw new FileNotFoundException("Unable to find PSScriptAnalyzer module on the module path");
                 }
@@ -486,7 +486,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                 runspacePool.ThreadOptions = PSThreadOptions.ReuseThread;
 
                 // Open the runspace pool here so we can deterministically handle the PSModulePath change issue
-                using (PSModulePathPreserver.Take())
+                using(PSModulePathPreserver.Take())
                 {
                     runspacePool.Open();
                 }

--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// The document for which CodeLenses should be provided.
         /// </param>
         /// <returns>An array of CodeLenses.</returns>
-        CodeLens[] ProvideCodeLenses(ScriptFile scriptFile);
+        CodeLens [] ProvideCodeLenses(ScriptFile scriptFile);
 
         /// <summary>
         /// Resolves a CodeLens that was created without a Command.

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -42,10 +42,10 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="pesterSymbol">The Pester symbol to get CodeLenses for.</param>
         /// <param name="scriptFile">The script file the Pester symbol comes from.</param>
         /// <returns>All CodeLenses for the given Pester symbol.</returns>
-        private CodeLens[] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
+        private CodeLens [] GetPesterLens(PesterSymbolReference pesterSymbol, ScriptFile scriptFile)
         {
             string word = pesterSymbol.Command == PesterCommandType.It ? "test" : "tests";
-            var codeLensResults = new CodeLens[]
+            var codeLensResults = new CodeLens []
             {
                 new CodeLens()
                 {
@@ -99,17 +99,17 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         /// <param name="scriptFile">The script file to get Pester CodeLenses for.</param>
         /// <returns>All Pester CodeLenses for the given script file.</returns>
-        public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
+        public CodeLens [] ProvideCodeLenses(ScriptFile scriptFile)
         {
             var lenses = new List<CodeLens>();
-            foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
+            foreach(SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
-                if (!(symbol is PesterSymbolReference pesterSymbol))
+                if(!(symbol is PesterSymbolReference pesterSymbol))
                 {
                     continue;
                 }
 
-                if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens
+                if(_configurationService.CurrentSettings.Pester.UseLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {
                     continue;

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
     /// </summary>
     internal class ReferencesCodeLensProvider : ICodeLensProvider
     {
-        private static readonly Location[] s_emptyLocationArray = Array.Empty<Location>();
+        private static readonly Location [] s_emptyLocationArray = Array.Empty<Location>();
 
         /// <summary>
         /// The document symbol provider to supply symbols to generate the code lenses.
@@ -53,12 +53,12 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         /// <param name="scriptFile">The PowerShell script file to get code lenses for.</param>
         /// <returns>An array of CodeLenses describing all functions in the given script file.</returns>
-        public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
+        public CodeLens [] ProvideCodeLenses(ScriptFile scriptFile)
         {
             var acc = new List<CodeLens>();
-            foreach (SymbolReference sym in _symbolProvider.ProvideDocumentSymbols(scriptFile))
+            foreach(SymbolReference sym in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
-                if (sym.SymbolType == SymbolType.Function)
+                if(sym.SymbolType == SymbolType.Function)
                 {
                     acc.Add(new CodeLens
                     {
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         public CodeLens ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile)
         {
 
-            ScriptFile[] references = _workspaceService.ExpandScriptReferences(
+            ScriptFile [] references = _workspaceService.ExpandScriptReferences(
                 scriptFile);
 
             SymbolReference foundSymbol = _symbolsService.FindFunctionDefinitionAtLocation(
@@ -96,24 +96,24 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 references,
                 _workspaceService);
 
-            Location[] referenceLocations;
-            if (referencesResult == null)
+            Location [] referenceLocations;
+            if(referencesResult == null)
             {
                 referenceLocations = s_emptyLocationArray;
             }
             else
             {
                 var acc = new List<Location>();
-                foreach (SymbolReference foundReference in referencesResult)
+                foreach(SymbolReference foundReference in referencesResult)
                 {
-                    if (IsReferenceDefinition(foundSymbol, foundReference))
+                    if(IsReferenceDefinition(foundSymbol, foundReference))
                     {
                         continue;
                     }
 
                     DocumentUri uri = DocumentUri.From(foundReference.FilePath);
                     // For any vscode-notebook-cell, we need to ignore the backing file on disk.
-                    if (uri.Scheme == "file" &&
+                    if(uri.Scheme == "file" &&
                         scriptFile.DocumentUri.Scheme == "vscode-notebook-cell" &&
                         uri.Path == scriptFile.DocumentUri.Path)
                     {
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 {
                     Name = "editor.action.showReferences",
                     Title = GetReferenceCountHeader(referenceLocations.Length),
-                    Arguments = JArray.FromObject(new object[]
+                    Arguments = JArray.FromObject(new object []
                     {
                         scriptFile.DocumentUri,
                         codeLens.Range.Start,
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <returns>The header string for the reference code lens.</returns>
         private static string GetReferenceCountHeader(int referenceCount)
         {
-            if (referenceCount == 1)
+            if(referenceCount == 1)
             {
                 return "1 reference";
             }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<List<Breakpoint>> GetBreakpointsAsync()
         {
-            if (BreakpointApiUtils.SupportsBreakpointApis)
+            if(BreakpointApiUtils.SupportsBreakpointApis)
             {
                 return BreakpointApiUtils.GetBreakpoints(
                     _powerShellContextService.CurrentRunspace.Runspace.Debugger,
@@ -53,9 +53,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<IEnumerable<BreakpointDetails>> SetBreakpointsAsync(string escapedScriptPath, IEnumerable<BreakpointDetails> breakpoints)
         {
-            if (BreakpointApiUtils.SupportsBreakpointApis)
+            if(BreakpointApiUtils.SupportsBreakpointApis)
             {
-                foreach (BreakpointDetails breakpointDetails in breakpoints)
+                foreach(BreakpointDetails breakpointDetails in breakpoints)
                 {
                     try
                     {
@@ -74,12 +74,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Legacy behavior
             PSCommand psCommand = null;
             List<BreakpointDetails> configuredBreakpoints = new List<BreakpointDetails>();
-            foreach (BreakpointDetails breakpoint in breakpoints)
+            foreach(BreakpointDetails breakpoint in breakpoints)
             {
                 ScriptBlock actionScriptBlock = null;
 
                 // Check if this is a "conditional" line breakpoint.
-                if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+                if(!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition) ||
                     !string.IsNullOrWhiteSpace(breakpoint.LogMessage))
                 {
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         breakpoint.LogMessage,
                         out string errorMessage);
 
-                    if (!string.IsNullOrEmpty(errorMessage))
+                    if(!string.IsNullOrEmpty(errorMessage))
                     {
                         breakpoint.Verified = false;
                         breakpoint.Message = errorMessage;
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 // On first iteration psCommand will be null, every subsequent
                 // iteration will need to start a new statement.
-                if (psCommand == null)
+                if(psCommand == null)
                 {
                     psCommand = new PSCommand();
                 }
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     .AddParameter("Line", breakpoint.LineNumber);
 
                 // Check if the user has specified the column number for the breakpoint.
-                if (breakpoint.ColumnNumber.HasValue && breakpoint.ColumnNumber.Value > 0)
+                if(breakpoint.ColumnNumber.HasValue && breakpoint.ColumnNumber.Value > 0)
                 {
                     // It bums me out that PowerShell will silently ignore a breakpoint
                     // where either the line or the column is invalid.  I'd rather have an
@@ -123,14 +123,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     psCommand.AddParameter("Column", breakpoint.ColumnNumber.Value);
                 }
 
-                if (actionScriptBlock != null)
+                if(actionScriptBlock != null)
                 {
                     psCommand.AddParameter("Action", actionScriptBlock);
                 }
             }
 
             // If no PSCommand was created then there are no breakpoints to set.
-            if (psCommand != null)
+            if(psCommand != null)
             {
                 IEnumerable<Breakpoint> setBreakpoints =
                     await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
@@ -143,9 +143,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<IEnumerable<CommandBreakpointDetails>> SetCommandBreakpoints(IEnumerable<CommandBreakpointDetails> breakpoints)
         {
-            if (BreakpointApiUtils.SupportsBreakpointApis)
+            if(BreakpointApiUtils.SupportsBreakpointApis)
             {
-                foreach (CommandBreakpointDetails commandBreakpointDetails in breakpoints)
+                foreach(CommandBreakpointDetails commandBreakpointDetails in breakpoints)
                 {
                     try
                     {
@@ -164,11 +164,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Legacy behavior
             PSCommand psCommand = null;
             List<CommandBreakpointDetails> configuredBreakpoints = new List<CommandBreakpointDetails>();
-            foreach (CommandBreakpointDetails breakpoint in breakpoints)
+            foreach(CommandBreakpointDetails breakpoint in breakpoints)
             {
                 // On first iteration psCommand will be null, every subsequent
                 // iteration will need to start a new statement.
-                if (psCommand == null)
+                if(psCommand == null)
                 {
                     psCommand = new PSCommand();
                 }
@@ -182,7 +182,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     .AddParameter("Command", breakpoint.Name);
 
                 // Check if this is a "conditional" line breakpoint.
-                if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+                if(!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
                     !string.IsNullOrWhiteSpace(breakpoint.HitCondition))
                 {
                     ScriptBlock actionScriptBlock =
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                     // If there was a problem with the condition string,
                     // move onto the next breakpoint.
-                    if (!string.IsNullOrEmpty(errorMessage))
+                    if(!string.IsNullOrEmpty(errorMessage))
                     {
                         breakpoint.Verified = false;
                         breakpoint.Message = errorMessage;
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             // If no PSCommand was created then there are no breakpoints to set.
-            if (psCommand != null)
+            if(psCommand != null)
             {
                 IEnumerable<Breakpoint> setBreakpoints =
                     await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand);
@@ -225,13 +225,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             try
             {
-                if (BreakpointApiUtils.SupportsBreakpointApis)
+                if(BreakpointApiUtils.SupportsBreakpointApis)
                 {
-                    foreach (Breakpoint breakpoint in BreakpointApiUtils.GetBreakpoints(
+                    foreach(Breakpoint breakpoint in BreakpointApiUtils.GetBreakpoints(
                             _powerShellContextService.CurrentRunspace.Runspace.Debugger,
                             _debugStateService.RunspaceId))
                     {
-                        if (scriptPath == null || scriptPath == breakpoint.Script)
+                        if(scriptPath == null || scriptPath == breakpoint.Script)
                         {
                             BreakpointApiUtils.RemoveBreakpoint(
                                 _powerShellContextService.CurrentRunspace.Runspace.Debugger,
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 PSCommand psCommand = new PSCommand();
                 psCommand.AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
 
-                if (!string.IsNullOrEmpty(scriptPath))
+                if(!string.IsNullOrEmpty(scriptPath))
                 {
                     psCommand.AddParameter("Script", scriptPath);
                 }
@@ -257,7 +257,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 await _powerShellContextService.ExecuteCommandAsync<object>(psCommand).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 _logger.LogException("Caught exception while clearing breakpoints from session", e);
             }
@@ -265,22 +265,22 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task RemoveBreakpointsAsync(IEnumerable<Breakpoint> breakpoints)
         {
-            if (BreakpointApiUtils.SupportsBreakpointApis)
+            if(BreakpointApiUtils.SupportsBreakpointApis)
             {
-                foreach (Breakpoint breakpoint in breakpoints)
+                foreach(Breakpoint breakpoint in breakpoints)
                 {
                     BreakpointApiUtils.RemoveBreakpoint(
                         _powerShellContextService.CurrentRunspace.Runspace.Debugger,
                         breakpoint,
                         _debugStateService.RunspaceId);
 
-                    switch (breakpoint)
+                    switch(breakpoint)
                     {
                         case CommandBreakpoint commandBreakpoint:
                             CommandBreakpoints.Remove(commandBreakpoint);
                             break;
                         case LineBreakpoint lineBreakpoint:
-                            if (BreakpointsPerFile.TryGetValue(lineBreakpoint.Script, out HashSet<Breakpoint> bps))
+                            if(BreakpointsPerFile.TryGetValue(lineBreakpoint.Script, out HashSet<Breakpoint> bps))
                             {
                                 bps.Remove(lineBreakpoint);
                             }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -69,10 +69,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // We don't support exception breakpoints and for "pause", we can't distinguish
             // between stepping and the user pressing the pause/break button in the debug toolbar.
             string debuggerStoppedReason = "step";
-            if (e.OriginalEvent.Breakpoints.Count > 0)
+            if(e.OriginalEvent.Breakpoints.Count > 0)
             {
                 debuggerStoppedReason =
-                    e.OriginalEvent.Breakpoints[0] is CommandBreakpoint
+                    e.OriginalEvent.Breakpoints [0] is CommandBreakpoint
                         ? "function breakpoint"
                         : "breakpoint";
             }
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void PowerShellContext_RunspaceChanged(object sender, RunspaceChangedEventArgs e)
         {
-            if (_debugStateService.WaitingForAttach &&
+            if(_debugStateService.WaitingForAttach &&
                 e.ChangeAction == RunspaceChangeAction.Enter &&
                 e.NewRunspace.Context == RunspaceContext.DebuggedRunspace)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 _debugStateService.WaitingForAttach = false;
                 _debugStateService.ServerStarted.SetResult(true);
             }
-            else if (
+            else if(
                 e.ChangeAction == RunspaceChangeAction.Exit &&
                 _powerShellContextService.IsDebuggerStopped)
             {
@@ -126,14 +126,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string reason = "changed";
 
-            if (_debugStateService.IsSetBreakpointInProgress)
+            if(_debugStateService.IsSetBreakpointInProgress)
             {
                 // Don't send breakpoint update notifications when setting
                 // breakpoints on behalf of the client.
                 return;
             }
 
-            switch (e.UpdateType)
+            switch(e.UpdateType)
             {
                 case BreakpointUpdateType.Set:
                     reason = "new";
@@ -149,11 +149,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 Verified = e.UpdateType != BreakpointUpdateType.Disabled
             };
 
-            if (e.Breakpoint is LineBreakpoint)
+            if(e.Breakpoint is LineBreakpoint)
             {
                 breakpoint = LspDebugUtils.CreateBreakpoint(BreakpointDetails.Create(e.Breakpoint));
             }
-            else if (e.Breakpoint is CommandBreakpoint)
+            else if(e.Breakpoint is CommandBreakpoint)
             {
                 _logger.LogTrace("Function breakpoint updated event is not supported yet");
                 return;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private const string PsesGlobalVariableNamePrefix = "__psEditorServices_";
         private const string TemporaryScriptFileName = "Script Listing.ps1";
-        private readonly BreakpointDetails[] s_emptyBreakpointDetailsArray = new BreakpointDetails[0];
+        private readonly BreakpointDetails [] s_emptyBreakpointDetailsArray = new BreakpointDetails [0];
 
         private readonly ILogger logger;
         private readonly PowerShellContextService powerShellContext;
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         private List<VariableDetailsBase> variables;
         private VariableContainerDetails globalScopeVariables;
         private VariableContainerDetails scriptScopeVariables;
-        private StackFrameDetails[] stackFrameDetails;
+        private StackFrameDetails [] stackFrameDetails;
         private readonly PropertyInfo invocationTypeScriptPositionProperty;
 
         private static int breakpointHitCounter;
@@ -132,9 +132,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
+        public async Task<BreakpointDetails []> SetLineBreakpointsAsync(
             ScriptFile scriptFile,
-            BreakpointDetails[] breakpoints,
+            BreakpointDetails [] breakpoints,
             bool clearExisting = true)
         {
             var dscBreakpoints =
@@ -144,10 +144,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             string scriptPath = scriptFile.FilePath;
             // Make sure we're using the remote script path
-            if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
+            if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
                 this.remoteFileManager != null)
             {
-                if (!this.remoteFileManager.IsUnderRemoteTempPath(scriptPath))
+                if(!this.remoteFileManager.IsUnderRemoteTempPath(scriptPath))
                 {
                     this.logger.LogTrace(
                         $"Could not set breakpoints for local path '{scriptPath}' in a remote session.");
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 scriptPath = mappedPath;
             }
-            else if (
+            else if(
                 this.temporaryScriptListingPath != null &&
                 this.temporaryScriptListingPath.Equals(scriptPath, StringComparison.CurrentCultureIgnoreCase))
             {
@@ -177,9 +177,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             string escapedScriptPath =
                 PowerShellContextService.WildcardEscapePath(scriptPath);
 
-            if (dscBreakpoints == null || !dscBreakpoints.IsDscResourcePath(escapedScriptPath))
+            if(dscBreakpoints == null || !dscBreakpoints.IsDscResourcePath(escapedScriptPath))
             {
-                if (clearExisting)
+                if(clearExisting)
                 {
                     await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
                 }
@@ -199,24 +199,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="breakpoints">CommandBreakpointDetails for each command breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing function breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<CommandBreakpointDetails[]> SetCommandBreakpointsAsync(
-            CommandBreakpointDetails[] breakpoints,
+        public async Task<CommandBreakpointDetails []> SetCommandBreakpointsAsync(
+            CommandBreakpointDetails [] breakpoints,
             bool clearExisting = true)
         {
-            CommandBreakpointDetails[] resultBreakpointDetails = null;
+            CommandBreakpointDetails [] resultBreakpointDetails = null;
 
-            if (clearExisting)
+            if(clearExisting)
             {
                 // Flatten dictionary values into one list and remove them all.
-                await _breakpointService.RemoveBreakpointsAsync((await _breakpointService.GetBreakpointsAsync()).Where( i => i is CommandBreakpoint)).ConfigureAwait(false);
+                await _breakpointService.RemoveBreakpointsAsync((await _breakpointService.GetBreakpointsAsync()).Where(i => i is CommandBreakpoint)).ConfigureAwait(false);
             }
 
-            if (breakpoints.Length > 0)
+            if(breakpoints.Length > 0)
             {
                 resultBreakpointDetails = (await _breakpointService.SetCommandBreakpoints(breakpoints).ConfigureAwait(false)).ToArray();
             }
 
-            return resultBreakpointDetails ?? new CommandBreakpointDetails[0];
+            return resultBreakpointDetails ?? new CommandBreakpointDetails [0];
         }
 
         /// <summary>
@@ -281,26 +281,26 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="variableReferenceId"></param>
         /// <returns>An array of VariableDetails instances which describe the requested variables.</returns>
-        public VariableDetailsBase[] GetVariables(int variableReferenceId)
+        public VariableDetailsBase [] GetVariables(int variableReferenceId)
         {
-            VariableDetailsBase[] childVariables;
+            VariableDetailsBase [] childVariables;
             this.debugInfoHandle.Wait();
             try
             {
-                if ((variableReferenceId < 0) || (variableReferenceId >= this.variables.Count))
+                if((variableReferenceId < 0) || (variableReferenceId >= this.variables.Count))
                 {
                     logger.LogWarning($"Received request for variableReferenceId {variableReferenceId} that is out of range of valid indices.");
                     return Array.Empty<VariableDetailsBase>();
                 }
 
-                VariableDetailsBase parentVariable = this.variables[variableReferenceId];
-                if (parentVariable.IsExpandable)
+                VariableDetailsBase parentVariable = this.variables [variableReferenceId];
+                if(parentVariable.IsExpandable)
                 {
                     childVariables = parentVariable.GetChildren(this.logger);
-                    foreach (var child in childVariables)
+                    foreach(var child in childVariables)
                     {
                         // Only add child if it hasn't already been added.
-                        if (child.Id < 0)
+                        if(child.Id < 0)
                         {
                             child.Id = this.nextVariableId++;
                             this.variables.Add(child);
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // references are very unlikely to find a matching variable e.g. "$i+5.2" will find no var matching "$i+5".
 
             // Break up the variable path
-            string[] variablePathParts = variableExpression.Split('.');
+            string [] variablePathParts = variableExpression.Split('.');
 
             VariableDetailsBase resolvedVariable = null;
             IEnumerable<VariableDetailsBase> variableList;
@@ -352,9 +352,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.debugInfoHandle.Release();
             }
 
-            foreach (var variableName in variablePathParts)
+            foreach(var variableName in variablePathParts)
             {
-                if (variableList == null)
+                if(variableList == null)
                 {
                     // If there are no children left to search, break out early
                     return null;
@@ -368,7 +368,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                                 variableName,
                                 StringComparison.CurrentCultureIgnoreCase));
 
-                if (resolvedVariable != null &&
+                if(resolvedVariable != null &&
                     resolvedVariable.IsExpandable)
                 {
                     // Continue by searching in this variable's children
@@ -398,7 +398,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             this.logger.LogTrace($"SetVariableRequest for '{name}' to value string (pre-quote processing): '{value}'");
 
             // An empty or whitespace only value is not a valid expression for SetVariable.
-            if (value.Trim().Length == 0)
+            if(value.Trim().Length == 0)
             {
                 throw new InvalidPowerShellExpressionException("Expected an expression.");
             }
@@ -416,14 +416,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Check if PowerShell's evaluation of the expression resulted in an error.
             object psobject = results.FirstOrDefault();
-            if ((psobject == null) && (errorMessages.Length > 0))
+            if((psobject == null) && (errorMessages.Length > 0))
             {
                 throw new InvalidPowerShellExpressionException(errorMessages.ToString());
             }
 
             // If PowerShellContext.ExecuteCommand returns an ErrorRecord as output, the expression failed evaluation.
             // Ideally we would have a separate means from communicating error records apart from normal output.
-            if (psobject is ErrorRecord errorRecord)
+            if(psobject is ErrorRecord errorRecord)
             {
                 throw new InvalidPowerShellExpressionException(errorRecord.ToString());
             }
@@ -434,32 +434,32 @@ namespace Microsoft.PowerShell.EditorServices.Services
             await this.debugInfoHandle.WaitAsync().ConfigureAwait(false);
             try
             {
-                variableContainer = (VariableContainerDetails)this.variables[variableContainerReferenceId];
+                variableContainer = (VariableContainerDetails)this.variables [variableContainerReferenceId];
             }
             finally
             {
                 this.debugInfoHandle.Release();
             }
 
-            VariableDetailsBase variable = variableContainer.Children[name];
+            VariableDetailsBase variable = variableContainer.Children [name];
             // Determine scope in which the variable lives. This is required later for the call to Get-Variable -Scope.
             string scope = null;
-            if (variableContainerReferenceId == this.scriptScopeVariables.Id)
+            if(variableContainerReferenceId == this.scriptScopeVariables.Id)
             {
                 scope = "Script";
             }
-            else if (variableContainerReferenceId == this.globalScopeVariables.Id)
+            else if(variableContainerReferenceId == this.globalScopeVariables.Id)
             {
                 scope = "Global";
             }
             else
             {
                 // Determine which stackframe's local scope the variable is in.
-                StackFrameDetails[] stackFrames = await this.GetStackFramesAsync().ConfigureAwait(false);
-                for (int i = 0; i < stackFrames.Length; i++)
+                StackFrameDetails [] stackFrames = await this.GetStackFramesAsync().ConfigureAwait(false);
+                for(int i = 0; i < stackFrames.Length; i++)
                 {
-                    var stackFrame = stackFrames[i];
-                    if (stackFrame.LocalVariables.ContainsVariable(variable.Id))
+                    var stackFrame = stackFrames [i];
+                    if(stackFrame.LocalVariables.ContainsVariable(variable.Id))
                     {
                         scope = i.ToString();
                         break;
@@ -467,7 +467,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
             }
 
-            if (scope == null)
+            if(scope == null)
             {
                 // Hmm, this would be unexpected.  No scope means do not pass GO, do not collect $200.
                 throw new Exception("Could not find the scope for this variable.");
@@ -482,7 +482,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             IEnumerable<PSVariable> result = await this.powerShellContext.ExecuteCommandAsync<PSVariable>(psCommand, sendErrorToHost: false).ConfigureAwait(false);
             PSVariable psVariable = result.FirstOrDefault();
-            if (psVariable == null)
+            if(psVariable == null)
             {
                 throw new Exception($"Failed to retrieve PSVariable object for '{name}' from scope '{scope}'.");
             }
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                           .OfType<ArgumentTransformationAttribute>()
                           .FirstOrDefault(a => a.GetType().Name.Equals("ArgumentTypeConverterAttribute"));
 
-            if (argTypeConverterAttr != null)
+            if(argTypeConverterAttr != null)
             {
                 // PSVariable is strongly typed. Need to apply the conversion/transform to the new value.
                 psCommand.Commands.Clear();
@@ -584,7 +584,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>
         /// An array of StackFrameDetails instances that contain the stack trace.
         /// </returns>
-        public StackFrameDetails[] GetStackFrames()
+        public StackFrameDetails [] GetStackFrames()
         {
             this.debugInfoHandle.Wait();
             try
@@ -597,7 +597,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        internal StackFrameDetails[] GetStackFrames(CancellationToken cancellationToken)
+        internal StackFrameDetails [] GetStackFrames(CancellationToken cancellationToken)
         {
             this.debugInfoHandle.Wait(cancellationToken);
             try
@@ -610,7 +610,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        internal async Task<StackFrameDetails[]> GetStackFramesAsync()
+        internal async Task<StackFrameDetails []> GetStackFramesAsync()
         {
             await this.debugInfoHandle.WaitAsync().ConfigureAwait(false);
             try
@@ -623,7 +623,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        internal async Task<StackFrameDetails[]> GetStackFramesAsync(CancellationToken cancellationToken)
+        internal async Task<StackFrameDetails []> GetStackFramesAsync(CancellationToken cancellationToken)
         {
             await this.debugInfoHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
@@ -642,13 +642,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="stackFrameId">The ID of the stack frame at which variable scopes should be retrieved.</param>
         /// <returns>The list of VariableScope instances which describe the available variable scopes.</returns>
-        public VariableScope[] GetVariableScopes(int stackFrameId)
+        public VariableScope [] GetVariableScopes(int stackFrameId)
         {
             var stackFrames = this.GetStackFrames();
-            int localStackFrameVariableId = stackFrames[stackFrameId].LocalVariables.Id;
-            int autoVariablesId = stackFrames[stackFrameId].AutoVariables.Id;
+            int localStackFrameVariableId = stackFrames [stackFrameId].LocalVariables.Id;
+            int autoVariablesId = stackFrames [stackFrameId].AutoVariables.Id;
 
-            return new VariableScope[]
+            return new VariableScope []
             {
                 new VariableScope(autoVariablesId, VariableContainerDetails.AutoVariablesName),
                 new VariableScope(localStackFrameVariableId, VariableContainerDetails.LocalScopeName),
@@ -708,15 +708,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
             this.variables.Add(scopeVariableContainer);
 
             var results = await this.powerShellContext.ExecuteCommandAsync<PSObject>(psCommand, sendErrorToHost: false).ConfigureAwait(false);
-            if (results != null)
+            if(results != null)
             {
-                foreach (PSObject psVariableObject in results)
+                foreach(PSObject psVariableObject in results)
                 {
                     var variableDetails = new VariableDetails(psVariableObject) { Id = this.nextVariableId++ };
                     this.variables.Add(variableDetails);
                     scopeVariableContainer.Children.Add(variableDetails.Name, variableDetails);
 
-                    if ((autoVariables != null) && AddToAutoVariables(psVariableObject, scope))
+                    if((autoVariables != null) && AddToAutoVariables(psVariableObject, scope))
                     {
                         autoVariables.Children.Add(variableDetails.Name, variableDetails);
                     }
@@ -728,7 +728,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private bool AddToAutoVariables(PSObject psvariable, string scope)
         {
-            if ((scope == VariableContainerDetails.GlobalScopeName) ||
+            if((scope == VariableContainerDetails.GlobalScopeName) ||
                 (scope == VariableContainerDetails.ScriptScopeName))
             {
                 // We don't A) have a good way of distinguishing built-in from user created variables
@@ -737,21 +737,21 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return false;
             }
 
-            string variableName = psvariable.Properties["Name"].Value as string;
-            object variableValue = psvariable.Properties["Value"].Value;
+            string variableName = psvariable.Properties ["Name"].Value as string;
+            object variableValue = psvariable.Properties ["Value"].Value;
 
             // Don't put any variables created by PSES in the Auto variable container.
-            if (variableName.StartsWith(PsesGlobalVariableNamePrefix) ||
+            if(variableName.StartsWith(PsesGlobalVariableNamePrefix) ||
                 variableName.Equals("PSDebugContext"))
             {
                 return false;
             }
 
             ScopedItemOptions variableScope = ScopedItemOptions.None;
-            PSPropertyInfo optionsProperty = psvariable.Properties["Options"];
-            if (string.Equals(optionsProperty.TypeNameOfValue, "System.String"))
+            PSPropertyInfo optionsProperty = psvariable.Properties ["Options"];
+            if(string.Equals(optionsProperty.TypeNameOfValue, "System.String"))
             {
-                if (!Enum.TryParse<ScopedItemOptions>(
+                if(!Enum.TryParse<ScopedItemOptions>(
                         optionsProperty.Value as string,
                         out variableScope))
                 {
@@ -759,19 +759,19 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         $"Could not parse a variable's ScopedItemOptions value of '{optionsProperty.Value}'");
                 }
             }
-            else if (optionsProperty.Value is ScopedItemOptions)
+            else if(optionsProperty.Value is ScopedItemOptions)
             {
                 variableScope = (ScopedItemOptions)optionsProperty.Value;
             }
 
             // Some local variables, if they exist, should be displayed by default
-            if (psvariable.TypeNames[0].EndsWith("LocalVariable"))
+            if(psvariable.TypeNames [0].EndsWith("LocalVariable"))
             {
-                if (variableName.Equals("_"))
+                if(variableName.Equals("_"))
                 {
                     return true;
                 }
-                else if (variableName.Equals("args", StringComparison.OrdinalIgnoreCase))
+                else if(variableName.Equals("args", StringComparison.OrdinalIgnoreCase))
                 {
                     return variableValue is Array array
                         && array.Length > 0;
@@ -779,7 +779,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 return false;
             }
-            else if (!psvariable.TypeNames[0].EndsWith(nameof(PSVariable)))
+            else if(!psvariable.TypeNames [0].EndsWith(nameof(PSVariable)))
             {
                 return false;
             }
@@ -787,11 +787,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var constantAllScope = ScopedItemOptions.AllScope | ScopedItemOptions.Constant;
             var readonlyAllScope = ScopedItemOptions.AllScope | ScopedItemOptions.ReadOnly;
 
-            if (((variableScope & constantAllScope) == constantAllScope) ||
+            if(((variableScope & constantAllScope) == constantAllScope) ||
                 ((variableScope & readonlyAllScope) == readonlyAllScope))
             {
                 string prefixedVariableName = VariableDetails.DollarPrefix + variableName;
-                if (this.globalScopeVariables.Children.ContainsKey(prefixedVariableName))
+                if(this.globalScopeVariables.Children.ContainsKey(prefixedVariableName))
                 {
                     return false;
                 }
@@ -815,9 +815,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             var callStackFrames = results.ToArray();
 
-            this.stackFrameDetails = new StackFrameDetails[callStackFrames.Length];
+            this.stackFrameDetails = new StackFrameDetails [callStackFrames.Length];
 
-            for (int i = 0; i < callStackFrames.Length; i++)
+            for(int i = 0; i < callStackFrames.Length; i++)
             {
                 VariableContainerDetails autoVariables =
                     new VariableContainerDetails(
@@ -833,20 +833,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // This is controlled by the "cwd:" setting in the launch config.
                 string workspaceRootPath = this.powerShellContext.InitialWorkingDirectory;
 
-                this.stackFrameDetails[i] =
-                    StackFrameDetails.Create(callStackFrames[i], autoVariables, localVariables, workspaceRootPath);
+                this.stackFrameDetails [i] =
+                    StackFrameDetails.Create(callStackFrames [i], autoVariables, localVariables, workspaceRootPath);
 
-                string stackFrameScriptPath = this.stackFrameDetails[i].ScriptPath;
-                if (scriptNameOverride != null &&
+                string stackFrameScriptPath = this.stackFrameDetails [i].ScriptPath;
+                if(scriptNameOverride != null &&
                     string.Equals(stackFrameScriptPath, StackFrameDetails.NoFileScriptPath))
                 {
-                    this.stackFrameDetails[i].ScriptPath = scriptNameOverride;
+                    this.stackFrameDetails [i].ScriptPath = scriptNameOverride;
                 }
-                else if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
+                else if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
                     this.remoteFileManager != null &&
                     !string.Equals(stackFrameScriptPath, StackFrameDetails.NoFileScriptPath))
                 {
-                    this.stackFrameDetails[i].ScriptPath =
+                    this.stackFrameDetails [i].ScriptPath =
                         this.remoteFileManager.GetMappedPath(
                             stackFrameScriptPath,
                             this.powerShellContext.CurrentRunspace);
@@ -858,9 +858,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string scriptLine = scriptLineObj.ToString();
 
-            if (!string.IsNullOrWhiteSpace(scriptLine))
+            if(!string.IsNullOrWhiteSpace(scriptLine))
             {
-                if (prefixLength == 0)
+                if(prefixLength == 0)
                 {
                     // The prefix is a padded integer ending with ':', an asterisk '*'
                     // if this is the current line, and one character of padding
@@ -888,7 +888,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             string localScriptPath = e.InvocationInfo.ScriptName;
 
             // If there's no ScriptName, get the "list" of the current source
-            if (this.remoteFileManager != null && string.IsNullOrEmpty(localScriptPath))
+            if(this.remoteFileManager != null && string.IsNullOrEmpty(localScriptPath))
             {
                 // Get the current script listing and create the buffer
                 PSCommand command = new PSCommand();
@@ -898,7 +898,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     await this.powerShellContext.ExecuteCommandAsync<PSObject>(
                         command, false, false).ConfigureAwait(false);
 
-                if (scriptListingLines != null)
+                if(scriptListingLines != null)
                 {
                     int linePrefixLength = 0;
 
@@ -933,7 +933,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // If this is a remote connection and the debugger stopped at a line
             // in a script file, get the file contents
-            if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
+            if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
                 this.remoteFileManager != null &&
                 !noScriptName)
             {
@@ -943,17 +943,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         powerShellContext.CurrentRunspace).ConfigureAwait(false);
             }
 
-            if (this.stackFrameDetails.Length > 0)
+            if(this.stackFrameDetails.Length > 0)
             {
                 // Augment the top stack frame with details from the stop event
 
-                if (this.invocationTypeScriptPositionProperty
+                if(this.invocationTypeScriptPositionProperty
                         .GetValue(e.InvocationInfo) is IScriptExtent scriptExtent)
                 {
-                    this.stackFrameDetails[0].StartLineNumber = scriptExtent.StartLineNumber;
-                    this.stackFrameDetails[0].EndLineNumber = scriptExtent.EndLineNumber;
-                    this.stackFrameDetails[0].StartColumnNumber = scriptExtent.StartColumnNumber;
-                    this.stackFrameDetails[0].EndColumnNumber = scriptExtent.EndColumnNumber;
+                    this.stackFrameDetails [0].StartLineNumber = scriptExtent.StartLineNumber;
+                    this.stackFrameDetails [0].EndLineNumber = scriptExtent.EndLineNumber;
+                    this.stackFrameDetails [0].StartColumnNumber = scriptExtent.StartColumnNumber;
+                    this.stackFrameDetails [0].EndColumnNumber = scriptExtent.EndColumnNumber;
                 }
             }
 
@@ -986,10 +986,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // of which line breakpoints exist per script file.  We use this later when
             // we need to clear all breakpoints in a script file.  We do not need to do
             // this for CommandBreakpoint, as those span all script files.
-            if (e.Breakpoint is LineBreakpoint lineBreakpoint)
+            if(e.Breakpoint is LineBreakpoint lineBreakpoint)
             {
                 string scriptPath = lineBreakpoint.Script;
-                if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
+                if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote &&
                     this.remoteFileManager != null)
                 {
                     string mappedPath =
@@ -997,7 +997,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             scriptPath,
                             this.powerShellContext.CurrentRunspace);
 
-                    if (mappedPath == null)
+                    if(mappedPath == null)
                     {
                         this.logger.LogError(
                             $"Could not map remote path '{scriptPath}' to a local path.");
@@ -1012,7 +1012,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 string normalizedScriptName = scriptPath.ToLower();
 
                 // Get the list of breakpoints for this file
-                if (!_breakpointService.BreakpointsPerFile.TryGetValue(normalizedScriptName, out HashSet<Breakpoint> breakpoints))
+                if(!_breakpointService.BreakpointsPerFile.TryGetValue(normalizedScriptName, out HashSet<Breakpoint> breakpoints))
                 {
                     breakpoints = new HashSet<Breakpoint>();
                     _breakpointService.BreakpointsPerFile.Add(
@@ -1021,11 +1021,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
 
                 // Add or remove the breakpoint based on the update type
-                if (e.UpdateType == BreakpointUpdateType.Set)
+                if(e.UpdateType == BreakpointUpdateType.Set)
                 {
                     breakpoints.Add(e.Breakpoint);
                 }
-                else if (e.UpdateType == BreakpointUpdateType.Removed)
+                else if(e.UpdateType == BreakpointUpdateType.Removed)
                 {
                     breakpoints.Remove(e.Breakpoint);
                 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -37,14 +37,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         {
             // If this version of PowerShell does not support the new Breakpoint APIs introduced in PowerShell 7.0.0,
             // do nothing as this class will not get used.
-            if (!SupportsBreakpointApis)
+            if(!SupportsBreakpointApis)
             {
                 return;
             }
 
             s_setLineBreakpointLazy = new Lazy<Func<Debugger, string, int, int, ScriptBlock, int?, LineBreakpoint>>(() =>
             {
-                Type[] setLineBreakpointParameters = new[] { typeof(string), typeof(int), typeof(int), typeof(ScriptBlock), typeof(int?) };
+                Type [] setLineBreakpointParameters = new [] { typeof(string), typeof(int), typeof(int), typeof(ScriptBlock), typeof(int?) };
                 MethodInfo setLineBreakpointMethod = typeof(Debugger).GetMethod("SetLineBreakpoint", setLineBreakpointParameters);
 
                 return (Func<Debugger, string, int, int, ScriptBlock, int?, LineBreakpoint>)Delegate.CreateDelegate(
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
             s_setCommandBreakpointLazy = new Lazy<Func<Debugger, string, ScriptBlock, string, int?, CommandBreakpoint>>(() =>
             {
-                Type[] setCommandBreakpointParameters = new[] { typeof(string), typeof(ScriptBlock), typeof(string), typeof(int?) };
+                Type [] setCommandBreakpointParameters = new [] { typeof(string), typeof(ScriptBlock), typeof(string), typeof(int?) };
                 MethodInfo setCommandBreakpointMethod = typeof(Debugger).GetMethod("SetCommandBreakpoint", setCommandBreakpointParameters);
 
                 return (Func<Debugger, string, ScriptBlock, string, int?, CommandBreakpoint>)Delegate.CreateDelegate(
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
             s_getBreakpointsLazy = new Lazy<Func<Debugger, int?, List<Breakpoint>>>(() =>
             {
-                Type[] getBreakpointsParameters = new[] { typeof(int?) };
+                Type [] getBreakpointsParameters = new [] { typeof(int?) };
                 MethodInfo getBreakpointsMethod = typeof(Debugger).GetMethod("GetBreakpoints", getBreakpointsParameters);
 
                 return (Func<Debugger, int?, List<Breakpoint>>)Delegate.CreateDelegate(
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
             s_removeBreakpointLazy = new Lazy<Func<Debugger, Breakpoint, int?, bool>>(() =>
             {
-                Type[] removeBreakpointParameters = new[] { typeof(Breakpoint), typeof(int?) };
+                Type [] removeBreakpointParameters = new [] { typeof(Breakpoint), typeof(int?) };
                 MethodInfo removeBreakpointMethod = typeof(Debugger).GetMethod("RemoveBreakpoint", removeBreakpointParameters);
 
                 return (Func<Debugger, Breakpoint, int?, bool>)Delegate.CreateDelegate(
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             ScriptBlock actionScriptBlock = null;
             string logMessage = breakpoint is BreakpointDetails bd ? bd.LogMessage : null;
             // Check if this is a "conditional" line breakpoint.
-            if (!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
+            if(!string.IsNullOrWhiteSpace(breakpoint.Condition) ||
                 !string.IsNullOrWhiteSpace(breakpoint.HitCondition) ||
                 !string.IsNullOrWhiteSpace(logMessage))
             {
@@ -126,14 +126,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     logMessage,
                     out string errorMessage);
 
-                if (!string.IsNullOrEmpty(errorMessage))
+                if(!string.IsNullOrEmpty(errorMessage))
                 {
                     // This is handled by the caller where it will set the 'Message' and 'Verified' on the BreakpointDetails
                     throw new InvalidOperationException(errorMessage);
                 }
             }
 
-            switch (breakpoint)
+            switch(breakpoint)
             {
                 case BreakpointDetails lineBreakpoint:
                     return SetLineBreakpointDelegate(debugger, lineBreakpoint.Source, lineBreakpoint.LineNumber, lineBreakpoint.ColumnNumber ?? 0, actionScriptBlock, runspaceId);
@@ -175,12 +175,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 StringBuilder builder = new StringBuilder(
                     string.IsNullOrEmpty(logMessage)
                         ? "break"
-                        : $"Microsoft.PowerShell.Utility\\Write-Host \"{logMessage.Replace("\"","`\"")}\"");
+                        : $"Microsoft.PowerShell.Utility\\Write-Host \"{logMessage.Replace("\"", "`\"")}\"");
 
                 // If HitCondition specified, parse and verify it.
-                if (!(string.IsNullOrWhiteSpace(hitCondition)))
+                if(!(string.IsNullOrWhiteSpace(hitCondition)))
                 {
-                    if (!int.TryParse(hitCondition, out int parsedHitCount))
+                    if(!int.TryParse(hitCondition, out int parsedHitCount))
                     {
                         throw new InvalidOperationException("Hit Count was not a valid integer.");
                     }
@@ -202,13 +202,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                         .Append(" }");
                 }
 
-                if (!string.IsNullOrWhiteSpace(condition))
+                if(!string.IsNullOrWhiteSpace(condition))
                 {
                     ScriptBlock parsed = ScriptBlock.Create(condition);
 
                     // Check for simple, common errors that ScriptBlock parsing will not catch
                     // e.g. $i == 3 and $i > 3
-                    if (!ValidateBreakpointConditionAst(parsed.Ast, out string message))
+                    if(!ValidateBreakpointConditionAst(parsed.Ast, out string message))
                     {
                         throw new InvalidOperationException(message);
                     }
@@ -216,8 +216,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     // Check for "advanced" condition syntax i.e. if the user has specified
                     // a "break" or  "continue" statement anywhere in their scriptblock,
                     // pass their scriptblock through to the Action parameter as-is.
-                    if (parsed.Ast.Find(ast =>
-                        (ast is BreakStatementAst || ast is ContinueStatementAst), true) != null)
+                    if(parsed.Ast.Find(ast =>
+                       (ast is BreakStatementAst || ast is ContinueStatementAst), true) != null)
                     {
                         return parsed;
                     }
@@ -228,12 +228,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
                 return ScriptBlock.Create(builder.ToString());
             }
-            catch (ParseException e)
+            catch(ParseException e)
             {
                 errorMessage = ExtractAndScrubParseExceptionMessage(e, condition);
                 return null;
             }
-            catch (InvalidOperationException e)
+            catch(InvalidOperationException e)
             {
                 errorMessage = e.Message;
                 return null;
@@ -245,24 +245,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             message = string.Empty;
 
             // We are only inspecting a few simple scenarios in the EndBlock only.
-            if (conditionAst is ScriptBlockAst scriptBlockAst &&
+            if(conditionAst is ScriptBlockAst scriptBlockAst &&
                 scriptBlockAst.BeginBlock == null &&
                 scriptBlockAst.ProcessBlock == null &&
                 scriptBlockAst.EndBlock != null &&
                 scriptBlockAst.EndBlock.Statements.Count == 1)
             {
-                StatementAst statementAst = scriptBlockAst.EndBlock.Statements[0];
+                StatementAst statementAst = scriptBlockAst.EndBlock.Statements [0];
                 string condition = statementAst.Extent.Text;
 
-                if (statementAst is AssignmentStatementAst)
+                if(statementAst is AssignmentStatementAst)
                 {
                     message = FormatInvalidBreakpointConditionMessage(condition, "Use '-eq' instead of '=='.");
                     return false;
                 }
 
-                if (statementAst is PipelineAst pipelineAst
+                if(statementAst is PipelineAst pipelineAst
                     && pipelineAst.PipelineElements.Count == 1
-                    && pipelineAst.PipelineElements[0].Redirections.Count > 0)
+                    && pipelineAst.PipelineElements [0].Redirections.Count > 0)
                 {
                     message = FormatInvalidBreakpointConditionMessage(condition, "Use '-gt' instead of '>'.");
                     return false;
@@ -274,33 +274,33 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
         private static string ExtractAndScrubParseExceptionMessage(ParseException parseException, string condition)
         {
-            string[] messageLines = parseException.Message.Split('\n');
+            string [] messageLines = parseException.Message.Split('\n');
 
             // Skip first line - it is a location indicator "At line:1 char: 4"
-            for (int i = 1; i < messageLines.Length; i++)
+            for(int i = 1; i < messageLines.Length; i++)
             {
-                string line = messageLines[i];
-                if (line.StartsWith("+"))
+                string line = messageLines [i];
+                if(line.StartsWith("+"))
                 {
                     continue;
                 }
 
-                if (!string.IsNullOrWhiteSpace(line))
+                if(!string.IsNullOrWhiteSpace(line))
                 {
                     // Note '==' and '>" do not generate parse errors
-                    if (line.Contains("'!='"))
+                    if(line.Contains("'!='"))
                     {
                         line += " Use operator '-ne' instead of '!='.";
                     }
-                    else if (line.Contains("'<'") && condition.Contains("<="))
+                    else if(line.Contains("'<'") && condition.Contains("<="))
                     {
                         line += " Use operator '-le' instead of '<='.";
                     }
-                    else if (line.Contains("'<'"))
+                    else if(line.Contains("'<'"))
                     {
                         line += " Use operator '-lt' instead of '<'.";
                     }
-                    else if (condition.Contains(">="))
+                    else if(condition.Contains(">="))
                     {
                         line += " Use operator '-ge' instead of '>='.";
                     }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 
-            if (!(breakpoint is LineBreakpoint lineBreakpoint))
+            if(!(breakpoint is LineBreakpoint lineBreakpoint))
             {
                 throw new ArgumentException(
                     "Unexpected breakpoint type: " + breakpoint.GetType().Name);
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 Condition = lineBreakpoint.Action?.ToString()
             };
 
-            if (lineBreakpoint.Column > 0)
+            if(lineBreakpoint.Column > 0)
             {
                 breakpointDetails.ColumnNumber = lineBreakpoint.Column;
             }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/CommandBreakpointDetails.cs
@@ -36,7 +36,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         {
             Validate.IsNotNull(nameof(name), name);
 
-            return new CommandBreakpointDetails {
+            return new CommandBreakpointDetails
+            {
                 Name = name,
                 Condition = condition
             };
@@ -52,13 +53,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 
-            if (!(breakpoint is CommandBreakpoint commandBreakpoint))
+            if(!(breakpoint is CommandBreakpoint commandBreakpoint))
             {
                 throw new ArgumentException(
                     "Unexpected breakpoint type: " + breakpoint.GetType().Name);
             }
 
-            var breakpointDetails = new CommandBreakpointDetails {
+            var breakpointDetails = new CommandBreakpointDetails
+            {
                 Verified = true,
                 Name = commandBreakpoint.Command,
                 Condition = commandBreakpoint.Action?.ToString()

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             Validate.IsNotNull(nameof(originalEvent), originalEvent);
             Validate.IsNotNull(nameof(runspaceDetails), runspaceDetails);
 
-            if (!string.IsNullOrEmpty(localScriptPath))
+            if(!string.IsNullOrEmpty(localScriptPath))
             {
                 this.ScriptPath = localScriptPath;
                 this.RemoteScriptPath = originalEvent.InvocationInfo.ScriptName;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
@@ -100,9 +100,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             string moduleId = string.Empty;
             var isExternal = false;
 
-            var invocationInfo = callStackFrameObject.Properties["InvocationInfo"]?.Value as InvocationInfo;
-            string scriptPath = (callStackFrameObject.Properties["ScriptName"].Value as string) ?? NoFileScriptPath;
-            int startLineNumber = (int)(callStackFrameObject.Properties["ScriptLineNumber"].Value ?? 0);
+            var invocationInfo = callStackFrameObject.Properties ["InvocationInfo"]?.Value as InvocationInfo;
+            string scriptPath = (callStackFrameObject.Properties ["ScriptName"].Value as string) ?? NoFileScriptPath;
+            int startLineNumber = (int)(callStackFrameObject.Properties ["ScriptLineNumber"].Value ?? 0);
 
             // TODO: RKH 2019-03-07 Temporarily disable "external" code until I have a chance to add
             // settings to control this feature.
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             return new StackFrameDetails
             {
                 ScriptPath = scriptPath,
-                FunctionName = callStackFrameObject.Properties["FunctionName"].Value as string,
+                FunctionName = callStackFrameObject.Properties ["FunctionName"].Value as string,
                 StartLineNumber = startLineNumber,
                 EndLineNumber = startLineNumber, // End line number isn't given in PowerShell stack frames
                 StartColumnNumber = 0,   // Column number isn't given in PowerShell stack frames

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableContainerDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableContainerDetails.cs
@@ -70,9 +70,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// Returns the details of the variable container's children.  If empty, returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public override VariableDetailsBase[] GetChildren(ILogger logger)
+        public override VariableDetailsBase [] GetChildren(ILogger logger)
         {
-            var variablesArray = new VariableDetailsBase[this.children.Count];
+            var variablesArray = new VariableDetailsBase [this.children.Count];
             this.children.Values.CopyTo(variablesArray, 0);
             return variablesArray;
         }
@@ -84,9 +84,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <returns>Returns true if this variable container directly contains the specified variableReferenceId, false otherwise.</returns>
         public bool ContainsVariable(int variableReferenceId)
         {
-            foreach (VariableDetailsBase value in this.children.Values)
+            foreach(VariableDetailsBase value in this.children.Values)
             {
-                if (value.Id == variableReferenceId)
+                if(value.Id == variableReferenceId)
                 {
                     return true;
                 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         public const string DollarPrefix = "$";
 
         private object valueObject;
-        private VariableDetails[] cachedChildren;
+        private VariableDetails [] cachedChildren;
 
         #endregion
 
@@ -56,8 +56,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// </param>
         public VariableDetails(PSObject psVariableObject)
             : this(
-                  DollarPrefix + psVariableObject.Properties["Name"].Value as string,
-                  psVariableObject.Properties["Value"].Value)
+                  DollarPrefix + psVariableObject.Properties ["Name"].Value as string,
+                  psVariableObject.Properties ["Value"].Value)
         {
         }
 
@@ -101,13 +101,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// details of its children.  Otherwise it returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public override VariableDetailsBase[] GetChildren(ILogger logger)
+        public override VariableDetailsBase [] GetChildren(ILogger logger)
         {
-            VariableDetails[] childVariables = null;
+            VariableDetails [] childVariables = null;
 
-            if (this.IsExpandable)
+            if(this.IsExpandable)
             {
-                if (this.cachedChildren == null)
+                if(this.cachedChildren == null)
                 {
                     this.cachedChildren = GetChildren(this.valueObject, logger);
                 }
@@ -128,14 +128,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
 
         private static bool GetIsExpandable(object valueObject)
         {
-            if (valueObject == null)
+            if(valueObject == null)
             {
                 return false;
             }
 
             // If a PSObject, unwrap it
             var psobject = valueObject as PSObject;
-            if (psobject != null)
+            if(psobject != null)
             {
                 valueObject = psobject.BaseObject;
             }
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             string valueString = null;
             typeName = null;
 
-            if (value == null)
+            if(value == null)
             {
                 // Set to identifier recognized by PowerShell to make setVariable from the debug UI more natural.
                 return "$null";
@@ -170,16 +170,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             Type objType = value.GetType();
             typeName = $"[{objType.FullName}]";
 
-            if (value is bool)
+            if(value is bool)
             {
                 // Set to identifier recognized by PowerShell to make setVariable from the debug UI more natural.
-                valueString = (bool) value ? "$true" : "$false";
+                valueString = (bool)value ? "$true" : "$false";
             }
-            else if (isExpandable)
+            else if(isExpandable)
             {
 
                 // Get the "value" for an expandable object.
-                if (value is DictionaryEntry)
+                if(value is DictionaryEntry)
                 {
                     // For DictionaryEntry - display the key/value as the value.
                     var entry = (DictionaryEntry)value;
@@ -192,22 +192,22 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 else
                 {
                     string valueToString = value.SafeToString();
-                    if (valueToString == null || valueToString.Equals(objType.ToString()))
+                    if(valueToString == null || valueToString.Equals(objType.ToString()))
                     {
                         // If the ToString() matches the type name or is null, then display the type
                         // name in PowerShell format.
                         string shortTypeName = objType.Name;
 
                         // For arrays and ICollection, display the number of contained items.
-                        if (value is Array)
+                        if(value is Array)
                         {
                             var arr = value as Array;
-                            if (arr.Rank == 1)
+                            if(arr.Rank == 1)
                             {
                                 shortTypeName = InsertDimensionSize(shortTypeName, arr.Length);
                             }
                         }
-                        else if (value is ICollection)
+                        else if(value is ICollection)
                         {
                             var collection = (ICollection)value;
                             shortTypeName = InsertDimensionSize(shortTypeName, collection.Count);
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             else
             {
                 // Value is a scalar (not expandable). If it's a string, display it directly otherwise use SafeToString()
-                if (value is string)
+                if(value is string)
                 {
                     valueString = "\"" + value + "\"";
                 }
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             string result = value;
 
             int indexLastRBracket = value.LastIndexOf("]");
-            if (indexLastRBracket > 0)
+            if(indexLastRBracket > 0)
             {
                 result =
                     value.Substring(0, indexLastRBracket) +
@@ -259,11 +259,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             return result;
         }
 
-        private VariableDetails[] GetChildren(object obj, ILogger logger)
+        private VariableDetails [] GetChildren(object obj, ILogger logger)
         {
             List<VariableDetails> childVariables = new List<VariableDetails>();
 
-            if (obj == null)
+            if(obj == null)
             {
                 return childVariables.ToArray();
             }
@@ -272,8 +272,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             {
                 PSObject psObject = obj as PSObject;
 
-                if ((psObject != null) &&
-                    (psObject.TypeNames[0] == typeof(PSCustomObject).ToString()))
+                if((psObject != null) &&
+                    (psObject.TypeNames [0] == typeof(PSCustomObject).ToString()))
                 {
                     // PowerShell PSCustomObject's properties are completely defined by the ETS type system.
                     childVariables.AddRange(
@@ -284,7 +284,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 else
                 {
                     // If a PSObject other than a PSCustomObject, unwrap it.
-                    if (psObject != null)
+                    if(psObject != null)
                     {
                         // First add the PSObject's ETS propeties
                         childVariables.AddRange(
@@ -300,7 +300,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     IEnumerable enumerable = obj as IEnumerable;
 
                     // We're in the realm of regular, unwrapped .NET objects
-                    if (dictionary != null)
+                    if(dictionary != null)
                     {
                         // Buckle up kids, this is a bit weird.  We could not use the LINQ
                         // operator OfType<DictionaryEntry>.  Even though R# will squiggle the
@@ -318,7 +318,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                         // If you open the $PSBoundParameters variable node in this scenario and see nothing,
                         // this code is broken.
                         int i = 0;
-                        foreach (DictionaryEntry entry in dictionary)
+                        foreach(DictionaryEntry entry in dictionary)
                         {
                             childVariables.Add(
                                 new VariableDetails(
@@ -326,10 +326,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                                     entry));
                         }
                     }
-                    else if (enumerable != null && !(obj is string))
+                    else if(enumerable != null && !(obj is string))
                     {
                         int i = 0;
-                        foreach (var item in enumerable)
+                        foreach(var item in enumerable)
                         {
                             childVariables.Add(
                                 new VariableDetails(
@@ -341,7 +341,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     AddDotNetProperties(obj, childVariables);
                 }
             }
-            catch (GetValueInvocationException ex)
+            catch(GetValueInvocationException ex)
             {
                 // This exception occurs when accessing the value of a
                 // variable causes a script to be executed.  Right now
@@ -361,10 +361,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 objectType.GetProperties(
                     BindingFlags.Public | BindingFlags.Instance);
 
-            foreach (var property in properties)
+            foreach(var property in properties)
             {
                 // Don't display indexer properties, it causes an exception anyway.
-                if (property.GetIndexParameters().Length > 0)
+                if(property.GetIndexParameters().Length > 0)
                 {
                     continue;
                 }
@@ -376,11 +376,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                             property.Name,
                             property.GetValue(obj)));
                 }
-                catch (Exception ex)
+                catch(Exception ex)
                 {
                     // Some properties can throw exceptions, add the property
                     // name and info about the error.
-                    if (ex is TargetInvocationException)
+                    if(ex is TargetInvocationException)
                     {
                         ex = ex.InnerException;
                     }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetailsBase.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetailsBase.cs
@@ -53,6 +53,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// details of its children.  Otherwise it returns an empty array.
         /// </summary>
         /// <returns></returns>
-        public abstract VariableDetailsBase[] GetChildren(ILogger logger);
+        public abstract VariableDetailsBase [] GetChildren(ILogger logger);
     }
 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<SetBreakpointsResponse> Handle(SetBreakpointsArguments request, CancellationToken cancellationToken)
         {
-            if (!_workspaceService.TryGetFile(request.Source.Path, out ScriptFile scriptFile))
+            if(!_workspaceService.TryGetFile(request.Source.Path, out ScriptFile scriptFile))
             {
                 string message = _debugStateService.NoDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
                 var srcBreakpoints = request.Breakpoints
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Verify source file is a PowerShell script file.
             string fileExtension = Path.GetExtension(scriptFile?.FilePath ?? "")?.ToLower();
             bool isUntitledPath = ScriptFile.IsUntitledPath(request.Source.Path);
-            if ((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
+            if((!isUntitledPath && fileExtension != ".ps1" && fileExtension != ".psm1") ||
                 (!BreakpointApiUtils.SupportsBreakpointApis && isUntitledPath))
             {
                 _logger.LogWarning(
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             // At this point, the source file has been verified as a PowerShell script.
-            BreakpointDetails[] breakpointDetails = request.Breakpoints
+            BreakpointDetails [] breakpointDetails = request.Breakpoints
                 .Select((srcBreakpoint) => BreakpointDetails.Create(
                     scriptFile.FilePath,
                     srcBreakpoint.Line,
@@ -86,8 +86,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .ToArray();
 
             // If this is a "run without debugging (Ctrl+F5)" session ignore requests to set breakpoints.
-            BreakpointDetails[] updatedBreakpointDetails = breakpointDetails;
-            if (!_debugStateService.NoDebug)
+            BreakpointDetails [] updatedBreakpointDetails = breakpointDetails;
+            if(!_debugStateService.NoDebug)
             {
                 await _debugStateService.WaitForSetBreakpointHandleAsync().ConfigureAwait(false);
 
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                             scriptFile,
                             breakpointDetails).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     // Log whatever the error is
                     _logger.LogException($"Caught error while setting breakpoints in SetBreakpoints handler for file {scriptFile?.FilePath}", e);
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<SetFunctionBreakpointsResponse> Handle(SetFunctionBreakpointsArguments request, CancellationToken cancellationToken)
         {
-            CommandBreakpointDetails[] breakpointDetails = request.Breakpoints
+            CommandBreakpointDetails [] breakpointDetails = request.Breakpoints
                 .Select((funcBreakpoint) => CommandBreakpointDetails.Create(
                     funcBreakpoint.Name,
                     funcBreakpoint.Condition,
@@ -126,8 +126,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .ToArray();
 
             // If this is a "run without debugging (Ctrl+F5)" session ignore requests to set breakpoints.
-            CommandBreakpointDetails[] updatedBreakpointDetails = breakpointDetails;
-            if (!_debugStateService.NoDebug)
+            CommandBreakpointDetails [] updatedBreakpointDetails = breakpointDetails;
+            if(!_debugStateService.NoDebug)
             {
                 await _debugStateService.WaitForSetBreakpointHandleAsync().ConfigureAwait(false);
 
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         await _debugService.SetCommandBreakpointsAsync(
                             breakpointDetails).ConfigureAwait(false);
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     // Log whatever the error is
                     _logger.LogException($"Caught error while setting command breakpoints", e);

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -48,16 +48,16 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             _debugService.IsClientAttached = true;
 
-            if (_debugStateService.OwnsEditorSession)
+            if(_debugStateService.OwnsEditorSession)
             {
                 // If this is a debug-only session, we need to start
                 // the command loop manually
                 _powerShellContextService.ConsoleReader.StartCommandLoop();
             }
 
-            if (!string.IsNullOrEmpty(_debugStateService.ScriptToLaunch))
+            if(!string.IsNullOrEmpty(_debugStateService.ScriptToLaunch))
             {
-                if (_powerShellContextService.SessionState == PowerShellContextState.Ready)
+                if(_powerShellContextService.SessionState == PowerShellContextState.Ready)
                 {
                     // Configuration is done, launch the script
                     var nonAwaitedTask = LaunchScriptAsync(_debugStateService.ScriptToLaunch)
@@ -69,11 +69,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            if (_debugStateService.IsInteractiveDebugSession)
+            if(_debugStateService.IsInteractiveDebugSession)
             {
-                if (_debugService.IsDebuggerStopped)
+                if(_debugService.IsDebuggerStopped)
                 {
-                    if (_debugService.CurrentDebuggerStoppedEventArgs != null)
+                    if(_debugService.CurrentDebuggerStoppedEventArgs != null)
                     {
                         // If this is an interactive session and there's a pending breakpoint,
                         // send that information along to the debugger client
@@ -94,22 +94,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private async Task LaunchScriptAsync(string scriptToLaunch)
         {
             // Is this an untitled script?
-            if (ScriptFile.IsUntitledPath(scriptToLaunch))
+            if(ScriptFile.IsUntitledPath(scriptToLaunch))
             {
                 ScriptFile untitledScript = _workspaceService.GetFile(scriptToLaunch);
 
-                if (BreakpointApiUtils.SupportsBreakpointApis)
+                if(BreakpointApiUtils.SupportsBreakpointApis)
                 {
                     // Parse untitled files with their `Untitled:` URI as the file name which will cache the URI & contents within the PowerShell parser.
                     // By doing this, we light up the ability to debug Untitled files with breakpoints.
                     // This is only possible via the direct usage of the breakpoint APIs in PowerShell because
                     // Set-PSBreakpoint validates that paths are actually on the filesystem.
-                    ScriptBlockAst ast = Parser.ParseInput(untitledScript.Contents, untitledScript.DocumentUri.ToString(), out Token[] tokens, out ParseError[] errors);
+                    ScriptBlockAst ast = Parser.ParseInput(untitledScript.Contents, untitledScript.DocumentUri.ToString(), out Token [] tokens, out ParseError [] errors);
 
                     // This seems to be the simplest way to invoke a script block (which contains breakpoint information) via the PowerShell API.
                     var cmd = new PSCommand().AddScript(". $args[0]").AddArgument(ast.GetScriptBlock());
                     await _powerShellContextService
-                        .ExecuteCommandAsync<object>(cmd, sendOutputToHost: true, sendErrorToHost:true)
+                        .ExecuteCommandAsync<object>(cmd, sendOutputToHost: true, sendErrorToHost: true)
                         .ConfigureAwait(false);
                 }
                 else

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     "repl",
                     StringComparison.CurrentCultureIgnoreCase);
 
-            if (isFromRepl)
+            if(isFromRepl)
             {
                 var notAwaited =
                     _powerShellContextService
@@ -50,14 +50,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 // VS Code might send this request after the debugger
                 // has been resumed, return an empty result in this case.
-                if (_powerShellContextService.IsDebuggerStopped)
+                if(_powerShellContextService.IsDebuggerStopped)
                 {
                     // First check to see if the watch expression refers to a naked variable reference.
                     result =
                         _debugService.GetVariableFromExpression(request.Expression, request.FrameId);
 
                     // If the expression is not a naked variable reference, then evaluate the expression.
-                    if (result == null)
+                    if(result == null)
                     {
                         result =
                             await _debugService.EvaluateExpressionAsync(
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     }
                 }
 
-                if (result != null)
+                if(result != null)
                 {
                     valueString = result.ValueString;
                     variableId =

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -41,27 +41,27 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public async Task<DisconnectResponse> Handle(DisconnectArguments request, CancellationToken cancellationToken)
         {
             _debugEventHandlerService.UnregisterEventHandlers();
-            if (_debugStateService.ExecutionCompleted == false)
+            if(_debugStateService.ExecutionCompleted == false)
             {
                 _debugStateService.ExecutionCompleted = true;
                 _powerShellContextService.AbortExecution(shouldAbortDebugSession: true);
 
-                if (_debugStateService.IsInteractiveDebugSession && _debugStateService.IsAttachSession)
+                if(_debugStateService.IsInteractiveDebugSession && _debugStateService.IsAttachSession)
                 {
                     // Pop the sessions
-                    if (_powerShellContextService.CurrentRunspace.Context == RunspaceContext.EnteredProcess)
+                    if(_powerShellContextService.CurrentRunspace.Context == RunspaceContext.EnteredProcess)
                     {
                         try
                         {
                             await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSHostProcess").ConfigureAwait(false);
 
-                            if (_debugStateService.IsRemoteAttach &&
+                            if(_debugStateService.IsRemoteAttach &&
                                 _powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
                             {
                                 await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSSession").ConfigureAwait(false);
                             }
                         }
-                        catch (Exception e)
+                        catch(Exception e)
                         {
                             _logger.LogException("Caught exception while popping attached process after debugging", e);
                         }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// <summary>
         /// Gets or sets optional arguments passed to the debuggee.
         /// </summary>
-        public string[] Args { get; set; }
+        public string [] Args { get; set; }
 
         /// <summary>
         /// Gets or sets the working directory of the launched debuggee (specified as an absolute path).
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// <summary>
         /// Gets or sets the optional arguments passed to the runtime executable.
         /// </summary>
-        public string[] RuntimeArgs { get; set; }
+        public string [] RuntimeArgs { get; set; }
 
         /// <summary>
         /// Gets or sets optional environment variables to pass to the debuggee. The string valued
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _debugEventHandlerService.RegisterEventHandlers();
 
             // Determine whether or not the working directory should be set in the PowerShellContext.
-            if ((_powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Local) &&
+            if((_powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Local) &&
                 !_debugService.IsDebuggerStopped)
             {
                 // Get the working directory that was passed via the debug config
@@ -128,16 +128,16 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 // Assuming we have a non-empty/null working dir, unescape the path and verify
                 // the path exists and is a directory.
-                if (!string.IsNullOrEmpty(workingDir))
+                if(!string.IsNullOrEmpty(workingDir))
                 {
                     try
                     {
-                        if ((File.GetAttributes(workingDir) & FileAttributes.Directory) != FileAttributes.Directory)
+                        if((File.GetAttributes(workingDir) & FileAttributes.Directory) != FileAttributes.Directory)
                         {
                             workingDir = Path.GetDirectoryName(workingDir);
                         }
                     }
-                    catch (Exception ex)
+                    catch(Exception ex)
                     {
                         workingDir = null;
                         _logger.LogError(
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 // If we have no working dir by this point and we are running in a temp console,
                 // pick some reasonable default.
-                if (string.IsNullOrEmpty(workingDir) && request.CreateTemporaryIntegratedConsole)
+                if(string.IsNullOrEmpty(workingDir) && request.CreateTemporaryIntegratedConsole)
                 {
                     workingDir = Environment.CurrentDirectory;
                 }
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 // At this point, we will either have a working dir that should be set to cwd in
                 // the PowerShellContext or the user has requested (via an empty/null cwd) that
                 // the working dir should not be changed.
-                if (!string.IsNullOrEmpty(workingDir))
+                if(!string.IsNullOrEmpty(workingDir))
                 {
                     await _powerShellContextService.SetWorkingDirectoryAsync(workingDir, isPathAlreadyEscaped: false).ConfigureAwait(false);
                 }
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Prepare arguments to the script - if specified
             string arguments = null;
-            if (request.Args?.Length > 0)
+            if(request.Args?.Length > 0)
             {
                 arguments = string.Join(" ", request.Args);
                 _logger.LogTrace("Script arguments are: " + arguments);
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _debugStateService.Arguments = arguments;
             _debugStateService.IsUsingTempIntegratedConsole = request.CreateTemporaryIntegratedConsole;
 
-            if (request.CreateTemporaryIntegratedConsole
+            if(request.CreateTemporaryIntegratedConsole
                 && !string.IsNullOrEmpty(request.Script)
                 && ScriptFile.IsUntitledPath(request.Script))
             {
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // If the current session is remote, map the script path to the remote
             // machine if necessary
-            if (_debugStateService.ScriptToLaunch != null &&
+            if(_debugStateService.ScriptToLaunch != null &&
                 _powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
             {
                 _debugStateService.ScriptToLaunch =
@@ -222,7 +222,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // This is not an error, just a request to stop the original "attach to" request.
             // Testing against "undefined" is a HACK because I don't know how to make "Cancel" on quick pick loading
             // to cancel on the VSCode side without sending an attachRequest with processId set to "undefined".
-            if (!processIdIsSet && !customPipeNameIsSet)
+            if(!processIdIsSet && !customPipeNameIsSet)
             {
                 _logger.LogInformation(
                     $"Attach request aborted, received {request.ProcessId} for processId.");
@@ -232,13 +232,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             StringBuilder errorMessages = new StringBuilder();
 
-            if (request.ComputerName != null)
+            if(request.ComputerName != null)
             {
-                if (runspaceVersion.Version.Major < 4)
+                if(runspaceVersion.Version.Major < 4)
                 {
                     throw new RpcErrorException(0, $"Remote sessions are only available with PowerShell 4 and higher (current session is {runspaceVersion.Version}).");
                 }
-                else if (_powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
+                else if(_powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
                 {
                     throw new RpcErrorException(0, "Cannot attach to a process in a remote session when already in a remote session.");
                 }
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     $"Enter-PSSession -ComputerName \"{request.ComputerName}\"",
                     errorMessages).ConfigureAwait(false);
 
-                if (errorMessages.Length > 0)
+                if(errorMessages.Length > 0)
                 {
                     throw new RpcErrorException(0, $"Could not establish remote session to computer '{request.ComputerName}'");
                 }
@@ -255,9 +255,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 _debugStateService.IsRemoteAttach = true;
             }
 
-            if (processIdIsSet && int.TryParse(request.ProcessId, out int processId) && (processId > 0))
+            if(processIdIsSet && int.TryParse(request.ProcessId, out int processId) && (processId > 0))
             {
-                if (runspaceVersion.Version.Major < 5)
+                if(runspaceVersion.Version.Major < 5)
                 {
                     throw new RpcErrorException(0, $"Attaching to a process is only available with PowerShell 5 and higher (current session is {runspaceVersion.Version}).");
                 }
@@ -266,14 +266,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     $"Enter-PSHostProcess -Id {processId}",
                     errorMessages);
 
-                if (errorMessages.Length > 0)
+                if(errorMessages.Length > 0)
                 {
                     throw new RpcErrorException(0, $"Could not attach to process '{processId}'");
                 }
             }
-            else if (customPipeNameIsSet)
+            else if(customPipeNameIsSet)
             {
-                if (runspaceVersion.Version < s_minVersionForCustomPipeName)
+                if(runspaceVersion.Version < s_minVersionForCustomPipeName)
                 {
                     throw new RpcErrorException(0, $"Attaching to a process with CustomPipeName is only available with PowerShell 6.2 and higher (current session is {runspaceVersion.Version}).");
                 }
@@ -282,12 +282,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     $"Enter-PSHostProcess -CustomPipeName {request.CustomPipeName}",
                     errorMessages);
 
-                if (errorMessages.Length > 0)
+                if(errorMessages.Length > 0)
                 {
                     throw new RpcErrorException(0, $"Could not attach to process with CustomPipeName: '{request.CustomPipeName}'");
                 }
             }
-            else if (request.ProcessId != "current")
+            else if(request.ProcessId != "current")
             {
                 _logger.LogError(
                     $"Attach request failed, '{request.ProcessId}' is an invalid value for the processId.");
@@ -301,23 +301,23 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // event gets fired with the attached runspace.
 
             string debugRunspaceCmd;
-            if (request.RunspaceName != null)
+            if(request.RunspaceName != null)
             {
                 IEnumerable<int?> ids = await _powerShellContextService.ExecuteCommandAsync<int?>(new PSCommand()
                     .AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace")
                     .AddParameter("Name", request.RunspaceName)
                     .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
                     .AddParameter("ExpandProperty", "Id"));
-                foreach (var id in ids)
+                foreach(var id in ids)
                 {
                     _debugStateService.RunspaceId = id;
                     break;
                 }
                 debugRunspaceCmd = $"\nDebug-Runspace -Name '{request.RunspaceName}'";
             }
-            else if (request.RunspaceId != null)
+            else if(request.RunspaceId != null)
             {
-                if (!int.TryParse(request.RunspaceId, out int runspaceId) || runspaceId <= 0)
+                if(!int.TryParse(request.RunspaceId, out int runspaceId) || runspaceId <= 0)
                 {
                     _logger.LogError(
                         $"Attach request failed, '{request.RunspaceId}' is an invalid value for the processId.");
@@ -325,13 +325,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     throw new RpcErrorException(0, "A positive integer must be specified for the RunspaceId field.");
                 }
 
-                _debugStateService.RunspaceId =  runspaceId;
+                _debugStateService.RunspaceId = runspaceId;
 
                 debugRunspaceCmd = $"\nDebug-Runspace -Id {runspaceId}";
             }
             else
             {
-                _debugStateService.RunspaceId =  1;
+                _debugStateService.RunspaceId = 1;
 
                 debugRunspaceCmd = "\nDebug-Runspace -Id 1";
             }
@@ -344,7 +344,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .ExecuteScriptStringAsync(debugRunspaceCmd)
                 .ContinueWith(OnExecutionCompletedAsync);
 
-            if (runspaceVersion.Version.Major >= 7)
+            if(runspaceVersion.Version.Major >= 7)
             {
                 _debugStateService.ServerStarted.SetResult(true);
             }
@@ -377,7 +377,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 await executeTask.ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 _logger.LogError(
                     "Exception occurred while awaiting debug launch task.\n\n" + e.ToString());
@@ -389,26 +389,26 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             _debugEventHandlerService.UnregisterEventHandlers();
 
-            if (_debugStateService.IsAttachSession)
+            if(_debugStateService.IsAttachSession)
             {
-               // Pop the sessions
-               if (_powerShellContextService.CurrentRunspace.Context == RunspaceContext.EnteredProcess)
-               {
-                   try
-                   {
-                       await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSHostProcess");
+                // Pop the sessions
+                if(_powerShellContextService.CurrentRunspace.Context == RunspaceContext.EnteredProcess)
+                {
+                    try
+                    {
+                        await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSHostProcess");
 
-                       if (_debugStateService.IsRemoteAttach &&
-                           _powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
-                       {
-                           await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSSession");
-                       }
-                   }
-                   catch (Exception e)
-                   {
-                       _logger.LogException("Caught exception while popping attached process after debugging", e);
-                   }
-               }
+                        if(_debugStateService.IsRemoteAttach &&
+                            _powerShellContextService.CurrentRunspace.Location == RunspaceLocation.Remote)
+                        {
+                            await _powerShellContextService.ExecuteScriptStringAsync("Exit-PSSession");
+                        }
+                    }
+                    catch(Exception e)
+                    {
+                        _logger.LogException("Caught exception while popping attached process after debugging", e);
+                    }
+                }
             }
 
             _debugService.IsClientAttached = false;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
@@ -28,9 +28,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<ScopesResponse> Handle(ScopesArguments request, CancellationToken cancellationToken)
         {
-            VariableScope[] variableScopes =
+            VariableScope [] variableScopes =
                 _debugService.GetVariableScopes(
-                    (int) request.FrameId);
+                    (int)request.FrameId);
 
             return Task.FromResult(new ScopesResponse
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SetVariableHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/SetVariableHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 string updatedValue =
                     await _debugService.SetVariableAsync(
-                        (int) request.VariablesReference,
+                        (int)request.VariablesReference,
                         request.Name,
                         request.Value).ConfigureAwait(false);
 
@@ -45,15 +45,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 };
 
             }
-                catch (Exception ex) when(ex is ArgumentTransformationMetadataException ||
-                                           ex is InvalidPowerShellExpressionException ||
-                                           ex is SessionStateUnauthorizedAccessException)
+            catch(Exception ex) when(ex is ArgumentTransformationMetadataException ||
+                                       ex is InvalidPowerShellExpressionException ||
+                                       ex is SessionStateUnauthorizedAccessException)
             {
                 // Catch common, innocuous errors caused by the user supplying a value that can't be converted or the variable is not settable.
                 _logger.LogTrace($"Failed to set variable: {ex.Message}");
                 throw new RpcErrorException(0, ex.Message);
             }
-            catch (Exception ex)
+            catch(Exception ex)
             {
                 _logger.LogError($"Unexpected error setting variable: {ex.Message}");
                 string msg =

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
@@ -29,12 +29,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<StackTraceResponse> Handle(StackTraceArguments request, CancellationToken cancellationToken)
         {
-            StackFrameDetails[] stackFrameDetails =
+            StackFrameDetails [] stackFrameDetails =
                 _debugService.GetStackFrames();
 
             // Handle a rare race condition where the adapter requests stack frames before they've
             // begun building.
-            if (stackFrameDetails == null)
+            if(stackFrameDetails == null)
             {
                 return Task.FromResult(new StackTraceResponse
                 {
@@ -51,12 +51,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // If the number of requested levels == 0 (or null), that means get all stack frames
             // after the specified startFrame index. Otherwise get all the stack frames.
             long requestedFrameCount = (request.Levels ?? 0);
-            if (requestedFrameCount > 0)
+            if(requestedFrameCount > 0)
             {
                 maxFrameCount = Math.Min(maxFrameCount, startFrameIndex + requestedFrameCount);
             }
 
-            for (long i = startFrameIndex; i < maxFrameCount; i++)
+            for(long i = startFrameIndex; i < maxFrameCount; i++)
             {
                 // Create the new StackFrame object with an ID that can
                 // be referenced back to the current list of stack frames
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 //        stackFrameDetails[i],
                 //        i));
                 newStackFrames.Add(
-                    LspDebugUtils.CreateStackFrame(stackFrameDetails[i], id: i));
+                    LspDebugUtils.CreateStackFrame(stackFrameDetails [i], id: i));
             }
 
             return Task.FromResult(new StackTraceResponse

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<VariablesResponse> Handle(VariablesArguments request, CancellationToken cancellationToken)
         {
-            VariableDetailsBase[] variables =
+            VariableDetailsBase [] variables =
                 _debugService.GetVariables(
                     (int)request.VariablesReference);
 
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                             .ToArray()
                 };
             }
-            catch (Exception)
+            catch(Exception)
             {
                 // TODO: This shouldn't be so broad
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoiceDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoiceDetails.cs
@@ -71,14 +71,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             this.HelpMessage = helpMessage;
 
             this.HotKeyIndex = label.IndexOf('&');
-            if (this.HotKeyIndex >= 0)
+            if(this.HotKeyIndex >= 0)
             {
                 this.Label = label.Remove(this.HotKeyIndex, 1);
 
-                if (this.HotKeyIndex < this.Label.Length)
+                if(this.HotKeyIndex < this.Label.Length)
                 {
-                    this.hotKeyString = this.Label[this.HotKeyIndex].ToString().ToUpper();
-                    this.HotKeyCharacter = this.hotKeyString[0];
+                    this.hotKeyString = this.Label [this.HotKeyIndex].ToString().ToUpper();
+                    this.HotKeyCharacter = this.hotKeyString [0];
                 }
             }
             else

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ChoicePromptHandler.cs
@@ -74,13 +74,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <summary>
         /// Gets the array of choices from which the user must select.
         /// </summary>
-        protected ChoiceDetails[] Choices { get; private set; }
+        protected ChoiceDetails [] Choices { get; private set; }
 
         /// <summary>
         /// Gets the index of the default choice so that the user
         /// interface can make it easy to select this option.
         /// </summary>
-        protected int[] DefaultChoices { get; private set; }
+        protected int [] DefaultChoices { get; private set; }
 
         #endregion
 
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public Task<int> PromptForChoiceAsync(
             string promptCaption,
             string promptMessage,
-            ChoiceDetails[] choices,
+            ChoiceDetails [] choices,
             int defaultChoice,
             CancellationToken cancellationToken)
         {
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             this.DefaultChoices =
                 defaultChoice == -1
                 ? Array.Empty<int>()
-                : new int[] { defaultChoice };
+                : new int [] { defaultChoice };
 
             // Cancel the TaskCompletionSource if the caller cancels the task
             cancellationToken.Register(this.CancelPrompt, true);
@@ -135,11 +135,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     .ContinueWith(
                         task =>
                         {
-                            if (task.IsFaulted)
+                            if(task.IsFaulted)
                             {
                                 throw task.Exception;
                             }
-                            else if (task.IsCanceled)
+                            else if(task.IsCanceled)
                             {
                                 throw new TaskCanceledException(task);
                             }
@@ -171,11 +171,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// A Task instance that can be monitored for completion to get
         /// the user's choices.
         /// </returns>
-        public Task<int[]> PromptForChoiceAsync(
+        public Task<int []> PromptForChoiceAsync(
             string promptCaption,
             string promptMessage,
-            ChoiceDetails[] choices,
-            int[] defaultChoices,
+            ChoiceDetails [] choices,
+            int [] defaultChoices,
             CancellationToken cancellationToken)
         {
             // TODO: Guard against multiple calls
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             _ = await Task.WhenAny(cancelTask.Task, taskToWait).ConfigureAwait(false);
 
-            if (this.cancelTask.Task.IsCanceled)
+            if(this.cancelTask.Task.IsCanceled)
             {
                 throw new PipelineStoppedException();
             }
@@ -206,18 +206,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             return await taskToWait.ConfigureAwait(false);
         }
 
-        private async Task<int[]> StartPromptLoopAsync(
+        private async Task<int []> StartPromptLoopAsync(
             CancellationToken cancellationToken)
         {
-            int[] choiceIndexes = null;
+            int [] choiceIndexes = null;
 
             // Show the prompt to the user
             this.ShowPrompt(PromptStyle.Full);
 
-            while (!cancellationToken.IsCancellationRequested)
+            while(!cancellationToken.IsCancellationRequested)
             {
                 string responseString = await ReadInputStringAsync(cancellationToken).ConfigureAwait(false);
-                if (responseString == null)
+                if(responseString == null)
                 {
                     // If the response string is null, the prompt has been cancelled
                     break;
@@ -226,13 +226,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 choiceIndexes = this.HandleResponse(responseString);
 
                 // Return the default choice values if no choices were entered
-                if (choiceIndexes == null && string.IsNullOrEmpty(responseString))
+                if(choiceIndexes == null && string.IsNullOrEmpty(responseString))
                 {
                     choiceIndexes = this.DefaultChoices;
                 }
 
                 // If the user provided no choices, we should prompt again
-                if (choiceIndexes != null)
+                if(choiceIndexes != null)
                 {
                     break;
                 }
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 this.ShowPrompt(PromptStyle.Minimal);
             }
 
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 // Throw a TaskCanceledException to stop the pipeline
                 throw new TaskCanceledException();
@@ -259,27 +259,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// True if the prompt is complete, false if the prompt is
         /// still waiting for a valid response.
         /// </returns>
-        protected virtual int[] HandleResponse(string responseString)
+        protected virtual int [] HandleResponse(string responseString)
         {
             List<int> choiceIndexes = new List<int>();
 
             // Clean up the response string and split it
             var choiceStrings =
                 responseString.Trim().Split(
-                    new char[] { ',' },
+                    new char [] { ',' },
                     StringSplitOptions.RemoveEmptyEntries);
 
-            foreach (string choiceString in choiceStrings)
+            foreach(string choiceString in choiceStrings)
             {
-                for (int i = 0; i < this.Choices.Length; i++)
+                for(int i = 0; i < this.Choices.Length; i++)
                 {
-                    if (this.Choices[i].MatchesInput(choiceString))
+                    if(this.Choices [i].MatchesInput(choiceString))
                     {
                         choiceIndexes.Add(i);
 
                         // If this is a single-choice prompt, break out after
                         // the first matched choice
-                        if (!this.IsMultiChoice)
+                        if(!this.IsMultiChoice)
                         {
                             break;
                         }
@@ -287,7 +287,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 }
             }
 
-            if (choiceIndexes.Count == 0)
+            if(choiceIndexes.Count == 0)
             {
                 // The user did not respond with a valid choice,
                 // show the prompt again to give another chance
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         #region Private Methods
 
-        private int GetSingleResult(int[] choiceArray)
+        private int GetSingleResult(int [] choiceArray)
         {
             return
                 choiceArray != null

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/CollectionFieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/CollectionFieldDetails.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             this.FieldType = typeof(object);
 
-            if (fieldType.IsArray)
+            if(fieldType.IsArray)
             {
                 this.isArray = true;
                 this.FieldType = fieldType.GetElementType();
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         public override FieldDetails GetNextField()
         {
-            if (!this.isEntryComplete)
+            if(!this.isEntryComplete)
             {
                 // Get the next collection field
                 this.currentCollectionIndex++;
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         public override void SetValue(object fieldValue, bool hasValue)
         {
-            if (hasValue)
+            if(hasValue)
             {
                 // Add the item to the collection
                 this.collectionItems.Add(fieldValue);
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             object collection = this.collectionItems;
 
             // Should the result collection be an array?
-            if (this.isArray)
+            if(this.isArray)
             {
                 // Convert the ArrayList to an array
                 collection =

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleChoicePromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleChoicePromptHandler.cs
@@ -49,24 +49,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         protected override void ShowPrompt(PromptStyle promptStyle)
         {
-            if (promptStyle == PromptStyle.Full)
+            if(promptStyle == PromptStyle.Full)
             {
-                if (this.Caption != null)
+                if(this.Caption != null)
                 {
                     this.hostOutput.WriteOutput(this.Caption);
                 }
 
-                if (this.Message != null)
+                if(this.Message != null)
                 {
                     this.hostOutput.WriteOutput(this.Message);
                 }
             }
 
-            foreach (var choice in this.Choices)
+            foreach(var choice in this.Choices)
             {
                 string hotKeyString =
                     choice.HotKeyIndex > -1 ?
-                        choice.Label[choice.HotKeyIndex].ToString().ToUpper() :
+                        choice.Label [choice.HotKeyIndex].ToString().ToUpper() :
                         string.Empty;
 
                 this.hostOutput.WriteOutput(
@@ -83,13 +83,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 this.DefaultChoices.Where(
                     choice => choice > -1 && choice < this.Choices.Length);
 
-            if (validDefaultChoices.Any())
+            if(validDefaultChoices.Any())
             {
                 var choiceString =
                     string.Join(
                         ", ",
                         this.DefaultChoices
-                            .Select(choice => this.Choices[choice].Label));
+                            .Select(choice => this.Choices [choice].Label));
 
                 this.hostOutput.WriteOutput(
                     $" (default is \"{choiceString}\"): ",
@@ -106,12 +106,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// True if the prompt is complete, false if the prompt is
         /// still waiting for a valid response.
         /// </returns>
-        protected override int[] HandleResponse(string responseString)
+        protected override int [] HandleResponse(string responseString)
         {
-            if (responseString.Trim() == "?")
+            if(responseString.Trim() == "?")
             {
                 // Print help text
-                foreach (var choice in this.Choices)
+                foreach(var choice in this.Choices)
                 {
                     this.hostOutput.WriteOutput(
                         string.Format(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleInputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleInputPromptHandler.cs
@@ -51,12 +51,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="message">The message string to be displayed.</param>
         protected override void ShowPromptMessage(string caption, string message)
         {
-            if (!string.IsNullOrEmpty(caption))
+            if(!string.IsNullOrEmpty(caption))
             {
                 this.hostOutput.WriteOutput(caption, true);
             }
 
-            if (!string.IsNullOrEmpty(message))
+            if(!string.IsNullOrEmpty(message))
             {
                 this.hostOutput.WriteOutput(message, true);
             }
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // For a simple prompt there won't be any field name.
             // In this case don't write anything
-            if (!string.IsNullOrEmpty(fieldDetails.Name))
+            if(!string.IsNullOrEmpty(fieldDetails.Name))
             {
                 this.hostOutput.WriteOutput(
                     fieldDetails.Name + ": ",

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleProxy.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "Platform specific initialization")]
         static ConsoleProxy()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 s_consoleProxy = new WindowsConsoleOperations();
                 return;
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
                 return s_consoleProxy.ReadKey(intercept, cancellationToken);
             }
-            catch (OperationCanceledException)
+            catch(OperationCanceledException)
             {
                 return new ConsoleKeyInfo(
                     keyChar: ' ',

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
@@ -55,32 +55,32 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             try
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while(!cancellationToken.IsCancellationRequested)
                 {
                     ConsoleKeyInfo keyInfo = await ReadKeyAsync(cancellationToken).ConfigureAwait(false);
 
-                    if ((int)keyInfo.Key == 3 ||
+                    if((int)keyInfo.Key == 3 ||
                         keyInfo.Key == ConsoleKey.C && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
                     {
                         throw new PipelineStoppedException();
                     }
-                    if (keyInfo.Key == ConsoleKey.Enter)
+                    if(keyInfo.Key == ConsoleKey.Enter)
                     {
                         // Break to return the completed string
                         break;
                     }
-                    if (keyInfo.Key == ConsoleKey.Tab)
+                    if(keyInfo.Key == ConsoleKey.Tab)
                     {
                         continue;
                     }
-                    if (keyInfo.Key == ConsoleKey.Backspace)
+                    if(keyInfo.Key == ConsoleKey.Backspace)
                     {
-                        if (secureString.Length > 0)
+                        if(secureString.Length > 0)
                         {
                             secureString.RemoveAt(secureString.Length - 1);
                         }
                     }
-                    else if (keyInfo.KeyChar != 0 && !char.IsControl(keyInfo.KeyChar))
+                    else if(keyInfo.KeyChar != 0 && !char.IsControl(keyInfo.KeyChar))
                     {
                         secureString.AppendChar(keyInfo.KeyChar);
                     }
@@ -89,18 +89,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     int currentInputLength = secureString.Length;
                     int consoleWidth = Console.WindowWidth;
 
-                    if (currentInputLength > previousInputLength)
+                    if(currentInputLength > previousInputLength)
                     {
                         Console.Write('*');
                     }
-                    else if (previousInputLength > 0 && currentInputLength < previousInputLength)
+                    else if(previousInputLength > 0 && currentInputLength < previousInputLength)
                     {
                         int row = await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false);
                         int col = await ConsoleProxy.GetCursorLeftAsync(cancellationToken).ConfigureAwait(false);
 
                         // Back up the cursor before clearing the character
                         col--;
-                        if (col < 0)
+                        if(col < 0)
                         {
                             col = consoleWidth - 1;
                             row--;
@@ -176,7 +176,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             try
             {
-                while (!cancellationToken.IsCancellationRequested)
+                while(!cancellationToken.IsCancellationRequested)
                 {
                     ConsoleKeyInfo keyInfo = await ReadKeyAsync(cancellationToken).ConfigureAwait(false);
 
@@ -186,21 +186,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     int promptStartRow = initialCursorRow;
                     int consoleWidth = Console.WindowWidth;
 
-                    if ((int)keyInfo.Key == 3 ||
+                    if((int)keyInfo.Key == 3 ||
                         keyInfo.Key == ConsoleKey.C && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control))
                     {
                         throw new PipelineStoppedException();
                     }
-                    else if (keyInfo.Key == ConsoleKey.Tab && isCommandLine)
+                    else if(keyInfo.Key == ConsoleKey.Tab && isCommandLine)
                     {
-                        if (currentCompletion == null)
+                        if(currentCompletion == null)
                         {
                             inputBeforeCompletion = inputLine.ToString();
                             inputAfterCompletion = null;
 
                             // TODO: This logic should be moved to AstOperations or similar!
 
-                            if (this.powerShellContext.IsDebuggerStopped)
+                            if(this.powerShellContext.IsDebuggerStopped)
                             {
                                 PSCommand command = new PSCommand();
                                 command.AddCommand("TabExpansion2");
@@ -216,8 +216,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             }
                             else
                             {
-                                using (RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandleAsync().ConfigureAwait(false))
-                                using (PowerShell powerShell = PowerShell.Create())
+                                using(RunspaceHandle runspaceHandle = await this.powerShellContext.GetRunspaceHandleAsync().ConfigureAwait(false))
+                                using(PowerShell powerShell = PowerShell.Create())
                                 {
                                     powerShell.Runspace = runspaceHandle.Runspace;
                                     currentCompletion =
@@ -227,7 +227,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                             null,
                                             powerShell);
 
-                                    if (currentCompletion.CompletionMatches.Count > 0)
+                                    if(currentCompletion.CompletionMatches.Count > 0)
                                     {
                                         int replacementEndIndex =
                                                 currentCompletion.ReplacementIndex +
@@ -250,7 +250,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             currentCompletion?.GetNextResult(
                                 !keyInfo.Modifiers.HasFlag(ConsoleModifiers.Shift));
 
-                        if (completion != null)
+                        if(completion != null)
                         {
                             currentCursorIndex =
                                 this.InsertInput(
@@ -264,11 +264,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     finalCursorIndex: currentCompletion.ReplacementIndex + completion.CompletionText.Length);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.LeftArrow)
+                    else if(keyInfo.Key == ConsoleKey.LeftArrow)
                     {
                         currentCompletion = null;
 
-                        if (currentCursorIndex > 0)
+                        if(currentCursorIndex > 0)
                         {
                             currentCursorIndex =
                                 this.MoveCursorToIndex(
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     currentCursorIndex - 1);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.Home)
+                    else if(keyInfo.Key == ConsoleKey.Home)
                     {
                         currentCompletion = null;
 
@@ -289,11 +289,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 consoleWidth,
                                 0);
                     }
-                    else if (keyInfo.Key == ConsoleKey.RightArrow)
+                    else if(keyInfo.Key == ConsoleKey.RightArrow)
                     {
                         currentCompletion = null;
 
-                        if (currentCursorIndex < inputLine.Length)
+                        if(currentCursorIndex < inputLine.Length)
                         {
                             currentCursorIndex =
                                 this.MoveCursorToIndex(
@@ -303,7 +303,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     currentCursorIndex + 1);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.End)
+                    else if(keyInfo.Key == ConsoleKey.End)
                     {
                         currentCompletion = null;
 
@@ -314,13 +314,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 consoleWidth,
                                 inputLine.Length);
                     }
-                    else if (keyInfo.Key == ConsoleKey.UpArrow && isCommandLine)
+                    else if(keyInfo.Key == ConsoleKey.UpArrow && isCommandLine)
                     {
                         currentCompletion = null;
 
                         // TODO: Ctrl+Up should allow navigation in multi-line input
 
-                        if (currentHistory == null)
+                        if(currentHistory == null)
                         {
                             historyIndex = -1;
 
@@ -331,13 +331,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 .ConfigureAwait(false)
                                 as Collection<PSObject>;
 
-                            if (currentHistory != null)
+                            if(currentHistory != null)
                             {
                                 historyIndex = currentHistory.Count;
                             }
                         }
 
-                        if (currentHistory != null && currentHistory.Count > 0 && historyIndex > 0)
+                        if(currentHistory != null && currentHistory.Count > 0 && historyIndex > 0)
                         {
                             historyIndex--;
 
@@ -346,37 +346,37 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     inputLine,
                                     promptStartCol,
                                     promptStartRow,
-                                    (string)currentHistory[historyIndex].Properties["CommandLine"].Value,
+                                    (string)currentHistory [historyIndex].Properties ["CommandLine"].Value,
                                     currentCursorIndex,
                                     insertIndex: 0,
                                     replaceLength: inputLine.Length);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.DownArrow && isCommandLine)
+                    else if(keyInfo.Key == ConsoleKey.DownArrow && isCommandLine)
                     {
                         currentCompletion = null;
 
                         // The down arrow shouldn't cause history to be loaded,
                         // it's only for navigating an active history array
 
-                        if (historyIndex > -1 && historyIndex < currentHistory.Count &&
+                        if(historyIndex > -1 && historyIndex < currentHistory.Count &&
                             currentHistory != null && currentHistory.Count > 0)
                         {
                             historyIndex++;
 
-                            if (historyIndex < currentHistory.Count)
+                            if(historyIndex < currentHistory.Count)
                             {
                                 currentCursorIndex =
                                     this.InsertInput(
                                         inputLine,
                                         promptStartCol,
                                         promptStartRow,
-                                        (string)currentHistory[historyIndex].Properties["CommandLine"].Value,
+                                        (string)currentHistory [historyIndex].Properties ["CommandLine"].Value,
                                         currentCursorIndex,
                                         insertIndex: 0,
                                         replaceLength: inputLine.Length);
                             }
-                            else if (historyIndex == currentHistory.Count)
+                            else if(historyIndex == currentHistory.Count)
                             {
                                 currentCursorIndex =
                                     this.InsertInput(
@@ -390,7 +390,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             }
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.Escape)
+                    else if(keyInfo.Key == ConsoleKey.Escape)
                     {
                         currentCompletion = null;
                         historyIndex = currentHistory != null ? currentHistory.Count : -1;
@@ -405,11 +405,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 insertIndex: 0,
                                 replaceLength: inputLine.Length);
                     }
-                    else if (keyInfo.Key == ConsoleKey.Backspace)
+                    else if(keyInfo.Key == ConsoleKey.Backspace)
                     {
                         currentCompletion = null;
 
-                        if (currentCursorIndex > 0)
+                        if(currentCursorIndex > 0)
                         {
                             currentCursorIndex =
                                 this.InsertInput(
@@ -423,11 +423,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     finalCursorIndex: currentCursorIndex - 1);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.Delete)
+                    else if(keyInfo.Key == ConsoleKey.Delete)
                     {
                         currentCompletion = null;
 
-                        if (currentCursorIndex < inputLine.Length)
+                        if(currentCursorIndex < inputLine.Length)
                         {
                             currentCursorIndex =
                                 this.InsertInput(
@@ -440,7 +440,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                     finalCursorIndex: currentCursorIndex);
                         }
                     }
-                    else if (keyInfo.Key == ConsoleKey.Enter)
+                    else if(keyInfo.Key == ConsoleKey.Enter)
                     {
                         string completedInput = inputLine.ToString();
                         currentCompletion = null;
@@ -454,8 +454,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
                         Parser.ParseInput(
                             completedInput,
-                            out Token[] tokens,
-                            out ParseError[] parseErrors);
+                            out Token [] tokens,
+                            out ParseError [] parseErrors);
 
                         //if (parseErrors.Any(e => e.IncompleteInput))
                         //{
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
                         return completedInput;
                     }
-                    else if (keyInfo.KeyChar != 0 && !char.IsControl(keyInfo.KeyChar))
+                    else if(keyInfo.KeyChar != 0 && !char.IsControl(keyInfo.KeyChar))
                     {
                         // Normal character input
                         currentCompletion = null;
@@ -526,7 +526,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             int consoleWidth = Console.WindowWidth;
             int previousInputLength = inputLine.Length;
 
-            if (insertIndex == -1)
+            if(insertIndex == -1)
             {
                 insertIndex = cursorIndex;
             }
@@ -539,9 +539,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 insertIndex);
 
             // Edit the input string based on the insertion
-            if (insertIndex < inputLine.Length)
+            if(insertIndex < inputLine.Length)
             {
-                if (replaceLength > 0)
+                if(replaceLength > 0)
                 {
                     inputLine.Remove(insertIndex, replaceLength);
                 }
@@ -559,7 +559,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     insertIndex,
                     inputLine.Length - insertIndex));
 
-            if (inputLine.Length < previousInputLength)
+            if(inputLine.Length < previousInputLength)
             {
                 Console.Write(
                     new string(
@@ -572,12 +572,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // input string is longer than the new one and needed to have
             // its old contents overwritten.  This will position the cursor
             // back at the end of the new text
-            if (finalCursorIndex == -1 && inputLine.Length < previousInputLength)
+            if(finalCursorIndex == -1 && inputLine.Length < previousInputLength)
             {
                 finalCursorIndex = inputLine.Length;
             }
 
-            if (finalCursorIndex > -1)
+            if(finalCursorIndex > -1)
             {
                 // Move the cursor to the final position
                 return

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/CredentialFieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/CredentialFieldDetails.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             string userName)
             : this(name, label, typeof(PSCredential), true, null)
         {
-            if (!string.IsNullOrEmpty(userName))
+            if(!string.IsNullOrEmpty(userName))
             {
                 // Call GetNextField to prepare the password field
                 this.userName = userName;
@@ -69,12 +69,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         public override FieldDetails GetNextField()
         {
-            if (this.password != null)
+            if(this.password != null)
             {
                 // No more fields to display
                 return null;
             }
-            else if (this.userName != null)
+            else if(this.userName != null)
             {
                 this.Name = $"Password for user {this.userName}";
                 this.FieldType = typeof(SecureString);
@@ -92,9 +92,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         public override void SetValue(object fieldValue, bool hasValue)
         {
-            if (hasValue)
+            if(hasValue)
             {
-                if (this.userName == null)
+                if(this.userName == null)
                 {
                     this.userName = (string)fieldValue;
                 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/FieldDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/FieldDetails.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             this.IsMandatory = isMandatory;
             this.DefaultValue = defaultValue;
 
-            if (fieldType.GetTypeInfo().IsGenericType)
+            if(fieldType.GetTypeInfo().IsGenericType)
             {
                 throw new PSArgumentException(
                     "Generic types are not supported for input fields at this time.");
@@ -108,7 +108,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         public virtual void SetValue(object fieldValue, bool hasValue)
         {
-            if (hasValue)
+            if(hasValue)
             {
                 this.fieldValue = fieldValue;
             }
@@ -123,9 +123,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             object fieldValue = this.OnGetValue();
 
-            if (fieldValue == null)
+            if(fieldValue == null)
             {
-                if (!this.IsMandatory)
+                if(!this.IsMandatory)
                 {
                     fieldValue = this.DefaultValue;
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     fieldDescription.ParameterAssemblyFullName,
                     logger);
 
-            if (typeof(IList).GetTypeInfo().IsAssignableFrom(fieldType.GetTypeInfo()))
+            if(typeof(IList).GetTypeInfo().IsAssignableFrom(fieldType.GetTypeInfo()))
             {
                 return new CollectionFieldDetails(
                     fieldDescription.Name,
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     fieldDescription.IsMandatory,
                     fieldDescription.DefaultValue);
             }
-            else if (typeof(PSCredential) == fieldType)
+            else if(typeof(PSCredential) == fieldType)
             {
                 return new CredentialFieldDetails(
                     fieldDescription.Name,
@@ -212,9 +212,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             Type fieldType = typeof(string);
 
-            if (!string.IsNullOrEmpty(assemblyFullName))
+            if(!string.IsNullOrEmpty(assemblyFullName))
             {
-                if (!LanguagePrimitives.TryConvertTo<Type>(assemblyFullName, out fieldType))
+                if(!LanguagePrimitives.TryConvertTo<Type>(assemblyFullName, out fieldType))
                 {
                     logger.LogWarning(
                         string.Format(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/InputPromptHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/InputPromptHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <summary>
         /// Gets the array of fields for which the user must enter values.
         /// </summary>
-        protected FieldDetails[] Fields { get; private set; }
+        protected FieldDetails [] Fields { get; private set; }
 
         #endregion
 
@@ -63,24 +63,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 this.PromptForInputAsync(
                     null,
                     null,
-                    new FieldDetails[] { new FieldDetails("", "", typeof(string), false, "") },
+                    new FieldDetails [] { new FieldDetails("", "", typeof(string), false, "") },
                     cancellationToken);
 
             return
                 innerTask.ContinueWith<string>(
                     task =>
                     {
-                        if (task.IsFaulted)
+                        if(task.IsFaulted)
                         {
                             throw task.Exception;
                         }
-                        else if (task.IsCanceled)
+                        else if(task.IsCanceled)
                         {
                             throw new TaskCanceledException(task);
                         }
 
                         // Return the value of the sole field
-                        return (string)task.Result[""];
+                        return (string)task.Result [""];
                     });
         }
 
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public async Task<Dictionary<string, object>> PromptForInputAsync(
             string promptCaption,
             string promptMessage,
-            FieldDetails[] fields,
+            FieldDetails [] fields,
             CancellationToken cancellationToken)
         {
             // Cancel the prompt if the caller cancels the task
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             _ = await Task.WhenAny(cancelTask.Task, promptTask).ConfigureAwait(false);
 
-            if (this.cancelTask.Task.IsCanceled)
+            if(this.cancelTask.Task.IsCanceled)
             {
                 throw new PipelineStoppedException();
             }
@@ -144,24 +144,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 this.PromptForInputAsync(
                     null,
                     null,
-                    new FieldDetails[] { new FieldDetails("", "", typeof(SecureString), false, "") },
+                    new FieldDetails [] { new FieldDetails("", "", typeof(SecureString), false, "") },
                     cancellationToken);
 
             return
                 innerTask.ContinueWith(
                     task =>
                     {
-                        if (task.IsFaulted)
+                        if(task.IsFaulted)
                         {
                             throw task.Exception;
                         }
-                        else if (task.IsCanceled)
+                        else if(task.IsCanceled)
                         {
                             throw new TaskCanceledException(task);
                         }
 
                         // Return the value of the sole field
-                        return (SecureString)task.Result?[""];
+                        return (SecureString)task.Result? [""];
                     });
         }
 
@@ -238,7 +238,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             this.GetNextField();
 
             // Loop until there are no more prompts to process
-            while (this.currentField != null && !cancellationToken.IsCancellationRequested)
+            while(this.currentField != null && !cancellationToken.IsCancellationRequested)
             {
                 // Show current prompt
                 this.ShowFieldPrompt(this.currentField);
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 string responseString = null;
 
                 // Read input depending on field type
-                if (this.currentField.FieldType == typeof(SecureString))
+                if(this.currentField.FieldType == typeof(SecureString))
                 {
                     SecureString secureString = await this.ReadSecureStringAsync(cancellationToken).ConfigureAwait(false);
                     responseValue = secureString;
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 this.currentField.FieldType,
                                 CultureInfo.CurrentCulture);
                     }
-                    catch (PSInvalidCastException e)
+                    catch(PSInvalidCastException e)
                     {
                         this.ShowErrorMessage(e.InnerException ?? e);
                         continue;
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 this.GetNextField();
             }
 
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 // Throw a TaskCanceledException to stop the pipeline
                 throw new TaskCanceledException();
@@ -294,14 +294,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             FieldDetails nextField = this.currentField?.GetNextField();
 
-            if (nextField == null)
+            if(nextField == null)
             {
                 this.currentFieldIndex++;
 
                 // Have we shown all the prompts already?
-                if (this.currentFieldIndex < this.Fields.Length)
+                if(this.currentFieldIndex < this.Fields.Length)
                 {
-                    nextField = this.Fields[this.currentFieldIndex];
+                    nextField = this.Fields [this.currentFieldIndex];
                 }
             }
 
@@ -313,7 +313,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             Dictionary<string, object> fieldValues = new Dictionary<string, object>();
 
-            foreach (FieldDetails field in this.Fields)
+            foreach(FieldDetails field in this.Fields)
             {
                 fieldValues.Add(field.OriginalName, field.GetValue(this.Logger));
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/UnixConsoleOperations.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // To work around this we wait for a key to be pressed before actually calling Console.ReadKey.
             // However, any pressed keys during this time will be echoed to the console. To get around
             // this we use the UnixConsoleEcho package to disable echo prior to waiting.
-            if (VersionUtils.IsPS6)
+            if(VersionUtils.IsPS6)
             {
                 InputEcho.Disable();
             }
@@ -57,11 +57,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 // The WaitForKeyAvailable delegate switches between a long delay between waits and
                 // a short timeout depending on how recently a key has been pressed. This allows us
                 // to let the CPU enter low power mode without compromising responsiveness.
-                while (!WaitForKeyAvailable(cancellationToken));
+                while(!WaitForKeyAvailable(cancellationToken)) ;
             }
             finally
             {
-                if (VersionUtils.IsPS6)
+                if(VersionUtils.IsPS6)
                 {
                     InputEcho.Disable();
                 }
@@ -87,18 +87,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             // I tried to replace this library with a call to `stty -echo`, but unfortunately
             // the library also sets up allowing backspace to trigger `Console.KeyAvailable`.
-            if (VersionUtils.IsPS6)
+            if(VersionUtils.IsPS6)
             {
                 InputEcho.Disable();
             }
 
             try
             {
-                while (!await WaitForKeyAvailableAsync(cancellationToken).ConfigureAwait(false)) ;
+                while(!await WaitForKeyAvailableAsync(cancellationToken).ConfigureAwait(false)) ;
             }
             finally
             {
-                if (VersionUtils.IsPS6)
+                if(VersionUtils.IsPS6)
                 {
                     InputEcho.Enable();
                 }
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // Wait for a key to be buffered (in other words, wait for Console.KeyAvailable to become
             // true) with a long delay between checks.
-            while (!IsKeyAvailable(cancellationToken))
+            while(!IsKeyAvailable(cancellationToken))
             {
                 s_waitHandle.Wait(LongWaitForKeySleepTime, cancellationToken);
             }
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private async Task<bool> LongWaitForKeyAsync(CancellationToken cancellationToken)
         {
-            while (!await IsKeyAvailableAsync(cancellationToken).ConfigureAwait(false))
+            while(!await IsKeyAvailableAsync(cancellationToken).ConfigureAwait(false))
             {
                 await Task.Delay(LongWaitForKeySleepTime, cancellationToken).ConfigureAwait(false);
             }
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private bool ShortWaitForKey(CancellationToken cancellationToken)
         {
             // Check frequently for a new key to be buffered.
-            if (SpinUntilKeyAvailable(ShortWaitForKeyTimeout, cancellationToken))
+            if(SpinUntilKeyAvailable(ShortWaitForKeyTimeout, cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return true;
@@ -232,7 +232,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private async Task<bool> ShortWaitForKeyAsync(CancellationToken cancellationToken)
         {
-            if (await SpinUntilKeyAvailableAsync(ShortWaitForKeyTimeout, cancellationToken).ConfigureAwait(false))
+            if(await SpinUntilKeyAvailableAsync(ShortWaitForKeyTimeout, cancellationToken).ConfigureAwait(false))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return true;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/WindowsConsoleOperations.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             await _readKeyHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                if (_bufferedKey == null)
+                if(_bufferedKey == null)
                 {
                     _bufferedKey = await Task.Run(() => Console.ReadKey(intercept)).ConfigureAwait(false);
                 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/EditorOperationsService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task<EditorContext> GetEditorContextAsync()
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return null;
             };
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task InsertTextAsync(string filePath, string text, BufferRange insertRange)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task SetSelectionAsync(BufferRange selectionRange)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task NewFileAsync()
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task OpenFileAsync(string filePath)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task OpenFileAsync(string filePath, bool preview)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task CloseFileAsync(string filePath)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task SaveFileAsync(string currentPath, string newSavePath)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task ShowInformationMessageAsync(string message)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task ShowErrorMessageAsync(string message)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -229,7 +229,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task ShowWarningMessageAsync(string message)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             };
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public async Task SetStatusBarMessageAsync(string message, int? timeout)
         {
-            if (!TestHasLanguageServer())
+            if(!TestHasLanguageServer())
             {
                 return;
             }
@@ -255,7 +255,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         public void ClearTerminal()
         {
-            if (!TestHasLanguageServer(warnUser: false))
+            if(!TestHasLanguageServer(warnUser: false))
             {
                 return;
             };
@@ -265,12 +265,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private bool TestHasLanguageServer(bool warnUser = true)
         {
-            if (_languageServer != null)
+            if(_languageServer != null)
             {
                 return true;
             }
 
-            if (warnUser)
+            if(warnUser)
             {
                 _powerShellContextService.ExternalHost.UI.WriteWarningLine(
                     "Editor operations are not supported in temporary consoles. Re-run the command in the main PowerShell Intergrated Console.");

--- a/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/ExtensionService.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Register the editor object in the runspace
             PSCommand variableCommand = new PSCommand();
-            using (RunspaceHandle handle = await this.PowerShellContext.GetRunspaceHandleAsync().ConfigureAwait(false))
+            using(RunspaceHandle handle = await this.PowerShellContext.GetRunspaceHandleAsync().ConfigureAwait(false))
             {
                 handle.Runspace.SessionStateProxy.PSVariable.Set(
                     "psEditor",
@@ -108,12 +108,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public async Task InvokeCommandAsync(string commandName, EditorContext editorContext)
         {
 
-            if (this.editorCommands.TryGetValue(commandName, out EditorCommand editorCommand))
+            if(this.editorCommands.TryGetValue(commandName, out EditorCommand editorCommand))
             {
                 PSCommand executeCommand = new PSCommand();
                 executeCommand.AddCommand("Invoke-Command");
                 executeCommand.AddParameter("ScriptBlock", editorCommand.ScriptBlock);
-                executeCommand.AddParameter("ArgumentList", new object[] { editorContext });
+                executeCommand.AddParameter("ArgumentList", new object [] { editorContext });
 
                 await this.PowerShellContext.ExecuteCommandAsync<object>(
                     executeCommand,
@@ -144,9 +144,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     editorCommand.Name);
 
             // Add or replace the editor command
-            this.editorCommands[editorCommand.Name] = editorCommand;
+            this.editorCommands [editorCommand.Name] = editorCommand;
 
-            if (!commandExists)
+            if(!commandExists)
             {
                 this.OnCommandAdded(editorCommand);
             }
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="commandName">The name of the command to be unregistered.</param>
         public void UnregisterCommand(string commandName)
         {
-            if (this.editorCommands.TryGetValue(commandName, out EditorCommand existingCommand))
+            if(this.editorCommands.TryGetValue(commandName, out EditorCommand existingCommand))
             {
                 this.editorCommands.Remove(commandName);
                 this.OnCommandRemoved(existingCommand);
@@ -182,10 +182,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Returns all registered EditorCommands.
         /// </summary>
         /// <returns>An Array of all registered EditorCommands.</returns>
-        public EditorCommand[] GetCommands()
+        public EditorCommand [] GetCommands()
         {
-            EditorCommand[] commands = new EditorCommand[this.editorCommands.Count];
-            this.editorCommands.Values.CopyTo(commands,0);
+            EditorCommand [] commands = new EditorCommand [this.editorCommands.Count];
+            this.editorCommands.Values.CopyTo(commands, 0);
             return commands;
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -49,21 +49,21 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Get-Command -CommandType Function,Cmdlet,ExternalScript | Sort-Object -Property Name
             psCommand
                 .AddCommand("Microsoft.PowerShell.Core\\Get-Command")
-                    .AddParameter("CommandType", new[] { "Function", "Cmdlet", "ExternalScript" })
+                    .AddParameter("CommandType", new [] { "Function", "Cmdlet", "ExternalScript" })
                 .AddCommand("Microsoft.PowerShell.Utility\\Sort-Object")
                     .AddParameter("Property", "Name");
 
             IEnumerable<CommandInfo> result = await _powerShellContextService.ExecuteCommandAsync<CommandInfo>(psCommand).ConfigureAwait(false);
 
             var commandList = new List<PSCommandMessage>();
-            if (result != null)
+            if(result != null)
             {
-                foreach (CommandInfo command in result)
+                foreach(CommandInfo command in result)
                 {
                     // Some info objects have a quicker way to get the DefaultParameterSet. These
                     // are also the most likely to show up so win-win.
                     string defaultParameterSet = null;
-                    switch (command)
+                    switch(command)
                     {
                         case CmdletInfo info:
                             defaultParameterSet = info.DefaultParameterSet;
@@ -73,12 +73,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                             break;
                     }
 
-                    if (defaultParameterSet == null)
+                    if(defaultParameterSet == null)
                     {
                         // Try to get the default ParameterSet if it isn't streamlined (ExternalScriptInfo for example)
-                        foreach (CommandParameterSetInfo parameterSetInfo in command.ParameterSets)
+                        foreach(CommandParameterSetInfo parameterSetInfo in command.ParameterSets)
                         {
-                            if (parameterSetInfo.IsDefault)
+                            if(parameterSetInfo.IsDefault)
                             {
                                 defaultParameterSet = parameterSetInfo.Name;
                                 break;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommentHelpHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             var result = new CommentHelpRequestResult();
 
-            if (!_workspaceService.TryGetFile(request.DocumentUri, out ScriptFile scriptFile))
+            if(!_workspaceService.TryGetFile(request.DocumentUri, out ScriptFile scriptFile))
             {
                 return result;
             }
@@ -47,22 +47,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 triggerLine,
                 out string helpLocation);
 
-            if (functionDefinitionAst == null)
+            if(functionDefinitionAst == null)
             {
                 return result;
             }
 
             IScriptExtent funcExtent = functionDefinitionAst.Extent;
             string funcText = funcExtent.Text;
-            if (helpLocation.Equals("begin"))
+            if(helpLocation.Equals("begin"))
             {
                 // check if the previous character is `<` because it invalidates
                 // the param block the follows it.
                 IList<string> lines = ScriptFile.GetLinesInternal(funcText);
                 int relativeTriggerLine0b = triggerLine - funcExtent.StartLineNumber;
-                if (relativeTriggerLine0b > 0 && lines[relativeTriggerLine0b].IndexOf("<", StringComparison.OrdinalIgnoreCase) > -1)
+                if(relativeTriggerLine0b > 0 && lines [relativeTriggerLine0b].IndexOf("<", StringComparison.OrdinalIgnoreCase) > -1)
                 {
-                    lines[relativeTriggerLine0b] = string.Empty;
+                    lines [relativeTriggerLine0b] = string.Empty;
                 }
 
                 funcText = string.Join("\n", lines);
@@ -70,14 +70,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             string helpText = await _analysisService.GetCommentHelpText(funcText, helpLocation, forBlockComment: request.BlockComment).ConfigureAwait(false);
 
-            if (helpText == null)
+            if(helpText == null)
             {
                 return result;
             }
 
             List<string> helpLines = ScriptFile.GetLinesInternal(helpText);
 
-            if (helpLocation != null &&
+            if(helpLocation != null &&
                 !helpLocation.Equals("before", StringComparison.OrdinalIgnoreCase))
             {
                 // we need to trim the leading `{` and newline when helpLocation=="begin"
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             // Trim trailing newline from help text.
-            if (string.IsNullOrEmpty(helpLines[helpLines.Count - 1]))
+            if(string.IsNullOrEmpty(helpLines [helpLines.Count - 1]))
             {
                 helpLines.RemoveAt(helpLines.Count - 1);
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetVersionHandler.cs
@@ -41,19 +41,19 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             var architecture = PowerShellProcessArchitecture.Unknown;
             // This should be changed to using a .NET call sometime in the future... but it's just for logging purposes.
             string arch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-            if (arch != null)
+            if(arch != null)
             {
-                if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
+                if(string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
                 {
                     architecture = PowerShellProcessArchitecture.X64;
                 }
-                else if (string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
+                else if(string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
                 {
                     architecture = PowerShellProcessArchitecture.X86;
                 }
             }
 
-            if (VersionUtils.IsPS5 && _configurationService.CurrentSettings.PromptToUpdatePackageManagement)
+            if(VersionUtils.IsPS5 && _configurationService.CurrentSettings.PromptToUpdatePackageManagement)
             {
                 await CheckPackageManagement().ConfigureAwait(false);
             }
@@ -77,17 +77,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private async Task CheckPackageManagement()
         {
             PSCommand getModule = new PSCommand().AddCommand("Get-Module").AddParameter("ListAvailable").AddParameter("Name", "PackageManagement");
-            foreach (PSModuleInfo module in await _powerShellContextService.ExecuteCommandAsync<PSModuleInfo>(getModule))
+            foreach(PSModuleInfo module in await _powerShellContextService.ExecuteCommandAsync<PSModuleInfo>(getModule))
             {
                 // The user has a good enough version of PackageManagement
-                if (module.Version >= s_desiredPackageManagementVersion)
+                if(module.Version >= s_desiredPackageManagementVersion)
                 {
                     break;
                 }
 
                 _logger.LogDebug("Old version of PackageManagement detected.");
 
-                if (_powerShellContextService.CurrentRunspace.Runspace.SessionStateProxy.LanguageMode != PSLanguageMode.FullLanguage)
+                if(_powerShellContextService.CurrentRunspace.Runspace.SessionStateProxy.LanguageMode != PSLanguageMode.FullLanguage)
                 {
                     _languageServer.Window.ShowWarning("You have an older version of PackageManagement known to cause issues with the PowerShell extension. Please run the following command in a new Windows PowerShell session and then restart the PowerShell extension: `Install-Module PackageManagement -Force -AllowClobber -MinimumVersion 1.4.6`");
                     return;
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 {
                     Message = "You have an older version of PackageManagement known to cause issues with the PowerShell extension. Would you like to update PackageManagement (You will need to restart the PowerShell extension after)?",
                     Type = MessageType.Warning,
-                    Actions = new[]
+                    Actions = new []
                     {
                         new MessageActionItem
                         {
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 });
 
                 // If the user chose "Not now" ignore it for the rest of the session.
-                if (messageAction?.Title == takeActionText)
+                if(messageAction?.Title == takeActionText)
                 {
                     StringBuilder errors = new StringBuilder();
                     await _powerShellContextService.ExecuteScriptStringAsync(
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         writeOutputToHost: true,
                         addToHistory: true).ConfigureAwait(false);
 
-                    if (errors.Length == 0)
+                    if(errors.Length == 0)
                     {
                         _logger.LogDebug("PackageManagement is updated.");
                         _languageServer.Window.ShowMessage(new ShowMessageParams

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetCommentHelpHandler.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
     internal class CommentHelpRequestResult
     {
-        public string[] Content { get; set; }
+        public string [] Content { get; set; }
     }
 
     internal class CommentHelpRequestParams : IRequest<CommentHelpRequestResult>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetPSHostProcessesHandler.cs
@@ -7,9 +7,9 @@ using OmniSharp.Extensions.JsonRpc;
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     [Serial, Method("powerShell/getPSHostProcesses")]
-    internal interface IGetPSHostProcessesHandler : IJsonRpcRequestHandler<GetPSHostProcesssesParams, PSHostProcessResponse[]> { }
+    internal interface IGetPSHostProcessesHandler : IJsonRpcRequestHandler<GetPSHostProcesssesParams, PSHostProcessResponse []> { }
 
-    internal class GetPSHostProcesssesParams : IRequest<PSHostProcessResponse[]> { }
+    internal class GetPSHostProcesssesParams : IRequest<PSHostProcessResponse []> { }
 
     internal class PSHostProcessResponse
     {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetRunspaceHandler.cs
@@ -7,11 +7,11 @@ using OmniSharp.Extensions.JsonRpc;
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     [Serial, Method("powerShell/getRunspace")]
-    internal interface IGetRunspaceHandler : IJsonRpcRequestHandler<GetRunspaceParams, RunspaceResponse[]> { }
+    internal interface IGetRunspaceHandler : IJsonRpcRequestHandler<GetRunspaceParams, RunspaceResponse []> { }
 
-    internal class GetRunspaceParams : IRequest<RunspaceResponse[]>
+    internal class GetRunspaceParams : IRequest<RunspaceResponse []>
     {
-        public string ProcessId {get; set; }
+        public string ProcessId { get; set; }
     }
 
     internal class RunspaceResponse

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/IGetVersionHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             this.DisplayVersion = $"{versionDetails.Version.Major}.{versionDetails.Version.Minor}";
             this.Edition = versionDetails.Edition;
 
-            switch (versionDetails.Architecture)
+            switch(versionDetails.Architecture)
             {
                 case PowerShellProcessArchitecture.X64:
                     this.Architecture = "x64";

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ITemplateHandlers.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     {
         public bool NeedsModuleInstall { get; set; }
 
-        public TemplateDetails[] Templates { get; set; }
+        public TemplateDetails [] Templates { get; set; }
     }
 
     /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
@@ -24,13 +24,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _powerShellContextService = powerShellContextService;
         }
 
-        public Task<PSHostProcessResponse[]> Handle(GetPSHostProcesssesParams request, CancellationToken cancellationToken)
+        public Task<PSHostProcessResponse []> Handle(GetPSHostProcesssesParams request, CancellationToken cancellationToken)
         {
             var psHostProcesses = new List<PSHostProcessResponse>();
 
             int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
 
-            using (var pwsh = PowerShell.Create())
+            using(var pwsh = PowerShell.Create())
             {
                 pwsh.AddCommand("Get-PSHostProcessInfo")
                     .AddCommand("Where-Object")
@@ -40,9 +40,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 var processes = pwsh.Invoke<PSObject>();
 
-                if (processes != null)
+                if(processes != null)
                 {
-                    foreach (dynamic p in processes)
+                    foreach(dynamic p in processes)
                     {
                         psHostProcesses.Add(
                             new PSHostProcessResponse
@@ -59,22 +59,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return Task.FromResult(psHostProcesses.ToArray());
         }
 
-        public async Task<RunspaceResponse[]> Handle(GetRunspaceParams request, CancellationToken cancellationToken)
+        public async Task<RunspaceResponse []> Handle(GetRunspaceParams request, CancellationToken cancellationToken)
         {
             IEnumerable<PSObject> runspaces = null;
 
-            if (request.ProcessId == null)
+            if(request.ProcessId == null)
             {
                 request.ProcessId = "current";
             }
 
             // If the processId is a valid int, we need to run Get-Runspace within that process
             // otherwise just use the current runspace.
-            if (int.TryParse(request.ProcessId, out int pid))
+            if(int.TryParse(request.ProcessId, out int pid))
             {
                 // Create a remote runspace that we will invoke Get-Runspace in.
-                using (var rs = RunspaceFactory.CreateRunspace(new NamedPipeConnectionInfo(pid)))
-                using (var ps = PowerShell.Create())
+                using(var rs = RunspaceFactory.CreateRunspace(new NamedPipeConnectionInfo(pid)))
+                using(var ps = PowerShell.Create())
                 {
                     rs.Open();
                     ps.Runspace = rs;
@@ -92,9 +92,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             var runspaceResponses = new List<RunspaceResponse>();
 
-            if (runspaces != null)
+            if(runspaces != null)
             {
-                foreach (dynamic runspace in runspaces)
+                foreach(dynamic runspace in runspaces)
                 {
                     runspaceResponses.Add(
                         new RunspaceResponse

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 ";
 
             string helpParams = request.Text;
-            if (string.IsNullOrEmpty(helpParams)) { helpParams = "Get-Help"; }
+            if(string.IsNullOrEmpty(helpParams)) { helpParams = "Get-Help"; }
 
             PSCommand checkHelpPSCommand = new PSCommand()
                 .AddScript(CheckHelpScript, useLocalScope: true)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/TemplateHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/TemplateHandlers.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             bool plasterInstalled = await _templateService.ImportPlasterIfInstalledAsync().ConfigureAwait(false);
 
-            if (plasterInstalled)
+            if(plasterInstalled)
             {
                 var availableTemplates =
                     await _templateService.GetAvailableTemplatesAsync(
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 await _templateService.CreateFromTemplateAsync(request.TemplatePath, request.DestinationPath).ConfigureAwait(false);
                 creationSuccessful = true;
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 // We don't really care if this worked or not but we report status.
                 _logger.LogException("New plaster template failed.", e);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -45,14 +45,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
         static PowerShellContextService()
         {
             // PowerShell ApartmentState APIs aren't available in PSStandard, so we need to use reflection.
-            if (!VersionUtils.IsNetCore || VersionUtils.IsPS7OrGreater)
+            if(!VersionUtils.IsNetCore || VersionUtils.IsPS7OrGreater)
             {
                 MethodInfo setterInfo = typeof(Runspace).GetProperty("ApartmentState").GetSetMethod();
                 Delegate setter = Delegate.CreateDelegate(typeof(Action<Runspace, ApartmentState>), firstArgument: null, method: setterInfo);
                 s_runspaceApartmentStateSetter = (Action<Runspace, ApartmentState>)setter;
             }
 
-            if (VersionUtils.IsPS7OrGreater)
+            if(VersionUtils.IsPS7OrGreater)
             {
                 // Used to write ErrorRecords to the Error stream. Using Public and NonPublic because the plan is to make this property
                 // public in 7.0.1
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             EditorServicesPSHostUserInterface hostUserInterface =
                 hostStartupInfo.ConsoleReplEnabled
-                    ? (EditorServicesPSHostUserInterface) new TerminalPSHostUserInterface(powerShellContext, hostStartupInfo.PSHost, logger)
+                    ? (EditorServicesPSHostUserInterface)new TerminalPSHostUserInterface(powerShellContext, hostStartupInfo.PSHost, logger)
                     : new ProtocolPSHostUserInterface(languageServer, powerShellContext, logger);
 
             EditorServicesPSHost psHost =
@@ -220,7 +220,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // TODO: This can be moved to the point after the $psEditor object
             // gets initialized when that is done earlier than LanguageServer.Initialize
-            foreach (string module in hostStartupInfo.AdditionalModules)
+            foreach(string module in hostStartupInfo.AdditionalModules)
             {
                 var command =
                     new PSCommand()
@@ -270,9 +270,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public static Runspace CreateRunspace(PSHost psHost, PSLanguageMode languageMode)
         {
             InitialSessionState initialSessionState;
-            if (Environment.GetEnvironmentVariable("PSES_TEST_USE_CREATE_DEFAULT") == "1") {
+            if(Environment.GetEnvironmentVariable("PSES_TEST_USE_CREATE_DEFAULT") == "1")
+            {
                 initialSessionState = InitialSessionState.CreateDefault();
-            } else {
+            }
+            else
+            {
                 initialSessionState = InitialSessionState.CreateDefault2();
             }
 
@@ -285,7 +288,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Windows PowerShell must be hosted in STA mode
             // This must be set on the runspace *before* it is opened
-            if (s_runspaceApartmentStateSetter != null)
+            if(s_runspaceApartmentStateSetter != null)
             {
                 s_runspaceApartmentStateSetter(runspace, ApartmentState.STA);
             }
@@ -341,7 +344,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             this.logger.LogInformation($"PowerShell Version: {this.LocalPowerShellVersion.Version}, Edition: {this.LocalPowerShellVersion.Edition}");
 
             Version powerShellVersion = this.LocalPowerShellVersion.Version;
-            if (powerShellVersion >= new Version(5, 0))
+            if(powerShellVersion >= new Version(5, 0))
             {
                 this.versionSpecificOperations = new PowerShell5Operations();
             }
@@ -360,7 +363,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Set the $profile variable in the runspace
             this.profilePaths = profilePaths;
-            if (profilePaths != null)
+            if(profilePaths != null)
             {
                 this.SetProfileVariableInCurrentRunspace(profilePaths);
             }
@@ -394,7 +397,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.versionSpecificOperations);
             this.InvocationEventQueue = InvocationEventQueue.Create(this, this.PromptNest);
 
-            if (powerShellVersion.Major >= 5 &&
+            if(powerShellVersion.Major >= 5 &&
                 this.isPSReadLineEnabled &&
                 PSReadLinePromptContext.TryGetPSReadLineProxy(logger, initialRunspace, out PSReadLineProxy proxy))
             {
@@ -409,7 +412,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.PromptContext = new LegacyReadLineContext(this);
             }
 
-            if (VersionUtils.IsWindows)
+            if(VersionUtils.IsWindows)
             {
                 this.SetExecutionPolicy();
             }
@@ -450,7 +453,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             this.logger.LogTrace("Configuring Runspace");
             runspaceDetails.Runspace.StateChanged += this.HandleRunspaceStateChanged;
-            if (runspaceDetails.Runspace.Debugger != null)
+            if(runspaceDetails.Runspace.Debugger != null)
             {
                 runspaceDetails.Runspace.Debugger.BreakpointUpdated += OnBreakpointUpdated;
                 runspaceDetails.Runspace.Debugger.DebuggerStop += OnDebuggerStop;
@@ -463,7 +466,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             this.logger.LogTrace("Cleaning Up Runspace");
             runspaceDetails.Runspace.StateChanged -= this.HandleRunspaceStateChanged;
-            if (runspaceDetails.Runspace.Debugger != null)
+            if(runspaceDetails.Runspace.Debugger != null)
             {
                 runspaceDetails.Runspace.Debugger.BreakpointUpdated -= OnBreakpointUpdated;
                 runspaceDetails.Runspace.Debugger.DebuggerStop -= OnDebuggerStop;
@@ -587,9 +590,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Add history to PSReadLine before cancelling, otherwise it will be restored as the
             // cancelled prompt when it's called again.
-            if (executionOptions.AddToHistory)
+            if(executionOptions.AddToHistory)
             {
-                this.PromptContext.AddToHistory(executionOptions.InputString ?? psCommand.Commands[0].CommandText);
+                this.PromptContext.AddToHistory(executionOptions.InputString ?? psCommand.Commands [0].CommandText);
             }
 
             bool hadErrors = false;
@@ -612,7 +615,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // 4. The command cannot be for a PSReadLine pipeline while we
             //    are currently in a out of process runspace
             var threadController = PromptNest.GetThreadController();
-            if (!(threadController == null ||
+            if(!(threadController == null ||
                 !threadController.IsPipelineThread ||
                 threadController.IsCurrentThread() ||
                 this.ShouldExecuteWithEventing(executionOptions) ||
@@ -620,7 +623,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 this.logger.LogTrace("Passing command execution to pipeline thread");
 
-                if (shouldCancelReadLine && PromptNest.IsReadLineBusy())
+                if(shouldCancelReadLine && PromptNest.IsReadLineBusy())
                 {
                     // If a ReadLine pipeline is running in the debugger then we'll stop responding here
                     // if we don't cancel it. Typically we can rely on OnExecutionStatusChanged but
@@ -641,9 +644,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             try
             {
                 // Instruct PowerShell to send output and errors to the host
-                if (executionOptions.WriteOutputToHost)
+                if(executionOptions.WriteOutputToHost)
                 {
-                    psCommand.Commands[0].MergeMyResults(
+                    psCommand.Commands [0].MergeMyResults(
                         PipelineResultTypes.Error,
                         PipelineResultTypes.Output);
 
@@ -656,7 +659,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 // If a ReadLine pipeline is running we can still execute commands that
                 // don't write output (e.g. command completion)
-                if (executionTarget == ExecutionTarget.InvocationEvent)
+                if(executionTarget == ExecutionTarget.InvocationEvent)
                 {
                     return await this.InvocationEventQueue.ExecuteCommandOnIdleAsync<TResult>(
                         psCommand,
@@ -666,7 +669,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 // Prompt is stopped and started based on the execution status, so naturally
                 // we don't want PSReadLine pipelines to factor in.
-                if (!executionOptions.IsReadLine)
+                if(!executionOptions.IsReadLine)
                 {
                     this.OnExecutionStatusChanged(
                         ExecutionStatus.Running,
@@ -675,18 +678,18 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
 
                 runspaceHandle = await this.GetRunspaceHandleAsync(executionOptions.IsReadLine).ConfigureAwait(false);
-                if (executionOptions.WriteInputToHost)
+                if(executionOptions.WriteInputToHost)
                 {
                     this.WriteOutput(
-                        executionOptions.InputString ?? psCommand.Commands[0].CommandText,
+                        executionOptions.InputString ?? psCommand.Commands [0].CommandText,
                         includeNewLine: true);
                 }
 
-                if (executionTarget == ExecutionTarget.Debugger)
+                if(executionTarget == ExecutionTarget.Debugger)
                 {
                     // Manually change the session state for debugger commands because
                     // we don't have an invocation state event to attach to.
-                    if (!executionOptions.IsReadLine)
+                    if(!executionOptions.IsReadLine)
                     {
                         this.OnSessionStateChanged(
                             this,
@@ -701,13 +704,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             psCommand,
                             executionOptions.WriteOutputToHost);
                     }
-                    catch (Exception e)
+                    catch(Exception e)
                     {
                         this.logger.LogException("Exception occurred while executing debugger command", e);
                     }
                     finally
                     {
-                        if (!executionOptions.IsReadLine)
+                        if(!executionOptions.IsReadLine)
                         {
                             this.OnSessionStateChanged(
                                 this,
@@ -732,13 +735,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // because PowerShell strips out CommandInfo:
                 // https://github.com/PowerShell/PowerShell/issues/12297
                 shell.Commands.Clear();
-                foreach (Command command in psCommand.Commands)
+                foreach(Command command in psCommand.Commands)
                 {
                     shell.Commands.AddCommand(command);
                 }
 
                 // Don't change our SessionState for ReadLine.
-                if (!executionOptions.IsReadLine)
+                if(!executionOptions.IsReadLine)
                 {
                     await this.sessionStateLock.AcquireForExecuteCommandAsync().ConfigureAwait(false);
                     shell.InvocationStateChanged += PowerShell_InvocationStateChanged;
@@ -751,7 +754,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     // Nested PowerShell instances can't be invoked asynchronously. This occurs
                     // in nested prompts and pipeline requests from eventing.
-                    if (shell.IsNested)
+                    if(shell.IsNested)
                     {
                         return shell.Invoke<TResult>(null, invocationSettings);
                     }
@@ -761,29 +764,29 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
                 finally
                 {
-                    if (!executionOptions.IsReadLine)
+                    if(!executionOptions.IsReadLine)
                     {
                         shell.InvocationStateChanged -= PowerShell_InvocationStateChanged;
                         await this.sessionStateLock.ReleaseForExecuteCommand().ConfigureAwait(false);
                     }
 
-                    if (shell.HadErrors)
+                    if(shell.HadErrors)
                     {
                         var strBld = new StringBuilder(1024);
                         strBld.AppendFormat("Execution of the following command(s) completed with errors:\r\n\r\n{0}\r\n",
                             GetStringForPSCommand(psCommand));
 
                         int i = 1;
-                        foreach (var error in shell.Streams.Error)
+                        foreach(var error in shell.Streams.Error)
                         {
-                            if (i > 1) strBld.Append("\r\n\r\n");
+                            if(i > 1) strBld.Append("\r\n\r\n");
                             strBld.Append($"Error #{i++}:\r\n");
                             strBld.Append(error.ToString() + "\r\n");
                             strBld.Append("ScriptStackTrace:\r\n");
                             strBld.Append((error.ScriptStackTrace ?? "<null>") + "\r\n");
                             strBld.Append($"Exception:\r\n   {error.Exception?.ToString() ?? "<null>"}");
                             Exception innerEx = error.Exception?.InnerException;
-                            while (innerEx != null)
+                            while(innerEx != null)
                             {
                                 strBld.Append($"InnerException:\r\n   {innerEx.ToString()}");
                                 innerEx = innerEx.InnerException;
@@ -806,31 +809,31 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     }
                 }
             }
-            catch (PSRemotingDataStructureException e)
+            catch(PSRemotingDataStructureException e)
             {
                 this.logger.LogHandledException("Pipeline stopped while executing command", e);
                 errorMessages?.Append(e.Message);
             }
-            catch (PipelineStoppedException e)
+            catch(PipelineStoppedException e)
             {
                 this.logger.LogHandledException("Pipeline stopped while executing command", e);
                 errorMessages?.Append(e.Message);
             }
-            catch (RuntimeException e)
+            catch(RuntimeException e)
             {
                 this.logger.LogHandledException("Runtime exception occurred while executing command", e);
 
                 hadErrors = true;
                 errorMessages?.Append(e.Message);
 
-                if (executionOptions.WriteErrorsToHost)
+                if(executionOptions.WriteErrorsToHost)
                 {
                     // Write the error to the host
                     // We must await this after the runspace handle has been released or we will deadlock
                     writeErrorsToConsoleTask = this.WriteExceptionToHostAsync(e);
                 }
             }
-            catch (Exception)
+            catch(Exception)
             {
                 this.OnExecutionStatusChanged(
                     ExecutionStatus.Failed,
@@ -846,28 +849,28 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // (and clean up the debugger) and then pop it off the stack.
                 // An example of when this happens is when the "attach" debug config is used and the
                 // process you're attached to dies randomly.
-                if (this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.None)
+                if(this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.None)
                 {
                     this.AbortExecution(shouldAbortDebugSession: true);
                     this.PopRunspace();
                 }
 
                 // Get the new prompt before releasing the runspace handle
-                if (executionOptions.WriteOutputToHost)
+                if(executionOptions.WriteOutputToHost)
                 {
                     SessionDetails sessionDetails = null;
 
                     // Get the SessionDetails and then write the prompt
-                    if (executionTarget == ExecutionTarget.Debugger)
+                    if(executionTarget == ExecutionTarget.Debugger)
                     {
                         sessionDetails = this.GetSessionDetailsInDebugger();
                     }
-                    else if (this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.Available)
+                    else if(this.CurrentRunspace.Runspace.RunspaceAvailability == RunspaceAvailability.Available)
                     {
                         // This state can happen if the user types a command that causes the
                         // debugger to exit before we reach this point.  No RunspaceHandle
                         // will exist already so we need to create one and then use it
-                        if (runspaceHandle == null)
+                        if(runspaceHandle == null)
                         {
                             runspaceHandle = await this.GetRunspaceHandleAsync().ConfigureAwait(false);
                         }
@@ -884,10 +887,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 }
 
                 // Dispose of the execution context
-                if (runspaceHandle != null)
+                if(runspaceHandle != null)
                 {
                     runspaceHandle.Dispose();
-                    if (writeErrorsToConsoleTask != null)
+                    if(writeErrorsToConsoleTask != null)
                     {
                         await writeErrorsToConsoleTask.ConfigureAwait(false);
                     }
@@ -999,7 +1002,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     PowerShell ps = scriptBlock.GetPowerShell(isTrustedInput: false, null);
                     command = ps.Commands;
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     logger.LogException("Exception getting trusted/untrusted PSCommand.", e);
                 }
@@ -1035,7 +1038,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             PSCommand command = new PSCommand();
 
-            if (arguments != null)
+            if(arguments != null)
             {
                 // Need to determine If the script string is a path to a script file.
                 string scriptAbsPath = string.Empty;
@@ -1054,7 +1057,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     workingDir = workingDir.TrimEnd(Path.DirectorySeparatorChar);
                     scriptAbsPath = workingDir + Path.DirectorySeparatorChar + script;
                 }
-                catch (System.Management.Automation.DriveNotFoundException e)
+                catch(System.Management.Automation.DriveNotFoundException e)
                 {
                     this.logger.LogHandledException("Could not determine current filesystem location", e);
                 }
@@ -1068,7 +1071,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // If the provided path is already quoted, then File.Exists will not find it.
                 // This keeps us from quoting an already quoted path.
                 // Related to issue #123.
-                if (File.Exists(script) || File.Exists(scriptAbsPath))
+                if(File.Exists(script) || File.Exists(scriptAbsPath))
                 {
                     // Dot-source the launched script path and single quote the path in case it includes
                     strBld.Append(". ").Append(QuoteEscapeString(script));
@@ -1138,7 +1141,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </remarks>
         internal Task InvokeOnPipelineThreadAsync(Action<PowerShell> invocationAction)
         {
-            if (this.PromptNest.IsReadLineBusy())
+            if(this.PromptNest.IsReadLineBusy())
             {
                 return this.InvocationEventQueue.InvokeOnPipelineThreadAsync(invocationAction);
             }
@@ -1163,7 +1166,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             TResult defaultValue = default,
             bool useLocalScope = false)
         {
-            using (PowerShell pwsh = PowerShell.Create())
+            using(PowerShell pwsh = PowerShell.Create())
             {
                 pwsh.Runspace = runspace;
                 IEnumerable<TResult> results = pwsh.AddScript(scriptToExecute, useLocalScope).Invoke<TResult>();
@@ -1179,7 +1182,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>A Task that can be awaited for completion.</returns>
         public async Task LoadHostProfilesAsync()
         {
-            if (this.profilePaths == null)
+            if(this.profilePaths == null)
             {
                 return;
             }
@@ -1187,13 +1190,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Load any of the profile paths that exist
             var command = new PSCommand();
             bool hasLoadablePath = false;
-            foreach (var profilePath in GetLoadableProfilePaths(this.profilePaths))
+            foreach(var profilePath in GetLoadableProfilePaths(this.profilePaths))
             {
                 hasLoadablePath = true;
                 command.AddCommand(profilePath, false).AddStatement();
             }
 
-            if (!hasLoadablePath)
+            if(!hasLoadablePath)
             {
                 return;
             }
@@ -1224,7 +1227,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </param>
         public void AbortExecution(bool shouldAbortDebugSession)
         {
-            if (this.SessionState == PowerShellContextState.Aborting
+            if(this.SessionState == PowerShellContextState.Aborting
                 || this.SessionState == PowerShellContextState.Disposed)
             {
                 this.logger.LogTrace($"Execution abort requested when already aborted (SessionState = {this.SessionState})");
@@ -1233,15 +1236,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             this.logger.LogTrace("Execution abort requested...");
 
-            if (shouldAbortDebugSession)
+            if(shouldAbortDebugSession)
             {
                 this.ExitAllNestedPrompts();
             }
 
-            if (this.PromptNest.IsInDebugger)
+            if(this.PromptNest.IsInDebugger)
             {
                 this.versionSpecificOperations.StopCommandInDebugger(this);
-                if (shouldAbortDebugSession)
+                if(shouldAbortDebugSession)
                 {
                     this.ResumeDebugger(DebuggerResumeAction.Stop);
                 }
@@ -1259,7 +1262,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Currently we try to acquire a lock on the execution status changed event.
             // If we can't, it's because a command is executing, so we shouldn't change the status.
             // If we can, we own the status and should fire the event.
-            if (this.sessionStateLock.TryAcquireForDebuggerAbort())
+            if(this.sessionStateLock.TryAcquireForDebuggerAbort())
             {
                 try
                 {
@@ -1282,7 +1285,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         internal void ExitAllNestedPrompts()
         {
-            while (this.PromptNest.IsNestedPrompt)
+            while(this.PromptNest.IsNestedPrompt)
             {
                 this.PromptNest.WaitForCurrentFrameExit(frame => this.ExitNestedPrompt());
                 this.versionSpecificOperations.ExitNestedPrompt(ExternalHost);
@@ -1297,7 +1300,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </returns>
         internal async Task ExitAllNestedPromptsAsync()
         {
-            while (this.PromptNest.IsNestedPrompt)
+            while(this.PromptNest.IsNestedPrompt)
             {
                 await this.PromptNest.WaitForCurrentFrameExitAsync(frame => this.ExitNestedPrompt()).ConfigureAwait(false);
                 this.versionSpecificOperations.ExitNestedPrompt(ExternalHost);
@@ -1328,23 +1331,23 @@ namespace Microsoft.PowerShell.EditorServices.Services
             resumeRequestHandle.Wait();
             try
             {
-                if (this.PromptNest.IsNestedPrompt)
+                if(this.PromptNest.IsNestedPrompt)
                 {
                     this.ExitAllNestedPrompts();
                 }
 
-                if (this.PromptNest.IsInDebugger)
+                if(this.PromptNest.IsInDebugger)
                 {
                     // Set the result so that the execution thread resumes.
                     // The execution thread will clean up the task.
-                    if (shouldWaitForExit)
+                    if(shouldWaitForExit)
                     {
                         this.PromptNest.WaitForCurrentFrameExit(
                             frame =>
                             {
                                 frame.ThreadController.StartThreadExit(resumeAction);
                                 this.ConsoleReader?.StopCommandLoop();
-                                if (this.SessionState != PowerShellContextState.Ready)
+                                if(this.SessionState != PowerShellContextState.Ready)
                                 {
                                     this.versionSpecificOperations.StopCommandInDebugger(this);
                                 }
@@ -1354,7 +1357,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     {
                         this.PromptNest.GetThreadController().StartThreadExit(resumeAction);
                         this.ConsoleReader?.StopCommandLoop();
-                        if (this.SessionState != PowerShellContextState.Ready)
+                        if(this.SessionState != PowerShellContextState.Ready)
                         {
                             this.versionSpecificOperations.StopCommandInDebugger(this);
                         }
@@ -1388,13 +1391,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Push the active runspace so it will be included in the loop
             this.runspaceStack.Push(this.CurrentRunspace);
 
-            while (this.runspaceStack.Count > 0)
+            while(this.runspaceStack.Count > 0)
             {
                 RunspaceDetails poppedRunspace = this.runspaceStack.Pop();
 
                 // Close the popped runspace if it isn't the initial runspace
                 // or if it is the initial runspace and we own that runspace
-                if (this.initialRunspace != poppedRunspace || this.ownsInitialRunspace)
+                if(this.initialRunspace != poppedRunspace || this.ownsInitialRunspace)
                 {
                     this.CloseRunspace(poppedRunspace);
                 }
@@ -1422,7 +1425,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private ExecutionTarget GetExecutionTarget(ExecutionOptions options = null)
         {
-            if (options == null)
+            if(options == null)
             {
                 options = new ExecutionOptions();
             }
@@ -1435,14 +1438,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Take over the pipeline if PSReadLine is running, we aren't trying to run PSReadLine, and
             // we aren't in a remote session.
-            if (!noBackgroundInvocation && PromptNest.IsReadLineBusy() && PromptNest.IsMainThreadBusy())
+            if(!noBackgroundInvocation && PromptNest.IsReadLineBusy() && PromptNest.IsMainThreadBusy())
             {
                 return ExecutionTarget.InvocationEvent;
             }
 
             // We can't take the pipeline from PSReadLine if it's in a remote session, so we need to
             // invoke locally in that case.
-            if (IsDebuggerStopped && PromptNest.IsInDebugger && !(options.IsReadLine && PromptNest.IsRemote))
+            if(IsDebuggerStopped && PromptNest.IsInDebugger && !(options.IsReadLine && PromptNest.IsRemote))
             {
                 return ExecutionTarget.Debugger;
             }
@@ -1465,10 +1468,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string exitCommand = null;
 
-            switch (runspaceDetails.Context)
+            switch(runspaceDetails.Context)
             {
                 case RunspaceContext.Original:
-                    if (runspaceDetails.Location == RunspaceLocation.Local)
+                    if(runspaceDetails.Location == RunspaceLocation.Local)
                     {
                         runspaceDetails.Runspace.Close();
                         runspaceDetails.Runspace.Dispose();
@@ -1490,29 +1493,29 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     break;
             }
 
-            if (exitCommand != null)
+            if(exitCommand != null)
             {
                 Exception exitException = null;
 
                 try
                 {
-                    using (PowerShell ps = PowerShell.Create())
+                    using(PowerShell ps = PowerShell.Create())
                     {
                         ps.Runspace = runspaceDetails.Runspace;
                         ps.AddCommand(exitCommand);
                         ps.Invoke();
                     }
                 }
-                catch (RemoteException e)
+                catch(RemoteException e)
                 {
                     exitException = e;
                 }
-                catch (RuntimeException e)
+                catch(RuntimeException e)
                 {
                     exitException = e;
                 }
 
-                if (exitException != null)
+                if(exitException != null)
                 {
                     this.logger.LogHandledException(
                         $"Caught {exitException.GetType().Name} while exiting {runspaceDetails.Location} runspace", exitException);
@@ -1524,7 +1527,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             Validate.IsNotNull("runspaceHandle", runspaceHandle);
 
-            if (PromptNest.IsMainThreadBusy() || (runspaceHandle.IsReadLine && PromptNest.IsReadLineBusy()))
+            if(PromptNest.IsMainThreadBusy() || (runspaceHandle.IsReadLine && PromptNest.IsReadLineBusy()))
             {
                 _ = PromptNest
                     .ReleaseRunspaceHandleAsync(runspaceHandle)
@@ -1559,7 +1562,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             this.logger.LogTrace("Entering nested prompt");
 
-            if (this.IsCurrentRunspaceOutOfProcess())
+            if(this.IsCurrentRunspaceOutOfProcess())
             {
                 throw new NotSupportedException();
             }
@@ -1581,13 +1584,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var localDebuggerStoppedTask = localThreadController.Exit();
 
             // Wait for off-thread pipeline requests and/or ExitNestedPrompt
-            while (true)
+            while(true)
             {
                 int taskIndex = Task.WaitAny(
                     localPipelineExecutionTask,
                     localDebuggerStoppedTask);
 
-                if (taskIndex == 0)
+                if(taskIndex == 0)
                 {
                     var localExecutionTask = localPipelineExecutionTask.GetAwaiter().GetResult();
                     localPipelineExecutionTask = localThreadController.TakeExecutionRequestAsync();
@@ -1606,7 +1609,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         internal void ExitNestedPrompt()
         {
-            if (this.PromptNest.NestedPromptLevel == 1 || !this.PromptNest.IsNestedPrompt)
+            if(this.PromptNest.NestedPromptLevel == 1 || !this.PromptNest.IsNestedPrompt)
             {
                 this.logger.LogError(
                     "ExitNestedPrompt was called outside of a nested prompt.");
@@ -1639,7 +1642,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             Validate.IsNotNull(nameof(path), path);
             this.InitialWorkingDirectory = path;
 
-            if (!isPathAlreadyEscaped)
+            if(!isPathAlreadyEscaped)
             {
                 path = WildcardEscapePath(path);
             }
@@ -1673,15 +1676,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             var sb = new StringBuilder(escapedPath.Length + 2); // Length of string plus two quotes
             sb.Append('\'');
-            if (!escapedPath.Contains('\''))
+            if(!escapedPath.Contains('\''))
             {
                 sb.Append(escapedPath);
             }
             else
             {
-                foreach (char c in escapedPath)
+                foreach(char c in escapedPath)
                 {
-                    if (c == '\'')
+                    if(c == '\'')
                     {
                         sb.Append("''");
                         continue;
@@ -1704,10 +1707,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
         internal static string WildcardEscapePath(string path, bool escapeSpaces = false)
         {
             var sb = new StringBuilder();
-            for (int i = 0; i < path.Length; i++)
+            for(int i = 0; i < path.Length; i++)
             {
-                char curr = path[i];
-                switch (curr)
+                char curr = path [i];
+                switch(curr)
                 {
                     // Escape '[', ']', '?' and '*' with '`'
                     case '[':
@@ -1720,7 +1723,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                     default:
                         // Escape whitespace if required
-                        if (escapeSpaces && char.IsWhiteSpace(curr))
+                        if(escapeSpaces && char.IsWhiteSpace(curr))
                         {
                             sb.Append('`').Append(curr);
                             break;
@@ -1751,21 +1754,21 @@ namespace Microsoft.PowerShell.EditorServices.Services
         internal static string UnescapeWildcardEscapedPath(string wildcardEscapedPath)
         {
             // Prevent relying on my implementation if we can help it
-            if (!wildcardEscapedPath.Contains('`'))
+            if(!wildcardEscapedPath.Contains('`'))
             {
                 return wildcardEscapedPath;
             }
 
             var sb = new StringBuilder(wildcardEscapedPath.Length);
-            for (int i = 0; i < wildcardEscapedPath.Length; i++)
+            for(int i = 0; i < wildcardEscapedPath.Length; i++)
             {
                 // If we see a backtick perform a lookahead
-                char curr = wildcardEscapedPath[i];
-                if (curr == '`' && i + 1 < wildcardEscapedPath.Length)
+                char curr = wildcardEscapedPath [i];
+                if(curr == '`' && i + 1 < wildcardEscapedPath.Length)
                 {
                     // If the next char is an escapable one, don't add this backtick to the new string
-                    char next = wildcardEscapedPath[i + 1];
-                    switch (next)
+                    char next = wildcardEscapedPath [i + 1];
+                    switch(next)
                     {
                         case '[':
                         case ']':
@@ -1774,7 +1777,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             continue;
 
                         default:
-                            if (char.IsWhiteSpace(next))
+                            if(char.IsWhiteSpace(next))
                             {
                                 continue;
                             }
@@ -1814,7 +1817,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void OnSessionStateChanged(object sender, SessionStateChangedEventArgs e)
         {
-            if (this.SessionState != PowerShellContextState.Disposed)
+            if(this.SessionState != PowerShellContextState.Disposed)
             {
                 this.logger.LogTrace(
                     string.Format(
@@ -1921,7 +1924,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // the goal of this method which is to send updates when the pipeline is actually running something.
             // In the event that we don't know if it was a ReadLine cancel, we default to sending the notification.
             var options = e?.ExecutionOptions;
-            if (options == null || !options.IsReadLine)
+            if(options == null || !options.IsReadLine)
             {
                 _languageServer?.SendNotification(
                     "powerShell/executionStatusChanged",
@@ -1945,7 +1948,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     sendOutputToHost,
                     out DebuggerResumeAction? debuggerResumeAction);
 
-            if (debuggerResumeAction.HasValue)
+            if(debuggerResumeAction.HasValue)
             {
                 // Resume the debugger with the specificed action
                 this.ResumeDebugger(
@@ -1969,7 +1972,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             bool includeNewLine,
             OutputType outputType)
         {
-            if (this.ConsoleWriter != null)
+            if(this.ConsoleWriter != null)
             {
                 this.ConsoleWriter.WriteOutput(
                     outputString,
@@ -1983,7 +1986,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             var psObject = PSObject.AsPSObject(e.ErrorRecord);
 
             // Used to write ErrorRecords to the Error stream so they are rendered in the console correctly.
-            if (VersionUtils.IsPS7OrGreater)
+            if(VersionUtils.IsPS7OrGreater)
             {
                 s_writeStreamProperty.SetValue(psObject, s_errorStreamValue);
             }
@@ -2016,7 +2019,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void WriteError(string errorMessage)
         {
-            if (this.ConsoleWriter != null)
+            if(this.ConsoleWriter != null)
             {
                 this.ConsoleWriter.WriteOutput(
                     errorMessage,
@@ -2038,7 +2041,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             PowerShellExecutionResult executionResult = PowerShellExecutionResult.NotFinished;
 
             PowerShellContextState newState;
-            switch (invocationState.State)
+            switch(invocationState.State)
             {
                 case PSInvocationState.NotStarted:
                     newState = PowerShellContextState.NotStarted;
@@ -2094,7 +2097,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     isScript: false,
                     useLocalScope: true);
 
-            if (this.PromptNest.IsInDebugger)
+            if(this.PromptNest.IsInDebugger)
             {
                 // Out-String needs the -Stream parameter added
                 outputCommand.Parameters.Add("Stream");
@@ -2107,13 +2110,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             StringBuilder stringBuilder = new StringBuilder();
 
-            foreach (var command in psCommand.Commands)
+            foreach(var command in psCommand.Commands)
             {
                 stringBuilder.Append("    ");
                 stringBuilder.Append(command.CommandText);
-                foreach (var param in command.Parameters)
+                foreach(var param in command.Parameters)
                 {
-                    if (param.Name != null)
+                    if(param.Name != null)
                     {
                         stringBuilder.Append($" -{param.Name} {param.Value}");
                     }
@@ -2155,22 +2158,22 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // set to expected values, so we must sift through those.
 
             ExecutionPolicy policyToSet = ExecutionPolicy.Bypass;
-            var currentUserPolicy = (ExecutionPolicy)policies[policies.Count - 2].Members["ExecutionPolicy"].Value;
-            if (currentUserPolicy != ExecutionPolicy.Undefined)
+            var currentUserPolicy = (ExecutionPolicy)policies [policies.Count - 2].Members ["ExecutionPolicy"].Value;
+            if(currentUserPolicy != ExecutionPolicy.Undefined)
             {
                 policyToSet = currentUserPolicy;
             }
             else
             {
-                var localMachinePolicy = (ExecutionPolicy)policies[policies.Count - 1].Members["ExecutionPolicy"].Value;
-                if (localMachinePolicy != ExecutionPolicy.Undefined)
+                var localMachinePolicy = (ExecutionPolicy)policies [policies.Count - 1].Members ["ExecutionPolicy"].Value;
+                if(localMachinePolicy != ExecutionPolicy.Undefined)
                 {
                     policyToSet = localMachinePolicy;
                 }
             }
 
             // If there's nothing to do, save ourselves a PowerShell invocation
-            if (policyToSet == ExecutionPolicy.Bypass)
+            if(policyToSet == ExecutionPolicy.Bypass)
             {
                 this.logger.LogTrace("Execution policy already set to Bypass. Skipping execution policy set");
                 return;
@@ -2187,7 +2190,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     .AddParameter("Force")
                     .Invoke();
             }
-            catch (CmdletInvocationException e)
+            catch(CmdletInvocationException e)
             {
                 this.logger.LogHandledException(
                     $"Error occurred calling 'Set-ExecutionPolicy -Scope Process -ExecutionPolicy {policyToSet} -Force'", e);
@@ -2209,11 +2212,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 return this.mostRecentSessionDetails;
             }
-            catch (RuntimeException e)
+            catch(RuntimeException e)
             {
                 this.logger.LogHandledException("Runtime exception occurred while gathering runspace info", e);
             }
-            catch (ArgumentNullException)
+            catch(ArgumentNullException)
             {
                 this.logger.LogError("Could not retrieve session details but no exception was thrown.");
             }
@@ -2225,7 +2228,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private async Task<SessionDetails> GetSessionDetailsInRunspaceAsync()
         {
-            using (RunspaceHandle runspaceHandle = await this.GetRunspaceHandleAsync().ConfigureAwait(false))
+            using(RunspaceHandle runspaceHandle = await this.GetRunspaceHandleAsync().ConfigureAwait(false))
             {
                 return this.GetSessionDetailsInRunspace(runspaceHandle.Runspace);
             }
@@ -2237,7 +2240,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.GetSessionDetails(
                     command =>
                     {
-                        using (PowerShell powerShell = PowerShell.Create())
+                        using(PowerShell powerShell = PowerShell.Create())
                         {
                             powerShell.Runspace = runspace;
                             powerShell.Commands = command;
@@ -2274,7 +2277,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return this.GetSessionDetails(
                 command =>
                 {
-                    using (var localPwsh = PowerShell.Create(RunspaceMode.CurrentRunspace))
+                    using(var localPwsh = PowerShell.Create(RunspaceMode.CurrentRunspace))
                     {
                         localPwsh.Commands = command;
                         return localPwsh.Invoke().FirstOrDefault();
@@ -2323,7 +2326,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void HandleRunspaceStateChanged(object sender, RunspaceStateEventArgs args)
         {
-            switch (args.RunspaceStateInfo.State)
+            switch(args.RunspaceStateInfo.State)
             {
                 case RunspaceState.Opening:
                 case RunspaceState.Opened:
@@ -2341,14 +2344,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private static IEnumerable<string> GetLoadableProfilePaths(ProfilePathInfo profilePaths)
         {
-            if (profilePaths == null)
+            if(profilePaths == null)
             {
                 yield break;
             }
 
-            foreach (string path in new [] { profilePaths.AllUsersAllHosts, profilePaths.AllUsersCurrentHost, profilePaths.CurrentUserAllHosts, profilePaths.CurrentUserCurrentHost })
+            foreach(string path in new [] { profilePaths.AllUsersAllHosts, profilePaths.AllUsersCurrentHost, profilePaths.CurrentUserAllHosts, profilePaths.CurrentUserCurrentHost })
             {
-                if (path != null && File.Exists(path))
+                if(path != null && File.Exists(path))
                 {
                     yield return path;
                 }
@@ -2370,14 +2373,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void StartCommandLoopOnRunspaceAvailable()
         {
-            if (Interlocked.CompareExchange(ref this.isCommandLoopRestarterSet, 1, 1) == 1)
+            if(Interlocked.CompareExchange(ref this.isCommandLoopRestarterSet, 1, 1) == 1)
             {
                 return;
             }
 
             void availabilityChangedHandler(object runspace, RunspaceAvailabilityEventArgs eventArgs)
             {
-                if (eventArgs.RunspaceAvailability != RunspaceAvailability.Available ||
+                if(eventArgs.RunspaceAvailability != RunspaceAvailability.Available ||
                     this.versionSpecificOperations.IsDebuggerStopped(this.PromptNest, (Runspace)runspace))
                 {
                     return;
@@ -2398,7 +2401,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // when the DebugServer is fully started.
             CurrentDebuggerStopEventArgs = e;
 
-            if (!IsDebugServerActive)
+            if(!IsDebugServerActive)
             {
                 _languageServer.SendNotification("powerShell/startDebugger");
             }
@@ -2406,7 +2409,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // We've hit a breakpoint so go to a new line so that the prompt can be rendered.
             this.WriteOutput("", includeNewLine: true);
 
-            if (CurrentRunspace.Context == RunspaceContext.Original)
+            if(CurrentRunspace.Context == RunspaceContext.Original)
             {
                 StartCommandLoopOnRunspaceAvailable();
             }
@@ -2435,13 +2438,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 sessionDetails = this.GetSessionDetailsInDebugger();
             }
-            catch (InvalidOperationException)
+            catch(InvalidOperationException)
             {
                 this.logger.LogTrace(
                     "Attempting to get session details failed, most likely due to a running pipeline that is attempting to stop.");
             }
 
-            if (!localThreadController.FrameExitTask.Task.IsCompleted)
+            if(!localThreadController.FrameExitTask.Task.IsCompleted)
             {
                 // Push the current runspace if the session has changed
                 this.UpdateRunspaceDetailsIfSessionChanged(sessionDetails, isDebuggerStop: true);
@@ -2456,14 +2459,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 localThreadController.TakeExecutionRequestAsync();
             Task<DebuggerResumeAction> localDebuggerStoppedTask =
                 localThreadController.Exit();
-            while (true)
+            while(true)
             {
                 int taskIndex =
                     Task.WaitAny(
                         localDebuggerStoppedTask,
                         localPipelineExecutionTask);
 
-                if (taskIndex == 0)
+                if(taskIndex == 0)
                 {
                     // Write a new output line before continuing
                     this.WriteOutput("", true);
@@ -2479,12 +2482,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                     // Pop the current RunspaceDetails if we were attached
                     // to a runspace and the resume action is Stop
-                    if (this.CurrentRunspace.Context == RunspaceContext.DebuggedRunspace &&
+                    if(this.CurrentRunspace.Context == RunspaceContext.DebuggedRunspace &&
                         e.ResumeAction == DebuggerResumeAction.Stop)
                     {
                         this.PopRunspace();
                     }
-                    else if (e.ResumeAction != DebuggerResumeAction.Stop)
+                    else if(e.ResumeAction != DebuggerResumeAction.Stop)
                     {
                         // Update the session state
                         this.OnSessionStateChanged(
@@ -2497,7 +2500,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                     break;
                 }
-                else if (taskIndex == 1)
+                else if(taskIndex == 1)
                 {
                     this.logger.LogTrace("Received pipeline thread execution request.");
 
@@ -2507,14 +2510,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                     this.logger.LogTrace("Pipeline thread execution completed.");
 
-                    if (!this.versionSpecificOperations.IsDebuggerStopped(
+                    if(!this.versionSpecificOperations.IsDebuggerStopped(
                         this.PromptNest,
                         this.CurrentRunspace.Runspace))
                     {
                         // Since we are no longer at a breakpoint, we set this to null.
                         CurrentDebuggerStopEventArgs = null;
 
-                        if (this.CurrentRunspace.Context == RunspaceContext.DebuggedRunspace)
+                        if(this.CurrentRunspace.Context == RunspaceContext.DebuggedRunspace)
                         {
                             // Notify listeners that the debugger has resumed
                             this.DebuggerResumed?.Invoke(this, DebuggerResumeAction.Stop);
@@ -2563,7 +2566,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             RunspaceDetails previousRunspace = this.CurrentRunspace;
 
-            if (newRunspaceDetails.Context == RunspaceContext.DebuggedRunspace)
+            if(newRunspaceDetails.Context == RunspaceContext.DebuggedRunspace)
             {
                 this.WriteOutput(
                     $"Entering debugged runspace on {newRunspaceDetails.Location.ToString().ToLower()} machine {newRunspaceDetails.SessionDetails.ComputerName}",
@@ -2571,7 +2574,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             // Switch out event handlers if necessary
-            if (CheckIfRunspaceNeedsEventHandlers(newRunspaceDetails))
+            if(CheckIfRunspaceNeedsEventHandlers(newRunspaceDetails))
             {
                 this.CleanupRunspace(previousRunspace);
                 this.ConfigureRunspace(newRunspaceDetails);
@@ -2597,7 +2600,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // If we've exited an entered process or debugged runspace, pop what we've
             // got before we evaluate where we're at
-            if (
+            if(
                 (this.CurrentRunspace.Context == RunspaceContext.DebuggedRunspace &&
                  this.CurrentRunspace.SessionDetails.InstanceId != sessionDetails.InstanceId) ||
                 (this.CurrentRunspace.Context == RunspaceContext.EnteredProcess &&
@@ -2618,7 +2621,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // will already be updated by PowerShell by the time we reach
             // these checks.
 
-            if (this.CurrentRunspace.SessionDetails.InstanceId != sessionDetails.InstanceId && isDebuggerStop)
+            if(this.CurrentRunspace.SessionDetails.InstanceId != sessionDetails.InstanceId && isDebuggerStop)
             {
                 // Are we on a local or remote computer?
                 bool differentComputer =
@@ -2635,7 +2638,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         RunspaceContext.DebuggedRunspace,
                         sessionDetails);
             }
-            else if (this.CurrentRunspace.SessionDetails.ProcessId != sessionDetails.ProcessId)
+            else if(this.CurrentRunspace.SessionDetails.ProcessId != sessionDetails.ProcessId)
             {
                 // We entered a different PowerShell host process
                 newRunspaceDetails =
@@ -2645,7 +2648,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         sessionDetails);
             }
 
-            if (newRunspaceDetails != null)
+            if(newRunspaceDetails != null)
             {
                 this.PushRunspace(newRunspaceDetails);
             }
@@ -2653,9 +2656,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void PopRunspace()
         {
-            if (this.SessionState != PowerShellContextState.Disposed)
+            if(this.SessionState != PowerShellContextState.Disposed)
             {
-                if (this.runspaceStack.Count > 0)
+                if(this.runspaceStack.Count > 0)
                 {
                     RunspaceDetails previousRunspace = this.CurrentRunspace;
                     this.CurrentRunspace = this.runspaceStack.Pop();
@@ -2663,7 +2666,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     this.logger.LogTrace(
                         $"Popping {previousRunspace.Location} ({previousRunspace.Context}), new runspace is {this.CurrentRunspace.Location} ({this.CurrentRunspace.Context}), connection: {this.CurrentRunspace.ConnectionString}");
 
-                    if (previousRunspace.Context == RunspaceContext.DebuggedRunspace)
+                    if(previousRunspace.Context == RunspaceContext.DebuggedRunspace)
                     {
                         this.WriteOutput(
                             $"Leaving debugged runspace on {previousRunspace.Location.ToString().ToLower()} machine {previousRunspace.SessionDetails.ComputerName}",
@@ -2671,7 +2674,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     }
 
                     // Switch out event handlers if necessary
-                    if (CheckIfRunspaceNeedsEventHandlers(previousRunspace))
+                    if(CheckIfRunspaceNeedsEventHandlers(previousRunspace))
                     {
                         this.CleanupRunspace(previousRunspace);
                         this.ConfigureRunspace(this.CurrentRunspace);
@@ -2772,7 +2775,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 await _internalLock.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    if (_executeCommandLockCount++ == 0)
+                    if(_executeCommandLockCount++ == 0)
                     {
                         await _sessionStateLock.WaitAsync().ConfigureAwait(false);
                     }
@@ -2799,7 +2802,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 await _internalLock.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    if (--_executeCommandLockCount == 0)
+                    if(--_executeCommandLockCount == 0)
                     {
                         _sessionStateLock.Release();
                     }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/RemoteFileManagerService.cs
@@ -294,17 +294,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string localFilePath = null;
 
-            if (!string.IsNullOrEmpty(remoteFilePath))
+            if(!string.IsNullOrEmpty(remoteFilePath))
             {
                 try
                 {
                     RemotePathMappings pathMappings = this.GetPathMappings(runspaceDetails);
                     localFilePath = this.GetMappedPath(remoteFilePath, runspaceDetails);
 
-                    if (!pathMappings.IsRemotePathOpened(remoteFilePath))
+                    if(!pathMappings.IsRemotePathOpened(remoteFilePath))
                     {
                         // Does the local file already exist?
-                        if (!File.Exists(localFilePath))
+                        if(!File.Exists(localFilePath))
                         {
                             // Load the file contents from the remote machine and create the buffer
                             PSCommand command = new PSCommand();
@@ -313,11 +313,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             command.AddParameter("Raw");
                             command.AddParameter("Encoding", "Byte");
 
-                            byte[] fileContent =
-                                (await this.powerShellContext.ExecuteCommandAsync<byte[]>(command, false, false).ConfigureAwait(false))
+                            byte [] fileContent =
+                                (await this.powerShellContext.ExecuteCommandAsync<byte []>(command, false, false).ConfigureAwait(false))
                                     .FirstOrDefault();
 
-                            if (fileContent != null)
+                            if(fileContent != null)
                             {
                                 this.StoreRemoteFile(localFilePath, fileContent, pathMappings);
                             }
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         }
                     }
                 }
-                catch (IOException e)
+                catch(IOException e)
                 {
                     this.logger.LogError(
                         $"Caught {e.GetType().Name} while attempting to get remote file at path '{remoteFilePath}'\r\n\r\n{e.ToString()}");
@@ -359,12 +359,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
             this.logger.LogTrace(
                 $"Saving remote file {remoteFilePath} (local path: {localFilePath})");
 
-            byte[] localFileContents = null;
+            byte [] localFileContents = null;
             try
             {
                 localFileContents = File.ReadAllBytes(localFilePath);
             }
-            catch (IOException e)
+            catch(IOException e)
             {
                 this.logger.LogException(
                     "Failed to read contents of local copy of remote file",
@@ -387,7 +387,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 false,
                 false).ConfigureAwait(false);
 
-            if (errorMessages.Length > 0)
+            if(errorMessages.Length > 0)
             {
                 this.logger.LogError($"Remote file save failed due to an error:\r\n\r\n{errorMessages}");
             }
@@ -418,7 +418,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 RemotePathMappings pathMappings = this.GetPathMappings(runspaceDetails);
                 pathMappings.AddOpenedLocalPath(temporaryFilePath);
             }
-            catch (IOException e)
+            catch(IOException e)
             {
                 this.logger.LogError(
                     $"Caught {e.GetType().Name} while attempting to write temporary file at path '{temporaryFilePath}'\r\n\r\n{e.ToString()}");
@@ -469,7 +469,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private string StoreRemoteFile(
             string remoteFilePath,
-            byte[] fileContent,
+            byte [] fileContent,
             RunspaceDetails runspaceDetails)
         {
             RemotePathMappings pathMappings = this.GetPathMappings(runspaceDetails);
@@ -485,7 +485,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void StoreRemoteFile(
             string localFilePath,
-            byte[] fileContent,
+            byte [] fileContent,
             RemotePathMappings pathMappings)
         {
             File.WriteAllBytes(localFilePath, fileContent);
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             RemotePathMappings remotePathMappings = null;
             string computerName = runspaceDetails.SessionDetails.ComputerName;
 
-            if (!this.filesPerComputer.TryGetValue(computerName, out remotePathMappings))
+            if(!this.filesPerComputer.TryGetValue(computerName, out remotePathMappings))
             {
                 remotePathMappings = new RemotePathMappings(runspaceDetails, this);
                 this.filesPerComputer.Add(computerName, remotePathMappings);
@@ -508,14 +508,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private async void HandleRunspaceChangedAsync(object sender, RunspaceChangedEventArgs e)
         {
-            if (e.ChangeAction == RunspaceChangeAction.Enter)
+            if(e.ChangeAction == RunspaceChangeAction.Enter)
             {
                 this.RegisterPSEditFunction(e.NewRunspace);
             }
             else
             {
                 // Close any remote files that were opened
-                if (e.PreviousRunspace.Location == RunspaceLocation.Remote &&
+                if(e.PreviousRunspace.Location == RunspaceLocation.Remote &&
                     (e.ChangeAction == RunspaceChangeAction.Shutdown ||
                      !string.Equals(
                          e.NewRunspace.SessionDetails.ComputerName,
@@ -523,16 +523,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                          StringComparison.CurrentCultureIgnoreCase)))
                 {
                     RemotePathMappings remotePathMappings;
-                    if (this.filesPerComputer.TryGetValue(e.PreviousRunspace.SessionDetails.ComputerName, out remotePathMappings))
+                    if(this.filesPerComputer.TryGetValue(e.PreviousRunspace.SessionDetails.ComputerName, out remotePathMappings))
                     {
-                        foreach (string remotePath in remotePathMappings.OpenedPaths)
+                        foreach(string remotePath in remotePathMappings.OpenedPaths)
                         {
                             await (this.editorOperations?.CloseFileAsync(remotePath)).ConfigureAwait(false);
                         }
                     }
                 }
 
-                if (e.PreviousRunspace != null)
+                if(e.PreviousRunspace != null)
                 {
                     this.RemovePSEditFunction(e.PreviousRunspace);
                 }
@@ -541,35 +541,35 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private async void HandlePSEventReceivedAsync(object sender, PSEventArgs args)
         {
-            if (string.Equals(RemoteSessionOpenFile, args.SourceIdentifier, StringComparison.CurrentCultureIgnoreCase))
+            if(string.Equals(RemoteSessionOpenFile, args.SourceIdentifier, StringComparison.CurrentCultureIgnoreCase))
             {
                 try
                 {
-                    if (args.SourceArgs.Length >= 1)
+                    if(args.SourceArgs.Length >= 1)
                     {
                         string localFilePath = string.Empty;
-                        string remoteFilePath = args.SourceArgs[0] as string;
+                        string remoteFilePath = args.SourceArgs [0] as string;
 
                         // Is this a local process runspace?  Treat as a local file
-                        if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Local)
+                        if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Local)
                         {
                             localFilePath = remoteFilePath;
                         }
                         else
                         {
-                            byte[] fileContent = null;
+                            byte [] fileContent = null;
 
-                            if (args.SourceArgs.Length >= 2)
+                            if(args.SourceArgs.Length >= 2)
                             {
                                 // Try to cast as a PSObject to get the BaseObject, if not, then try to case as a byte[]
-                                PSObject sourceObj = args.SourceArgs[1] as PSObject;
-                                if (sourceObj != null)
+                                PSObject sourceObj = args.SourceArgs [1] as PSObject;
+                                if(sourceObj != null)
                                 {
-                                    fileContent = sourceObj.BaseObject as byte[];
+                                    fileContent = sourceObj.BaseObject as byte [];
                                 }
                                 else
                                 {
-                                    fileContent = args.SourceArgs[1] as byte[];
+                                    fileContent = args.SourceArgs [1] as byte [];
                                 }
                             }
 
@@ -578,7 +578,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             // array.
                             fileContent = fileContent ?? Array.Empty<byte>();
 
-                            if (remoteFilePath != null)
+                            if(remoteFilePath != null)
                             {
                                 localFilePath =
                                     this.StoreRemoteFile(
@@ -595,9 +595,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         }
 
                         bool preview = true;
-                        if (args.SourceArgs.Length >= 3)
+                        if(args.SourceArgs.Length >= 3)
                         {
-                            bool? previewCheck = args.SourceArgs[2] as bool?;
+                            bool? previewCheck = args.SourceArgs [2] as bool?;
                             preview = previewCheck ?? true;
                         }
 
@@ -605,7 +605,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         this.editorOperations?.OpenFileAsync(localFilePath, preview);
                     }
                 }
-                catch (NullReferenceException e)
+                catch(NullReferenceException e)
                 {
                     this.logger.LogException("Could not store null remote file content", e);
                 }
@@ -614,7 +614,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void RegisterPSEditFunction(RunspaceDetails runspaceDetails)
         {
-            if (runspaceDetails.Location == RunspaceLocation.Remote &&
+            if(runspaceDetails.Location == RunspaceLocation.Remote &&
                 runspaceDetails.Context == RunspaceContext.Original)
             {
                 try
@@ -626,13 +626,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         .AddScript(CreatePSEditFunctionScript)
                         .AddParameter("PSEditModule", PSEditModule);
 
-                    if (runspaceDetails.Context == RunspaceContext.DebuggedRunspace)
+                    if(runspaceDetails.Context == RunspaceContext.DebuggedRunspace)
                     {
                         this.powerShellContext.ExecuteCommandAsync(createCommand).Wait();
                     }
                     else
                     {
-                        using (var powerShell = System.Management.Automation.PowerShell.Create())
+                        using(var powerShell = System.Management.Automation.PowerShell.Create())
                         {
                             powerShell.Runspace = runspaceDetails.Runspace;
                             powerShell.Commands = createCommand;
@@ -640,7 +640,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         }
                     }
                 }
-                catch (RemoteException e)
+                catch(RemoteException e)
                 {
                     this.logger.LogException("Could not create psedit function.", e);
                 }
@@ -649,19 +649,19 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private void RemovePSEditFunction(RunspaceDetails runspaceDetails)
         {
-            if (runspaceDetails.Location == RunspaceLocation.Remote &&
+            if(runspaceDetails.Location == RunspaceLocation.Remote &&
                 runspaceDetails.Context == RunspaceContext.Original)
             {
                 try
                 {
-                    if (runspaceDetails.Runspace.Events != null)
+                    if(runspaceDetails.Runspace.Events != null)
                     {
                         runspaceDetails.Runspace.Events.ReceivedEvents.PSEventReceived -= HandlePSEventReceivedAsync;
                     }
 
-                    if (runspaceDetails.Runspace.RunspaceStateInfo.State == RunspaceState.Opened)
+                    if(runspaceDetails.Runspace.RunspaceStateInfo.State == RunspaceState.Opened)
                     {
-                        using (var powerShell = System.Management.Automation.PowerShell.Create())
+                        using(var powerShell = System.Management.Automation.PowerShell.Create())
                         {
                             powerShell.Runspace = runspaceDetails.Runspace;
                             powerShell.Commands.AddScript(RemovePSEditFunctionScript);
@@ -669,7 +669,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         }
                     }
                 }
-                catch (Exception e) when (e is RemoteException || e is PSInvalidOperationException)
+                catch(Exception e) when(e is RemoteException || e is PSInvalidOperationException)
                 {
                     this.logger.LogException("Could not remove psedit function.", e);
                 }
@@ -680,14 +680,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             try
             {
-                if (Directory.Exists(this.processTempPath))
+                if(Directory.Exists(this.processTempPath))
                 {
                     Directory.Delete(this.processTempPath, true);
                 }
 
                 Directory.CreateDirectory(this.processTempPath);
             }
-            catch (IOException e)
+            catch(IOException e)
             {
                 this.logger.LogException(
                     $"Could not delete temporary folder for current process: {this.processTempPath}", e);
@@ -721,8 +721,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             public void AddPathMapping(string remotePath, string localPath)
             {
                 // Add mappings in both directions
-                this.pathMappings[localPath.ToLower()] = remotePath;
-                this.pathMappings[remotePath.ToLower()] = localPath;
+                this.pathMappings [localPath.ToLower()] = remotePath;
+                this.pathMappings [remotePath.ToLower()] = localPath;
             }
 
             public void AddOpenedLocalPath(string openedLocalPath)
@@ -739,10 +739,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 string mappedPath = filePath;
 
-                if (!this.pathMappings.TryGetValue(filePath.ToLower(), out mappedPath))
+                if(!this.pathMappings.TryGetValue(filePath.ToLower(), out mappedPath))
                 {
                     // If the path isn't mapped yet, generate it
-                    if (!filePath.StartsWith(this.remoteFileManager.remoteFilesPath))
+                    if(!filePath.StartsWith(this.remoteFileManager.remoteFilesPath))
                     {
                         mappedPath =
                             this.MapRemotePathToLocal(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
@@ -17,25 +17,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
     internal class DscBreakpointCapability : IRunspaceCapability
     {
-        private string[] dscResourceRootPaths = Array.Empty<string>();
+        private string [] dscResourceRootPaths = Array.Empty<string>();
 
-        private Dictionary<string, int[]> breakpointsPerFile =
-            new Dictionary<string, int[]>();
+        private Dictionary<string, int []> breakpointsPerFile =
+            new Dictionary<string, int []>();
 
-        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
+        public async Task<BreakpointDetails []> SetLineBreakpointsAsync(
             PowerShellContextService powerShellContext,
             string scriptPath,
-            BreakpointDetails[] breakpoints)
+            BreakpointDetails [] breakpoints)
         {
             List<BreakpointDetails> resultBreakpointDetails =
                 new List<BreakpointDetails>();
 
             // We always get the latest array of breakpoint line numbers
             // so store that for future use
-            if (breakpoints.Length > 0)
+            if(breakpoints.Length > 0)
             {
                 // Set the breakpoints for this scriptPath
-                this.breakpointsPerFile[scriptPath] =
+                this.breakpointsPerFile [scriptPath] =
                     breakpoints.Select(b => b.LineNumber).ToArray();
             }
             else
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 false).ConfigureAwait(false);
 
             // Verify all the breakpoints and return them
-            foreach (var breakpoint in breakpoints)
+            foreach(var breakpoint in breakpoints)
             {
                 breakpoint.Verified = true;
             }
@@ -86,10 +86,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             DscBreakpointCapability capability = null;
 
             // DSC support is enabled only for Windows PowerShell.
-            if ((runspaceDetails.PowerShellVersion.Version.Major < 6) &&
+            if((runspaceDetails.PowerShellVersion.Version.Major < 6) &&
                 (runspaceDetails.Context != RunspaceContext.DebuggedRunspace))
             {
-                using (PowerShell powerShell = PowerShell.Create())
+                using(PowerShell powerShell = PowerShell.Create())
                 {
                     powerShell.Runspace = runspaceDetails.Runspace;
 
@@ -105,12 +105,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     {
                         moduleInfo = powerShell.Invoke().FirstOrDefault();
                     }
-                    catch (RuntimeException e)
+                    catch(RuntimeException e)
                     {
                         logger.LogException("Could not load the DSC module!", e);
                     }
 
-                    if (moduleInfo != null)
+                    if(moduleInfo != null)
                     {
                         logger.LogTrace("Side-by-side DSC module found, gathering DSC resource paths...");
 
@@ -137,12 +137,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         {
                             resourcePaths = powerShell.Invoke();
                         }
-                        catch (CmdletInvocationException e)
+                        catch(CmdletInvocationException e)
                         {
                             logger.LogException("Get-DscResource failed!", e);
                         }
 
-                        if (resourcePaths != null)
+                        if(resourcePaths != null)
                         {
                             capability.dscResourceRootPaths =
                                 resourcePaths

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHost.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             internal ConsoleColorProxy(EditorServicesPSHostUserInterface hostUserInterface)
             {
-                if (hostUserInterface == null) throw new ArgumentNullException("hostUserInterface");
+                if(hostUserInterface == null) throw new ArgumentNullException("hostUserInterface");
                 _hostUserInterface = hostUserInterface;
             }
 
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             get
             {
-                if (hostUserInterface == null) return null;
+                if(hostUserInterface == null) return null;
                 return _consoleColorProxy ?? (_consoleColorProxy = PSObject.AsPSObject(new ConsoleColorProxy(hostUserInterface)));
             }
         }
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="exitCode"></param>
         public override void SetShouldExit(int exitCode)
         {
-            if (this.IsRunspacePushed)
+            if(this.IsRunspacePushed)
             {
                 this.PopRunspace();
             }
@@ -326,7 +326,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             get
             {
-                if (this.hostSupportsInteractiveSession != null)
+                if(this.hostSupportsInteractiveSession != null)
                 {
                     return this.hostSupportsInteractiveSession.IsRunspacePushed;
                 }
@@ -345,7 +345,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             get
             {
-                if (this.hostSupportsInteractiveSession != null)
+                if(this.hostSupportsInteractiveSession != null)
                 {
                     return this.hostSupportsInteractiveSession.Runspace;
                 }
@@ -362,7 +362,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="runspace"></param>
         public void PushRunspace(Runspace runspace)
         {
-            if (this.hostSupportsInteractiveSession != null)
+            if(this.hostSupportsInteractiveSession != null)
             {
                 this.hostSupportsInteractiveSession.PushRunspace(runspace);
             }
@@ -377,7 +377,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         public void PopRunspace()
         {
-            if (this.hostSupportsInteractiveSession != null)
+            if(this.hostSupportsInteractiveSession != null)
             {
                 this.hostSupportsInteractiveSession.PopRunspace();
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         public void StartCommandLoop()
         {
-            if (!this.IsCommandLoopRunning)
+            if(!this.IsCommandLoopRunning)
             {
                 this.IsCommandLoopRunning = true;
                 this.ShowCommandPrompt();
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         public void StopCommandLoop()
         {
-            if (this.IsCommandLoopRunning)
+            if(this.IsCommandLoopRunning)
             {
                 this.IsCommandLoopRunning = false;
                 this.CancelCommandPrompt();
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private void ShowCommandPrompt()
         {
-            if (this.commandLoopCancellationToken == null)
+            if(this.commandLoopCancellationToken == null)
             {
                 this.commandLoopCancellationToken = new CancellationTokenSource();
                 Task.Run(() => this.StartReplLoopAsync(this.commandLoopCancellationToken.Token));
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private void CancelCommandPrompt()
         {
-            if (this.commandLoopCancellationToken != null)
+            if(this.commandLoopCancellationToken != null)
             {
                 // Set this to false so that Ctrl+C isn't trapped by any
                 // lingering ReadKey
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         public void SendControlC()
         {
-            if (this.activePromptHandler != null)
+            if(this.activePromptHandler != null)
             {
                 this.activePromptHandler.CancelPrompt();
             }
@@ -268,7 +268,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             string promptMessage,
             Collection<FieldDescription> fieldDescriptions)
         {
-            FieldDetails[] fields =
+            FieldDetails [] fields =
                 fieldDescriptions
                     .Select(f => { return FieldDetails.Create(f, this.Logger); })
                     .ToArray();
@@ -292,10 +292,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             var psObjectDict = new Dictionary<string, PSObject>();
 
             // The result will be null if the prompt was cancelled
-            if (promptTask.Result != null)
+            if(promptTask.Result != null)
             {
                 // Convert all values to PSObjects
-                foreach (var keyValuePair in promptTask.Result)
+                foreach(var keyValuePair in promptTask.Result)
                 {
                     psObjectDict.Add(
                         keyValuePair.Key,
@@ -321,7 +321,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             Collection<ChoiceDescription> choiceDescriptions,
             int defaultChoice)
         {
-            ChoiceDetails[] choices =
+            ChoiceDetails [] choices =
                 choiceDescriptions
                     .Select(ChoiceDetails.Create)
                     .ToArray();
@@ -371,24 +371,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     .PromptForInputAsync(
                         promptCaption,
                         promptMessage,
-                        new FieldDetails[] { new CredentialFieldDetails("Credential", "Credential", userName) },
+                        new FieldDetails [] { new CredentialFieldDetails("Credential", "Credential", userName) },
                         cancellationToken.Token);
 
             Task<PSCredential> unpackTask =
                 promptTask.ContinueWith(
                     task =>
                     {
-                        if (task.IsFaulted)
+                        if(task.IsFaulted)
                         {
                             throw task.Exception;
                         }
-                        else if (task.IsCanceled)
+                        else if(task.IsCanceled)
                         {
                             throw new TaskCanceledException(task);
                         }
 
                         // Return the value of the sole field
-                        return (PSCredential)task.Result?["Credential"];
+                        return (PSCredential)task.Result? ["Credential"];
                     });
 
             // Run the prompt task and wait for it to return
@@ -571,7 +571,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // PowerShell's ConsoleHost also skips over empty lines:
             // https://github.com/PowerShell/PowerShell/blob/8e683972284a5a7f773ea6d027d9aac14d7e7524/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs#L1334-L1337
-            if (string.IsNullOrEmpty(value))
+            if(string.IsNullOrEmpty(value))
             {
                 return;
             }
@@ -600,7 +600,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             ProgressRecord record)
         {
             // Maintain old behavior if this isn't overridden.
-            if (!this.SupportsWriteProgress)
+            if(!this.SupportsWriteProgress)
             {
                 this.UpdateProgress(sourceId, ProgressDetails.Create(record));
                 return;
@@ -608,7 +608,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             // Keep a list of progress records we write so we can automatically
             // clean them up after the pipeline ends.
-            if (record.RecordType == ProgressRecordType.Completed)
+            if(record.RecordType == ProgressRecordType.Completed)
             {
                 this.currentProgressMessages.TryRemove(new ProgressKey(sourceId, record), out _);
             }
@@ -640,12 +640,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         internal void ClearProgress()
         {
             const string nonEmptyString = "noop";
-            if (!this.SupportsWriteProgress)
+            if(!this.SupportsWriteProgress)
             {
                 return;
             }
 
-            foreach (ProgressKey key in this.currentProgressMessages.Keys)
+            foreach(ProgressKey key in this.currentProgressMessages.Keys)
             {
                 // This constructor throws if the activity description is empty even
                 // with completed records.
@@ -679,13 +679,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             Collection<ChoiceDescription> choiceDescriptions,
             IEnumerable<int> defaultChoices)
         {
-            ChoiceDetails[] choices =
+            ChoiceDetails [] choices =
                 choiceDescriptions
                     .Select(ChoiceDetails.Create)
                     .ToArray();
 
             CancellationTokenSource cancellationToken = new CancellationTokenSource();
-            Task<int[]> promptTask =
+            Task<int []> promptTask =
                 this.CreateChoicePromptHandler()
                     .PromptForChoiceAsync(
                         promptCaption,
@@ -714,7 +714,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             try
             {
-                if (this.lastPromptLocation != null &&
+                if(this.lastPromptLocation != null &&
                     this.lastPromptLocation.X == await ConsoleProxy.GetCursorLeftAsync(cancellationToken).ConfigureAwait(false) &&
                     this.lastPromptLocation.Y == await ConsoleProxy.GetCursorTopAsync(cancellationToken).ConfigureAwait(false))
                 {
@@ -723,7 +723,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
             // When output is redirected (like when running tests) attempting to get
             // the cursor position will throw.
-            catch (System.IO.IOException)
+            catch(System.IO.IOException)
             {
             }
 
@@ -737,7 +737,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     .FirstOrDefault() ?? "PS> ";
 
             // Add the [DBG] prefix if we're stopped in the debugger and the prompt doesn't already have [DBG] in it
-            if (this.powerShellContext.IsDebuggerStopped && !promptString.Contains("[DBG]"))
+            if(this.powerShellContext.IsDebuggerStopped && !promptString.Contains("[DBG]"))
             {
                 promptString =
                     string.Format(
@@ -747,7 +747,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
 
             // Update the stored prompt string if the session is remote
-            if (this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote)
+            if(this.powerShellContext.CurrentRunspace.Location == RunspaceLocation.Remote)
             {
                 promptString =
                     string.Format(
@@ -772,11 +772,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // TODO: What do we display when we don't know why we stopped?
 
-            if (eventArgs.Breakpoints.Count > 0)
+            if(eventArgs.Breakpoints.Count > 0)
             {
                 // The breakpoint classes have nice ToString output so use that
                 this.WriteOutput(
-                    Environment.NewLine + $"Hit {eventArgs.Breakpoints[0].ToString()}\n",
+                    Environment.NewLine + $"Hit {eventArgs.Breakpoints [0].ToString()}\n",
                     true,
                     OutputType.Normal,
                     ConsoleColor.Blue);
@@ -805,7 +805,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private async Task StartReplLoopAsync(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            while(!cancellationToken.IsCancellationRequested)
             {
                 string commandString = null;
 
@@ -813,7 +813,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 {
                     await this.WritePromptStringToHostAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
+                catch(OperationCanceledException)
                 {
                     break;
                 }
@@ -822,7 +822,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 {
                     commandString = await this.ReadCommandLineAsync(cancellationToken).ConfigureAwait(false);
                 }
-                catch (PipelineStoppedException)
+                catch(PipelineStoppedException)
                 {
                     this.WriteOutput(
                         "^C",
@@ -831,11 +831,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         foregroundColor: ConsoleColor.Red);
                 }
                 // Do nothing here, the while loop condition will exit.
-                catch (TaskCanceledException)
+                catch(TaskCanceledException)
                 { }
-                catch (OperationCanceledException)
+                catch(OperationCanceledException)
                 { }
-                catch (Exception e) // Narrow this if possible
+                catch(Exception e) // Narrow this if possible
                 {
                     this.WriteOutput(
                         $"\n\nAn error occurred while reading input:\n\n{e.ToString()}\n",
@@ -853,13 +853,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     // TODO: This still gives an extra newline when you hit ENTER in the PSReadLine experience. We should figure
                     // out if there's any way to avoid that... but unfortunately, in both scenarios, we only see that empty
                     // string is returned.
-                    if (!cancellationToken.IsCancellationRequested)
+                    if(!cancellationToken.IsCancellationRequested)
                     {
                         this.WriteLine();
                     }
                 }
 
-                if (!string.IsNullOrWhiteSpace(commandString))
+                if(!string.IsNullOrWhiteSpace(commandString))
                 {
                     var unusedTask =
                         this.powerShellContext
@@ -877,7 +877,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private InputPromptHandler CreateInputPromptHandler()
         {
-            if (this.activePromptHandler != null)
+            if(this.activePromptHandler != null)
             {
                 Logger.LogError(
                     "Prompt handler requested while another prompt is already active.");
@@ -892,7 +892,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private ChoicePromptHandler CreateChoicePromptHandler()
         {
-            if (this.activePromptHandler != null)
+            if(this.activePromptHandler != null)
             {
                 Logger.LogError(
                     "Prompt handler requested while another prompt is already active.");
@@ -922,7 +922,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 // method which gets run on another thread.
                 promptTask.Wait();
 
-                if (promptTask.Status == TaskStatus.WaitingForActivation)
+                if(promptTask.Status == TaskStatus.WaitingForActivation)
                 {
                     // The Wait() call has timed out, cancel the prompt
                     cancellationToken.Cancel();
@@ -931,22 +931,22 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     throw new PipelineStoppedException();
                 }
             }
-            catch (AggregateException e)
+            catch(AggregateException e)
             {
                 // Find the right InnerException
                 Exception innerException = e.InnerException;
-                while (innerException is AggregateException)
+                while(innerException is AggregateException)
                 {
                     innerException = innerException.InnerException;
                 }
 
                 // Was the task cancelled?
-                if (innerException is TaskCanceledException)
+                if(innerException is TaskCanceledException)
                 {
                     // Stop the pipeline if the prompt was cancelled
                     throw new PipelineStoppedException();
                 }
-                else if (innerException is PipelineStoppedException)
+                else if(innerException is PipelineStoppedException)
                 {
                     // The prompt is being cancelled, rethrow the exception
                     throw innerException;
@@ -965,7 +965,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private void PowerShellContext_DebuggerStop(object sender, System.Management.Automation.DebuggerStopEventArgs e)
         {
-            if (!this.IsCommandLoopRunning)
+            if(!this.IsCommandLoopRunning)
             {
                 StartCommandLoop();
                 return;
@@ -986,24 +986,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private void PowerShellContext_ExecutionStatusChanged(object sender, ExecutionStatusChangedEventArgs eventArgs)
         {
             // The command loop should only be manipulated if it's already started
-            if (eventArgs.ExecutionStatus == ExecutionStatus.Aborted)
+            if(eventArgs.ExecutionStatus == ExecutionStatus.Aborted)
             {
                 this.ClearProgress();
 
                 // When aborted, cancel any lingering prompts
-                if (this.activePromptHandler != null)
+                if(this.activePromptHandler != null)
                 {
                     this.activePromptHandler.CancelPrompt();
                     this.WriteOutput(string.Empty);
                 }
             }
-            else if (
+            else if(
                 eventArgs.ExecutionOptions.WriteOutputToHost ||
                 eventArgs.ExecutionOptions.InterruptCommandPrompt)
             {
                 // Any command which writes output to the host will affect
                 // the display of the prompt
-                if (eventArgs.ExecutionStatus != ExecutionStatus.Running)
+                if(eventArgs.ExecutionStatus != ExecutionStatus.Running)
                 {
                     this.ClearProgress();
 
@@ -1018,7 +1018,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     this.CancelCommandPrompt();
                 }
             }
-            else if (
+            else if(
                 eventArgs.ExecutionOptions.WriteErrorsToHost &&
                 (eventArgs.ExecutionStatus == ExecutionStatus.Failed ||
                     eventArgs.HadErrors))

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptEvents.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptEvents.cs
@@ -11,9 +11,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         public string Message { get; set; }
 
-        public ChoiceDetails[] Choices { get; set; }
+        public ChoiceDetails [] Choices { get; set; }
 
-        public int[] DefaultChoices { get; set; }
+        public int [] DefaultChoices { get; set; }
     }
 
     internal class ShowChoicePromptResponse

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/PromptHandlers.cs
@@ -56,11 +56,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private void HandlePromptResponse(
             Task<ShowChoicePromptResponse> responseTask)
         {
-            if (responseTask.IsCompleted)
+            if(responseTask.IsCompleted)
             {
                 ShowChoicePromptResponse response = responseTask.Result;
 
-                if (!response.PromptCancelled)
+                if(!response.PromptCancelled)
                 {
                     this.hostOutput.WriteOutput(
                         response.ResponseText,
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
             else
             {
-                if (responseTask.IsFaulted)
+                if(responseTask.IsFaulted)
                 {
                     // Log the error
                     Logger.LogError(
@@ -134,11 +134,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         private void HandlePromptResponse(
             Task<ShowInputPromptResponse> responseTask)
         {
-            if (responseTask.IsCompleted)
+            if(responseTask.IsCompleted)
             {
                 ShowInputPromptResponse response = responseTask.Result;
 
-                if (!response.PromptCancelled)
+                if(!response.PromptCancelled)
                 {
                     this.hostOutput.WriteOutput(
                         response.ResponseText,
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             }
             else
             {
-                if (responseTask.IsFaulted)
+                if(responseTask.IsFaulted)
                 {
                     // Log the error
                     Logger.LogError(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/ProtocolPSHostUserInterface.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             ILanguageServerFacade languageServer,
             PowerShellContextService powerShellContext,
             ILogger logger)
-            : base (
+            : base(
                 powerShellContext,
                 new SimplePSHostRawUserInterface(logger),
                 logger)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/SimplePSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/SimplePSHostRawUserInterface.cs
@@ -170,9 +170,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         /// <param name="rectangle">The rectangle inside which buffer contents will be accessed.</param>
         /// <returns>A BufferCell array with the requested buffer contents.</returns>
-        public override BufferCell[,] GetBufferContents(Rectangle rectangle)
+        public override BufferCell [,] GetBufferContents(Rectangle rectangle)
         {
-            return new BufferCell[0,0];
+            return new BufferCell [0, 0];
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="contents">The new contents for the buffer at the given coordinate.</param>
         public override void SetBufferContents(
             Coordinates origin,
-            BufferCell[,] contents)
+            BufferCell [,] contents)
         {
             Logger.LogWarning(
                 "PSHostRawUserInterface.SetBufferContents was called");

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             bool includeUp = (options & ReadKeyOptions.IncludeKeyUp) != 0;
 
             // Key Up was requested and we have a cached key down we can return.
-            if (includeUp && this.lastKeyDown != null)
+            if(includeUp && this.lastKeyDown != null)
             {
                 KeyInfo info = this.lastKeyDown.Value;
                 this.lastKeyDown = null;
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             bool intercept = (options & ReadKeyOptions.NoEcho) != 0;
             bool includeDown = (options & ReadKeyOptions.IncludeKeyDown) != 0;
-            if (!(includeDown || includeUp))
+            if(!(includeDown || includeUp))
             {
                 throw new PSArgumentException(
                     "Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.",
@@ -174,10 +174,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 System.Console.TreatControlCAsInput = true;
                 ConsoleKeyInfo key = ConsoleProxy.ReadKey(intercept, default(CancellationToken));
 
-                if (IsCtrlC(key))
+                if(IsCtrlC(key))
                 {
                     // Caller wants CtrlC as input so return it.
-                    if ((options & ReadKeyOptions.AllowCtrlC) != 0)
+                    if((options & ReadKeyOptions.AllowCtrlC) != 0)
                     {
                         return ProcessKey(key, includeDown);
                     }
@@ -210,7 +210,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         /// <param name="rectangle">The rectangle inside which buffer contents will be accessed.</param>
         /// <returns>A BufferCell array with the requested buffer contents.</returns>
-        public override BufferCell[,] GetBufferContents(Rectangle rectangle)
+        public override BufferCell [,] GetBufferContents(Rectangle rectangle)
         {
             return this.internalRawUI.GetBufferContents(rectangle);
         }
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             BufferCell fill)
         {
             // If the rectangle is all -1s then it means clear the visible buffer
-            if (rectangle.Top == -1 &&
+            if(rectangle.Top == -1 &&
                 rectangle.Bottom == -1 &&
                 rectangle.Left == -1 &&
                 rectangle.Right == -1)
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="contents">The new contents for the buffer at the given coordinate.</param>
         public override void SetBufferContents(
             Coordinates origin,
-            BufferCell[,] contents)
+            BufferCell [,] contents)
         {
             this.internalRawUI.SetBufferContents(origin, contents);
         }
@@ -279,7 +279,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // In the VSCode terminal Ctrl C is processed as virtual key code "3", which
             // is not a named value in the ConsoleKey enum.
-            if ((int)keyInfo.Key == 3)
+            if((int)keyInfo.Key == 3)
             {
                 return true;
             }
@@ -300,23 +300,23 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             // Translate ConsoleModifiers to ControlKeyStates
             ControlKeyStates states = default;
-            if ((key.Modifiers & ConsoleModifiers.Alt) != 0)
+            if((key.Modifiers & ConsoleModifiers.Alt) != 0)
             {
                 states |= ControlKeyStates.LeftAltPressed;
             }
 
-            if ((key.Modifiers & ConsoleModifiers.Control) != 0)
+            if((key.Modifiers & ConsoleModifiers.Control) != 0)
             {
                 states |= ControlKeyStates.LeftCtrlPressed;
             }
 
-            if ((key.Modifiers & ConsoleModifiers.Shift) != 0)
+            if((key.Modifiers & ConsoleModifiers.Shift) != 0)
             {
                 states |= ControlKeyStates.ShiftPressed;
             }
 
             var result = new KeyInfo((int)key.Key, key.KeyChar, states, isDown);
-            if (isDown)
+            if(isDown)
             {
                 this.lastKeyDown = result;
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostUserInterface.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             PowerShellContextService powerShellContext,
             PSHost internalHost,
             ILogger logger)
-            : base (
+            : base(
                 powerShellContext,
                 new TerminalPSHostRawUserInterface(logger, internalHost),
                 logger)
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             System.Console.CancelKeyPress +=
                 (obj, args) =>
                 {
-                    if (!IsNativeApplicationRunning)
+                    if(!IsNativeApplicationRunning)
                     {
                         // We'll handle Ctrl+C
                         args.Cancel = true;
@@ -80,8 +80,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal override ConsoleColor ProgressForegroundColor
         {
-            get => (ConsoleColor)_internalHostPrivateData.Properties["ProgressForegroundColor"].Value;
-            set => _internalHostPrivateData.Properties["ProgressForegroundColor"].Value = value;
+            get => (ConsoleColor)_internalHostPrivateData.Properties ["ProgressForegroundColor"].Value;
+            set => _internalHostPrivateData.Properties ["ProgressForegroundColor"].Value = value;
         }
 
         /// <summary>
@@ -89,8 +89,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal override ConsoleColor ProgressBackgroundColor
         {
-            get => (ConsoleColor)_internalHostPrivateData.Properties["ProgressBackgroundColor"].Value;
-            set => _internalHostPrivateData.Properties["ProgressBackgroundColor"].Value = value;
+            get => (ConsoleColor)_internalHostPrivateData.Properties ["ProgressBackgroundColor"].Value;
+            set => _internalHostPrivateData.Properties ["ProgressBackgroundColor"].Value = value;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/InvocationEventQueue.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             var request = new InvocationRequest(pwsh =>
             {
-                using (_promptNest.GetRunspaceHandle(CancellationToken.None, isReadLine: false))
+                using(_promptNest.GetRunspaceHandle(CancellationToken.None, isReadLine: false))
                 {
                     pwsh.Runspace = _runspace;
                     invocationAction(pwsh);
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             try
             {
                 existingRequest = _invocationRequest;
-                if (existingRequest == null || existingRequest.Task.IsCompleted)
+                if(existingRequest == null || existingRequest.Task.IsCompleted)
                 {
                     return;
                 }
@@ -169,7 +169,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private void OnPowerShellIdle(object sender, EventArgs e)
         {
-            if (!_lock.Wait(0))
+            if(!_lock.Wait(0))
             {
                 return;
             }
@@ -177,7 +177,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             InvocationRequest currentRequest = null;
             try
             {
-                if (_invocationRequest == null)
+                if(_invocationRequest == null)
                 {
                     return;
                 }
@@ -251,7 +251,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     // may take over the pipeline thread.
                     System.Threading.Tasks.Task.Run(() => SetResult(true));
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     System.Threading.Tasks.Task.Run(() => SetException(e));
                 }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             readLineProxy = null;
             logger.LogTrace("Attempting to load PSReadLine");
-            using (var pwsh = PowerShell.Create())
+            using(var pwsh = PowerShell.Create())
             {
                 pwsh.Runspace = runspace;
                 pwsh.AddCommand("Microsoft.PowerShell.Core\\Import-Module")
@@ -92,9 +92,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
                 var psReadLineType = Type.GetType("Microsoft.PowerShell.PSConsoleReadLine, Microsoft.PowerShell.PSReadLine2");
 
-                if (psReadLineType == null)
+                if(psReadLineType == null)
                 {
-                    logger.LogWarning("PSConsoleReadline type not found: {Reason}", pwsh.HadErrors ? pwsh.Streams.Error[0].ToString() : "<Unknown reason>");
+                    logger.LogWarning("PSConsoleReadline type not found: {Reason}", pwsh.HadErrors ? pwsh.Streams.Error [0].ToString() : "<Unknown reason>");
                     return false;
                 }
 
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 {
                     readLineProxy = new PSReadLineProxy(psReadLineType, logger);
                 }
-                catch (InvalidOperationException e)
+                catch(InvalidOperationException e)
                 {
                     // The Type we got back from PowerShell doesn't have the members we expected.
                     // Could be an older version, a custom build, or something a newer version with
@@ -119,12 +119,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         {
             _readLineCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             var localTokenSource = _readLineCancellationSource;
-            if (localTokenSource.Token.IsCancellationRequested)
+            if(localTokenSource.Token.IsCancellationRequested)
             {
                 throw new TaskCanceledException();
             }
 
-            if (!isCommandLine)
+            if(!isCommandLine)
             {
                 return await _consoleReadLine.InvokeLegacyReadLineAsync(
                     isCommandLine: false,
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         public void AbortReadLine()
         {
-            if (_readLineCancellationSource == null)
+            if(_readLineCancellationSource == null)
             {
                 return;
             }
@@ -159,8 +159,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             WaitForReadLineExit();
         }
 
-        public async Task AbortReadLineAsync() {
-            if (_readLineCancellationSource == null)
+        public async Task AbortReadLineAsync()
+        {
+            if(_readLineCancellationSource == null)
             {
                 return;
             }
@@ -172,12 +173,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         public void WaitForReadLineExit()
         {
-            using (_promptNest.GetRunspaceHandle(CancellationToken.None, isReadLine: true))
+            using(_promptNest.GetRunspaceHandle(CancellationToken.None, isReadLine: true))
             { }
         }
 
-        public async Task WaitForReadLineExitAsync() {
-            using (await _promptNest.GetRunspaceHandleAsync(CancellationToken.None, isReadLine: true).ConfigureAwait(false))
+        public async Task WaitForReadLineExitAsync()
+        {
+            using(await _promptNest.GetRunspaceHandleAsync(CancellationToken.None, isReadLine: true).ConfigureAwait(false))
             { }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLineProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLineProxy.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private const string ForcePSEventHandlingMethodName = "ForcePSEventHandling";
 
-        private static readonly Type[] s_setKeyHandlerTypes =
+        private static readonly Type [] s_setKeyHandlerTypes =
         {
             typeof(string[]),
             typeof(Action<ConsoleKeyInfo?, object>),
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             typeof(string)
         };
 
-        private static readonly Type[] s_addToHistoryTypes = { typeof(string) };
+        private static readonly Type [] s_addToHistoryTypes = { typeof(string) };
 
         private readonly FieldInfo _readKeyOverrideField;
 
@@ -49,16 +49,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 ?.CreateDelegate(typeof(Action<string>));
 
             SetKeyHandler =
-                (Action<string[], Action<ConsoleKeyInfo?, object>, string, string>)psConsoleReadLine.GetMethod(
+                (Action<string [], Action<ConsoleKeyInfo?, object>, string, string>)psConsoleReadLine.GetMethod(
                     SetKeyHandlerMethodName,
                     s_setKeyHandlerTypes)
-                    ?.CreateDelegate(typeof(Action<string[], Action<ConsoleKeyInfo?, object>, string, string>));
+                    ?.CreateDelegate(typeof(Action<string [], Action<ConsoleKeyInfo?, object>, string, string>));
 
             _readKeyOverrideField = psConsoleReadLine.GetTypeInfo().Assembly
                 .GetType(VirtualTerminalTypeName)
                 ?.GetField(ReadKeyOverrideFieldName, BindingFlags.Static | BindingFlags.NonPublic);
 
-            if (_readKeyOverrideField == null)
+            if(_readKeyOverrideField == null)
             {
                 throw NewInvalidPSReadLineVersionException(
                     FieldMemberType,
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     logger);
             }
 
-            if (SetKeyHandler == null)
+            if(SetKeyHandler == null)
             {
                 throw NewInvalidPSReadLineVersionException(
                     MethodMemberType,
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     logger);
             }
 
-            if (AddToHistory == null)
+            if(AddToHistory == null)
             {
                 throw NewInvalidPSReadLineVersionException(
                     MethodMemberType,
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     logger);
             }
 
-            if (ForcePSEventHandling == null)
+            if(ForcePSEventHandling == null)
             {
                 throw NewInvalidPSReadLineVersionException(
                     MethodMemberType,
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         internal Action<string> AddToHistory { get; }
 
-        internal Action<string[], Action<Nullable<ConsoleKeyInfo>, object>, string, string> SetKeyHandler { get; }
+        internal Action<string [], Action<Nullable<ConsoleKeyInfo>, object>, string, string> SetKeyHandler { get; }
 
         internal Action ForcePSEventHandling { get; }
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PipelineExecutionRequest.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PipelineExecutionRequest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 {
                     WriteOutputToHost = sendOutputToHost
                 })
-            { }
+        { }
 
 
         public PipelineExecutionRequest(

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShell5Operations.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShell5Operations.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
     {
         public void ConfigureDebugger(Runspace runspace)
         {
-            if (runspace.Debugger != null)
+            if(runspace.Debugger != null)
             {
                 runspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
             }
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         public virtual void PauseDebugger(Runspace runspace)
         {
-            if (runspace.Debugger != null)
+            if(runspace.Debugger != null)
             {
                 runspace.Debugger.SetDebuggerStepMode(true);
             }
@@ -42,15 +42,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             debuggerResumeAction = null;
             PSDataCollection<PSObject> outputCollection = new PSDataCollection<PSObject>();
 
-            if (sendOutputToHost)
+            if(sendOutputToHost)
             {
                 outputCollection.DataAdded +=
                     (obj, e) =>
                     {
-                        for (int i = e.Index; i < outputCollection.Count; i++)
+                        for(int i = e.Index; i < outputCollection.Count; i++)
                         {
                             powerShellContext.WriteOutput(
-                                outputCollection[i].ToString(),
+                                outputCollection [i].ToString(),
                                 true);
                         }
                     };
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             debuggerResumeAction = commandResults.ResumeAction;
 
             IEnumerable<TResult> results = null;
-            if (typeof(TResult) != typeof(PSObject))
+            if(typeof(TResult) != typeof(PSObject))
             {
                 results =
                     outputCollection
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         public void StopCommandInDebugger(PowerShellContextService powerShellContext)
         {
             // If the RunspaceAvailability is None, the runspace is dead and we should not try to run anything in it.
-            if (powerShellContext.CurrentRunspace.Runspace.RunspaceAvailability != RunspaceAvailability.None)
+            if(powerShellContext.CurrentRunspace.Runspace.RunspaceAvailability != RunspaceAvailability.None)
             {
                 powerShellContext.CurrentRunspace.Runspace.Debugger.StopProcessCommand();
             }
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             {
                 host.ExitNestedPrompt();
             }
-            catch (FlowControlException)
+            catch(FlowControlException)
             {
             }
         }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PowerShellVersionDetails.cs
@@ -100,10 +100,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             try
             {
                 var psVersionTable = PowerShellContextService.ExecuteScriptAndGetItem<Hashtable>("$PSVersionTable", runspace, useLocalScope: true);
-                if (psVersionTable != null)
+                if(psVersionTable != null)
                 {
-                    var edition = psVersionTable["PSEdition"] as string;
-                    if (edition != null)
+                    var edition = psVersionTable ["PSEdition"] as string;
+                    if(edition != null)
                     {
                         powerShellEdition = edition;
                     }
@@ -111,19 +111,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     // The PSVersion value will either be of Version or SemanticVersion.
                     // In the former case, take the value directly.  In the latter case,
                     // generate a Version from its string representation.
-                    var version = psVersionTable["PSVersion"];
-                    if (version is Version)
+                    var version = psVersionTable ["PSVersion"];
+                    if(version is Version)
                     {
                         powerShellVersion = (Version)version;
                     }
-                    else if (version != null)
+                    else if(version != null)
                     {
                         // Expected version string format is 6.0.0-alpha so build a simpler version from that
-                        powerShellVersion = new Version(version.ToString().Split('-')[0]);
+                        powerShellVersion = new Version(version.ToString().Split('-') [0]);
                     }
 
-                    var gitCommitId = psVersionTable["GitCommitId"] as string;
-                    if (gitCommitId != null)
+                    var gitCommitId = psVersionTable ["GitCommitId"] as string;
+                    if(gitCommitId != null)
                     {
                         versionString = gitCommitId;
                     }
@@ -133,20 +133,20 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     }
 
                     var arch = PowerShellContextService.ExecuteScriptAndGetItem<string>("$env:PROCESSOR_ARCHITECTURE", runspace, useLocalScope: true);
-                    if (arch != null)
+                    if(arch != null)
                     {
-                        if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
+                        if(string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
                         {
                             architecture = PowerShellProcessArchitecture.X64;
                         }
-                        else if (string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
+                        else if(string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
                         {
                             architecture = PowerShellProcessArchitecture.X86;
                         }
                     }
                 }
             }
-            catch (Exception ex)
+            catch(Exception ex)
             {
                 logger.LogWarning(
                     "Failed to look up PowerShell version, defaulting to version 5.\r\n\r\n" + ex.ToString());

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNest.cs
@@ -112,18 +112,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         protected virtual void Dispose(bool disposing)
         {
-            lock (_disposeSyncObject)
+            lock(_disposeSyncObject)
             {
-                if (_isDisposed || !disposing)
+                if(_isDisposed || !disposing)
                 {
                     return;
                 }
 
-                while (NestedPromptLevel > 1)
+                while(NestedPromptLevel > 1)
                 {
                     _consoleReader?.StopCommandLoop();
                     var currentFrame = CurrentFrame;
-                    if (currentFrame.FrameType.HasFlag(PromptNestFrameType.Debug))
+                    if(currentFrame.FrameType.HasFlag(PromptNestFrameType.Debug))
                     {
                         _versionSpecificOperations.StopCommandInDebugger(_powerShellContext);
                         currentFrame.ThreadController.StartThreadExit(DebuggerResumeAction.Stop);
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                         continue;
                     }
 
-                    if (currentFrame.FrameType.HasFlag(PromptNestFrameType.NestedPrompt))
+                    if(currentFrame.FrameType.HasFlag(PromptNestFrameType.NestedPrompt))
                     {
                         _powerShellContext.ExitAllNestedPrompts();
                         continue;
@@ -160,7 +160,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal ThreadController GetThreadController()
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return null;
             }
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal void PushPromptContext()
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -187,7 +187,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <param name="frameType">The frame type.</param>
         internal void PushPromptContext(PromptNestFrameType frameType)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -207,9 +207,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         internal void PopPromptContext()
         {
             PromptNestFrame currentFrame;
-            lock (_syncObject)
+            lock(_syncObject)
             {
-                if (_isDisposed || _frameStack.Count == 1)
+                if(_isDisposed || _frameStack.Count == 1)
                 {
                     return;
                 }
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <returns>The <see cref="PowerShell" /> instance for the current frame.</returns>
         internal PowerShell GetPowerShell(bool isReadLine = false)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return null;
             }
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // The exception is when the current frame is remote, in which
             // case we need to run it in it's own frame because we can't take
             // over a remote pipeline through event invocation.
-            if (NestedPromptLevel > 1 && !IsRemote)
+            if(NestedPromptLevel > 1 && !IsRemote)
             {
                 return CurrentFrame.PowerShell;
             }
@@ -255,14 +255,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// <returns>The <see cref="RunspaceHandle" /> for the current frame.</returns>
         internal RunspaceHandle GetRunspaceHandle(CancellationToken cancellationToken, bool isReadLine)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return null;
             }
 
             // Also grab the main runspace handle if this is for a ReadLine pipeline and the runspace
             // is in process.
-            if (isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
+            if(isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
                 GetRunspaceHandleImpl(cancellationToken, isReadLine: false);
             }
@@ -286,14 +286,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task<RunspaceHandle> GetRunspaceHandleAsync(CancellationToken cancellationToken, bool isReadLine)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return null;
             }
 
             // Also grab the main runspace handle if this is for a ReadLine pipeline and the runspace
             // is in process.
-            if (isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
+            if(isReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
                 await GetRunspaceHandleImplAsync(cancellationToken, isReadLine: false).ConfigureAwait(false);
             }
@@ -309,13 +309,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         internal void ReleaseRunspaceHandle(RunspaceHandle runspaceHandle)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
 
             ReleaseRunspaceHandleImpl(runspaceHandle.IsReadLine);
-            if (runspaceHandle.IsReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
+            if(runspaceHandle.IsReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
                 ReleaseRunspaceHandleImpl(isReadLine: false);
             }
@@ -333,13 +333,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task ReleaseRunspaceHandleAsync(RunspaceHandle runspaceHandle)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
 
             await ReleaseRunspaceHandleImplAsync(runspaceHandle.IsReadLine).ConfigureAwait(false);
-            if (runspaceHandle.IsReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
+            if(runspaceHandle.IsReadLine && !_powerShellContext.IsCurrentRunspaceOutOfProcess())
             {
                 await ReleaseRunspaceHandleImplAsync(isReadLine: false).ConfigureAwait(false);
             }
@@ -375,7 +375,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         internal void WaitForCurrentFrameExit(Action<PromptNestFrame> initiator)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </summary>
         internal void WaitForCurrentFrameExit()
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -413,7 +413,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </param>
         internal void WaitForCurrentFrameExit(CancellationToken cancellationToken)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -432,7 +432,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task WaitForCurrentFrameExitAsync(Func<PromptNestFrame, Task> initiator)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -459,7 +459,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task WaitForCurrentFrameExitAsync(Action<PromptNestFrame> initiator)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -483,7 +483,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task WaitForCurrentFrameExitAsync()
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -502,7 +502,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         /// </returns>
         internal async Task WaitForCurrentFrameExitAsync(CancellationToken cancellationToken)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
@@ -519,7 +519,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private RunspaceHandle GetRunspaceHandleImpl(CancellationToken cancellationToken, bool isReadLine)
         {
-            if (isReadLine)
+            if(isReadLine)
             {
                 return _readLineFrame.Queue.Dequeue(cancellationToken);
             }
@@ -529,7 +529,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private async Task<RunspaceHandle> GetRunspaceHandleImplAsync(CancellationToken cancellationToken, bool isReadLine)
         {
-            if (isReadLine)
+            if(isReadLine)
             {
                 return await _readLineFrame.Queue.DequeueAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -539,7 +539,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private void ReleaseRunspaceHandleImpl(bool isReadLine)
         {
-            if (isReadLine)
+            if(isReadLine)
             {
                 _readLineFrame.Queue.Enqueue(new RunspaceHandle(_powerShellContext, true));
                 return;
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         private async Task ReleaseRunspaceHandleImplAsync(bool isReadLine)
         {
-            if (isReadLine)
+            if(isReadLine)
             {
                 await _readLineFrame.Queue.EnqueueAsync(new RunspaceHandle(_powerShellContext, true)).ConfigureAwait(false);
                 return;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrame.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PromptNestFrame.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         internal PromptNestFrame(PowerShell powerShell, AsyncQueue<RunspaceHandle> handleQueue)
             : this(powerShell, handleQueue, PromptNestFrameType.Normal)
-            { }
+        { }
 
         internal PromptNestFrame(
             PowerShell powerShell,
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             Queue = handleQueue;
             FrameType = frameType;
             IsThreadController = (frameType & (PromptNestFrameType.Debug | PromptNestFrameType.NestedPrompt)) != 0;
-            if (!IsThreadController)
+            if(!IsThreadController)
             {
                 return;
             }
@@ -75,14 +75,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
         protected virtual void Dispose(bool disposing)
         {
-            if (_isDisposed)
+            if(_isDisposed)
             {
                 return;
             }
 
-            if (disposing)
+            if(disposing)
             {
-                if (IndisposableStates.HasFlag(PowerShell.InvocationStateInfo.State))
+                if(IndisposableStates.HasFlag(PowerShell.InvocationStateInfo.State))
                 {
                     PowerShell.BeginStop(
                         asyncResult =>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/RunspaceDetails.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             where TCapability : IRunspaceCapability
         {
             IRunspaceCapability capabilityAsInterface = default(TCapability);
-            if (this.capabilities.TryGetValue(typeof(TCapability), out capabilityAsInterface))
+            if(this.capabilities.TryGetValue(typeof(TCapability), out capabilityAsInterface))
             {
                 capability = (TCapability)capabilityAsInterface;
                 return true;
@@ -198,20 +198,20 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             string connectionString = null;
 
-            if (runspace.ConnectionInfo != null)
+            if(runspace.ConnectionInfo != null)
             {
                 // Use 'dynamic' to avoid missing NamedPipeRunspaceConnectionInfo
                 // on PS v3 and v4
                 try
                 {
                     dynamic connectionInfo = runspace.ConnectionInfo;
-                    if (connectionInfo.ProcessId != null)
+                    if(connectionInfo.ProcessId != null)
                     {
                         connectionString = connectionInfo.ProcessId.ToString();
                         runspaceContext = RunspaceContext.EnteredProcess;
                     }
                 }
-                catch (RuntimeBinderException)
+                catch(RuntimeBinderException)
                 {
                     // ProcessId property isn't on the object, move on.
                 }
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 // ex. Enter-PSSession
                 // Attaching to process currently needs to be marked as a local session
                 // so we skip this if block if the runspace is from Enter-PSHostProcess
-                if (hostName.Equals("ServerRemoteHost", StringComparison.Ordinal)
+                if(hostName.Equals("ServerRemoteHost", StringComparison.Ordinal)
                     && runspace.OriginalConnectionInfo?.GetType().ToString() != "System.Management.Automation.Runspaces.NamedPipeConnectionInfo")
                 {
                     runspaceLocation = RunspaceLocation.Remote;

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/SessionDetails.cs
@@ -40,9 +40,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             Hashtable innerHashtable = detailsObject.BaseObject as Hashtable;
 
-            this.ProcessId = (int)innerHashtable["processId"] as int?;
-            this.ComputerName = innerHashtable["computerName"] as string;
-            this.InstanceId = innerHashtable["instanceId"] as Guid?;
+            this.ProcessId = (int)innerHashtable ["processId"] as int?;
+            this.ComputerName = innerHashtable ["computerName"] as string;
+            this.InstanceId = innerHashtable ["instanceId"] as Guid?;
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/ThreadController.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
         internal void StartThreadExit(DebuggerResumeAction action, bool waitForExit)
         {
             Task.Run(() => FrameExitTask.TrySetResult(action));
-            if (!waitForExit)
+            if(!waitForExit)
             {
                 return;
             }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/TemplateService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/TemplateService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>A Task that can be awaited until the check is complete.  The result will be true if Plaster is installed.</returns>
         public async Task<bool> ImportPlasterIfInstalledAsync()
         {
-            if (!this.isPlasterInstalled.HasValue)
+            if(!this.isPlasterInstalled.HasValue)
             {
                 PSCommand psCommand = new PSCommand();
 
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 this.logger.LogTrace($"Plaster is {installedQualifier}installed!");
 
                 // Attempt to load plaster
-                if (this.isPlasterInstalled.Value && this.isPlasterLoaded == false)
+                if(this.isPlasterInstalled.Value && this.isPlasterLoaded == false)
                 {
                     this.logger.LogTrace("Loading Plaster...");
 
@@ -121,10 +121,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// included templates.
         /// </param>
         /// <returns>A Task which can be awaited for the TemplateDetails list to be returned.</returns>
-        public async Task<TemplateDetails[]> GetAvailableTemplatesAsync(
+        public async Task<TemplateDetails []> GetAvailableTemplatesAsync(
             bool includeInstalledModules)
         {
-            if (!this.isPlasterLoaded)
+            if(!this.isPlasterLoaded)
             {
                 throw new InvalidOperationException("Plaster is not loaded, templates cannot be accessed.");
             }
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             PSCommand psCommand = new PSCommand();
             psCommand.AddCommand("Get-PlasterTemplate");
 
-            if (includeInstalledModules)
+            if(includeInstalledModules)
             {
                 psCommand.AddParameter("IncludeModules");
             }
@@ -192,13 +192,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             return new TemplateDetails
             {
-                Title = psObject.Members["Title"].Value as string,
-                Author = psObject.Members["Author"].Value as string,
-                Version = psObject.Members["Version"].Value.ToString(),
-                Description = psObject.Members["Description"].Value as string,
-                TemplatePath = psObject.Members["TemplatePath"].Value as string,
+                Title = psObject.Members ["Title"].Value as string,
+                Author = psObject.Members ["Author"].Value as string,
+                Version = psObject.Members ["Version"].Value.ToString(),
+                Description = psObject.Members ["Description"].Value as string,
+                TemplatePath = psObject.Members ["TemplatePath"].Value as string,
                 Tags =
-                    psObject.Members["Tags"].Value is object[] tags
+                    psObject.Members ["Tags"].Value is object [] tags
                     ? string.Join(", ", tags)
                     : string.Empty
             };

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
             // If we have a CommandInfo cached, return that.
-            if (s_commandInfoCache.TryGetValue(commandName, out CommandInfo cmdInfo))
+            if(s_commandInfoCache.TryGetValue(commandName, out CommandInfo cmdInfo))
             {
                 return cmdInfo;
             }
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // load PackageManagement or PowerShellGet v2 because they cause
             // a major slowdown in IntelliSense.
             var commandParts = commandName.Split('-');
-            if ((commandParts.Length == 2 && s_nounExclusionList.Contains(commandParts[1]))
+            if((commandParts.Length == 2 && s_nounExclusionList.Contains(commandParts [1]))
                     || s_cmdletExclusionList.Contains(commandName))
             {
                 return null;
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 .FirstOrDefault();
 
             // Only cache CmdletInfos since they're exposed in binaries they are likely to not change throughout the session.
-            if (commandInfo?.CommandType == CommandTypes.Cmdlet)
+            if(commandInfo?.CommandType == CommandTypes.Cmdlet)
             {
                 s_commandInfoCache.TryAdd(commandName, commandInfo);
             }
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             Validate.IsNotNull(nameof(powerShellContext), powerShellContext);
 
             // A small optimization to not run Get-Help on things like DSC resources.
-            if (commandInfo.CommandType != CommandTypes.Cmdlet &&
+            if(commandInfo.CommandType != CommandTypes.Cmdlet &&
                 commandInfo.CommandType != CommandTypes.Function &&
                 commandInfo.CommandType != CommandTypes.Filter)
             {
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             // NOTE: If the user runs Update-Help, it's possible that this synopsis will be out of date.
             // Given the perf increase of doing this, and the simple workaround of restarting the extension,
             // this seems worth it.
-            if (s_synopsisCache.TryGetValue(commandInfo.Name, out string synopsis))
+            if(s_synopsisCache.TryGetValue(commandInfo.Name, out string synopsis))
             {
                 return synopsis;
             }
@@ -145,17 +145,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             // Extract the synopsis string from the object
             string synopsisString =
-                (string)helpObject?.Properties["synopsis"].Value ??
+                (string)helpObject?.Properties ["synopsis"].Value ??
                 string.Empty;
 
             // Only cache cmdlet infos because since they're exposed in binaries, the can never change throughout the session.
-            if (commandInfo.CommandType == CommandTypes.Cmdlet)
+            if(commandInfo.CommandType == CommandTypes.Cmdlet)
             {
                 s_synopsisCache.TryAdd(commandInfo.Name, synopsisString);
             }
 
             // Ignore the placeholder value for this field
-            if (string.Equals(synopsisString, "SHORT DESCRIPTION", System.StringComparison.CurrentCultureIgnoreCase))
+            if(string.Equals(synopsisString, "SHORT DESCRIPTION", System.StringComparison.CurrentCultureIgnoreCase))
             {
                 return string.Empty;
             }

--- a/src/PowerShellEditorServices/Services/Symbols/ParameterSetSignatures.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ParameterSetSignatures.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <summary>
         /// Gets the collection of signatures for the command
         /// </summary>
-        public ParameterSetSignature[] Signatures { get; internal set; }
+        public ParameterSetSignature [] Signatures { get; internal set; }
 
         /// <summary>
         /// Gets the script extent of the command
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         public ParameterSetSignatures(IEnumerable<CommandParameterSetInfo> commandInfoSet, SymbolReference foundSymbol)
         {
             List<ParameterSetSignature> paramSetSignatures = new List<ParameterSetSignature>();
-            foreach (CommandParameterSetInfo setInfo in commandInfoSet)
+            foreach(CommandParameterSetInfo setInfo in commandInfoSet)
             {
                 paramSetSignatures.Add(new ParameterSetSignature(setInfo));
             }
@@ -93,9 +93,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         public ParameterSetSignature(CommandParameterSetInfo commandParamInfoSet)
         {
             List<ParameterInfo> parameterInfo = new List<ParameterInfo>();
-            foreach (CommandParameterInfo commandParameterInfo in commandParamInfoSet.Parameters)
+            foreach(CommandParameterInfo commandParameterInfo in commandParamInfoSet.Parameters)
             {
-                if (!commonParameterNames.ContainsKey(commandParameterInfo.Name))
+                if(!commonParameterNames.ContainsKey(commandParameterInfo.Name))
                 {
                     parameterInfo.Add(new ParameterInfo(commandParameterInfo));
                 }

--- a/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         IEnumerable<ISymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(
             ScriptFile scriptFile)
         {
-            if (!scriptFile.FilePath.EndsWith(
+            if(!scriptFile.FilePath.EndsWith(
                     "tests.ps1",
                     StringComparison.OrdinalIgnoreCase))
             {
@@ -57,19 +57,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>true if the CommandAst represents a Pester command, false otherwise</returns>
         private static bool IsPesterCommand(CommandAst commandAst)
         {
-            if (commandAst == null)
+            if(commandAst == null)
             {
                 return false;
             }
 
             // Ensure the first word is a Pester keyword
-            if (!PesterSymbolReference.PesterKeywords.ContainsKey(commandAst.GetCommandName()))
+            if(!PesterSymbolReference.PesterKeywords.ContainsKey(commandAst.GetCommandName()))
             {
                 return false;
             }
 
             // Ensure that the last argument of the command is a scriptblock
-            if (!(commandAst.CommandElements[commandAst.CommandElements.Count-1] is ScriptBlockExpressionAst))
+            if(!(commandAst.CommandElements [commandAst.CommandElements.Count - 1] is ScriptBlockExpressionAst))
             {
                 return false;
             }
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         {
             string testLine = scriptFile.GetLine(pesterCommandAst.Extent.StartLineNumber);
             PesterCommandType? commandName = PesterSymbolReference.GetCommandType(pesterCommandAst.GetCommandName());
-            if (commandName == null)
+            if(commandName == null)
             {
                 return null;
             }
@@ -97,17 +97,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             // If the test has more than one argument for names, we set it to null
             string testName = null;
             bool alreadySawName = false;
-            for (int i = 1; i < pesterCommandAst.CommandElements.Count; i++)
+            for(int i = 1; i < pesterCommandAst.CommandElements.Count; i++)
             {
-                CommandElementAst currentCommandElement = pesterCommandAst.CommandElements[i];
+                CommandElementAst currentCommandElement = pesterCommandAst.CommandElements [i];
 
                 // Check for an explicit "-Name" parameter
-                if (currentCommandElement is CommandParameterAst parameterAst)
+                if(currentCommandElement is CommandParameterAst parameterAst)
                 {
                     // Found -Name parameter, move to next element which is the argument for -TestName
                     i++;
 
-                    if (!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements[i], out testName))
+                    if(!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements [i], out testName))
                     {
                         alreadySawName = true;
                     }
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
                 // Otherwise, if an argument is given with no parameter, we assume it's the name
                 // If we've already seen a name, we set the name to null
-                if (!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements[i], out testName))
+                if(!alreadySawName && TryGetTestNameArgument(pesterCommandAst.CommandElements [i], out testName))
                 {
                     alreadySawName = true;
                 }
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         {
             testName = null;
 
-            if (commandElementAst is StringConstantExpressionAst testNameStrAst)
+            if(commandElementAst is StringConstantExpressionAst testNameStrAst)
             {
                 testName = testNameStrAst.Value;
                 return true;
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 .Cast<PesterCommandType>()
                 .ToDictionary(pct => pct.ToString(), pct => pct, StringComparer.OrdinalIgnoreCase);
 
-        private static char[] DefinitionTrimChars = new char[] { ' ', '{' };
+        private static char [] DefinitionTrimChars = new char [] { ' ', '{' };
 
         /// <summary>
         /// Gets the name of the test
@@ -213,7 +213,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         internal static PesterCommandType? GetCommandType(string commandName)
         {
             PesterCommandType pesterCommandType;
-            if (commandName == null || !PesterKeywords.TryGetValue(commandName, out pesterCommandType))
+            if(commandName == null || !PesterKeywords.TryGetValue(commandName, out pesterCommandType))
             {
                 return null;
             }

--- a/src/PowerShellEditorServices/Services/Symbols/PsdDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PsdDocumentSymbolProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         IEnumerable<ISymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(
             ScriptFile scriptFile)
         {
-            if ((scriptFile.FilePath != null &&
+            if((scriptFile.FilePath != null &&
                  scriptFile.FilePath.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase)) ||
                  IsPowerShellDataFileAst(scriptFile.ScriptAst))
             {
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             // part of a psd1 file.
             return IsPowerShellDataFileAstNode(
                         new { Item = ast, Children = new List<dynamic>() },
-                        new Type[] {
+                        new Type [] {
                             typeof(ScriptBlockAst),
                             typeof(NamedBlockAst),
                             typeof(PipelineAst),
@@ -53,25 +53,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                         0);
         }
 
-        static private bool IsPowerShellDataFileAstNode(dynamic node, Type[] levelAstMap, int level)
+        static private bool IsPowerShellDataFileAstNode(dynamic node, Type [] levelAstMap, int level)
         {
-            var levelAstTypeMatch = node.Item.GetType().Equals(levelAstMap[level]);
-            if (!levelAstTypeMatch)
+            var levelAstTypeMatch = node.Item.GetType().Equals(levelAstMap [level]);
+            if(!levelAstTypeMatch)
             {
                 return false;
             }
 
-            if (level == levelAstMap.Length - 1)
+            if(level == levelAstMap.Length - 1)
             {
                 return levelAstTypeMatch;
             }
 
             var astsFound = (node.Item as Ast).FindAll(a => a is Ast, false);
-            if (astsFound != null)
+            if(astsFound != null)
             {
-                foreach (var astFound in astsFound)
+                foreach(var astFound in astsFound)
                 {
-                    if (!astFound.Equals(node.Item)
+                    if(!astFound.Equals(node.Item)
                         && node.Item.Equals(astFound.Parent)
                         && IsPowerShellDataFileAstNode(
                             new { Item = astFound, Children = new List<dynamic>() },

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
@@ -45,21 +45,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 SymbolReference = symbolReference
             };
 
-            switch (symbolReference.SymbolType)
+            switch(symbolReference.SymbolType)
             {
                 case SymbolType.Function:
                     CommandInfo commandInfo = await CommandHelpers.GetCommandInfoAsync(
                         symbolReference.SymbolName,
                         powerShellContext).ConfigureAwait(false);
 
-                    if (commandInfo != null)
+                    if(commandInfo != null)
                     {
                         symbolDetails.Documentation =
                             await CommandHelpers.GetCommandSynopsisAsync(
                                 commandInfo,
                                 powerShellContext).ConfigureAwait(false);
 
-                        if (commandInfo.CommandType == CommandTypes.Application)
+                        if(commandInfo.CommandType == CommandTypes.Application)
                         {
                             symbolDetails.DisplayString = "(application) " + symbolReference.SymbolName;
                             return symbolDetails;

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -57,24 +57,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _workspaceService = workspaceService;
 
             _codeLensProviders = new ConcurrentDictionary<string, ICodeLensProvider>();
-            var codeLensProviders = new ICodeLensProvider[]
+            var codeLensProviders = new ICodeLensProvider []
             {
                 new ReferencesCodeLensProvider(_workspaceService, this),
                 new PesterCodeLensProvider(configurationService),
             };
-            foreach (ICodeLensProvider codeLensProvider in codeLensProviders)
+            foreach(ICodeLensProvider codeLensProvider in codeLensProviders)
             {
                 _codeLensProviders.TryAdd(codeLensProvider.ProviderId, codeLensProvider);
             }
 
             _documentSymbolProviders = new ConcurrentDictionary<string, IDocumentSymbolProvider>();
-            var documentSymbolProviders = new IDocumentSymbolProvider[]
+            var documentSymbolProviders = new IDocumentSymbolProvider []
             {
                 new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
                 new PesterDocumentSymbolProvider(),
             };
-            foreach (IDocumentSymbolProvider documentSymbolProvider in documentSymbolProviders)
+            foreach(IDocumentSymbolProvider documentSymbolProvider in documentSymbolProviders)
             {
                 _documentSymbolProviders.TryAdd(documentSymbolProvider.ProviderId, documentSymbolProvider);
             }
@@ -122,9 +122,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             Validate.IsNotNull(nameof(scriptFile), scriptFile);
 
             var foundOccurrences = new List<SymbolReference>();
-            foreach (IDocumentSymbolProvider symbolProvider in GetDocumentSymbolProviders())
+            foreach(IDocumentSymbolProvider symbolProvider in GetDocumentSymbolProviders())
             {
-                foreach (SymbolReference reference in symbolProvider.ProvideDocumentSymbols(scriptFile))
+                foreach(SymbolReference reference in symbolProvider.ProvideDocumentSymbols(scriptFile))
                 {
                     reference.SourceLine = scriptFile.GetLine(reference.ScriptRegion.StartLineNumber);
                     reference.FilePath = scriptFile.FilePath;
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     lineNumber,
                     columnNumber);
 
-            if (symbolReference != null)
+            if(symbolReference != null)
             {
                 symbolReference.FilePath = scriptFile.FilePath;
             }
@@ -172,10 +172,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <returns>FindReferencesResult</returns>
         public List<SymbolReference> FindReferencesOfSymbol(
             SymbolReference foundSymbol,
-            ScriptFile[] referencedFiles,
+            ScriptFile [] referencedFiles,
             WorkspaceService workspace)
         {
-            if (foundSymbol == null)
+            if(foundSymbol == null)
             {
                 return null;
             }
@@ -188,42 +188,42 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 ? new OrderedDictionary()
                 : new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
 
-            foreach (ScriptFile scriptFile in referencedFiles)
+            foreach(ScriptFile scriptFile in referencedFiles)
             {
-                fileMap[scriptFile.FilePath] = scriptFile;
+                fileMap [scriptFile.FilePath] = scriptFile;
             }
 
-            foreach (string filePath in workspace.EnumeratePSFiles())
+            foreach(string filePath in workspace.EnumeratePSFiles())
             {
-                if (!fileMap.Contains(filePath))
+                if(!fileMap.Contains(filePath))
                 {
-                    if (!workspace.TryGetFile(filePath, out ScriptFile scriptFile))
+                    if(!workspace.TryGetFile(filePath, out ScriptFile scriptFile))
                     {
                         // If we can't access the file for some reason, just ignore it
                         continue;
                     }
 
-                    fileMap[filePath] = scriptFile;
+                    fileMap [filePath] = scriptFile;
                 }
             }
 
             var symbolReferences = new List<SymbolReference>();
-            foreach (object fileName in fileMap.Keys)
+            foreach(object fileName in fileMap.Keys)
             {
-                var file = (ScriptFile)fileMap[fileName];
+                var file = (ScriptFile)fileMap [fileName];
 
                 IEnumerable<SymbolReference> references = AstOperations.FindReferencesOfSymbol(
                     file.ScriptAst,
                     foundSymbol,
                     needsAliases: false);
 
-                foreach (SymbolReference reference in references)
+                foreach(SymbolReference reference in references)
                 {
                     try
                     {
                         reference.SourceLine = file.GetLine(reference.ScriptRegion.StartLineNumber);
                     }
-                    catch (ArgumentOutOfRangeException e)
+                    catch(ArgumentOutOfRangeException e)
                     {
                         reference.SourceLine = string.Empty;
                         _logger.LogException("Found reference is out of range in script file", e);
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 symbolLineNumber,
                 symbolColumnNumber);
 
-            if (foundSymbol == null)
+            if(foundSymbol == null)
             {
                 return null;
             }
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     columnNumber,
                     includeFunctionDefinitions: true);
 
-            if (symbolReference != null)
+            if(symbolReference != null)
             {
                 symbolReference.FilePath = scriptFile.FilePath;
             }
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     lineNumber,
                     columnNumber);
 
-            if (symbolReference == null)
+            if(symbolReference == null)
             {
                 return null;
             }
@@ -346,7 +346,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // If we are not possibly looking at a Function, we don't
             // need to continue because we won't be able to get the
             // CommandInfo object.
-            if (foundSymbol?.SymbolType != SymbolType.Function
+            if(foundSymbol?.SymbolType != SymbolType.Function
                 && foundSymbol?.SymbolType != SymbolType.Unknown)
             {
                 return null;
@@ -357,7 +357,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     foundSymbol.SymbolName,
                     powerShellContext).ConfigureAwait(false);
 
-            if (commandInfo == null)
+            if(commandInfo == null)
             {
                 return null;
             }
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 IEnumerable<CommandParameterSetInfo> commandParamSets = commandInfo.ParameterSets;
                 return new ParameterSetSignatures(commandParamSets, foundSymbol);
             }
-            catch (RuntimeException e)
+            catch(RuntimeException e)
             {
                 // A RuntimeException will be thrown when an invalid attribute is
                 // on a parameter binding block and then that command/script has
@@ -376,7 +376,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 return null;
             }
-            catch (InvalidOperationException)
+            catch(InvalidOperationException)
             {
                 // For some commands there are no paramsets (like applications).  Until
                 // the valid command types are better understood, catch this exception
@@ -399,7 +399,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             Validate.IsNotNull(nameof(sourceFile), sourceFile);
             Validate.IsNotNull(nameof(foundSymbol), foundSymbol);
 
-            ScriptFile[] referencedFiles =
+            ScriptFile [] referencedFiles =
                 _workspaceService.ExpandScriptReferences(
                     sourceFile);
 
@@ -408,7 +408,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // look through the referenced files until definition is found
             // or there are no more file to look through
             SymbolReference foundDefinition = null;
-            foreach (ScriptFile scriptFile in referencedFiles)
+            foreach(ScriptFile scriptFile in referencedFiles)
             {
                 foundDefinition =
                     AstOperations.FindDefinitionOfSymbol(
@@ -416,17 +416,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         foundSymbol);
 
                 filesSearched.Add(scriptFile.FilePath);
-                if (foundDefinition != null)
+                if(foundDefinition != null)
                 {
                     foundDefinition.FilePath = scriptFile.FilePath;
                     break;
                 }
 
-                if (foundSymbol.SymbolType == SymbolType.Function)
+                if(foundSymbol.SymbolType == SymbolType.Function)
                 {
                     // Dot-sourcing is parsed as a "Function" Symbol.
                     string dotSourcedPath = GetDotSourcedPath(foundSymbol, scriptFile);
-                    if (scriptFile.FilePath == dotSourcedPath)
+                    if(scriptFile.FilePath == dotSourcedPath)
                     {
                         foundDefinition = new SymbolReference(SymbolType.Function, foundSymbol.SymbolName, scriptFile.ScriptAst.Extent, scriptFile.FilePath);
                         break;
@@ -436,24 +436,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // if the definition the not found in referenced files
             // look for it in all the files in the workspace
-            if (foundDefinition == null)
+            if(foundDefinition == null)
             {
                 // Get a list of all powershell files in the workspace path
                 IEnumerable<string> allFiles = _workspaceService.EnumeratePSFiles();
-                foreach (string file in allFiles)
+                foreach(string file in allFiles)
                 {
-                    if (filesSearched.Contains(file))
+                    if(filesSearched.Contains(file))
                     {
                         continue;
                     }
 
                     foundDefinition =
                         AstOperations.FindDefinitionOfSymbol(
-                            Parser.ParseFile(file, out Token[] tokens, out ParseError[] parseErrors),
+                            Parser.ParseFile(file, out Token [] tokens, out ParseError [] parseErrors),
                             foundSymbol);
 
                     filesSearched.Add(file);
-                    if (foundDefinition != null)
+                    if(foundDefinition != null)
                     {
                         foundDefinition.FilePath = file;
                         break;
@@ -464,7 +464,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // if the definition is not found in a file in the workspace
             // look for it in the builtin commands but only if the symbol
             // we are looking at is possibly a Function.
-            if (foundDefinition == null
+            if(foundDefinition == null
                 && (foundSymbol.SymbolType == SymbolType.Function
                     || foundSymbol.SymbolType == SymbolType.Unknown))
             {
@@ -500,23 +500,23 @@ namespace Microsoft.PowerShell.EditorServices.Services
             CommandInfo commandInfo,
             SymbolReference foundSymbol)
         {
-            if (commandInfo == null)
+            if(commandInfo == null)
             {
                 return null;
             }
 
-            ScriptFile[] nestedModuleFiles =
+            ScriptFile [] nestedModuleFiles =
                 GetBuiltinCommandScriptFiles(
                     commandInfo.Module);
 
             SymbolReference foundDefinition = null;
-            foreach (ScriptFile nestedModuleFile in nestedModuleFiles)
+            foreach(ScriptFile nestedModuleFile in nestedModuleFiles)
             {
                 foundDefinition = AstOperations.FindDefinitionOfSymbol(
                     nestedModuleFile.ScriptAst,
                     foundSymbol);
 
-                if (foundDefinition != null)
+                if(foundDefinition != null)
                 {
                     foundDefinition.FilePath = nestedModuleFile.FilePath;
                     break;
@@ -526,10 +526,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return foundDefinition;
         }
 
-        private ScriptFile[] GetBuiltinCommandScriptFiles(
+        private ScriptFile [] GetBuiltinCommandScriptFiles(
             PSModuleInfo moduleInfo)
         {
-            if (moduleInfo == null)
+            if(moduleInfo == null)
             {
                 return Array.Empty<ScriptFile>();
             }
@@ -540,7 +540,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // find any files where the moduleInfo's path ends with ps1 or psm1
             // and add it to allowed script files
-            if (modPath.EndsWith(@".ps1", StringComparison.OrdinalIgnoreCase) ||
+            if(modPath.EndsWith(@".ps1", StringComparison.OrdinalIgnoreCase) ||
                 modPath.EndsWith(@".psm1", StringComparison.OrdinalIgnoreCase))
             {
                 newFile = _workspaceService.GetFile(modPath);
@@ -548,12 +548,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 scriptFiles.Add(newFile);
             }
 
-            if (moduleInfo.NestedModules.Count > 0)
+            if(moduleInfo.NestedModules.Count > 0)
             {
-                foreach (PSModuleInfo nestedInfo in moduleInfo.NestedModules)
+                foreach(PSModuleInfo nestedInfo in moduleInfo.NestedModules)
                 {
                     string nestedModPath = nestedInfo.Path;
-                    if (nestedModPath.EndsWith(@".ps1", StringComparison.OrdinalIgnoreCase) ||
+                    if(nestedModPath.EndsWith(@".ps1", StringComparison.OrdinalIgnoreCase) ||
                         nestedModPath.EndsWith(@".psm1", StringComparison.OrdinalIgnoreCase))
                     {
                         newFile = _workspaceService.GetFile(nestedModPath);
@@ -580,7 +580,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             // check if the next line contains a function definition
             FunctionDefinitionAst funcDefnAst = GetFunctionDefinitionAtLine(scriptFile, lineNumber + 1);
-            if (funcDefnAst != null)
+            if(funcDefnAst != null)
             {
                 helpLocation = "before";
                 return funcDefnAst;
@@ -590,7 +590,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             IEnumerable<Ast> foundAsts = scriptFile.ScriptAst.FindAll(
                 ast =>
                 {
-                    if (!(ast is FunctionDefinitionAst fdAst))
+                    if(!(ast is FunctionDefinitionAst fdAst))
                     {
                         return false;
                     }
@@ -600,7 +600,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 },
                 true);
 
-            if (foundAsts == null || !foundAsts.Any())
+            if(foundAsts == null || !foundAsts.Any())
             {
                 helpLocation = null;
                 return null;
@@ -608,15 +608,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // of all the function definitions found, return the innermost function
             // definition that contains `lineNumber`
-            foreach (FunctionDefinitionAst foundAst in foundAsts.Cast<FunctionDefinitionAst>())
+            foreach(FunctionDefinitionAst foundAst in foundAsts.Cast<FunctionDefinitionAst>())
             {
-                if (funcDefnAst == null)
+                if(funcDefnAst == null)
                 {
                     funcDefnAst = foundAst;
                     continue;
                 }
 
-                if (funcDefnAst.Extent.StartOffset >= foundAst.Extent.StartOffset
+                if(funcDefnAst.Extent.StartOffset >= foundAst.Extent.StartOffset
                     && funcDefnAst.Extent.EndOffset <= foundAst.Extent.EndOffset)
                 {
                     funcDefnAst = foundAst;
@@ -624,13 +624,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             // TODO use tokens to check for non empty character instead of just checking for line offset
-            if (funcDefnAst.Body.Extent.StartLineNumber == lineNumber - 1)
+            if(funcDefnAst.Body.Extent.StartLineNumber == lineNumber - 1)
             {
                 helpLocation = "begin";
                 return funcDefnAst;
             }
 
-            if (funcDefnAst.Body.Extent.EndLineNumber == lineNumber + 1)
+            if(funcDefnAst.Body.Extent.EndLineNumber == lineNumber + 1)
             {
                 helpLocation = "end";
                 return funcDefnAst;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -56,13 +56,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// </returns>
         public static async Task<CommandCompletion> GetCompletionsAsync(
             Ast scriptAst,
-            Token[] currentTokens,
+            Token [] currentTokens,
             int fileOffset,
             PowerShellContextService powerShellContext,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            if (!s_completionHandle.Wait(0))
+            if(!s_completionHandle.Wait(0))
             {
                 return null;
             }
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             {
                 IScriptPosition cursorPosition = (IScriptPosition)s_extentCloneWithNewOffset.Invoke(
                 scriptAst.Extent.StartScriptPosition,
-                new object[] { fileOffset });
+                new object [] { fileOffset });
 
                 logger.LogTrace(
                     string.Format(
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                         cursorPosition.LineNumber,
                         cursorPosition.ColumnNumber));
 
-                if (!powerShellContext.IsAvailable)
+                if(!powerShellContext.IsAvailable)
                 {
                     return null;
                 }
@@ -90,10 +90,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 // If the current runspace is out of process we can use
                 // CommandCompletion.CompleteInput because PSReadLine won't be taking up the
                 // main runspace.
-                if (powerShellContext.IsCurrentRunspaceOutOfProcess())
+                if(powerShellContext.IsCurrentRunspaceOutOfProcess())
                 {
-                    using (RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandleAsync(cancellationToken).ConfigureAwait(false))
-                    using (System.Management.Automation.PowerShell powerShell = System.Management.Automation.PowerShell.Create())
+                    using(RunspaceHandle runspaceHandle = await powerShellContext.GetRunspaceHandleAsync(cancellationToken).ConfigureAwait(false))
+                    using(System.Management.Automation.PowerShell powerShell = System.Management.Automation.PowerShell.Create())
                     {
                         powerShell.Runspace = runspaceHandle.Runspace;
                         stopwatch.Start();
@@ -281,7 +281,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             // part of a psd1 file.
             return IsPowerShellDataFileAstNode(
                         new { Item = ast, Children = new List<dynamic>() },
-                        new Type[] {
+                        new Type [] {
                             typeof(ScriptBlockAst),
                             typeof(NamedBlockAst),
                             typeof(PipelineAst),
@@ -290,25 +290,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                         0);
         }
 
-        static private bool IsPowerShellDataFileAstNode(dynamic node, Type[] levelAstMap, int level)
+        static private bool IsPowerShellDataFileAstNode(dynamic node, Type [] levelAstMap, int level)
         {
-            var levelAstTypeMatch = node.Item.GetType().Equals(levelAstMap[level]);
-            if (!levelAstTypeMatch)
+            var levelAstTypeMatch = node.Item.GetType().Equals(levelAstMap [level]);
+            if(!levelAstTypeMatch)
             {
                 return false;
             }
 
-            if (level == levelAstMap.Length - 1)
+            if(level == levelAstMap.Length - 1)
             {
                 return levelAstTypeMatch;
             }
 
             var astsFound = (node.Item as Ast).FindAll(a => a is Ast, false);
-            if (astsFound != null)
+            if(astsFound != null)
             {
-                foreach (var astFound in astsFound)
+                foreach(var astFound in astsFound)
                 {
-                    if (!astFound.Equals(node.Item)
+                    if(!astFound.Equals(node.Item)
                         && node.Item.Equals(astFound.Parent)
                         && IsPowerShellDataFileAstNode(
                             new { Item = astFound, Children = new List<dynamic>() },
@@ -329,7 +329,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
         /// <param name="psScriptRoot">Pre-calculated value of $PSScriptRoot</param>
         /// <returns></returns>
-        public static string[] FindDotSourcedIncludes(Ast scriptAst, string psScriptRoot)
+        public static string [] FindDotSourcedIncludes(Ast scriptAst, string psScriptRoot)
         {
             FindDotSourcedVisitor dotSourcedVisitor = new FindDotSourcedVisitor(psScriptRoot);
             scriptAst.Visit(dotSourcedVisitor);

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindCommandVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindCommandVisitor.cs
@@ -24,15 +24,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
         public override AstVisitAction VisitPipeline(PipelineAst pipelineAst)
         {
-            if (this.lineNumber == pipelineAst.Extent.StartLineNumber)
+            if(this.lineNumber == pipelineAst.Extent.StartLineNumber)
             {
                 // Which command is the cursor in?
-                foreach (var commandAst in pipelineAst.PipelineElements.OfType<CommandAst>())
+                foreach(var commandAst in pipelineAst.PipelineElements.OfType<CommandAst>())
                 {
                     int trueEndColumnNumber = commandAst.Extent.EndColumnNumber;
                     string currentLine = commandAst.Extent.StartScriptPosition.Line;
 
-                    if (currentLine.Length >= trueEndColumnNumber)
+                    if(currentLine.Length >= trueEndColumnNumber)
                     {
                         // Get the text left in the line after the command's extent
                         string remainingLine =
@@ -51,13 +51,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                             (preTrimLength - postTrimLength) + 1;
                     }
 
-                    if (commandAst.Extent.StartColumnNumber <= columnNumber &&
+                    if(commandAst.Extent.StartColumnNumber <= columnNumber &&
                         trueEndColumnNumber >= columnNumber)
                     {
                         this.FoundCommandReference =
                             new SymbolReference(
                                 SymbolType.Function,
-                                commandAst.CommandElements[0].Extent);
+                                commandAst.CommandElements [0].Extent);
 
                         return AstVisitAction.StopVisit;
                     }

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
@@ -14,12 +14,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         private SymbolReference symbolRef;
         private string variableName;
 
-        public SymbolReference FoundDeclaration{ get; private set; }
+        public SymbolReference FoundDeclaration { get; private set; }
 
         public FindDeclarationVisitor(SymbolReference symbolRef)
         {
             this.symbolRef = symbolRef;
-            if (this.symbolRef.SymbolType == SymbolType.Variable)
+            if(this.symbolRef.SymbolType == SymbolType.Variable)
             {
                 // converts `$varName` to `varName` or of the form ${varName} to varName
                 variableName = symbolRef.SymbolName.TrimStart('$').Trim('{', '}');
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 File = functionDefinitionAst.Extent.File
             };
 
-            if (symbolRef.SymbolType.Equals(SymbolType.Function) &&
+            if(symbolRef.SymbolType.Equals(SymbolType.Function) &&
                 nameExtent.Text.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase))
             {
                 this.FoundDeclaration =
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst)
         {
-            if (variableName == null)
+            if(variableName == null)
             {
                 return AstVisitAction.Continue;
             }
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             FindDeclarationVariableExpressionVisitor visitor = new FindDeclarationVariableExpressionVisitor(symbolRef);
             assignmentStatementAst.Left.Visit(visitor);
 
-            if (visitor.FoundDeclaration != null)
+            if(visitor.FoundDeclaration != null)
             {
                 FoundDeclaration = visitor.FoundDeclaration;
                 return AstVisitAction.StopVisit;
@@ -100,12 +100,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             private SymbolReference symbolRef;
             private string variableName;
 
-            public SymbolReference FoundDeclaration{ get; private set; }
+            public SymbolReference FoundDeclaration { get; private set; }
 
             public FindDeclarationVariableExpressionVisitor(SymbolReference symbolRef)
             {
                 this.symbolRef = symbolRef;
-                if (this.symbolRef.SymbolType == SymbolType.Variable)
+                if(this.symbolRef.SymbolType == SymbolType.Variable)
                 {
                     // converts `$varName` to `varName` or of the form ${varName} to varName
                     variableName = symbolRef.SymbolName.TrimStart('$').Trim('{', '}');
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             /// or a decision to continue if it wasn't found</returns>
             public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
             {
-                if (variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+                if(variableExpressionAst.VariablePath.UserPath.Equals(variableName, StringComparison.OrdinalIgnoreCase))
                 {
                     // TODO also find instances of set-variable
                     FoundDeclaration = new SymbolReference(SymbolType.Variable, variableExpressionAst.Extent);

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDotSourcedVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDotSourcedVisitor.cs
@@ -39,11 +39,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
-            CommandElementAst commandElementAst = commandAst.CommandElements[0];
-            if (commandAst.InvocationOperator.Equals(TokenKind.Dot))
+            CommandElementAst commandElementAst = commandAst.CommandElements [0];
+            if(commandAst.InvocationOperator.Equals(TokenKind.Dot))
             {
                 string path;
-                switch (commandElementAst)
+                switch(commandElementAst)
                 {
                     case StringConstantExpressionAst stringConstantExpressionAst:
                         path = stringConstantExpressionAst.Value;
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                         break;
                 }
 
-                if (!string.IsNullOrWhiteSpace(path))
+                if(!string.IsNullOrWhiteSpace(path))
                 {
                     DotSourcedFiles.Add(PathUtils.NormalizePathSeparators(path));
                 }
@@ -70,10 +70,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         private string GetPathFromExpandableStringExpression(ExpandableStringExpressionAst expandableStringExpressionAst)
         {
             var path = expandableStringExpressionAst.Value;
-            foreach (var nestedExpression in expandableStringExpressionAst.NestedExpressions)
+            foreach(var nestedExpression in expandableStringExpressionAst.NestedExpressions)
             {
                 // If the string contains the variable $PSScriptRoot, we replace it with the corresponding value.
-                if (!(nestedExpression is VariableExpressionAst variableAst
+                if(!(nestedExpression is VariableExpressionAst variableAst
                     && variableAst.VariablePath.UserPath.Equals("PSScriptRoot", StringComparison.OrdinalIgnoreCase)))
                 {
                     return null; // We return null instead of a partially evaluated ExpandableStringExpression.

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             // if a command name does not exists (if the symbol isn't an alias to a command)
             // set symbolRefCommandName to and empty string value
             AliasToCmdletDictionary.TryGetValue(symbolReference.ScriptRegion.Text, out symbolRefCommandName);
-            if (symbolRefCommandName == null) { symbolRefCommandName = string.Empty; }
+            if(symbolRefCommandName == null) { symbolRefCommandName = string.Empty; }
 
         }
 
@@ -65,12 +65,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>A visit action that continues the search for references</returns>
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
-            Ast commandNameAst = commandAst.CommandElements[0];
+            Ast commandNameAst = commandAst.CommandElements [0];
             string commandName = commandNameAst.Extent.Text;
 
             if(symbolRef.SymbolType.Equals(SymbolType.Function))
             {
-                if (needsAliases)
+                if(needsAliases)
                 {
                     // Try to get the commandAst's name and aliases,
                     // if a command does not exists (if the symbol isn't an alias to a command)
@@ -81,15 +81,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                     List<string> alaises;
                     CmdletToAliasDictionary.TryGetValue(commandName, out alaises);
                     AliasToCmdletDictionary.TryGetValue(commandName, out command);
-                    if (alaises == null) { alaises = new List<string>(); }
-                    if (command == null) { command = string.Empty; }
+                    if(alaises == null) { alaises = new List<string>(); }
+                    if(command == null) { command = string.Empty; }
 
-                    if (symbolRef.SymbolType.Equals(SymbolType.Function))
+                    if(symbolRef.SymbolType.Equals(SymbolType.Function))
                     {
                         // Check if the found symbol's name is the same as the commandAst's name OR
                         // if the symbol's name is an alias for this commandAst's name (commandAst is a cmdlet) OR
                         // if the symbol's name is the same as the commandAst's cmdlet name (commandAst is a alias)
-                        if (commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase) ||
+                        if(commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase) ||
                         alaises.Contains(symbolRef.ScriptRegion.Text.ToLower()) ||
                         command.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase) ||
                         (!string.IsNullOrEmpty(command) && command.Equals(symbolRefCommandName, StringComparison.CurrentCultureIgnoreCase)))
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 }
                 else // search does not include aliases
                 {
-                    if (commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
+                    if(commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
                     {
                         this.FoundReferences.Add(new SymbolReference(
                             SymbolType.Function,
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 File = functionDefinitionAst.Extent.File
             };
 
-            if (symbolRef.SymbolType.Equals(SymbolType.Function) &&
+            if(symbolRef.SymbolType.Equals(SymbolType.Function) &&
                 nameExtent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
                 this.FoundReferences.Add(new SymbolReference(
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>A visit action that continues the search for references</returns>
         public override AstVisitAction VisitCommandParameter(CommandParameterAst commandParameterAst)
         {
-            if (symbolRef.SymbolType.Equals(SymbolType.Parameter) &&
+            if(symbolRef.SymbolType.Equals(SymbolType.Parameter) &&
                 commandParameterAst.Extent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
                 this.FoundReferences.Add(new SymbolReference(
@@ -188,11 +188,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             int startLineNumber = ast.Extent.StartLineNumber;
             int astOffset = 0;
 
-            if (ast.IsFilter)
+            if(ast.IsFilter)
             {
                 astOffset = "filter".Length;
             }
-            else if (ast.IsWorkflow)
+            else if(ast.IsWorkflow)
             {
                 astOffset = "workflow".Length;
             }
@@ -205,21 +205,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             // The line offset represents the offset on the line that we're on where as
             // astOffset is the offset on the entire text of the AST.
             int lineOffset = astOffset;
-            for (; astOffset < astText.Length; astOffset++, lineOffset++)
+            for(; astOffset < astText.Length; astOffset++, lineOffset++)
             {
-                if (astText[astOffset] == '\n')
+                if(astText [astOffset] == '\n')
                 {
                     // reset numbers since we are operating on a different line and increment the line number.
                     startColumnNumber = 0;
                     startLineNumber++;
                     lineOffset = 0;
                 }
-                else if (astText[astOffset] == '\r')
+                else if(astText [astOffset] == '\r')
                 {
                     // Do nothing with carriage returns... we only look for line feeds since those
                     // are used on every platform.
                 }
-                else if (!char.IsWhiteSpace(astText[astOffset]))
+                else if(!char.IsWhiteSpace(astText [astOffset]))
                 {
                     // This is the start of the function name so we've found our start column and line number.
                     break;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolVisitor.cs
@@ -34,9 +34,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitCommand(CommandAst commandAst)
         {
-            Ast commandNameAst = commandAst.CommandElements[0];
+            Ast commandNameAst = commandAst.CommandElements [0];
 
-            if (this.IsPositionInExtent(commandNameAst.Extent))
+            if(this.IsPositionInExtent(commandNameAst.Extent))
             {
                 this.FoundSymbolReference =
                     new SymbolReference(
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         {
             int startColumnNumber = 1;
 
-            if (!this.includeFunctionDefinitions)
+            if(!this.includeFunctionDefinitions)
             {
                 startColumnNumber =
                     functionDefinitionAst.Extent.Text.IndexOf(
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 File = functionDefinitionAst.Extent.File
             };
 
-            if (this.IsPositionInExtent(nameExtent))
+            if(this.IsPositionInExtent(nameExtent))
             {
                 this.FoundSymbolReference =
                     new SymbolReference(
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitCommandParameter(CommandParameterAst commandParameterAst)
         {
-            if (this.IsPositionInExtent(commandParameterAst.Extent))
+            if(this.IsPositionInExtent(commandParameterAst.Extent))
             {
                 this.FoundSymbolReference =
                     new SymbolReference(
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (this.IsPositionInExtent(variableExpressionAst.Extent))
+            if(this.IsPositionInExtent(variableExpressionAst.Extent))
             {
                 this.FoundSymbolReference =
                     new SymbolReference(

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindSymbolsVisitor.cs
@@ -29,7 +29,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
         {
-            IScriptExtent nameExtent = new ScriptExtent() {
+            IScriptExtent nameExtent = new ScriptExtent()
+            {
                 Text = functionDefinitionAst.Name,
                 StartLineNumber = functionDefinitionAst.Extent.StartLineNumber,
                 EndLineNumber = functionDefinitionAst.Extent.EndLineNumber,
@@ -58,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// or a decision to continue if it wasn't found</returns>
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if (!IsAssignedAtScriptScope(variableExpressionAst))
+            if(!IsAssignedAtScriptScope(variableExpressionAst))
             {
                 return AstVisitAction.Continue;
             }
@@ -74,13 +75,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         private bool IsAssignedAtScriptScope(VariableExpressionAst variableExpressionAst)
         {
             Ast parent = variableExpressionAst.Parent;
-            if (!(parent is AssignmentStatementAst))
+            if(!(parent is AssignmentStatementAst))
             {
                 return false;
             }
 
             parent = parent.Parent;
-            if (parent == null || parent.Parent == null || parent.Parent.Parent == null)
+            if(parent == null || parent.Parent == null || parent.Parent.Parent == null)
             {
                 return true;
             }
@@ -112,14 +113,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// </summary>
         public override AstVisitAction VisitHashtable(HashtableAst hashtableAst)
         {
-            if (hashtableAst.KeyValuePairs == null)
+            if(hashtableAst.KeyValuePairs == null)
             {
                 return AstVisitAction.Continue;
             }
 
-            foreach (var kvp in hashtableAst.KeyValuePairs)
+            foreach(var kvp in hashtableAst.KeyValuePairs)
             {
-                if (kvp.Item1 is StringConstantExpressionAst keyStrConstExprAst)
+                if(kvp.Item1 is StringConstantExpressionAst keyStrConstExprAst)
                 {
                     IScriptExtent nameExtent = new ScriptExtent()
                     {

--- a/src/PowerShellEditorServices/Services/TextDocument/BufferPosition.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/BufferPosition.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>True if the positions are equal, false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is BufferPosition))
+            if(!(obj is BufferPosition))
             {
                 return false;
             }

--- a/src/PowerShellEditorServices/Services/TextDocument/BufferRange.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/BufferRange.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <param name="end">The end position of the range.</param>
         public BufferRange(BufferPosition start, BufferPosition end)
         {
-            if (start > end)
+            if(start > end)
             {
                 throw new ArgumentException(
                     string.Format(
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>True if the ranges are equal, false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is BufferRange))
+            if(!(obj is BufferRange))
             {
                 return false;
             }

--- a/src/PowerShellEditorServices/Services/TextDocument/CompletionResults.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/CompletionResults.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// Gets the completions that were found during the
         /// completion request.
         /// </summary>
-        public CompletionDetails[] Completions { get; private set; }
+        public CompletionDetails [] Completions { get; private set; }
 
         /// <summary>
         /// Gets the range in the buffer that should be replaced by this
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             BufferRange replacedRange = null;
 
             // Only calculate the replacement range if there are completion results
-            if (commandCompletion.CompletionMatches.Count > 0)
+            if(commandCompletion.CompletionMatches.Count > 0)
             {
                 replacedRange =
                     scriptFile.GetRangeBetweenOffsets(
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
         #region Private Methods
 
-        private static CompletionDetails[] GetCompletionsArray(
+        private static CompletionDetails [] GetCompletionsArray(
             CommandCompletion commandCompletion)
         {
             IEnumerable<CompletionDetails> completionList =
@@ -197,7 +197,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             // Some tooltips may have newlines or whitespace for unknown reasons
             string toolTipText = completionResult.ToolTip;
-            if (toolTipText != null)
+            if(toolTipText != null)
             {
                 toolTipText = toolTipText.Trim();
             }
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>True if the CompletionResults instances have the same details.</returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is CompletionDetails otherDetails))
+            if(!(obj is CompletionDetails otherDetails))
             {
                 return false;
             }
@@ -277,7 +277,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         private static CompletionType ConvertCompletionResultType(
             CompletionResultType completionResultType)
         {
-            switch (completionResultType)
+            switch(completionResultType)
             {
                 case CompletionResultType.Command:
                     return CompletionType.Command;
@@ -325,10 +325,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             // brackets.  Attempt to extract such strings for further processing.
             var matches = Regex.Matches(toolTipText, @"^\[(.+)\]");
 
-            if (matches.Count > 0 && matches[0].Groups.Count > 1)
+            if(matches.Count > 0 && matches [0].Groups.Count > 1)
             {
                 // Return the symbol type name
-                return matches[0].Groups[1].Value;
+                return matches [0].Groups [1].Value;
             }
 
             return null;

--- a/src/PowerShellEditorServices/Services/TextDocument/FilePosition.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/FilePosition.cs
@@ -75,12 +75,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>A new FilePosition instance for the calculated position.</returns>
         public FilePosition GetLineStart()
         {
-            string scriptLine = scriptFile.FileLines[this.Line - 1];
+            string scriptLine = scriptFile.FileLines [this.Line - 1];
 
             int lineStartColumn = 1;
-            for (int i = 0; i < scriptLine.Length; i++)
+            for(int i = 0; i < scriptLine.Length; i++)
             {
-                if (!char.IsWhiteSpace(scriptLine[i]))
+                if(!char.IsWhiteSpace(scriptLine [i]))
                 {
                     lineStartColumn = i + 1;
                     break;
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>A new FilePosition instance for the calculated position.</returns>
         public FilePosition GetLineEnd()
         {
-            string scriptLine = scriptFile.FileLines[this.Line - 1];
+            string scriptLine = scriptFile.FileLines [this.Line - 1];
             return new FilePosition(this.scriptFile, this.Line, scriptLine.Length + 1);
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/FoldingReference.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/FoldingReference.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
     /// <summary>
     /// A class that holds the information for a foldable region of text in a document
     /// </summary>
-    internal class FoldingReference: IComparable<FoldingReference>, IEquatable<FoldingReference>
+    internal class FoldingReference : IComparable<FoldingReference>, IEquatable<FoldingReference>
     {
         /// <summary>
         /// The zero-based line number from where the folded range starts.
@@ -40,26 +40,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// A custom comparable method which can properly sort FoldingReference objects
         /// </summary>
-        public int CompareTo(FoldingReference that) {
+        public int CompareTo(FoldingReference that)
+        {
             // Initially look at the start line
-            if (this.StartLine < that.StartLine) { return -1; }
-            if (this.StartLine > that.StartLine) { return 1; }
+            if(this.StartLine < that.StartLine) { return -1; }
+            if(this.StartLine > that.StartLine) { return 1; }
 
             // They have the same start line so now consider the end line.
             // The biggest line range is sorted first
-            if (this.EndLine > that.EndLine) { return -1; }
-            if (this.EndLine < that.EndLine) { return 1; }
+            if(this.EndLine > that.EndLine) { return -1; }
+            if(this.EndLine < that.EndLine) { return 1; }
 
             // They have the same lines, but what about character offsets
-            if (this.StartCharacter < that.StartCharacter) { return -1; }
-            if (this.StartCharacter > that.StartCharacter) { return 1; }
-            if (this.EndCharacter < that.EndCharacter) { return -1; }
-            if (this.EndCharacter > that.EndCharacter) { return 1; }
+            if(this.StartCharacter < that.StartCharacter) { return -1; }
+            if(this.StartCharacter > that.StartCharacter) { return 1; }
+            if(this.EndCharacter < that.EndCharacter) { return -1; }
+            if(this.EndCharacter > that.EndCharacter) { return 1; }
 
             // They're the same range, but what about kind
-            if (this.Kind == null)
+            if(this.Kind == null)
             {
-                if (that.Kind == null)
+                if(that.Kind == null)
                 {
                     return 0;
                 }
@@ -67,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 return 1;
             }
 
-            if (that.Kind != null)
+            if(that.Kind != null)
             {
                 return that.Kind.Value - this.Kind.Value;
             }
@@ -103,25 +104,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// </summary>
         public void SafeAdd(FoldingReference item)
         {
-            if (item == null) { return; }
+            if(item == null) { return; }
 
             // Only add the item if it hasn't been seen before or it's the largest range
-            if (references.TryGetValue(item.StartLine, out FoldingReference currentItem))
+            if(references.TryGetValue(item.StartLine, out FoldingReference currentItem))
             {
-                if (currentItem.CompareTo(item) == 1) { references[item.StartLine] = item; }
+                if(currentItem.CompareTo(item) == 1) { references [item.StartLine] = item; }
             }
             else
             {
-                references[item.StartLine] = item;
+                references [item.StartLine] = item;
             }
         }
 
         /// <summary>
         /// Helper method to easily convert the Dictionary Values into an array
         /// </summary>
-        public FoldingReference[] ToArray()
+        public FoldingReference [] ToArray()
         {
-            var result = new FoldingReference[references.Count];
+            var result = new FoldingReference [references.Count];
             references.Values.CopyTo(result, 0);
             return result;
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -31,17 +31,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         }
 
         protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities) => new CodeActionRegistrationOptions
-            {
+        {
             // TODO: What do we do with the arguments?
             DocumentSelector = LspUtils.PowerShellDocumentSelector,
-            CodeActionKinds = new CodeActionKind[] { CodeActionKind.QuickFix }
+            CodeActionKinds = new CodeActionKind [] { CodeActionKind.QuickFix }
         };
 
         // TODO: Either fix or ignore "method lacks 'await'" warning.
         public override async Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
         {
             // TODO: How on earth do we handle a CodeAction? This is new...
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("CodeAction request canceled for: {0}", request.Title);
             }
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<CommandOrCodeActionContainer> Handle(CodeActionParams request, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug($"CodeAction request canceled at range: {request.Range}");
                 return Array.Empty<CommandOrCodeAction>();
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 request.TextDocument.Uri)
                 .ConfigureAwait(false);
 
-            if (corrections == null)
+            if(corrections == null)
             {
                 return Array.Empty<CommandOrCodeAction>();
             }
@@ -68,9 +68,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             var codeActions = new List<CommandOrCodeAction>();
 
             // If there are any code fixes, send these commands first so they appear at top of "Code Fix" menu in the client UI.
-            foreach (Diagnostic diagnostic in request.Context.Diagnostics)
+            foreach(Diagnostic diagnostic in request.Context.Diagnostics)
             {
-                if (string.IsNullOrEmpty(diagnostic.Code?.String))
+                if(string.IsNullOrEmpty(diagnostic.Code?.String))
                 {
                     _logger.LogWarning(
                         $"textDocument/codeAction skipping diagnostic with empty Code field: {diagnostic.Source} {diagnostic.Message}");
@@ -79,7 +79,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
 
                 string diagnosticId = AnalysisService.GetUniqueIdFromDiagnostic(diagnostic);
-                if (corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
+                if(corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
                 {
                     codeActions.Add(new CodeAction
                     {
@@ -106,9 +106,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // These commands do not require code fixes. Sometimes we get a batch of diagnostics
             // to create commands for. No need to create multiple show doc commands for the same rule.
             var ruleNamesProcessed = new HashSet<string>();
-            foreach (Diagnostic diagnostic in request.Context.Diagnostics)
+            foreach(Diagnostic diagnostic in request.Context.Diagnostics)
             {
-                if (
+                if(
                     !diagnostic.Code.HasValue ||
                     !diagnostic.Code.Value.IsString ||
                     string.IsNullOrEmpty(diagnostic.Code?.String))
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     continue;
                 }
 
-                if (string.Equals(diagnostic.Source, "PSScriptAnalyzer", StringComparison.OrdinalIgnoreCase) &&
+                if(string.Equals(diagnostic.Source, "PSScriptAnalyzer", StringComparison.OrdinalIgnoreCase) &&
                     !ruleNamesProcessed.Contains(diagnostic.Code?.String))
                 {
                     ruleNamesProcessed.Add(diagnostic.Code?.String);
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         {
                             Title = title,
                             Name = "PowerShell.ShowCodeActionDocumentation",
-                            Arguments = JArray.FromObject(new[] { diagnostic.Code?.String })
+                            Arguments = JArray.FromObject(new [] { diagnostic.Code?.String })
                         }
                     });
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
-            CodeLens[] codeLensResults = ProvideCodeLenses(scriptFile);
+            CodeLens [] codeLensResults = ProvideCodeLenses(scriptFile);
 
             return Task.FromResult(new CodeLensContainer(codeLensResults));
         }
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// </summary>
         /// <param name="scriptFile">The PowerShell script file to get CodeLenses for.</param>
         /// <returns>All generated CodeLenses for the given script file.</returns>
-        private CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
+        private CodeLens [] ProvideCodeLenses(ScriptFile scriptFile)
         {
             return InvokeProviders(provider => provider.ProvideCodeLenses(scriptFile))
                 .SelectMany(codeLens => codeLens)
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             Stopwatch invokeTimer = new Stopwatch();
             List<TResult> providerResults = new List<TResult>();
 
-            foreach (ICodeLensProvider provider in _symbolsService.GetCodeLensProviders())
+            foreach(ICodeLensProvider provider in _symbolsService.GetCodeLensProviders())
             {
                 try
                 {
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     this._logger.LogTrace(
                         $"Invocation of provider '{provider.GetType().Name}' completed in {invokeTimer.ElapsedMilliseconds}ms.");
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     this._logger.LogException(
                         $"Exception caught while invoking provider {provider.GetType().Name}:",

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             DocumentSelector = LspUtils.PowerShellDocumentSelector,
             ResolveProvider = true,
-            TriggerCharacters = new[] { ".", "-", ":", "\\", "$" }
+            TriggerCharacters = new [] { ".", "-", ":", "\\", "$" }
         };
 
         public async Task<CompletionList> Handle(CompletionParams request, CancellationToken cancellationToken)
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 await _completionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch(OperationCanceledException)
             {
                 _logger.LogDebug("Completion request canceled for file: {0}", request.TextDocument.Uri);
                 return Array.Empty<CompletionItem>();
@@ -72,7 +72,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             try
             {
-                if (cancellationToken.IsCancellationRequested)
+                if(cancellationToken.IsCancellationRequested)
                 {
                     _logger.LogDebug("Completion request canceled for file: {0}", request.TextDocument.Uri);
                     return Array.Empty<CompletionItem>();
@@ -84,15 +84,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         cursorLine,
                         cursorColumn).ConfigureAwait(false);
 
-                if (completionResults == null)
+                if(completionResults == null)
                 {
                     return Array.Empty<CompletionItem>();
                 }
 
-                CompletionItem[] completionItems = new CompletionItem[completionResults.Completions.Length];
-                for (int i = 0; i < completionItems.Length; i++)
+                CompletionItem [] completionItems = new CompletionItem [completionResults.Completions.Length];
+                for(int i = 0; i < completionItems.Length; i++)
                 {
-                    completionItems[i] = CreateCompletionItem(completionResults.Completions[i], completionResults.ReplacedRange, i + 1);
+                    completionItems [i] = CreateCompletionItem(completionResults.Completions [i], completionResults.ReplacedRange, i + 1);
                 }
 
                 return completionItems;
@@ -112,13 +112,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public async Task<CompletionItem> Handle(CompletionItem request, CancellationToken cancellationToken)
         {
             // We currently only support this request for anything that returns a CommandInfo: functions, cmdlets, aliases.
-            if (request.Kind != CompletionItemKind.Function)
+            if(request.Kind != CompletionItemKind.Function)
             {
                 return request;
             }
 
             // No details means the module hasn't been imported yet and Intellisense shouldn't import the module to get this info.
-            if (request.Detail is null)
+            if(request.Detail is null)
             {
                 return request;
             }
@@ -127,7 +127,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 await _completionResolveLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch(OperationCanceledException)
             {
                 _logger.LogDebug("CompletionItemResolve request canceled for item: {0}", request.Label);
                 return request;
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         request.Label,
                         _powerShellContextService).ConfigureAwait(false);
 
-                if (commandInfo != null)
+                if(commandInfo != null)
                 {
                     request = request with
                     {
@@ -194,7 +194,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     columnNumber);
 
             CommandCompletion commandCompletion = null;
-            using (var cts = new CancellationTokenSource(DefaultWaitTimeoutMilliseconds))
+            using(var cts = new CancellationTokenSource(DefaultWaitTimeoutMilliseconds))
             {
                 commandCompletion =
                     await AstOperations.GetCompletionsAsync(
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         cts.Token).ConfigureAwait(false);
             }
 
-            if (commandCompletion == null)
+            if(commandCompletion == null)
             {
                 return new CompletionResults();
             }
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 return completionResults;
             }
-            catch (ArgumentException e)
+            catch(ArgumentException e)
             {
                 // Bad completion results could return an invalid
                 // replacement range, catch that here
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             string completionText = completionDetails.CompletionText;
             InsertTextFormat insertTextFormat = InsertTextFormat.PlainText;
 
-            switch (completionDetails.CompletionType)
+            switch(completionDetails.CompletionType)
             {
                 case CompletionType.Type:
                 case CompletionType.Namespace:
@@ -262,13 +262,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     // Display PowerShell type names in [] to be consistent with PowerShell syntax
                     // and how the debugger displays type names.
                     var matches = Regex.Matches(completionDetails.ToolTipText, @"^(\[.+\])");
-                    if ((matches.Count > 0) && (matches[0].Groups.Count > 1))
+                    if((matches.Count > 0) && (matches [0].Groups.Count > 1))
                     {
-                        detailString = matches[0].Groups[1].Value;
+                        detailString = matches [0].Groups [1].Value;
                     }
                     // The comparison operators (-eq, -not, -gt, etc) are unfortunately fall into ParameterName
                     // but they don't have a type associated to them. This allows those tooltips to show up.
-                    else if (!string.IsNullOrEmpty(completionDetails.ToolTipText))
+                    else if(!string.IsNullOrEmpty(completionDetails.ToolTipText))
                     {
                         detailString = completionDetails.ToolTipText;
                     }
@@ -276,14 +276,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 case CompletionType.Command:
                     // For Commands, let's extract the resolved command or the path for an exe
                     // from the ToolTipText - if there is any ToolTipText.
-                    if (completionDetails.ToolTipText != null)
+                    if(completionDetails.ToolTipText != null)
                     {
                         // Fix for #240 - notepad++.exe in tooltip text caused regex parser to throw.
                         string escapedToolTipText = Regex.Escape(completionDetails.ToolTipText);
 
                         // Don't display ToolTipText if it is the same as the ListItemText.
                         // Reject command syntax ToolTipText - it's too much to display as a detailString.
-                        if (!completionDetails.ListItemText.Equals(
+                        if(!completionDetails.ListItemText.Equals(
                                 completionDetails.ToolTipText,
                                 StringComparison.OrdinalIgnoreCase) &&
                             !Regex.IsMatch(completionDetails.ToolTipText,
@@ -303,7 +303,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     // https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 
                     // Since we want to use a "tab stop" we need to escape a few things for Textmate to render properly.
-                    if (EndsWithQuote(completionText))
+                    if(EndsWithQuote(completionText))
                     {
                         var sb = new StringBuilder(completionDetails.CompletionText)
                             .Replace(@"\", @"\\")
@@ -355,7 +355,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private static CompletionItemKind MapCompletionKind(CompletionType completionType)
         {
-            switch (completionType)
+            switch(completionType)
             {
                 case CompletionType.Command:
                     return CompletionItemKind.Function;
@@ -383,12 +383,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private static bool EndsWithQuote(string text)
         {
-            if (string.IsNullOrEmpty(text))
+            if(string.IsNullOrEmpty(text))
             {
                 return false;
             }
 
-            char lastChar = text[text.Length - 1];
+            char lastChar = text [text.Length - 1];
             return lastChar == '"' || lastChar == '\'';
         }
     }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -48,13 +48,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     request.Position.Character + 1);
 
             List<LocationOrLocationLink> definitionLocations = new List<LocationOrLocationLink>();
-            if (foundSymbol != null)
+            if(foundSymbol != null)
             {
                 SymbolReference foundDefinition = await _symbolsService.GetDefinitionOfSymbolAsync(
                         scriptFile,
                         foundSymbol).ConfigureAwait(false);
 
-                if (foundDefinition != null)
+                if(foundDefinition != null)
                 {
                     definitionLocations.Add(
                         new LocationOrLocationLink(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -49,18 +49,18 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 request.Position.Line + 1,
                 request.Position.Character + 1);
 
-            if (symbolOccurrences == null)
+            if(symbolOccurrences == null)
             {
                 return Task.FromResult(s_emptyHighlightContainer);
             }
 
-            var highlights = new DocumentHighlight[symbolOccurrences.Count];
-            for (int i = 0; i < symbolOccurrences.Count; i++)
+            var highlights = new DocumentHighlight [symbolOccurrences.Count];
+            for(int i = 0; i < symbolOccurrences.Count; i++)
             {
-                highlights[i] = new DocumentHighlight
+                highlights [i] = new DocumentHighlight
                 {
                     Kind = DocumentHighlightKind.Write, // TODO: Which symbol types are writable?
-                    Range = symbolOccurrences[i].ScriptRegion.ToRange()
+                    Range = symbolOccurrences [i].ScriptRegion.ToRange()
                 };
             }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -25,13 +25,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     {
         private readonly ILogger _logger;
         private readonly WorkspaceService _workspaceService;
-        private readonly IDocumentSymbolProvider[] _providers;
+        private readonly IDocumentSymbolProvider [] _providers;
 
         public PsesDocumentSymbolHandler(ILoggerFactory factory, ConfigurationService configurationService, WorkspaceService workspaceService)
         {
             _logger = factory.CreateLogger<PsesDocumentSymbolHandler>();
             _workspaceService = workspaceService;
-            _providers = new IDocumentSymbolProvider[]
+            _providers = new IDocumentSymbolProvider []
             {
                 new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
@@ -51,11 +51,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             IEnumerable<ISymbolReference> foundSymbols =
                 this.ProvideDocumentSymbols(scriptFile);
 
-            SymbolInformationOrDocumentSymbol[] symbols = null;
+            SymbolInformationOrDocumentSymbol [] symbols = null;
 
             string containerName = Path.GetFileNameWithoutExtension(scriptFile.FilePath);
 
-            if (foundSymbols != null)
+            if(foundSymbols != null)
             {
                 symbols =
                     foundSymbols
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             Stopwatch invokeTimer = new Stopwatch();
             List<TResult> providerResults = new List<TResult>();
 
-            foreach (var provider in this._providers)
+            foreach(var provider in this._providers)
             {
                 try
                 {
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     this._logger.LogTrace(
                         $"Invocation of provider '{provider.GetType().Name}' completed in {invokeTimer.ElapsedMilliseconds}ms.");
                 }
-                catch (Exception e)
+                catch(Exception e)
                 {
                     this._logger.LogException(
                         $"Exception caught while invoking provider {provider.GetType().Name}:",
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private static SymbolKind GetSymbolKind(SymbolType symbolType)
         {
-            switch (symbolType)
+            switch(symbolType)
             {
                 case SymbolType.Configuration:
                 case SymbolType.Function:
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             string name = symbolReference.SymbolName;
 
-            if (symbolReference.SymbolType == SymbolType.Configuration ||
+            if(symbolReference.SymbolType == SymbolType.Configuration ||
                 symbolReference.SymbolType == SymbolType.Function ||
                 symbolReference.SymbolType == SymbolType.Workflow)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -34,35 +34,36 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override Task<Container<FoldingRange>> Handle(FoldingRangeRequestParam request, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("FoldingRange request canceled for file: {0}", request.TextDocument.Uri);
                 return Task.FromResult(new Container<FoldingRange>());
             }
 
             // TODO Should be using dynamic registrations
-            if (!_configurationService.CurrentSettings.CodeFolding.Enable) { return null; }
+            if(!_configurationService.CurrentSettings.CodeFolding.Enable) { return null; }
 
             // Avoid crash when using untitled: scheme or any other scheme where the document doesn't
             // have a backing file.  https://github.com/PowerShell/vscode-powershell/issues/1676
             // Perhaps a better option would be to parse the contents of the document as a string
             // as opposed to reading a file but the scenario of "no backing file" probably doesn't
             // warrant the extra effort.
-            if (!_workspaceService.TryGetFile(request.TextDocument.Uri, out ScriptFile scriptFile)) { return null; }
+            if(!_workspaceService.TryGetFile(request.TextDocument.Uri, out ScriptFile scriptFile)) { return null; }
 
             var result = new List<FoldingRange>();
 
             // If we're showing the last line, decrement the Endline of all regions by one.
             int endLineOffset = _configurationService.CurrentSettings.CodeFolding.ShowLastLine ? -1 : 0;
 
-            foreach (FoldingReference fold in TokenOperations.FoldableReferences(scriptFile.ScriptTokens).References)
+            foreach(FoldingReference fold in TokenOperations.FoldableReferences(scriptFile.ScriptTokens).References)
             {
-                result.Add(new FoldingRange {
-                    EndCharacter   = fold.EndCharacter,
-                    EndLine        = fold.EndLine + endLineOffset,
-                    Kind           = fold.Kind,
+                result.Add(new FoldingRange
+                {
+                    EndCharacter = fold.EndCharacter,
+                    EndLine = fold.EndLine + endLineOffset,
+                    Kind = fold.Kind,
                     StartCharacter = fold.StartCharacter,
-                    StartLine      = fold.StartLine
+                    StartLine = fold.StartLine
                 });
             }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             };
 
             Range range = request.Range;
-            var rangeList = range == null ? null : new int[]
+            var rangeList = range == null ? null : new int []
             {
                 range.Start.Line + 1,
                 range.Start.Character + 1,
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 pssaSettings,
                 rangeList).ConfigureAwait(false);
 
-            if (formattedScript == null)
+            if(formattedScript == null)
             {
                 _logger.LogWarning("Formatting returned null. Returning original contents for file: {0}", scriptFile.DocumentUri);
                 formattedScript = scriptFile.Contents;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<Hover> Handle(HoverParams request, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("Hover request canceled for file: {0}", request.TextDocument.Uri);
                 return null;
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         request.Position.Line + 1,
                         request.Position.Character + 1).ConfigureAwait(false);
 
-            if (symbolDetails == null)
+            if(symbolDetails == null)
             {
                 return null;
             }
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             List<MarkedString> symbolInfo = new List<MarkedString>();
             symbolInfo.Add(new MarkedString("PowerShell", symbolDetails.DisplayString));
 
-            if (!string.IsNullOrEmpty(symbolDetails.Documentation))
+            if(!string.IsNullOrEmpty(symbolDetails.Documentation))
             {
                 symbolInfo.Add(new MarkedString("markdown", symbolDetails.Documentation));
             }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             CancellationToken cancellationToken)
         {
             ScriptFile file = _workspaceService.GetFile(identifier.TextDocument.Uri);
-            foreach (Token token in file.ScriptTokens)
+            foreach(Token token in file.ScriptTokens)
             {
                 PushToken(token, builder);
             }
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private static void PushToken(Token token, SemanticTokensBuilder builder)
         {
-            foreach (SemanticToken sToken in ConvertToSemanticTokens(token))
+            foreach(SemanticToken sToken in ConvertToSemanticTokens(token))
             {
                 builder.Push(
                     sToken.Line,
@@ -64,14 +64,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         internal static IEnumerable<SemanticToken> ConvertToSemanticTokens(Token token)
         {
-            if (token is StringExpandableToken stringExpandableToken)
+            if(token is StringExpandableToken stringExpandableToken)
             {
                 // Try parsing tokens within the string
-                if (stringExpandableToken.NestedTokens != null)
+                if(stringExpandableToken.NestedTokens != null)
                 {
-                    foreach (Token t in stringExpandableToken.NestedTokens)
+                    foreach(Token t in stringExpandableToken.NestedTokens)
                     {
-                        foreach (SemanticToken subToken in ConvertToSemanticTokens(t))
+                        foreach(SemanticToken subToken in ConvertToSemanticTokens(t))
                             yield return subToken;
                     }
                     yield break;
@@ -79,7 +79,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             SemanticTokenType mappedType = MapSemanticTokenType(token);
-            if (mappedType == null)
+            if(mappedType == null)
             {
                 yield break;
             }
@@ -96,35 +96,35 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private static SemanticTokenType MapSemanticTokenType(Token token)
         {
             // First check token flags
-            if ((token.TokenFlags & TokenFlags.Keyword) != 0)
+            if((token.TokenFlags & TokenFlags.Keyword) != 0)
             {
                 return SemanticTokenType.Keyword;
             }
 
-            if ((token.TokenFlags & TokenFlags.CommandName) != 0)
+            if((token.TokenFlags & TokenFlags.CommandName) != 0)
             {
                 return SemanticTokenType.Function;
             }
 
-            if (token.Kind != TokenKind.Generic && (token.TokenFlags &
+            if(token.Kind != TokenKind.Generic && (token.TokenFlags &
                 (TokenFlags.BinaryOperator | TokenFlags.UnaryOperator | TokenFlags.AssignmentOperator)) != 0)
             {
                 return SemanticTokenType.Operator;
             }
 
-            if ((token.TokenFlags & TokenFlags.TypeName) != 0)
+            if((token.TokenFlags & TokenFlags.TypeName) != 0)
             {
                 return SemanticTokenType.Type;
             }
 
             // This represents keys in hashtables and also properties like `Foo` in `$myVar.Foo`
-            if ((token.TokenFlags & TokenFlags.MemberName) != 0)
+            if((token.TokenFlags & TokenFlags.MemberName) != 0)
             {
                 return SemanticTokenType.Property;
             }
 
             // Only check token kind after checking flags
-            switch (token.Kind)
+            switch(token.Kind)
             {
                 case TokenKind.Comment:
                     return SemanticTokenType.Comment;

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -52,9 +52,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             var locations = new List<Location>();
 
-            if (referencesResult != null)
+            if(referencesResult != null)
             {
-                foreach (SymbolReference foundReference in referencesResult)
+                foreach(SymbolReference foundReference in referencesResult)
                 {
                     locations.Add(new Location
                     {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/SignatureHelpHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<SignatureHelp> Handle(SignatureHelpParams request, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
+            if(cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("SignatureHelp request canceled for file: {0}", request.TextDocument.Uri);
                 return new SignatureHelp();
@@ -58,23 +58,23 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     request.Position.Character + 1,
                     _powerShellContextService).ConfigureAwait(false);
 
-            if (parameterSets == null)
+            if(parameterSets == null)
             {
                 return new SignatureHelp();
             }
 
-            var signatures = new SignatureInformation[parameterSets.Signatures.Length];
-            for (int i = 0; i < signatures.Length; i++)
+            var signatures = new SignatureInformation [parameterSets.Signatures.Length];
+            for(int i = 0; i < signatures.Length; i++)
             {
                 var parameters = new List<ParameterInformation>();
-                foreach (ParameterInfo param in parameterSets.Signatures[i].Parameters)
+                foreach(ParameterInfo param in parameterSets.Signatures [i].Parameters)
                 {
                     parameters.Add(CreateParameterInfo(param));
                 }
 
-                signatures[i] = new SignatureInformation
+                signatures [i] = new SignatureInformation
                 {
-                    Label = parameterSets.CommandName + " " + parameterSets.Signatures[i].SignatureText,
+                    Label = parameterSets.CommandName + " " + parameterSets.Signatures [i].SignatureText,
                     Documentation = null,
                     Parameters = parameters,
                 };

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             ScriptFile changedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
             // A text change notification can batch multiple change requests
-            foreach (TextDocumentContentChangeEvent textChange in notification.ContentChanges)
+            foreach(TextDocumentContentChangeEvent textChange in notification.ContentChanges)
             {
                 changedFile.ApplyChange(
                     GetFileChangeDetails(
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Kick off script diagnostics without blocking the response
             // TODO: Get all recently edited files in the workspace
-            _analysisService.RunScriptDiagnostics(new ScriptFile[] { changedFile });
+            _analysisService.RunScriptDiagnostics(new ScriptFile [] { changedFile });
             return Unit.Task;
         }
 
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     notification.TextDocument.Uri,
                     notification.TextDocument.Text);
 
-            if (LspUtils.PowerShellDocumentSelector.IsMatch(new TextDocumentAttributes(
+            if(LspUtils.PowerShellDocumentSelector.IsMatch(new TextDocumentAttributes(
                 // We use a fake Uri because we only want to test the LanguageId here and not if the
                 // file ends in ps*1.
                 s_fakeUri,
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 // Kick off script diagnostics if we got a PowerShell file without blocking the response
                 // TODO: Get all recently edited files in the workspace
-                _analysisService.RunScriptDiagnostics(new ScriptFile[] { openedFile });
+                _analysisService.RunScriptDiagnostics(new ScriptFile [] { openedFile });
             }
 
             _logger.LogTrace("Finished opening document.");
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Find and close the file in the current session
             var fileToClose = _workspaceService.GetFile(notification.TextDocument.Uri);
 
-            if (fileToClose != null)
+            if(fileToClose != null)
             {
                 _workspaceService.CloseFile(fileToClose);
                 _analysisService.ClearMarkers(fileToClose);
@@ -107,9 +107,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             ScriptFile savedFile = _workspaceService.GetFile(notification.TextDocument.Uri);
 
-            if (savedFile != null)
+            if(savedFile != null)
             {
-                if (_remoteFileManagerService.IsUnderRemoteTempPath(savedFile.FilePath))
+                if(_remoteFileManagerService.IsUnderRemoteTempPath(savedFile.FilePath))
                 {
                     await _remoteFileManagerService.SaveRemoteFileAsync(savedFile.FilePath).ConfigureAwait(false);
                 }
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             // The protocol's positions are zero-based so add 1 to all offsets
 
-            if (changeRange == null) return new FileChange { InsertString = insertString, IsReload = true };
+            if(changeRange == null) return new FileChange { InsertString = insertString, IsReload = true };
 
             return new FileChange
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
     {
         #region Private Fields
 
-        private static readonly string[] s_newlines = new[]
+        private static readonly string [] s_newlines = new []
         {
             "\r\n",
             "\n"
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// Gets the array of Tokens representing the parsed script contents.
         /// </summary>
-        public Token[] ScriptTokens
+        public Token [] ScriptTokens
         {
             get;
             private set;
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// Gets the array of filepaths dot sourced in this ScriptFile
         /// </summary>
-        public string[] ReferencedFiles
+        public string [] ReferencedFiles
         {
             get;
             private set;
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>The lines in the string.</returns>
         internal static List<string> GetLinesInternal(string text)
         {
-            if (text == null)
+            if(text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
@@ -232,7 +232,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 "lineNumber", lineNumber,
                 1, this.FileLines.Count + 1);
 
-            return this.FileLines[lineNumber - 1];
+            return this.FileLines [lineNumber - 1];
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// </summary>
         /// <param name="bufferRange">The buffer range from which lines will be extracted.</param>
         /// <returns>An array of strings from the specified range of the file.</returns>
-        public string[] GetLinesInRange(BufferRange bufferRange)
+        public string [] GetLinesInRange(BufferRange bufferRange)
         {
             this.ValidatePosition(bufferRange.Start);
             this.ValidatePosition(bufferRange.End);
@@ -250,9 +250,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             int startLine = bufferRange.Start.Line,
                 endLine = bufferRange.End.Line;
 
-            for (int line = startLine; line <= endLine; line++)
+            for(int line = startLine; line <= endLine; line++)
             {
-                string currentLine = this.FileLines[line - 1];
+                string currentLine = this.FileLines [line - 1];
                 int startColumn =
                     line == startLine
                     ? bufferRange.Start.Column
@@ -294,17 +294,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         public void ValidatePosition(int line, int column)
         {
             int maxLine = this.FileLines.Count;
-            if (line < 1 || line > maxLine)
+            if(line < 1 || line > maxLine)
             {
                 throw new ArgumentOutOfRangeException($"Position {line}:{column} is outside of the line range of 1 to {maxLine}.");
             }
 
             // The maximum column is either **one past** the length of the string
             // or 1 if the string is empty.
-            string lineString = this.FileLines[line - 1];
+            string lineString = this.FileLines [line - 1];
             int maxColumn = lineString.Length > 0 ? lineString.Length + 1 : 1;
 
-            if (column < 1 || column > maxColumn)
+            if(column < 1 || column > maxColumn)
             {
                 throw new ArgumentOutOfRangeException($"Position {line}:{column} is outside of the column range of 1 to {maxColumn}.");
             }
@@ -317,12 +317,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         public void ApplyChange(FileChange fileChange)
         {
             // Break up the change lines
-            string[] changeLines = fileChange.InsertString.Split('\n');
+            string [] changeLines = fileChange.InsertString.Split('\n');
 
-            if (fileChange.IsReload)
+            if(fileChange.IsReload)
             {
                 this.FileLines.Clear();
-                foreach (var changeLine in changeLines)
+                foreach(var changeLine in changeLines)
                 {
                     this.FileLines.Add(changeLine);
                 }
@@ -332,9 +332,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 // VSCode sometimes likes to give the change start line as (FileLines.Count + 1).
                 // This used to crash EditorServices, but we now treat it as an append.
                 // See https://github.com/PowerShell/vscode-powershell/issues/1283
-                if (fileChange.Line == this.FileLines.Count + 1)
+                if(fileChange.Line == this.FileLines.Count + 1)
                 {
-                    foreach (string addedLine in changeLines)
+                    foreach(string addedLine in changeLines)
                     {
                         string finalLine = addedLine.TrimEnd('\r');
                         this.FileLines.Add(finalLine);
@@ -342,7 +342,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 }
                 // Similarly, when lines are deleted from the end of the file,
                 // VSCode likes to give the end line as (FileLines.Count + 1).
-                else if (fileChange.EndLine == this.FileLines.Count + 1 && String.Empty.Equals(fileChange.InsertString))
+                else if(fileChange.EndLine == this.FileLines.Count + 1 && String.Empty.Equals(fileChange.InsertString))
                 {
                     int lineIndex = fileChange.Line - 1;
                     this.FileLines.RemoveRange(lineIndex, this.FileLines.Count - lineIndex);
@@ -355,37 +355,37 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
                     // Get the first fragment of the first line
                     string firstLineFragment =
-                    this.FileLines[fileChange.Line - 1]
+                    this.FileLines [fileChange.Line - 1]
                         .Substring(0, fileChange.Offset - 1);
 
                     // Get the last fragment of the last line
-                    string endLine = this.FileLines[fileChange.EndLine - 1];
+                    string endLine = this.FileLines [fileChange.EndLine - 1];
                     string lastLineFragment =
                     endLine.Substring(
                         fileChange.EndOffset - 1,
-                        (this.FileLines[fileChange.EndLine - 1].Length - fileChange.EndOffset) + 1);
+                        (this.FileLines [fileChange.EndLine - 1].Length - fileChange.EndOffset) + 1);
 
                     // Remove the old lines
-                    for (int i = 0; i <= fileChange.EndLine - fileChange.Line; i++)
+                    for(int i = 0; i <= fileChange.EndLine - fileChange.Line; i++)
                     {
                         this.FileLines.RemoveAt(fileChange.Line - 1);
                     }
 
                     // Build and insert the new lines
                     int currentLineNumber = fileChange.Line;
-                    for (int changeIndex = 0; changeIndex < changeLines.Length; changeIndex++)
+                    for(int changeIndex = 0; changeIndex < changeLines.Length; changeIndex++)
                     {
                         // Since we split the lines above using \n, make sure to
                         // trim the ending \r's off as well.
-                        string finalLine = changeLines[changeIndex].TrimEnd('\r');
+                        string finalLine = changeLines [changeIndex].TrimEnd('\r');
 
                         // Should we add first or last line fragments?
-                        if (changeIndex == 0)
+                        if(changeIndex == 0)
                         {
                             // Append the first line fragment
                             finalLine = firstLineFragment + finalLine;
                         }
-                        if (changeIndex == changeLines.Length - 1)
+                        if(changeIndex == changeLines.Length - 1)
                         {
                             // Append the last line fragment
                             finalLine = finalLine + lastLineFragment;
@@ -415,9 +415,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             int offset = 0;
 
-            for (int i = 0; i < lineNumber; i++)
+            for(int i = 0; i < lineNumber; i++)
             {
-                if (i == lineNumber - 1)
+                if(i == lineNumber - 1)
                 {
                     // Subtract 1 to account for 1-based column numbering
                     offset += columnNumber - 1;
@@ -425,7 +425,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 else
                 {
                     // Add an offset to account for the current platform's newline characters
-                    offset += this.FileLines[i].Length + Environment.NewLine.Length;
+                    offset += this.FileLines [i].Length + Environment.NewLine.Length;
                 }
             }
 
@@ -450,7 +450,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             this.ValidatePosition(newLine, newColumn);
 
-            string scriptLine = this.FileLines[newLine - 1];
+            string scriptLine = this.FileLines [newLine - 1];
             newColumn = Math.Min(scriptLine.Length + 1, newColumn);
 
             return new FilePosition(this, newLine, newColumn);
@@ -488,14 +488,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             BufferPosition endPosition = startPosition;
 
             int line = 0;
-            while (line < this.FileLines.Count)
+            while(line < this.FileLines.Count)
             {
-                if (searchedOffset <= currentOffset + this.FileLines[line].Length)
+                if(searchedOffset <= currentOffset + this.FileLines [line].Length)
                 {
                     int column = searchedOffset - currentOffset;
 
                     // Have we already found the start position?
-                    if (foundStart)
+                    if(foundStart)
                     {
                         // Assign the end position and end the search
                         endPosition = new BufferPosition(line + 1, column + 1);
@@ -506,7 +506,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                         startPosition = new BufferPosition(line + 1, column + 1);
 
                         // Do we only need to find the start position?
-                        if (startOffset == endOffset)
+                        if(startOffset == endOffset)
                         {
                             endPosition = startPosition;
                             break;
@@ -524,7 +524,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 }
 
                 // Increase the current offset and include newline length
-                currentOffset += this.FileLines[line].Length + Environment.NewLine.Length;
+                currentOffset += this.FileLines [line].Length + Environment.NewLine.Length;
                 line++;
             }
 
@@ -551,18 +551,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// </summary>
         private void ParseFileContents()
         {
-            ParseError[] parseErrors = null;
+            ParseError [] parseErrors = null;
 
             // First, get the updated file range
             int lineCount = this.FileLines.Count;
-            if (lineCount > 0)
+            if(lineCount > 0)
             {
                 this.FileRange =
                     new BufferRange(
                         new BufferPosition(1, 1),
                         new BufferPosition(
                             lineCount + 1,
-                            this.FileLines[lineCount - 1].Length + 1));
+                            this.FileLines [lineCount - 1].Length + 1));
             }
             else
             {
@@ -571,10 +571,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             try
             {
-                Token[] scriptTokens;
+                Token [] scriptTokens;
 
                 // This overload appeared with Windows 10 Update 1
-                if (this.powerShellVersion.Major >= 6 ||
+                if(this.powerShellVersion.Major >= 6 ||
                     (this.powerShellVersion.Major == 5 && this.powerShellVersion.Build >= 10586))
                 {
                     // Include the file path so that module relative
@@ -597,7 +597,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
                 this.ScriptTokens = scriptTokens;
             }
-            catch (RuntimeException ex)
+            catch(RuntimeException ex)
             {
                 var parseError =
                     new ParseError(
@@ -605,7 +605,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                         ex.ErrorRecord.FullyQualifiedErrorId,
                         ex.Message);
 
-                parseErrors = new[] { parseError };
+                parseErrors = new [] { parseError };
                 this.ScriptTokens = Array.Empty<Token>();
                 this.ScriptAst = null;
             }
@@ -620,7 +620,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             // Discussed in https://github.com/PowerShell/PowerShellEditorServices/pull/815.
             // Rather than working hard to enable things for untitled files like a phantom directory,
             // users should save the file.
-            if (IsInMemory)
+            if(IsInMemory)
             {
                 // Need to initialize the ReferencedFiles property to an empty array.
                 this.ReferencedFiles = Array.Empty<string>();

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// Gets or sets the list of ScriptRegions that define the edits to be made by the correction.
         /// </summary>
-        public ScriptRegion[] Edits { get; set; }
+        public ScriptRegion [] Edits { get; set; }
     }
 
     /// <summary>
@@ -34,19 +34,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <summary>
         /// Information: This warning is trivial, but may be useful. They are recommended by PowerShell best practice.
         /// </summary>
-        Information = 0,
+        Information = 0,
         /// <summary>
         /// WARNING: This warning may cause a problem or does not follow PowerShell's recommended guidelines.
         /// </summary>
-        Warning = 1,
+        Warning = 1,
         /// <summary>
         /// ERROR: This warning is likely to cause a problem or does not follow PowerShell's required guidelines.
         /// </summary>
-        Error = 2,
+        Error = 2,
         /// <summary>
         /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
         /// </summary>
-        ParseError = 3
+        ParseError = 3
     };
 
     /// <summary>
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             MarkerCorrection correction = null;
 
             // make sure psobject is of type DiagnosticRecord
-            if (!psObject.TypeNames.Contains(
+            if(!psObject.TypeNames.Contains(
                     "Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord",
                     StringComparer.OrdinalIgnoreCase))
             {
@@ -125,11 +125,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             // without having to go through PSObject's Members property.
             var diagnosticRecord = psObject as dynamic;
 
-            if (diagnosticRecord.SuggestedCorrections != null)
+            if(diagnosticRecord.SuggestedCorrections != null)
             {
                 var editRegions = new List<ScriptRegion>();
                 string correctionMessage = null;
-                foreach (dynamic suggestedCorrection in diagnosticRecord.SuggestedCorrections)
+                foreach(dynamic suggestedCorrection in diagnosticRecord.SuggestedCorrections)
                 {
                     editRegions.Add(
                         new ScriptRegion(
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             }
 
             string severity = diagnosticRecord.Severity.ToString();
-            if (!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
+            if(!Enum.TryParse(severity, out ScriptFileMarkerLevel level))
             {
                 throw new ArgumentException(
                     $"The provided DiagnosticSeverity value '{severity}' is unknown.",

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptRegion.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptRegion.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             {
                 scriptExtentText = scriptExtent.Text;
             }
-            catch (ArgumentOutOfRangeException)
+            catch(ArgumentOutOfRangeException)
             {
                 scriptExtentText = string.Empty;
             }

--- a/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/SemanticToken.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             TokenModifiers = tokenModifiers;
         }
 
-        public string Text { get; set ;}
+        public string Text { get; set; }
 
         public int Line { get; set; }
 

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             LanguageServerSettingsWrapper incomingSettings = request.Settings.ToObject<LanguageServerSettingsWrapper>();
             this._logger.LogTrace("Handling DidChangeConfiguration");
-            if (incomingSettings is null || incomingSettings.Powershell is null)
+            if(incomingSettings is null || incomingSettings.Powershell is null)
             {
                 this._logger.LogTrace("Incoming settings were null");
                 return await Unit.Task.ConfigureAwait(false);
@@ -70,9 +70,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 _workspaceService.WorkspacePath,
                 _logger);
 
-            if (!this._cwdSet)
+            if(!this._cwdSet)
             {
-                if (!string.IsNullOrEmpty(_configurationService.CurrentSettings.Cwd)
+                if(!string.IsNullOrEmpty(_configurationService.CurrentSettings.Cwd)
                     && Directory.Exists(_configurationService.CurrentSettings.Cwd))
                 {
                     this._logger.LogTrace($"Setting CWD (from config) to {_configurationService.CurrentSettings.Cwd}");
@@ -80,14 +80,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         _configurationService.CurrentSettings.Cwd,
                         isPathAlreadyEscaped: false).ConfigureAwait(false);
 
-                } else if (_workspaceService.WorkspacePath != null
-                    && Directory.Exists(_workspaceService.WorkspacePath))
+                }
+                else if(_workspaceService.WorkspacePath != null
+                  && Directory.Exists(_workspaceService.WorkspacePath))
                 {
                     this._logger.LogTrace($"Setting CWD (from workspace) to {_workspaceService.WorkspacePath}");
                     await _powerShellContextService.SetWorkingDirectoryAsync(
                         _workspaceService.WorkspacePath,
                         isPathAlreadyEscaped: false).ConfigureAwait(false);
-                } else {
+                }
+                else
+                {
                     this._logger.LogTrace("Tried to set CWD but in bad state");
                 }
 
@@ -98,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // - Profile loading is configured, AND
             //   - Profiles haven't been loaded before, OR
             //   - The profile loading configuration just changed
-            if (_configurationService.CurrentSettings.EnableProfileLoading
+            if(_configurationService.CurrentSettings.EnableProfileLoading
                 && (!this._profilesLoaded || !profileLoadingPreviouslyEnabled))
             {
                 this._logger.LogTrace("Loading profiles...");
@@ -109,7 +112,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // Wait until after profiles are loaded (or not, if that's the
             // case) before starting the interactive console.
-            if (!this._consoleReplStarted)
+            if(!this._consoleReplStarted)
             {
                 // Start the interactive terminal
                 this._logger.LogTrace("Starting command loop");
@@ -129,24 +132,24 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             //     "build/*": true
             // }
             var excludeFilePatterns = new List<string>();
-            if (incomingSettings.Files?.Exclude != null)
+            if(incomingSettings.Files?.Exclude != null)
             {
                 foreach(KeyValuePair<string, bool> patternEntry in incomingSettings.Files.Exclude)
                 {
-                    if (patternEntry.Value) { excludeFilePatterns.Add(patternEntry.Key); }
+                    if(patternEntry.Value) { excludeFilePatterns.Add(patternEntry.Key); }
                 }
             }
-            if (incomingSettings.Search?.Exclude != null)
+            if(incomingSettings.Search?.Exclude != null)
             {
                 foreach(KeyValuePair<string, bool> patternEntry in incomingSettings.Search.Exclude)
                 {
-                    if (patternEntry.Value && !excludeFilePatterns.Contains(patternEntry.Key)) { excludeFilePatterns.Add(patternEntry.Key); }
+                    if(patternEntry.Value && !excludeFilePatterns.Contains(patternEntry.Key)) { excludeFilePatterns.Add(patternEntry.Key); }
                 }
             }
             _workspaceService.ExcludeFilesGlob = excludeFilePatterns;
 
             // Convert the editor file search options to Workspace properties
-            if (incomingSettings.Search?.FollowSymlinks != null)
+            if(incomingSettings.Search?.FollowSymlinks != null)
             {
                 _workspaceService.FollowSymlinks = incomingSettings.Search.FollowSymlinks;
             }
@@ -156,7 +159,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         private void SendFeatureChangesTelemetry(LanguageServerSettingsWrapper incomingSettings)
         {
-            if (incomingSettings is null)
+            if(incomingSettings is null)
             {
                 this._logger.LogTrace("Incoming settings were null");
                 return;
@@ -164,43 +167,43 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             var configChanges = new Dictionary<string, bool>();
             // Send telemetry if the user opted-out of ScriptAnalysis
-            if (incomingSettings.Powershell.ScriptAnalysis.Enable == false &&
+            if(incomingSettings.Powershell.ScriptAnalysis.Enable == false &&
                 _configurationService.CurrentSettings.ScriptAnalysis.Enable != incomingSettings.Powershell.ScriptAnalysis.Enable)
             {
-                configChanges["ScriptAnalysis"] = incomingSettings.Powershell.ScriptAnalysis.Enable ?? false;
+                configChanges ["ScriptAnalysis"] = incomingSettings.Powershell.ScriptAnalysis.Enable ?? false;
             }
 
             // Send telemetry if the user opted-out of CodeFolding
-            if (!incomingSettings.Powershell.CodeFolding.Enable &&
+            if(!incomingSettings.Powershell.CodeFolding.Enable &&
                 _configurationService.CurrentSettings.CodeFolding.Enable != incomingSettings.Powershell.CodeFolding.Enable)
             {
-                configChanges["CodeFolding"] = incomingSettings.Powershell.CodeFolding.Enable;
+                configChanges ["CodeFolding"] = incomingSettings.Powershell.CodeFolding.Enable;
             }
 
             // Send telemetry if the user opted-out of the prompt to update PackageManagement
-            if (!incomingSettings.Powershell.PromptToUpdatePackageManagement &&
+            if(!incomingSettings.Powershell.PromptToUpdatePackageManagement &&
                 _configurationService.CurrentSettings.PromptToUpdatePackageManagement != incomingSettings.Powershell.PromptToUpdatePackageManagement)
             {
-                configChanges["PromptToUpdatePackageManagement"] = incomingSettings.Powershell.PromptToUpdatePackageManagement;
+                configChanges ["PromptToUpdatePackageManagement"] = incomingSettings.Powershell.PromptToUpdatePackageManagement;
             }
 
             // Send telemetry if the user opted-out of Profile loading
-            if (!incomingSettings.Powershell.EnableProfileLoading &&
+            if(!incomingSettings.Powershell.EnableProfileLoading &&
                 _configurationService.CurrentSettings.EnableProfileLoading != incomingSettings.Powershell.EnableProfileLoading)
             {
-                configChanges["ProfileLoading"] = incomingSettings.Powershell.EnableProfileLoading;
+                configChanges ["ProfileLoading"] = incomingSettings.Powershell.EnableProfileLoading;
             }
 
             // Send telemetry if the user opted-in to Pester 5+ CodeLens
-            if (!incomingSettings.Powershell.Pester.UseLegacyCodeLens &&
+            if(!incomingSettings.Powershell.Pester.UseLegacyCodeLens &&
                 _configurationService.CurrentSettings.Pester.UseLegacyCodeLens != incomingSettings.Powershell.Pester.UseLegacyCodeLens)
             {
                 // From our perspective we want to see how many people are opting in to this so we flip the value
-                configChanges["Pester5CodeLens"] = !incomingSettings.Powershell.Pester.UseLegacyCodeLens;
+                configChanges ["Pester5CodeLens"] = !incomingSettings.Powershell.Pester.UseLegacyCodeLens;
             }
 
             // No need to send any telemetry since nothing changed
-            if (configChanges.Count == 0)
+            if(configChanges.Count == 0)
             {
                 return;
             }

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -23,7 +23,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
 
-        public PsesWorkspaceSymbolsHandler(ILoggerFactory loggerFactory, SymbolsService symbols, WorkspaceService workspace) {
+        public PsesWorkspaceSymbolsHandler(ILoggerFactory loggerFactory, SymbolsService symbols, WorkspaceService workspace)
+        {
             _logger = loggerFactory.CreateLogger<PsesWorkspaceSymbolsHandler>();
             _symbolsService = symbols;
             _workspaceService = workspace;
@@ -35,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             var symbols = new List<SymbolInformation>();
 
-            foreach (ScriptFile scriptFile in _workspaceService.GetOpenedFiles())
+            foreach(ScriptFile scriptFile in _workspaceService.GetOpenedFiles())
             {
                 List<SymbolReference> foundSymbols =
                     _symbolsService.FindSymbolsInFile(
@@ -44,9 +45,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 // TODO: Need to compute a relative path that is based on common path for all workspace files
                 string containerName = Path.GetFileNameWithoutExtension(scriptFile.FilePath);
 
-                foreach (SymbolReference foundOccurrence in foundSymbols)
+                foreach(SymbolReference foundOccurrence in foundSymbols)
                 {
-                    if (!IsQueryMatch(request.Query, foundOccurrence.SymbolName))
+                    if(!IsQueryMatch(request.Query, foundOccurrence.SymbolName))
                     {
                         continue;
                     }
@@ -99,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             string name = symbolReference.SymbolName;
 
-            if (symbolReference.SymbolType == SymbolType.Configuration ||
+            if(symbolReference.SymbolType == SymbolType.Configuration ||
                 symbolReference.SymbolType == SymbolType.Function ||
                 symbolReference.SymbolType == SymbolType.Workflow)
             {

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -44,9 +44,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
             string workspaceRootPath,
             ILogger logger)
         {
-            if (settings != null)
+            if(settings != null)
             {
-                lock (updateLock)
+                lock(updateLock)
                 {
                     this.EnableProfileLoading = settings.EnableProfileLoading;
                     this.PromptToUpdatePackageManagement = settings.PromptToUpdatePackageManagement;
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
             string workspaceRootPath,
             ILogger logger)
         {
-            if (settings != null)
+            if(settings != null)
             {
                 lock(updateLock)
                 {
@@ -91,13 +91,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
                     try
                     {
-                        if (string.IsNullOrWhiteSpace(settingsPath))
+                        if(string.IsNullOrWhiteSpace(settingsPath))
                         {
                             settingsPath = null;
                         }
-                        else if (!Path.IsPathRooted(settingsPath))
+                        else if(!Path.IsPathRooted(settingsPath))
                         {
-                            if (string.IsNullOrEmpty(workspaceRootPath))
+                            if(string.IsNullOrEmpty(workspaceRootPath))
                             {
                                 // The workspace root path could be an empty string
                                 // when the user has opened a PowerShell script file
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                         this.SettingsPath = settingsPath;
                         logger.LogTrace($"Using Script Analyzer settings path - '{settingsPath ?? ""}'.");
                     }
-                    catch (Exception ex) when (
+                    catch(Exception ex) when(
                         ex is NotSupportedException ||
                         ex is PathTooLongException ||
                         ex is SecurityException)
@@ -202,12 +202,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         /// <param name="codeFormattingSettings">An instance of type CodeFormattingSettings.</param>
         public CodeFormattingSettings(CodeFormattingSettings codeFormattingSettings)
         {
-            if (codeFormattingSettings == null)
+            if(codeFormattingSettings == null)
             {
                 throw new ArgumentNullException(nameof(codeFormattingSettings));
             }
 
-            foreach (var prop in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            foreach(var prop in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {
                 prop.SetValue(this, prop.GetValue(codeFormattingSettings));
             }
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         public bool WhitespaceBeforeOpenParen { get; set; }
         public bool WhitespaceAroundOperator { get; set; }
         public bool WhitespaceAfterSeparator { get; set; }
-        public bool WhitespaceBetweenParameters  { get; set; }
+        public bool WhitespaceBetweenParameters { get; set; }
         public bool WhitespaceInsideBrace { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
@@ -245,27 +245,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
             ILogger logger)
         {
             var settings = GetCustomPSSASettingsHashtable(tabSize, insertSpaces);
-            var ruleSettings = (Hashtable)(settings["Rules"]);
-            var closeBraceSettings = (Hashtable)ruleSettings["PSPlaceCloseBrace"];
-            var openBraceSettings = (Hashtable)ruleSettings["PSPlaceOpenBrace"];
+            var ruleSettings = (Hashtable)(settings ["Rules"]);
+            var closeBraceSettings = (Hashtable)ruleSettings ["PSPlaceCloseBrace"];
+            var openBraceSettings = (Hashtable)ruleSettings ["PSPlaceOpenBrace"];
             switch(Preset)
             {
                 case CodeFormattingPreset.Allman:
-                    openBraceSettings["OnSameLine"] = false;
-                    openBraceSettings["NewLineAfter"] = true;
-                    closeBraceSettings["NewLineAfter"] = true;
+                    openBraceSettings ["OnSameLine"] = false;
+                    openBraceSettings ["NewLineAfter"] = true;
+                    closeBraceSettings ["NewLineAfter"] = true;
                     break;
 
                 case CodeFormattingPreset.OTBS:
-                    openBraceSettings["OnSameLine"] = true;
-                    openBraceSettings["NewLineAfter"] = true;
-                    closeBraceSettings["NewLineAfter"] = false;
+                    openBraceSettings ["OnSameLine"] = true;
+                    openBraceSettings ["NewLineAfter"] = true;
+                    closeBraceSettings ["NewLineAfter"] = false;
                     break;
 
                 case CodeFormattingPreset.Stroustrup:
-                    openBraceSettings["OnSameLine"] = true;
-                    openBraceSettings["NewLineAfter"] = true;
-                    closeBraceSettings["NewLineAfter"] = true;
+                    openBraceSettings ["OnSameLine"] = true;
+                    openBraceSettings ["NewLineAfter"] = true;
+                    closeBraceSettings ["NewLineAfter"] = true;
                     break;
 
                 default:
@@ -320,7 +320,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                 }},
             };
 
-            if (AutoCorrectAliases)
+            if(AutoCorrectAliases)
             {
                 // Empty hashtable required to activate the rule,
                 // since PSAvoidUsingCmdletAliases inherits from IScriptRule and not ConfigurableRule
@@ -366,12 +366,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
             CodeFoldingSettings settings,
             ILogger logger)
         {
-            if (settings != null) {
-                if (this.Enable != settings.Enable) {
+            if(settings != null)
+            {
+                if(this.Enable != settings.Enable)
+                {
                     this.Enable = settings.Enable;
                     logger.LogTrace(string.Format("Using Code Folding Enabled - {0}", this.Enable));
                 }
-                if (this.ShowLastLine != settings.ShowLastLine) {
+                if(this.ShowLastLine != settings.ShowLastLine)
+                {
                     this.ShowLastLine = settings.ShowLastLine;
                     logger.LogTrace(string.Format("Using Code Folding ShowLastLine - {0}", this.ShowLastLine));
                 }

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceFileSystemWrapper.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceFileSystemWrapper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
     internal class WorkspaceFileSystemWrapperFactory
     {
         private readonly DirectoryInfoBase _rootDirectory;
-        private readonly string[] _allowedExtensions;
+        private readonly string [] _allowedExtensions;
         private readonly bool _ignoreReparsePoints;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
         /// <param name="allowedExtensions">An array of file extensions that will be visible from the factory. For example [".ps1", ".psm1"]</param>
         /// <param name="ignoreReparsePoints">Whether objects which are Reparse Points should be ignored. https://docs.microsoft.com/en-us/windows/desktop/fileio/reparse-points</param>
         /// <param name="logger">An ILogger implementation used for writing log messages.</param>
-        public WorkspaceFileSystemWrapperFactory(String rootPath, int recursionDepthLimit, string[] allowedExtensions, bool ignoreReparsePoints, ILogger logger)
+        public WorkspaceFileSystemWrapperFactory(String rootPath, int recursionDepthLimit, string [] allowedExtensions, bool ignoreReparsePoints, ILogger logger)
         {
             MaxRecursionDepth = recursionDepthLimit;
             _rootDirectory = new WorkspaceFileSystemDirectoryWrapper(this, new DirectoryInfo(rootPath), 0);
@@ -77,12 +77,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
         internal IEnumerable<FileSystemInfo> SafeEnumerateFileSystemInfos(DirectoryInfo dirInfo)
         {
             // Find the subdirectories
-            string[] subDirs;
+            string [] subDirs;
             try
             {
                 subDirs = Directory.GetDirectories(dirInfo.FullName, "*", SearchOption.TopDirectoryOnly);
             }
-            catch (DirectoryNotFoundException e)
+            catch(DirectoryNotFoundException e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate directories in the path '{dirInfo.FullName}' due to it being an invalid path",
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (PathTooLongException e)
+            catch(PathTooLongException e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate directories in the path '{dirInfo.FullName}' due to the path being too long",
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            catch(Exception e) when(e is SecurityException || e is UnauthorizedAccessException)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate directories in the path '{dirInfo.FullName}' due to the path not being accessible",
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate directories in the path '{dirInfo.FullName}' due to an exception",
@@ -114,20 +114,20 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            foreach (string dirPath in subDirs)
+            foreach(string dirPath in subDirs)
             {
                 var subDirInfo = new DirectoryInfo(dirPath);
-                if (_ignoreReparsePoints && (subDirInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
+                if(_ignoreReparsePoints && (subDirInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
                 yield return subDirInfo;
             }
 
             // Find the files
-            string[] filePaths;
+            string [] filePaths;
             try
             {
                 filePaths = Directory.GetFiles(dirInfo.FullName, "*", SearchOption.TopDirectoryOnly);
             }
-            catch (DirectoryNotFoundException e)
+            catch(DirectoryNotFoundException e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate files in the path '{dirInfo.FullName}' due to it being an invalid path",
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (PathTooLongException e)
+            catch(PathTooLongException e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate files in the path '{dirInfo.FullName}' due to the path being too long",
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            catch(Exception e) when(e is SecurityException || e is UnauthorizedAccessException)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate files in the path '{dirInfo.FullName}' due to the path not being accessible",
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 Logger.LogHandledException(
                     $"Could not enumerate files in the path '{dirInfo.FullName}' due to an exception",
@@ -159,14 +159,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
 
                 yield break;
             }
-            foreach (string filePath in filePaths)
+            foreach(string filePath in filePaths)
             {
                 var fileInfo = new FileInfo(filePath);
-                if (_allowedExtensions == null || _allowedExtensions.Length == 0) { yield return fileInfo; continue; }
-                if (_ignoreReparsePoints && (fileInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
-                foreach (string extension in _allowedExtensions)
+                if(_allowedExtensions == null || _allowedExtensions.Length == 0) { yield return fileInfo; continue; }
+                if(_ignoreReparsePoints && (fileInfo.Attributes & FileAttributes.ReparsePoint) != 0) { continue; }
+                foreach(string extension in _allowedExtensions)
                 {
-                    if (fileInfo.Extension == extension) { yield return fileInfo; break; }
+                    if(fileInfo.Extension == extension) { yield return fileInfo; break; }
                 }
             }
         }
@@ -198,10 +198,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
         /// <inheritdoc />
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
         {
-            if (!_concreteDirectoryInfo.Exists || _depth >= _fsWrapperFactory.MaxRecursionDepth) { yield break; }
-            foreach (FileSystemInfo fileSystemInfo in _fsWrapperFactory.SafeEnumerateFileSystemInfos(_concreteDirectoryInfo))
+            if(!_concreteDirectoryInfo.Exists || _depth >= _fsWrapperFactory.MaxRecursionDepth) { yield break; }
+            foreach(FileSystemInfo fileSystemInfo in _fsWrapperFactory.SafeEnumerateFileSystemInfos(_concreteDirectoryInfo))
             {
-                switch (fileSystemInfo)
+                switch(fileSystemInfo)
                 {
                     case DirectoryInfo dirInfo:
                         yield return _fsWrapperFactory.CreateDirectoryInfoWrapper(dirInfo, _depth + 1);
@@ -228,12 +228,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
         {
             bool isParentPath = string.Equals(name, "..", StringComparison.Ordinal);
 
-            if (isParentPath) { return ParentDirectory; }
+            if(isParentPath) { return ParentDirectory; }
 
             var dirs = _concreteDirectoryInfo.GetDirectories(name);
 
-            if (dirs.Length == 1) { return _fsWrapperFactory.CreateDirectoryInfoWrapper(dirs[0], _depth + 1); }
-            if (dirs.Length == 0) { return null; }
+            if(dirs.Length == 1) { return _fsWrapperFactory.CreateDirectoryInfoWrapper(dirs [0], _depth + 1); }
+            if(dirs.Length == 0) { return null; }
             // This shouldn't happen. The parameter name isn't supposed to contain wild card.
             throw new InvalidOperationException(
                 string.Format(
@@ -262,25 +262,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
             {
                 return _fsWrapperFactory.CreateDirectoryInfoWrapper(_concreteDirectoryInfo.Parent, _depth - 1);
             }
-            catch (DirectoryNotFoundException e)
+            catch(DirectoryNotFoundException e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to it being an invalid path",
                     e);
             }
-            catch (PathTooLongException e)
+            catch(PathTooLongException e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to the path being too long",
                     e);
             }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            catch(Exception e) when(e is SecurityException || e is UnauthorizedAccessException)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to the path not being accessible",
                     e);
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteDirectoryInfo.FullName}' due to an exception",
@@ -339,25 +339,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.Workspace
             {
                 return _fsWrapperFactory.CreateDirectoryInfoWrapper(_concreteFileInfo.Directory, _depth);
             }
-            catch (DirectoryNotFoundException e)
+            catch(DirectoryNotFoundException e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteFileInfo.FullName}' due to it being an invalid path",
                     e);
             }
-            catch (PathTooLongException e)
+            catch(PathTooLongException e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteFileInfo.FullName}' due to the path being too long",
                     e);
             }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            catch(Exception e) when(e is SecurityException || e is UnauthorizedAccessException)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteFileInfo.FullName}' due to the path not being accessible",
                     e);
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 _fsWrapperFactory.Logger.LogHandledException(
                     $"Could not get parent of '{_concreteFileInfo.FullName}' due to an exception",

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         #region Private Fields
 
         // List of all file extensions considered PowerShell files in the .Net Core Framework.
-        private static readonly string[] s_psFileExtensionsCoreFramework =
+        private static readonly string [] s_psFileExtensionsCoreFramework =
         {
             ".ps1",
             ".psm1",
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         // .Net Core doesn't appear to use the same three letter pattern matching rule although the docs
         // suggest it should be find the '.ps1xml' files because we search for the pattern '*.ps1'.
         // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
-        private static readonly string[] s_psFileExtensionsFullFramework =
+        private static readonly string [] s_psFileExtensionsFullFramework =
         {
             ".ps1",
             ".psm1",
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         };
 
         // An array of globs which includes everything.
-        private static readonly string[] s_psIncludeAllGlob = new []
+        private static readonly string [] s_psIncludeAllGlob = new []
         {
             "**/*"
         };
@@ -143,12 +143,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 : documentUri.ToString().ToLower();
 
             // Make sure the file isn't already loaded into the workspace
-            if (!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile))
+            if(!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile))
             {
                 // This method allows FileNotFoundException to bubble up
                 // if the file isn't found.
-                using (FileStream fileStream = new FileStream(documentUri.GetFileSystemPath(), FileMode.Open, FileAccess.Read))
-                using (StreamReader streamReader = new StreamReader(fileStream, Encoding.UTF8))
+                using(FileStream fileStream = new FileStream(documentUri.GetFileSystemPath(), FileMode.Open, FileAccess.Read))
+                using(StreamReader streamReader = new StreamReader(fileStream, Encoding.UTF8))
                 {
                     scriptFile =
                         new ScriptFile(
@@ -156,7 +156,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             streamReader,
                             this.powerShellVersion);
 
-                    this.workspaceFiles[keyName] = scriptFile;
+                    this.workspaceFiles [keyName] = scriptFile;
                 }
 
                 this.logger.LogDebug("Opened file on disk: " + documentUri.ToString());
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
         public bool TryGetFile(DocumentUri documentUri, out ScriptFile scriptFile)
         {
-            switch (documentUri.Scheme)
+            switch(documentUri.Scheme)
             {
                 // List supported schemes here
                 case "file":
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 scriptFile = GetFile(documentUri);
                 return true;
             }
-            catch (Exception e) when (
+            catch(Exception e) when(
                 e is NotSupportedException ||
                 e is FileNotFoundException ||
                 e is DirectoryNotFoundException ||
@@ -270,7 +270,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 : documentUri.ToString().ToLower();
 
             // Make sure the file isn't already loaded into the workspace
-            if (!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile) && initialBuffer != null)
+            if(!this.workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile) && initialBuffer != null)
             {
                 scriptFile =
                     new ScriptFile(
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         initialBuffer,
                         this.powerShellVersion);
 
-                this.workspaceFiles[keyName] = scriptFile;
+                this.workspaceFiles [keyName] = scriptFile;
 
                 this.logger.LogDebug("Opened file as in-memory buffer: " + documentUri.ToString());
             }
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Gets an array of all opened ScriptFiles in the workspace.
         /// </summary>
         /// <returns>An array of all opened ScriptFiles in the workspace.</returns>
-        public ScriptFile[] GetOpenedFiles()
+        public ScriptFile [] GetOpenedFiles()
         {
             return workspaceFiles.Values.ToArray();
         }
@@ -313,7 +313,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="scriptFile">Contains the details and contents of an open script file</param>
         /// <returns>A scriptfile array where the first file
         /// in the array is the "root file" of the search</returns>
-        public ScriptFile[] ExpandScriptReferences(ScriptFile scriptFile)
+        public ScriptFile [] ExpandScriptReferences(ScriptFile scriptFile)
         {
             Dictionary<string, ScriptFile> referencedScriptFiles = new Dictionary<string, ScriptFile>();
             List<ScriptFile> expandedReferences = new List<ScriptFile>();
@@ -327,7 +327,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             referencedScriptFiles.Remove(scriptFile.Id);
             expandedReferences.Add(scriptFile);
 
-            if (referencedScriptFiles.Count > 0)
+            if(referencedScriptFiles.Count > 0)
             {
                 expandedReferences.AddRange(referencedScriptFiles.Values);
             }
@@ -344,7 +344,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             string resolvedPath = filePath;
 
-            if (!IsPathInMemory(filePath) && !string.IsNullOrEmpty(this.WorkspacePath))
+            if(!IsPathInMemory(filePath) && !string.IsNullOrEmpty(this.WorkspacePath))
             {
                 Uri workspaceUri = new Uri(this.WorkspacePath);
                 Uri fileUri = new Uri(filePath);
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 resolvedPath = workspaceUri.MakeRelativeUri(fileUri).ToString();
 
                 // Convert the directory separators if necessary
-                if (System.IO.Path.DirectorySeparatorChar == '\\')
+                if(System.IO.Path.DirectorySeparatorChar == '\\')
                 {
                     resolvedPath = resolvedPath.Replace('/', '\\');
                 }
@@ -380,20 +380,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <returns>An enumerator over the PowerShell files found in the workspace.</returns>
         public IEnumerable<string> EnumeratePSFiles(
-            string[] excludeGlobs,
-            string[] includeGlobs,
+            string [] excludeGlobs,
+            string [] includeGlobs,
             int maxDepth,
             bool ignoreReparsePoints
         )
         {
-            if (WorkspacePath == null || !Directory.Exists(WorkspacePath))
+            if(WorkspacePath == null || !Directory.Exists(WorkspacePath))
             {
                 yield break;
             }
 
             var matcher = new Matcher();
-            foreach (string pattern in includeGlobs) { matcher.AddInclude(pattern); }
-            foreach (string pattern in excludeGlobs) { matcher.AddExclude(pattern); }
+            foreach(string pattern in includeGlobs) { matcher.AddInclude(pattern); }
+            foreach(string pattern in excludeGlobs) { matcher.AddExclude(pattern); }
 
             var fsFactory = new WorkspaceFileSystemWrapperFactory(
                 WorkspacePath,
@@ -403,7 +403,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 logger
             );
             var fileMatchResult = matcher.Execute(fsFactory.RootDirectory);
-            foreach (FilePatternMatch item in fileMatchResult.Files)
+            foreach(FilePatternMatch item in fileMatchResult.Files)
             {
                 // item.Path always contains forward slashes in paths when it should be backslashes on Windows.
                 // Since we're returning strings here, it's important to use the correct directory separator.
@@ -430,7 +430,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 ? WorkspacePath
                 : Path.GetDirectoryName(scriptFile.FilePath);
 
-            foreach (string referencedFileName in scriptFile.ReferencedFiles)
+            foreach(string referencedFileName in scriptFile.ReferencedFiles)
             {
                 string resolvedScriptPath =
                     this.ResolveRelativeScriptPath(
@@ -438,7 +438,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         referencedFileName);
 
                 // If there was an error resolving the string, skip this reference
-                if (resolvedScriptPath == null)
+                if(resolvedScriptPath == null)
                 {
                     continue;
                 }
@@ -450,12 +450,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         resolvedScriptPath));
 
                 // Get the referenced file if it's not already in referencedScriptFiles
-                if (TryGetFile(resolvedScriptPath, out ScriptFile referencedFile))
+                if(TryGetFile(resolvedScriptPath, out ScriptFile referencedFile))
                 {
                     // Normalize the resolved script path and add it to the
                     // referenced files list if it isn't there already
                     resolvedScriptPath = resolvedScriptPath.ToLower();
-                    if (!referencedScriptFiles.ContainsKey(resolvedScriptPath))
+                    if(!referencedScriptFiles.ContainsKey(resolvedScriptPath))
                     {
                         referencedScriptFiles.Add(resolvedScriptPath, referencedFile);
                         RecursivelyFindReferences(referencedFile, referencedScriptFiles);
@@ -479,7 +479,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 var uri = new Uri(filePath);
                 isInMemory = !uri.IsFile;
             }
-            catch (UriFormatException)
+            catch(UriFormatException)
             {
                 // Relative file paths cause a UriFormatException.
                 // In this case, fallback to using Path.GetFullPath().
@@ -487,11 +487,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 {
                     Path.GetFullPath(filePath);
                 }
-                catch (Exception ex) when (ex is ArgumentException || ex is NotSupportedException)
+                catch(Exception ex) when(ex is ArgumentException || ex is NotSupportedException)
                 {
                     isInMemory = true;
                 }
-                catch (PathTooLongException)
+                catch(PathTooLongException)
                 {
                     // If we ever get here, it should be an actual file so, not in memory
                 }
@@ -514,7 +514,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 // If the path is already absolute there's no need to resolve it relatively
                 // to the baseFilePath.
-                if (Path.IsPathRooted(relativePath))
+                if(Path.IsPathRooted(relativePath))
                 {
                     return relativePath;
                 }
@@ -527,21 +527,21 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             baseFilePath,
                             relativePath));
             }
-            catch (NotSupportedException e)
+            catch(NotSupportedException e)
             {
                 // Occurs if the path is incorrectly formatted for any reason.  One
                 // instance where this occurred is when a user had curly double-quote
                 // characters in their source instead of normal double-quotes.
                 resolveException = e;
             }
-            catch (ArgumentException e)
+            catch(ArgumentException e)
             {
                 // Occurs if the path contains invalid characters, specifically those
                 // listed in System.IO.Path.InvalidPathChars.
                 resolveException = e;
             }
 
-            if (resolveException != null)
+            if(resolveException != null)
             {
                 this.logger.LogError(
                     $"Could not resolve relative script path\r\n" +

--- a/src/PowerShellEditorServices/Utility/AsyncQueue.cs
+++ b/src/PowerShellEditorServices/Utility/AsyncQueue.cs
@@ -69,16 +69,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </returns>
         public async Task EnqueueAsync(T item)
         {
-            using (await queueLock.LockAsync().ConfigureAwait(false))
+            using(await queueLock.LockAsync().ConfigureAwait(false))
             {
                 TaskCompletionSource<T> requestTaskSource = null;
 
                 // Are any requests waiting?
-                while (this.requestQueue.Count > 0)
+                while(this.requestQueue.Count > 0)
                 {
                     // Is the next request cancelled already?
                     requestTaskSource = this.requestQueue.Dequeue();
-                    if (!requestTaskSource.Task.IsCanceled)
+                    if(!requestTaskSource.Task.IsCanceled)
                     {
                         // Dispatch the item
                         requestTaskSource.SetResult(item);
@@ -98,12 +98,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="item">The item to be added to the queue.</param>
         public void Enqueue(T item)
         {
-            using (queueLock.Lock())
+            using(queueLock.Lock())
             {
-                while (this.requestQueue.Count > 0)
+                while(this.requestQueue.Count > 0)
                 {
                     var requestTaskSource = this.requestQueue.Dequeue();
-                    if (requestTaskSource.Task.IsCanceled)
+                    if(requestTaskSource.Task.IsCanceled)
                     {
                         continue;
                     }
@@ -144,9 +144,9 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         {
             Task<T> requestTask;
 
-            using (await queueLock.LockAsync(cancellationToken).ConfigureAwait(false))
+            using(await queueLock.LockAsync(cancellationToken).ConfigureAwait(false))
             {
-                if (this.itemQueue.Count > 0)
+                if(this.itemQueue.Count > 0)
                 {
                     // Items are waiting to be taken so take one immediately
                     T item = this.itemQueue.Dequeue();
@@ -194,9 +194,9 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public T Dequeue(CancellationToken cancellationToken)
         {
             TaskCompletionSource<T> requestTask;
-            using (queueLock.Lock(cancellationToken))
+            using(queueLock.Lock(cancellationToken))
             {
-                if (this.itemQueue.Count > 0)
+                if(this.itemQueue.Count > 0)
                 {
                     T item = this.itemQueue.Dequeue();
                     this.IsEmpty = this.itemQueue.Count == 0;
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 requestTask = new TaskCompletionSource<T>();
                 this.requestQueue.Enqueue(requestTask);
 
-                if (cancellationToken.CanBeCanceled)
+                if(cancellationToken.CanBeCanceled)
                 {
                     cancellationToken.Register(() => requestTask.TrySetCanceled());
                 }

--- a/src/PowerShellEditorServices/Utility/Extensions.cs
+++ b/src/PowerShellEditorServices/Utility/Extensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             {
                 str = obj.ToString();
             }
-            catch (Exception ex)
+            catch(Exception ex)
             {
                 str = $"<Error converting property value to string - {ex.Message}>";
             }
@@ -39,19 +39,19 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="elements">An enumerable object of type T</param>
         /// <param name="comparer">A comparer for ordering elements of type T. The comparer should handle null values.</param>
         /// <returns>An object of type T. If the enumerable is empty or has all null elements, then the method returns null.</returns>
-        public static T MaxElement<T>(this IEnumerable<T> elements, Func<T,T,int> comparer) where T:class
+        public static T MaxElement<T>(this IEnumerable<T> elements, Func<T, T, int> comparer) where T : class
         {
-            if (elements == null)
+            if(elements == null)
             {
                 throw new ArgumentNullException(nameof(elements));
             }
 
-            if (comparer == null)
+            if(comparer == null)
             {
                 throw new ArgumentNullException(nameof(comparer));
             }
 
-            if (!elements.Any())
+            if(!elements.Any())
             {
                 return null;
             }
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             var maxElement = elements.First();
             foreach(var element in elements.Skip(1))
             {
-                if (element != null && comparer(element, maxElement) > 0)
+                if(element != null && comparer(element, maxElement) > 0)
                 {
                     maxElement = element;
                 }
@@ -91,28 +91,28 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static int ExtentWidthComparer(this IScriptExtent extentX, IScriptExtent extentY)
         {
 
-            if (extentX == null && extentY == null)
+            if(extentX == null && extentY == null)
             {
                 return 0;
             }
 
-            if (extentX != null && extentY == null)
+            if(extentX != null && extentY == null)
             {
                 return 1;
             }
 
-            if (extentX == null)
+            if(extentX == null)
             {
                 return -1;
             }
 
             var extentWidthX = extentX.EndOffset - extentX.StartOffset;
             var extentWidthY = extentY.EndOffset - extentY.StartOffset;
-            if (extentWidthX > extentWidthY)
+            if(extentWidthX > extentWidthY)
             {
                 return 1;
             }
-            else if (extentWidthX < extentWidthY)
+            else if(extentWidthX < extentWidthY)
             {
                 return -1;
             }
@@ -131,17 +131,17 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <returns>True if the coordinates are wholly contained in the instance's extent, otherwise, false.</returns>
         public static bool Contains(this IScriptExtent scriptExtent, int line, int column)
         {
-            if (scriptExtent.StartLineNumber > line || scriptExtent.EndLineNumber < line)
+            if(scriptExtent.StartLineNumber > line || scriptExtent.EndLineNumber < line)
             {
                 return false;
             }
 
-            if (scriptExtent.StartLineNumber == line)
+            if(scriptExtent.StartLineNumber == line)
             {
                 return scriptExtent.StartColumnNumber <= column;
             }
 
-            if (scriptExtent.EndLineNumber == line)
+            if(scriptExtent.EndLineNumber == line)
             {
                 return scriptExtent.EndColumnNumber >= column;
             }

--- a/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             // We need to make sure the user can't open the file associated with this stack frame.
             // It will generate a VSCode error in this case.
             Source source = null;
-            if (!stackFrame.ScriptPath.Contains("<"))
+            if(!stackFrame.ScriptPath.Contains("<"))
             {
                 source = new Source
                 {

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -18,14 +18,14 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             var ctor = typeof(Command).GetConstructor(
                 BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
                 binder: null,
-                new[] { typeof(CommandInfo) },
+                new [] { typeof(CommandInfo) },
                 modifiers: null);
 
             ParameterExpression commandInfo = Expression.Parameter(typeof(CommandInfo), nameof(commandInfo));
 
             s_commandCtor = Expression.Lambda<Func<CommandInfo, Command>>(
                 Expression.New(ctor, commandInfo),
-                new[] { commandInfo })
+                new [] { commandInfo })
                 .Compile();
         }
 

--- a/src/PowerShellEditorServices/Utility/Validate.cs
+++ b/src/PowerShellEditorServices/Utility/Validate.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="valueToCheck">The value of the parameter being validated.</param>
         public static void IsNotNull(string parameterName, object valueToCheck)
         {
-            if (valueToCheck == null)
+            if(valueToCheck == null)
             {
                 throw new ArgumentNullException(parameterName);
             }
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         {
             // TODO: Debug assert here if lowerLimit >= upperLimit
 
-            if (valueToCheck < lowerLimit || valueToCheck > upperLimit)
+            if(valueToCheck < lowerLimit || valueToCheck > upperLimit)
             {
                 throw new ArgumentOutOfRangeException(
                     parameterName,
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             int valueToCheck,
             int upperLimit)
         {
-            if (valueToCheck >= upperLimit)
+            if(valueToCheck >= upperLimit)
             {
                 throw new ArgumentOutOfRangeException(
                     parameterName,
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             int valueToCheck,
             int lowerLimit)
         {
-            if (valueToCheck < lowerLimit)
+            if(valueToCheck < lowerLimit)
             {
                 throw new ArgumentOutOfRangeException(
                     parameterName,
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             TValue valueToCheck,
             TValue undesiredValue)
         {
-            if (EqualityComparer<TValue>.Default.Equals(valueToCheck, undesiredValue))
+            if(EqualityComparer<TValue>.Default.Equals(valueToCheck, undesiredValue))
             {
                 throw new ArgumentException(
                     string.Format(
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <param name="valueToCheck">The value of the parameter being validated.</param>
         public static void IsNotNullOrEmptyString(string parameterName, string valueToCheck)
         {
-            if (string.IsNullOrWhiteSpace(valueToCheck))
+            if(string.IsNullOrWhiteSpace(valueToCheck))
             {
                 throw new ArgumentException(
                     "Parameter contains a null, empty, or whitespace string.",

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
@@ -22,7 +22,7 @@ namespace PowerShellEditorServices.Test.E2E
                 CreateTemporaryIntegratedConsole = false,
             }).ConfigureAwait(false);
 
-            if (launchResponse == null)
+            if(launchResponse == null)
             {
                 throw new Exception("Launch response was null.");
             }

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -51,13 +51,15 @@ namespace PowerShellEditorServices.Test.E2E
                     .WithOutput(_psesProcess.InputStream)
                     // The OnStarted delegate gets run when we receive the _Initialized_ event from the server:
                     // https://microsoft.github.io/debug-adapter-protocol/specification#Events_Initialized
-                    .OnStarted((client, token) => {
+                    .OnStarted((client, token) =>
+                    {
                         Started.SetResult(true);
                         return Task.CompletedTask;
                     })
                     // The OnInitialized delegate gets run when we first receive the _Initialize_ response:
                     // https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Initialize
-                    .OnInitialized((client, request, response, token) => {
+                    .OnInitialized((client, request, response, token) =>
+                    {
                         initialized.SetResult(true);
                         return Task.CompletedTask;
                     });
@@ -86,14 +88,14 @@ namespace PowerShellEditorServices.Test.E2E
             try
             {
                 await PsesDebugAdapterClient.RequestDisconnect(new DisconnectArguments
-                    {
-                        Restart = false,
-                        TerminateDebuggee = true
-                    }).ConfigureAwait(false);
+                {
+                    Restart = false,
+                    TerminateDebuggee = true
+                }).ConfigureAwait(false);
                 await _psesProcess.Stop().ConfigureAwait(false);
                 PsesDebugAdapterClient?.Dispose();
             }
-            catch (ObjectDisposedException)
+            catch(ObjectDisposedException)
             {
                 // Language client has a disposal bug in it
             }
@@ -108,19 +110,19 @@ namespace PowerShellEditorServices.Test.E2E
             return filePath;
         }
 
-        private string GenerateScriptFromLoggingStatements(params string[] logStatements)
+        private string GenerateScriptFromLoggingStatements(params string [] logStatements)
         {
-            if (logStatements.Length == 0)
+            if(logStatements.Length == 0)
             {
                 throw new ArgumentNullException("Expected at least one argument.");
             }
 
             // Have script create/overwrite file first with `>`.
-            StringBuilder builder = new StringBuilder().Append('\'').Append(logStatements[0]).Append("' > '").Append(s_testOutputPath).AppendLine("'");
-            for (int i = 1; i < logStatements.Length; i++)
+            StringBuilder builder = new StringBuilder().Append('\'').Append(logStatements [0]).Append("' > '").Append(s_testOutputPath).AppendLine("'");
+            for(int i = 1; i < logStatements.Length; i++)
             {
                 // Then append to that script with `>>`.
-                builder.Append('\'').Append(logStatements[i]).Append("' >> '").Append(s_testOutputPath).AppendLine("'");
+                builder.Append('\'').Append(logStatements [i]).Append("' >> '").Append(s_testOutputPath).AppendLine("'");
             }
 
             _output.WriteLine("Script is:");
@@ -128,7 +130,7 @@ namespace PowerShellEditorServices.Test.E2E
             return builder.ToString();
         }
 
-        private string[] GetLog()
+        private string [] GetLog()
         {
             return File.ReadLines(s_testOutputPath).ToArray();
         }
@@ -159,8 +161,8 @@ namespace PowerShellEditorServices.Test.E2E
             // At this point the script should be running so lets give it time
             await Task.Delay(2000).ConfigureAwait(false);
 
-            string[] log = GetLog();
-            Assert.Equal("works", log[0]);
+            string [] log = GetLog();
+            Assert.Equal("works", log [0]);
         }
 
         [Trait("Category", "DAP")]
@@ -187,8 +189,8 @@ namespace PowerShellEditorServices.Test.E2E
                     Name = Path.GetFileName(filePath),
                     Path = filePath
                 },
-                Lines = new long[] { 2 },
-                Breakpoints = new SourceBreakpoint[]
+                Lines = new long [] { 2 },
+                Breakpoints = new SourceBreakpoint []
                 {
                     new SourceBreakpoint
                     {
@@ -209,7 +211,7 @@ namespace PowerShellEditorServices.Test.E2E
             // At this point the script should be running so lets give it time
             await Task.Delay(2000).ConfigureAwait(false);
 
-            string[] log = GetLog();
+            string [] log = GetLog();
             Assert.Single(log, (i) => i == "before breakpoint");
 
             ContinueResponse continueResponse = await PsesDebugAdapterClient.RequestContinue(new ContinueArguments

--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -61,15 +61,15 @@ namespace PowerShellEditorServices.Test.E2E
                     .OnTelemetryEvent(telemetryEventParams => TelemetryEvents.Add(
                         new PsesTelemetryEvent
                         {
-                            EventName = (string)telemetryEventParams.ExtensionData["eventName"],
-                            Data = telemetryEventParams.ExtensionData["data"] as JObject
+                            EventName = (string)telemetryEventParams.ExtensionData ["eventName"],
+                            Data = telemetryEventParams.ExtensionData ["data"] as JObject
                         }));
 
                 // Enable all capabilities this this is for testing.
                 // This will be a built in feature of the Omnisharp client at some point.
                 var capabilityTypes = typeof(ICapability).Assembly.GetExportedTypes()
                     .Where(z => typeof(ICapability).IsAssignableFrom(z) && z.IsClass && !z.IsAbstract);
-                foreach (Type capabilityType in capabilityTypes)
+                foreach(Type capabilityType in capabilityTypes)
                 {
                     options.WithCapability(Activator.CreateInstance(capabilityType, Array.Empty<object>()) as ICapability);
                 }
@@ -99,7 +99,7 @@ namespace PowerShellEditorServices.Test.E2E
                 await _psesProcess.Stop().ConfigureAwait(false);
                 PsesLanguageClient?.Dispose();
             }
-            catch (ObjectDisposedException)
+            catch(ObjectDisposedException)
             {
                 // Language client has a disposal bug in it
             }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -221,10 +221,10 @@ function CanSendWorkspaceSymbolRequest {
             });
 
             await WaitForDiagnosticsAsync();
-            if (Diagnostics.Count > 1)
+            if(Diagnostics.Count > 1)
             {
                 StringBuilder errorBuilder = new StringBuilder().AppendLine("Multiple diagnostics found when there should be only 1:");
-                foreach (Diagnostic diag in Diagnostics)
+                foreach(Diagnostic diag in Diagnostics)
                 {
                     errorBuilder.AppendLine(diag.Message);
                 }
@@ -399,16 +399,16 @@ Get-Process
                     {
                         Range = new Range
                         {
-                        Start = new Position
-                        {
-                            Line = 2,
-                            Character = 0
-                        },
-                        End = new Position
-                        {
-                            Line = 3,
-                            Character = 0
-                        }
+                            Start = new Position
+                            {
+                                Line = 2,
+                                Character = 0
+                            },
+                            End = new Position
+                            {
+                                Line = 3,
+                                Character = 0
+                            }
                         },
                         TextDocument = new TextDocumentIdentifier
                         {
@@ -454,7 +454,8 @@ CanSendDocumentSymbolRequest
                     .Returning<SymbolInformationOrDocumentSymbolContainer>(CancellationToken.None);
 
             Assert.Collection(symbolInformationOrDocumentSymbols,
-                symInfoOrDocSym => {
+                symInfoOrDocSym =>
+                {
                     Range range = symInfoOrDocSym.SymbolInformation.Location.Range;
 
                     Assert.Equal(1, range.Start.Line);
@@ -587,7 +588,7 @@ Write-Host 'Goodbye'
             // Wait for the process to start.
             Thread.Sleep(1000);
 
-            PSHostProcessResponse[] pSHostProcessResponses = null;
+            PSHostProcessResponse [] pSHostProcessResponses = null;
 
             try
             {
@@ -596,7 +597,7 @@ Write-Host 'Goodbye'
                         .SendRequest<GetPSHostProcesssesParams>(
                             "powerShell/getPSHostProcesses",
                             new GetPSHostProcesssesParams { })
-                        .Returning<PSHostProcessResponse[]>(CancellationToken.None);
+                        .Returning<PSHostProcessResponse []>(CancellationToken.None);
             }
             finally
             {
@@ -629,7 +630,7 @@ Write-Host 'Goodbye'
             // Wait for the process to start.
             Thread.Sleep(1000);
 
-            RunspaceResponse[] runspaceResponses = null;
+            RunspaceResponse [] runspaceResponses = null;
             try
             {
                 runspaceResponses =
@@ -640,7 +641,7 @@ Write-Host 'Goodbye'
                             {
                                 ProcessId = $"{process.Id}"
                             })
-                        .Returning<RunspaceResponse[]>(CancellationToken.None);
+                        .Returning<RunspaceResponse []>(CancellationToken.None);
             }
             finally
             {
@@ -1146,7 +1147,7 @@ function CanSendGetCommentHelpRequest {
                     .Returning<CommentHelpRequestResult>(CancellationToken.None);
 
             Assert.NotEmpty(commentHelpRequestResult.Content);
-            Assert.Contains("myParam", commentHelpRequestResult.Content[7]);
+            Assert.Contains("myParam", commentHelpRequestResult.Content [7]);
         }
 
         [Trait("Category", "LSP")]
@@ -1225,7 +1226,7 @@ function CanSendGetCommentHelpRequest {
 
             // More information about how this data is generated can be found at
             // https://github.com/microsoft/vscode-extension-samples/blob/5ae1f7787122812dcc84e37427ca90af5ee09f14/semantic-tokens-sample/vscode.proposed.d.ts#L71
-            var expectedArr = new int[5]
+            var expectedArr = new int [5]
                 {
                     // line, index, token length, token type, token modifiers
                     0, 0, scriptContent.Length, 1, 0 //function token: line 0, index 0, length of script, type 1 = keyword, no modifiers

--- a/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
@@ -34,11 +34,11 @@ namespace PowerShellEditorServices.Test.E2E
             $"pses_test_logs_{Path.GetRandomFileName()}");
 
         const string s_logLevel = "Diagnostic";
-        readonly static string[] s_featureFlags = { "PSReadLine" };
+        readonly static string [] s_featureFlags = { "PSReadLine" };
         const string s_hostName = "TestHost";
         const string s_hostProfileId = "TestHost";
         const string s_hostVersion = "1.0.0";
-        private readonly static string[] s_additionalModules = { "PowerShellEditorServices.VSCode" };
+        private readonly static string [] s_additionalModules = { "PowerShellEditorServices.VSCode" };
 
         #endregion
 
@@ -68,7 +68,7 @@ namespace PowerShellEditorServices.Test.E2E
                 FileName = PwshExe
             };
 
-            foreach (string arg in GeneratePsesArguments(isDebugAdapter))
+            foreach(string arg in GeneratePsesArguments(isDebugAdapter))
             {
                 processStartInfo.ArgumentList.Add(arg);
             }
@@ -76,7 +76,7 @@ namespace PowerShellEditorServices.Test.E2E
             return processStartInfo;
         }
 
-        private static string[] GeneratePsesArguments(bool isDebugAdapter)
+        private static string [] GeneratePsesArguments(bool isDebugAdapter)
         {
             List<string> args = new List<string>
             {
@@ -94,7 +94,7 @@ namespace PowerShellEditorServices.Test.E2E
                 "-Stdio"
             };
 
-            if (isDebugAdapter)
+            if(isDebugAdapter)
             {
                 args.Add("-DebugServiceOnly");
             }
@@ -102,7 +102,7 @@ namespace PowerShellEditorServices.Test.E2E
             string base64Str = Convert.ToBase64String(
                 System.Text.Encoding.Unicode.GetBytes(string.Join(' ', args)));
 
-            return new string[]
+            return new string []
             {
                 "-NoLogo",
                 "-NoProfile",

--- a/test/PowerShellEditorServices.Test.E2E/Processes/ServerProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/ServerProcess.cs
@@ -23,7 +23,7 @@ namespace PowerShellEditorServices.Test.E2E
         /// </param>
         protected ServerProcess(ILoggerFactory loggerFactory)
         {
-            if (loggerFactory == null)
+            if(loggerFactory == null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
             }

--- a/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/StdioServerProcess.cs
@@ -37,7 +37,7 @@ namespace PowerShellEditorServices.Test.E2E
         public StdioServerProcess(ILoggerFactory loggerFactory, ProcessStartInfo serverStartInfo)
             : base(loggerFactory)
         {
-            if (serverStartInfo == null)
+            if(serverStartInfo == null)
             {
                 throw new ArgumentNullException(nameof(serverStartInfo));
             }
@@ -53,12 +53,12 @@ namespace PowerShellEditorServices.Test.E2E
         /// </param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            if(disposing)
             {
                 Process serverProcess = Interlocked.Exchange(ref _serverProcess, null);
-                if (serverProcess != null)
+                if(serverProcess != null)
                 {
-                    if (!serverProcess.HasExited)
+                    if(!serverProcess.HasExited)
                     {
                         serverProcess.Kill();
                     }
@@ -102,7 +102,7 @@ namespace PowerShellEditorServices.Test.E2E
             };
             serverProcess.Exited += ServerProcess_Exit;
 
-            if (!serverProcess.Start())
+            if(!serverProcess.Start())
             {
                 throw new InvalidOperationException("Failed to launch language server .");
             }
@@ -118,7 +118,7 @@ namespace PowerShellEditorServices.Test.E2E
         public override async Task Stop()
         {
             Process serverProcess = Interlocked.Exchange(ref _serverProcess, null);
-            if (serverProcess != null && !serverProcess.HasExited)
+            if(serverProcess != null && !serverProcess.HasExited)
             {
                 serverProcess.Kill();
             }

--- a/test/PowerShellEditorServices.Test.E2E/xunit.runner.json
+++ b/test/PowerShellEditorServices.Test.E2E/xunit.runner.json
@@ -1,4 +1,3 @@
 {
   "parallelizeTestCollections": false
 }
-

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
 {
     internal class CompleteCommandFromModule
     {
-        private static readonly string[] s_getRandomParamSets = {
+        private static readonly string [] s_getRandomParamSets = {
             "Get-Random [[-Maximum] <Object>] [-SetSeed <int>] [-Minimum <Object>] [<CommonParameters>]",
             "Get-Random [-InputObject] <Object[]> [-SetSeed <int>] [-Count <int>] [<CommonParameters>]"
         };

--- a/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
+++ b/test/PowerShellEditorServices.Test.Shared/TestUtilities/TestUtilities.cs
@@ -14,9 +14,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared
     /// </summary>
     public static class TestUtilities
     {
-        private static readonly char[] s_unixPathSeparators = new [] { '/' };
+        private static readonly char [] s_unixPathSeparators = new [] { '/' };
 
-        private static readonly char[] s_unixNewlines = new [] { '\n' };
+        private static readonly char [] s_unixNewlines = new [] { '\n' };
 
         /// <summary>
         /// Takes a UNIX-style path and converts it to the path appropriate to the platform.
@@ -25,12 +25,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared
         /// <returns>A path with directories separated by the appropriate separator.</returns>
         public static string NormalizePath(string unixPath)
         {
-            if (unixPath == null)
+            if(unixPath == null)
             {
                 return unixPath;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return unixPath.Replace('/', Path.DirectorySeparatorChar);
             }
@@ -45,12 +45,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared
         /// <returns>The platform-newline-normalized string.</returns>
         public static string NormalizeNewlines(string unixString)
         {
-            if (unixString == null)
+            if(unixString == null)
             {
                 return unixString;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 return String.Join(Environment.NewLine, unixString.Split(s_unixNewlines));
             }
@@ -76,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared
             [CallerFilePath] string callerPath = null,
             [CallerLineNumber] int callerLine = -1)
         {
-            if (Debugger.IsAttached)
+            if(Debugger.IsAttached)
             {
                 return;
             }

--- a/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Console/ChoicePromptHandlerTests.cs
@@ -11,8 +11,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
 {
     public class ChoicePromptHandlerTests
     {
-        private readonly ChoiceDetails[] Choices =
-            new ChoiceDetails[]
+        private readonly ChoiceDetails [] Choices =
+            new ChoiceDetails []
             {
                 new ChoiceDetails("&Apple", ""),
                 new ChoiceDetails("Ba&nana", ""),

--- a/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/LanguageServiceTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                         // On Windows, Location points to a temp directory.
                         ? typeof(LanguageServiceTests).Assembly.CodeBase
                         : typeof(LanguageServiceTests).Assembly.Location),
-                    "..","..","..","..",
+                    "..", "..", "..", "..",
                     "PowerShellEditorServices.Test.Shared");
 
         public LanguageServiceTests()
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.NotEmpty(completionResults.Completions);
             Assert.Equal(
                 CompleteCommandInFile.ExpectedCompletion,
-                completionResults.Completions[0]);
+                completionResults.Completions [0]);
         }
 
         [Trait("Category", "Completions")]
@@ -82,15 +82,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             Assert.Equal(
                 CompleteCommandFromModule.ExpectedCompletion.CompletionText,
-                completionResults.Completions[0].CompletionText
+                completionResults.Completions [0].CompletionText
             );
 
             Assert.Equal(
                 CompleteCommandFromModule.ExpectedCompletion.CompletionType,
-                completionResults.Completions[0].CompletionType
+                completionResults.Completions [0].CompletionType
             );
 
-            Assert.NotNull(completionResults.Completions[0].ToolTipText);
+            Assert.NotNull(completionResults.Completions [0].ToolTipText);
         }
 
         [Trait("Category", "Completions")]
@@ -109,15 +109,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             Assert.Equal(
                 CompleteTypeName.ExpectedCompletion.CompletionText,
-                completionResults.Completions[0].CompletionText
+                completionResults.Completions [0].CompletionText
             );
 
             Assert.Equal(
                 CompleteTypeName.ExpectedCompletion.CompletionType,
-                completionResults.Completions[0].CompletionType
+                completionResults.Completions [0].CompletionType
             );
 
-            Assert.NotNull(completionResults.Completions[0].ToolTipText);
+            Assert.NotNull(completionResults.Completions [0].ToolTipText);
         }
 
         [Trait("Category", "Completions")]
@@ -136,15 +136,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
             Assert.Equal(
                 CompleteNamespace.ExpectedCompletion.CompletionText,
-                completionResults.Completions[0].CompletionText
+                completionResults.Completions [0].CompletionText
             );
 
             Assert.Equal(
                 CompleteNamespace.ExpectedCompletion.CompletionType,
-                completionResults.Completions[0].CompletionType
+                completionResults.Completions [0].CompletionType
             );
 
-            Assert.NotNull(completionResults.Completions[0].ToolTipText);
+            Assert.NotNull(completionResults.Completions [0].ToolTipText);
         }
 
         [Trait("Category", "Completions")]
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.Single(completionResults.Completions);
             Assert.Equal(
                 CompleteVariableInFile.ExpectedCompletion,
-                completionResults.Completions[0]);
+                completionResults.Completions [0]);
         }
 
         [Trait("Category", "Completions")]
@@ -325,10 +325,10 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                 this.GetReferences(
                     FindsReferencesOnBuiltInCommandWithAlias.SourceDetails);
 
-            SymbolReference[] foundRefs = refsResult.ToArray();
+            SymbolReference [] foundRefs = refsResult.ToArray();
             Assert.Equal(4, foundRefs.Length);
-            Assert.Equal("gci", foundRefs[1].SymbolName);
-            Assert.Equal("Get-ChildItem", foundRefs[foundRefs.Length - 1].SymbolName);
+            Assert.Equal("gci", foundRefs [1].SymbolName);
+            Assert.Equal("Get-ChildItem", foundRefs [foundRefs.Length - 1].SymbolName);
         }
 
         [Trait("Category", "Symbols")]
@@ -340,7 +340,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
                     FindsReferencesOnBuiltInCommandWithAlias.SourceDetails);
 
             Assert.Equal(4, refsResult.Count());
-            Assert.Equal("dir", refsResult.ToArray()[2].SymbolName);
+            Assert.Equal("dir", refsResult.ToArray() [2].SymbolName);
             Assert.Equal("Get-ChildItem", refsResult.Last().SymbolName);
         }
 

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -31,10 +31,10 @@ function Get-Sum {
                 text,
                 Version.Parse("5.0"));
 
-            foreach (Token t in scriptFile.ScriptTokens)
+            foreach(Token t in scriptFile.ScriptTokens)
             {
                 List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(t));
-                switch (t.Text)
+                switch(t.Text)
                 {
                     case "function":
                     case "param":
@@ -68,11 +68,11 @@ function Get-Sum {
                 text,
                 Version.Parse("5.0"));
 
-            Token commandToken = scriptFile.ScriptTokens[0];
+            Token commandToken = scriptFile.ScriptTokens [0];
             List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(commandToken));
             Assert.Single(mappedTokens, sToken => SemanticTokenType.Function == sToken.Type);
 
-            Token stringExpandableToken = scriptFile.ScriptTokens[1];
+            Token stringExpandableToken = scriptFile.ScriptTokens [1];
             mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(stringExpandableToken));
             Assert.Collection(mappedTokens,
                 sToken => Assert.Equal(SemanticTokenType.Function, sToken.Type),
@@ -95,10 +95,10 @@ Get-A*A
                 text,
                 Version.Parse("5.0"));
 
-            foreach (Token t in scriptFile.ScriptTokens)
+            foreach(Token t in scriptFile.ScriptTokens)
             {
                 List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(t));
-                switch (t.Text)
+                switch(t.Text)
                 {
                     case "function":
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Keyword == sToken.Type);
@@ -120,10 +120,10 @@ Get-A*A
                 text,
                 Version.Parse("5.0"));
 
-            foreach (Token t in scriptFile.ScriptTokens)
+            foreach(Token t in scriptFile.ScriptTokens)
             {
                 List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(t));
-                switch (t.Text)
+                switch(t.Text)
                 {
                     case "$Array":
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Variable == sToken.Type);
@@ -145,14 +145,14 @@ Get-A*A
                 text,
                 Version.Parse("5.0"));
 
-            List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(scriptFile.ScriptTokens[0]));
+            List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(scriptFile.ScriptTokens [0]));
             Assert.Single(mappedTokens, sToken => SemanticTokenType.String == sToken.Type);
         }
 
         [Fact]
         public async Task RecognizeEnum()
         {
-            string text =  @"
+            string text = @"
 enum MyEnum{
     one
     two
@@ -165,10 +165,10 @@ enum MyEnum{
                 text,
                 Version.Parse("5.0"));
 
-            foreach (Token t in scriptFile.ScriptTokens)
+            foreach(Token t in scriptFile.ScriptTokens)
             {
                 List<SemanticToken> mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(t));
-                switch (t.Text)
+                switch(t.Text)
                 {
                     case "enum":
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Keyword == sToken.Type);

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -15,7 +15,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         /// <summary>
         /// Helper method to create a stub script file and then call FoldableRegions
         /// </summary>
-        private FoldingReference[] GetRegions(string text) {
+        private FoldingReference [] GetRegions(string text)
+        {
             ScriptFile scriptFile = new ScriptFile(
                 // Use any absolute path. Even if it doesn't exist.
                 DocumentUri.FromFileSystemPath(Path.Combine(Path.GetTempPath(), "TestFile.ps1")),
@@ -31,13 +32,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         /// <summary>
         /// Helper method to create FoldingReference objects with less typing
         /// </summary>
-        private static FoldingReference CreateFoldingReference(int startLine, int startCharacter, int endLine, int endCharacter, FoldingRangeKind? matchKind) {
-            return new FoldingReference {
-                StartLine      = startLine,
+        private static FoldingReference CreateFoldingReference(int startLine, int startCharacter, int endLine, int endCharacter, FoldingRangeKind? matchKind)
+        {
+            return new FoldingReference
+            {
+                StartLine = startLine,
                 StartCharacter = startCharacter,
-                EndLine        = endLine,
-                EndCharacter   = endCharacter,
-                Kind           = matchKind
+                EndLine = endLine,
+                EndCharacter = endCharacter,
+                Kind = matchKind
             };
         }
 
@@ -131,7 +134,7 @@ valid} = 5
 $foo = 'bar'
 #EnDReGion
 ";
-        private FoldingReference[] expectedAllInOneScriptFolds = {
+        private FoldingReference [] expectedAllInOneScriptFolds = {
             CreateFoldingReference(0,   0,  4, 10, FoldingRangeKind.Region),
             CreateFoldingReference(1,   0,  3,  2, FoldingRangeKind.Comment),
             CreateFoldingReference(10,  0, 15,  2, FoldingRangeKind.Comment),
@@ -154,45 +157,49 @@ $foo = 'bar'
         /// Assertion helper to compare two FoldingReference arrays.
         /// </summary>
         private void AssertFoldingReferenceArrays(
-            FoldingReference[] expected,
-            FoldingReference[] actual)
+            FoldingReference [] expected,
+            FoldingReference [] actual)
         {
-            for (int index = 0; index < expected.Length; index++)
+            for(int index = 0; index < expected.Length; index++)
             {
-                Assert.Equal(expected[index], actual[index]);
+                Assert.Equal(expected [index], actual [index]);
             }
             Assert.Equal(expected.Length, actual.Length);
         }
 
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithLF() {
+        public void LaguageServiceFindsFoldablRegionsWithLF()
+        {
             // Remove and CR characters
             string testString = allInOneScript.Replace("\r", "");
             // Ensure that there are no CR characters in the string
             Assert.True(testString.IndexOf("\r\n") == -1, "CRLF should not be present in the test string");
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
             AssertFoldingReferenceArrays(expectedAllInOneScriptFolds, result);
         }
 
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithCRLF() {
+        public void LaguageServiceFindsFoldablRegionsWithCRLF()
+        {
             // The Foldable regions should be the same regardless of line ending type
             // Enforce CRLF line endings, if none exist
             string testString = allInOneScript;
-            if (testString.IndexOf("\r\n") == -1) {
+            if(testString.IndexOf("\r\n") == -1)
+            {
                 testString = testString.Replace("\n", "\r\n");
             }
             // Ensure that there are CRLF characters in the string
             Assert.True(testString.IndexOf("\r\n") != -1, "CRLF should be present in the teststring");
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
             AssertFoldingReferenceArrays(expectedAllInOneScriptFolds, result);
         }
 
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithMismatchedRegions() {
+        public void LaguageServiceFindsFoldablRegionsWithMismatchedRegions()
+        {
             string testString =
 @"#endregion should not fold - mismatched
 
@@ -202,17 +209,18 @@ $something = 'foldable'
 
 #region should not fold - mismatched
 ";
-            FoldingReference[] expectedFolds = {
+            FoldingReference [] expectedFolds = {
                 CreateFoldingReference(2, 0, 4, 10, FoldingRangeKind.Region)
             };
 
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
 
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithDuplicateRegions() {
+        public void LaguageServiceFindsFoldablRegionsWithDuplicateRegions()
+        {
             string testString =
 @"# This script causes duplicate/overlapping ranges due to the `(` and `{` characters
 $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
@@ -220,12 +228,12 @@ $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
         # Do Something
 })
 ";
-            FoldingReference[] expectedFolds = {
+            FoldingReference [] expectedFolds = {
                 CreateFoldingReference(1, 64, 2, 27, null),
                 CreateFoldingReference(2, 35, 4,  2, null)
             };
 
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
 
@@ -233,7 +241,8 @@ $AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
         // ( -> ), @( -> ) and $( -> ) does not confuse the folder
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithSameEndToken() {
+        public void LaguageServiceFindsFoldablRegionsWithSameEndToken()
+        {
             string testString =
 @"foreach ($1 in $2) {
 
@@ -246,13 +255,13 @@ $y = $(
     $arr = @('1', '2'); Write-Host ($arr)
 )
 ";
-            FoldingReference[] expectedFolds = {
+            FoldingReference [] expectedFolds = {
                 CreateFoldingReference(0, 19, 5, 1, null),
                 CreateFoldingReference(2,  9, 4, 5, null),
                 CreateFoldingReference(7,  5, 9, 1, null)
             };
 
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
@@ -260,7 +269,8 @@ $y = $(
         // A simple PowerShell Classes test
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithClasses() {
+        public void LaguageServiceFindsFoldablRegionsWithClasses()
+        {
             string testString =
 @"class TestClass {
     [string[]] $TestProperty = @(
@@ -273,13 +283,13 @@ $y = $(
     }
 }
 ";
-            FoldingReference[] expectedFolds = {
+            FoldingReference [] expectedFolds = {
                 CreateFoldingReference(0, 16, 9,  1, null),
                 CreateFoldingReference(1, 31, 4, 16, null),
                 CreateFoldingReference(6, 26, 8,  5, null)
             };
 
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }
@@ -287,7 +297,8 @@ $y = $(
         // This tests DSC style keywords and param blocks
         [Trait("Category", "Folding")]
         [Fact]
-        public void LaguageServiceFindsFoldablRegionsWithDSC() {
+        public void LaguageServiceFindsFoldablRegionsWithDSC()
+        {
             string testString =
 @"Configuration Example
 {
@@ -324,7 +335,7 @@ $y = $(
     }
 }
 ";
-            FoldingReference[] expectedFolds = {
+            FoldingReference [] expectedFolds = {
                 CreateFoldingReference(1,  0, 33, 1, null),
                 CreateFoldingReference(3,  4, 12, 5, null),
                 CreateFoldingReference(17, 4, 32, 5, null),
@@ -332,7 +343,7 @@ $y = $(
                 CreateFoldingReference(25, 8, 31, 9, null)
             };
 
-            FoldingReference[] result = GetRegions(testString);
+            FoldingReference [] result = GetRegions(testString);
 
             AssertFoldingReferenceArrays(expectedFolds, result);
         }

--- a/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
@@ -36,7 +36,7 @@ function
 
     FunctionNameOnDifferentLine
 ";
-        private static ScriptBlockAst s_ast = (ScriptBlockAst) ScriptBlock.Create(s_scriptString).Ast;
+        private static ScriptBlockAst s_ast = (ScriptBlockAst)ScriptBlock.Create(s_scriptString).Ast;
 
         [Trait("Category", "AstOperations")]
         [Theory]
@@ -53,25 +53,25 @@ function
         [Trait("Category", "AstOperations")]
         [Theory]
         [MemberData(nameof(FindReferencesOfSymbolAtPostionData), parameters: 3)]
-        public void CanFindReferencesOfSymbolAtPostion(int lineNumber, int columnNumber, Position[] positions)
+        public void CanFindReferencesOfSymbolAtPostion(int lineNumber, int columnNumber, Position [] positions)
         {
             SymbolReference symbol = AstOperations.FindSymbolAtPosition(s_ast, lineNumber, columnNumber);
 
             IEnumerable<SymbolReference> references = AstOperations.FindReferencesOfSymbol(s_ast, symbol, needsAliases: false);
 
             int positionsIndex = 0;
-            foreach (SymbolReference reference in references)
+            foreach(SymbolReference reference in references)
             {
-                Assert.Equal(positions[positionsIndex].Line, reference.ScriptRegion.StartLineNumber);
-                Assert.Equal(positions[positionsIndex].Character, reference.ScriptRegion.StartColumnNumber);
+                Assert.Equal(positions [positionsIndex].Line, reference.ScriptRegion.StartLineNumber);
+                Assert.Equal(positions [positionsIndex].Character, reference.ScriptRegion.StartColumnNumber);
 
                 positionsIndex++;
             }
         }
 
-        public static object[][] FindReferencesOfSymbolAtPostionData => s_findReferencesOfSymbolAtPostionData;
+        public static object [] [] FindReferencesOfSymbolAtPostionData => s_findReferencesOfSymbolAtPostionData;
 
-        private static readonly object[][] s_findReferencesOfSymbolAtPostionData = new object[][]
+        private static readonly object [] [] s_findReferencesOfSymbolAtPostionData = new object [] []
         {
             new object[] { 2, 3, new[] { new Position(1, 10), new Position(2, 1) } },
             new object[] { 7, 18, new[] { new Position(4, 19), new Position(7, 3) } },

--- a/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
 
             var psCommand = new System.Management.Automation.PSCommand().AddScript($". {quotedPath}");
 
-            using (var pwsh = System.Management.Automation.PowerShell.Create())
+            using(var pwsh = System.Management.Automation.PowerShell.Create())
             {
                 pwsh.Commands = psCommand;
                 pwsh.Invoke();

--- a/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PowerShellContextTests.cs
@@ -111,8 +111,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         [Fact]
         public async Task CanResolveAndLoadProfilesForHostId()
         {
-            string[] expectedProfilePaths =
-                new string[]
+            string [] expectedProfilePaths =
+                new string []
                 {
                     PowerShellContextFactory.TestProfilePaths.AllUsersAllHosts,
                     PowerShellContextFactory.TestProfilePaths.AllUsersCurrentHost,

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -180,13 +180,13 @@ namespace PSLanguageService.Test
         public void FindsDotSourcedFiles()
         {
             string exampleScriptContents = TestUtilities.PlatformNormalize(
-                ". ./athing.ps1\n"+
-                ". ./somefile.ps1\n"+
-                ". ./somefile.ps1\n"+
-                "Do-Stuff $uri\n"+
+                ". ./athing.ps1\n" +
+                ". ./somefile.ps1\n" +
+                ". ./somefile.ps1\n" +
+                "Do-Stuff $uri\n" +
                 ". simpleps.ps1");
 
-            using (StringReader stringReader = new StringReader(exampleScriptContents))
+            using(StringReader stringReader = new StringReader(exampleScriptContents))
             {
                 ScriptFile scriptFile =
                     new ScriptFile(
@@ -196,8 +196,8 @@ namespace PSLanguageService.Test
                         PowerShellVersion);
 
                 Assert.Equal(3, scriptFile.ReferencedFiles.Length);
-                System.Console.Write("a" + scriptFile.ReferencedFiles[0]);
-                Assert.Equal(TestUtilities.NormalizePath("./athing.ps1"), scriptFile.ReferencedFiles[0]);
+                System.Console.Write("a" + scriptFile.ReferencedFiles [0]);
+                Assert.Equal(TestUtilities.NormalizePath("./athing.ps1"), scriptFile.ReferencedFiles [0]);
             }
         }
 
@@ -242,7 +242,7 @@ namespace PSLanguageService.Test
 
         internal static ScriptFile CreateScriptFile(string initialString)
         {
-            using (StringReader stringReader = new StringReader(initialString))
+            using(StringReader stringReader = new StringReader(initialString))
             {
                 // Create an in-memory file from the StringReader
                 ScriptFile fileToChange =
@@ -278,11 +278,11 @@ namespace PSLanguageService.Test
         private static readonly string TestString_TrailingNewline = TestUtilities.NormalizeNewlines(
             TestString_NoTrailingNewline + "\n");
 
-        private static readonly string[] s_newLines = new string[] { Environment.NewLine };
+        private static readonly string [] s_newLines = new string [] { Environment.NewLine };
 
-        private static readonly string[] s_testStringLines_noTrailingNewline = TestString_NoTrailingNewline.Split(s_newLines, StringSplitOptions.None);
+        private static readonly string [] s_testStringLines_noTrailingNewline = TestString_NoTrailingNewline.Split(s_newLines, StringSplitOptions.None);
 
-        private static readonly string[] s_testStringLines_trailingNewline = TestString_TrailingNewline.Split(s_newLines, StringSplitOptions.None);
+        private static readonly string [] s_testStringLines_trailingNewline = TestString_TrailingNewline.Split(s_newLines, StringSplitOptions.None);
 
         private ScriptFile _scriptFile_trailingNewline;
 
@@ -301,19 +301,19 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanGetWholeLine()
         {
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(5, 1, 5, 10));
 
             Assert.Single(lines);
-            Assert.Equal("Line Five", lines[0]);
+            Assert.Equal("Line Five", lines [0]);
         }
 
         [Trait("Category", "ScriptFile")]
         [Fact]
         public void CanGetMultipleWholeLines()
         {
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(2, 1, 4, 10));
 
@@ -324,38 +324,38 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanGetSubstringInSingleLine()
         {
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(4, 3, 4, 8));
 
             Assert.Single(lines);
-            Assert.Equal("ne Fo", lines[0]);
+            Assert.Equal("ne Fo", lines [0]);
         }
 
         [Trait("Category", "ScriptFile")]
         [Fact]
         public void CanGetEmptySubstringRange()
         {
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(4, 3, 4, 3));
 
             Assert.Single(lines);
-            Assert.Equal("", lines[0]);
+            Assert.Equal("", lines [0]);
         }
 
         [Trait("Category", "ScriptFile")]
         [Fact]
         public void CanGetSubstringInMultipleLines()
         {
-            string[] expectedLines = new string[]
+            string [] expectedLines = new string []
             {
                 "Two",
                 "Line Three",
                 "Line Fou"
             };
 
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(2, 6, 4, 9));
 
@@ -366,14 +366,14 @@ namespace PSLanguageService.Test
         [Fact]
         public void CanGetRangeAtLineBoundaries()
         {
-            string[] expectedLines = new string[]
+            string [] expectedLines = new string []
             {
                 "",
                 "Line Three",
                 ""
             };
 
-            string[] lines =
+            string [] lines =
                 _scriptFile_noTrailingNewline.GetLinesInRange(
                     new BufferRange(2, 9, 4, 1));
 
@@ -408,7 +408,7 @@ namespace PSLanguageService.Test
         {
             var emptyFile = ScriptFileChangeTests.CreateScriptFile(string.Empty);
             Assert.Single(emptyFile.FileLines);
-            Assert.Equal(string.Empty, emptyFile.FileLines[0]);
+            Assert.Equal(string.Empty, emptyFile.FileLines [0]);
         }
 
         [Trait("Category", "ScriptFile")]
@@ -417,7 +417,7 @@ namespace PSLanguageService.Test
         {
             var spaceFile = ScriptFileChangeTests.CreateScriptFile(" ");
             Assert.Single(spaceFile.FileLines);
-            Assert.Equal(" ", spaceFile.FileLines[0]);
+            Assert.Equal(" ", spaceFile.FileLines [0]);
         }
     }
 
@@ -596,7 +596,7 @@ First line
     'foo'
 }";
 
-            using (StringReader stringReader = new StringReader(script))
+            using(StringReader stringReader = new StringReader(script))
             {
                 // Create an in-memory file from the StringReader
                 var scriptFile = new ScriptFile(DocumentUri.From(path), stringReader, PowerShellVersion);
@@ -620,7 +620,7 @@ First line
             ScriptFile scriptFile;
             var emptyStringReader = new StringReader("");
 
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if(Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
                 path = @"C:\Users\AmosBurton\projects\Rocinate\ProtoMolecule.ps1";
                 scriptFile = new ScriptFile(DocumentUri.FromFileSystemPath(path), emptyStringReader, PowerShellVersion);

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -48,22 +48,23 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
 
         internal static WorkspaceService FixturesWorkspace()
         {
-            return new WorkspaceService(NullLoggerFactory.Instance) {
+            return new WorkspaceService(NullLoggerFactory.Instance)
+            {
                 WorkspacePath = TestUtilities.NormalizePath("Fixtures/Workspace")
             };
         }
 
         // These are the default values for the EnumeratePSFiles() method
         // in Microsoft.PowerShell.EditorServices.Workspace class
-        private static string[] s_defaultExcludeGlobs        = new string[0];
-        private static string[] s_defaultIncludeGlobs        = new [] { "**/*" };
-        private static int      s_defaultMaxDepth            = 64;
-        private static bool     s_defaultIgnoreReparsePoints = false;
+        private static string [] s_defaultExcludeGlobs = new string [0];
+        private static string [] s_defaultIncludeGlobs = new [] { "**/*" };
+        private static int s_defaultMaxDepth = 64;
+        private static bool s_defaultIgnoreReparsePoints = false;
 
         internal static List<string> ExecuteEnumeratePSFiles(
             WorkspaceService workspace,
-            string[] excludeGlobs,
-            string[] includeGlobs,
+            string [] excludeGlobs,
+            string [] includeGlobs,
             int maxDepth,
             bool ignoreReparsePoints
         )
@@ -75,7 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 ignoreReparsePoints: ignoreReparsePoints
             );
             var fileList = new List<string>();
-            foreach (string file in result) { fileList.Add(file); }
+            foreach(string file in result) { fileList.Add(file); }
             // Assume order is not important from EnumeratePSFiles and sort the array so we can use deterministic asserts
             fileList.Sort();
 
@@ -95,25 +96,25 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 ignoreReparsePoints: s_defaultIgnoreReparsePoints
             );
 
-            if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
+            if(!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
             {
                 // .Net Core doesn't appear to use the same three letter pattern matching rule although the docs
                 // suggest it should be find the '.ps1xml' files because we search for the pattern '*.ps1'
                 // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
                 Assert.Equal(4, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList[2]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[3]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList [0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList [1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList [2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList [3]);
             }
             else
             {
                 Assert.Equal(5, fileList.Count);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList[0]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[1]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList[2]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "other", "other.ps1xml"), fileList[3]);
-                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[4]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"), fileList [0]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList [1]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"), fileList [2]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "other", "other.ps1xml"), fileList [3]);
+                Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList [4]);
             }
         }
 
@@ -131,7 +132,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             );
 
             Assert.Equal(1, fileList.Count);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[0]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList [0]);
         }
 
         [Fact]
@@ -141,15 +142,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             var workspace = FixturesWorkspace();
             var fileList = ExecuteEnumeratePSFiles(
                 workspace: workspace,
-                excludeGlobs: new [] {"**/donotfind*"},         // Exclude any files starting with donotfind
-                includeGlobs: new [] {"**/*.ps1", "**/*.psd1"}, // Only include PS1 and PSD1 files
+                excludeGlobs: new [] { "**/donotfind*" },         // Exclude any files starting with donotfind
+                includeGlobs: new [] { "**/*.ps1", "**/*.psd1" }, // Only include PS1 and PSD1 files
                 maxDepth: s_defaultMaxDepth,
                 ignoreReparsePoints: s_defaultIgnoreReparsePoints
             );
 
             Assert.Equal(2, fileList.Count);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList[0]);
-            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList[1]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"), fileList [0]);
+            Assert.Equal(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"), fileList [1]);
         }
 
         [Fact]
@@ -162,7 +163,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
             string shortUriForm = "git:/c%3A/Users/Keith/GitHub/dahlbyk/posh-git/src/PoshGitTypes.ps1?%7B%22path%22%3A%22c%3A%5C%5CUsers%5C%5CKeith%5C%5CGitHub%5C%5Cdahlbyk%5C%5Cposh-git%5C%5Csrc%5C%5CPoshGitTypes.ps1%22%2C%22ref%22%3A%22~%22%7D";
             string longUriForm = "gitlens-git:c%3A%5CUsers%5CKeith%5CGitHub%5Cdahlbyk%5Cposh-git%5Csrc%5CPoshGitTypes%3Ae0022701.ps1?%7B%22fileName%22%3A%22src%2FPoshGitTypes.ps1%22%2C%22repoPath%22%3A%22c%3A%2FUsers%2FKeith%2FGitHub%2Fdahlbyk%2Fposh-git%22%2C%22sha%22%3A%22e0022701fa12e0bc22d0458673d6443c942b974a%22%7D";
 
-            var testCases = new[] {
+            var testCases = new [] {
                 // Test short file absolute paths
                 new { IsInMemory = false, Path = shortDirPath },
                 new { IsInMemory = false, Path = shortFilePath },
@@ -182,7 +183,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Session
                 new { IsInMemory = true,  Path = longUriForm },
             };
 
-            foreach (var testCase in testCases)
+            foreach(var testCase in testCases)
             {
                 Assert.True(
                     WorkspaceService.IsPathInMemory(testCase.Path) == testCase.IsInMemory,

--- a/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
+++ b/test/PowerShellEditorServices.Test/Utility/AsyncQueueTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
                             // Wait for a bit and then add more items to the queue
                             await Task.Delay(250);
 
-                            foreach (var i in Enumerable.Range(100, 200))
+                            foreach(var i in Enumerable.Range(100, 200))
                             {
                                 await inputQueue.EnqueueAsync(i);
                             }
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
                             cancellationTokenSource.Cancel();
                         }));
             }
-            catch (TaskCanceledException)
+            catch(TaskCanceledException)
             {
                 // Do nothing, this is expected.
             }
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Utility
             ConcurrentBag<int> outputItems,
             CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            while(!cancellationToken.IsCancellationRequested)
             {
                 int consumedItem = await inputQueue.DequeueAsync(cancellationToken);
                 outputItems.Add(consumedItem);


### PR DESCRIPTION
There has been a general lack of convention for code formatting. Reformatted all code according to the .editorconfig to hopefully prevent unintentional whitespace changes in the future.