### PR TITLE
Initialize runspaces with `InitialSessionState` object

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ insert_final_newline = true
 indent_size = 4
 trim_trailing_whitespace = true
 csharp_space_before_open_square_brackets = true
-csharp_space_after_keywords_in_control_flow_statements = false
+csharp_space_after_keywords_in_control_flow_statements = true
 
 [*.{json}]
 indent_size = 2

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -349,7 +349,16 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             var profile = (PSObject)GetVariableValue("profile");
 
             var hostInfo = new HostInfo(HostName, HostProfileId, HostVersion);
-            var editorServicesConfig = new EditorServicesConfig(hostInfo, Host, SessionDetailsPath, bundledModulesPath, LogPath)
+
+            var initialSessionState = Runspace.DefaultRunspace.InitialSessionState;
+            initialSessionState.LanguageMode = Runspace.DefaultRunspace.SessionStateProxy.LanguageMode;
+
+            var editorServicesConfig = new EditorServicesConfig(
+                hostInfo,
+                Host,
+                SessionDetailsPath,
+                bundledModulesPath,
+                LogPath)
             {
                 FeatureFlags = FeatureFlags,
                 LogLevel = LogLevel,
@@ -357,7 +366,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 AdditionalModules = AdditionalModules,
                 LanguageServiceTransport = GetLanguageServiceTransport(),
                 DebugServiceTransport = GetDebugServiceTransport(),
-                LanguageMode = Runspace.DefaultRunspace.SessionStateProxy.LanguageMode,
+                InitialSessionState = initialSessionState,
                 ProfilePaths = new ProfilePathConfig
                 {
                     AllUsersAllHosts = GetProfilePathFromProfileObject(profile, ProfileUserKind.AllUsers, ProfileHostKind.AllHosts),

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Management.Automation;
 using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices.Hosting
 {
@@ -111,10 +111,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public ProfilePathConfig ProfilePaths { get; set; }
 
         /// <summary>
-        /// The language mode inherited from the orginal PowerShell process.
-        /// This will be used when creating runspaces so that we honor the same language mode.
+        /// The InitialSessionState to use when creating runspaces. LanguageMode can be set here.
         /// </summary>
-        public PSLanguageMode LanguageMode { get; internal set; }
+        public InitialSessionState InitialSessionState { get; internal set; }
 
         public string StartupBanner { get; set; } = @"
 

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -288,7 +288,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 profilePaths,
                 _config.FeatureFlags,
                 _config.AdditionalModules,
-                _config.LanguageMode,
+                _config.InitialSessionState,
                 _config.LogPath,
                 (int)_config.LogLevel,
                 consoleReplEnabled: _config.ConsoleRepl != ConsoleReplKind.None,

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Management.Automation;
 using System.Management.Automation.Host;
+using System.Management.Automation.Runspaces;
 
 namespace Microsoft.PowerShell.EditorServices.Hosting
 {
@@ -92,10 +92,10 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public string LogPath { get; }
 
         /// <summary>
-        /// The language mode inherited from the orginal PowerShell process.
-        /// This will be used when creating runspaces so that we honor the same language mode.
+        /// The InitialSessionState will be inherited from the orginal PowerShell process. This will
+        /// be used when creating runspaces so that we honor the same InitialSessionState.
         /// </summary>
-        public PSLanguageMode LanguageMode { get; }
+        public InitialSessionState InitialSessionState { get; }
 
         /// <summary>
         /// The minimum log level of log events to be logged.
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="currentUsersProfilePath">The path to the user specific profile.</param>
         /// <param name="featureFlags">Flags of features to enable.</param>
         /// <param name="additionalModules">Names or paths of additional modules to import.</param>
-        /// <param name="languageMode">The language mode inherited from the orginal PowerShell process. This will be used when creating runspaces so that we honor the same language mode.</param>
+        /// <param name="initialSessionState">The language mode inherited from the orginal PowerShell process. This will be used when creating runspaces so that we honor the same initialSessionState including allowed modules, cmdlets and language mode.</param>
         /// <param name="logPath">The path to log to.</param>
         /// <param name="logLevel">The minimum log event level.</param>
         /// <param name="consoleReplEnabled">Enable console if true.</param>
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ProfilePathInfo profilePaths,
             IReadOnlyList<string> featureFlags,
             IReadOnlyList<string> additionalModules,
-            PSLanguageMode languageMode,
+            InitialSessionState initialSessionState,
             string logPath,
             int logLevel,
             bool consoleReplEnabled,
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ProfilePaths = profilePaths;
             FeatureFlags = featureFlags ?? Array.Empty<string>();
             AdditionalModules = additionalModules ?? Array.Empty<string>();
-            LanguageMode = languageMode;
+            InitialSessionState = initialSessionState;
             LogPath = logPath;
             LogLevel = logLevel;
             ConsoleReplEnabled = consoleReplEnabled;


### PR DESCRIPTION
Instead of passing values for `LanguageMode` and `ExecutionPolicy` as
fields that are set on an `InitialSessionState` object that's eventually
created, we now pass a fully initialized `InitialSessionState` object
from the start.

We also rename `SetExecutionPolicy` to `RestoreExecutionPolicy` to
reflect what it actually does: restores the user's policy after we
overrode it with `Bypass` while initializing the integrated console's
runspace. We override it because we need to be able to load `PSReadLine`
etc. without policy issues.

Finally, we fix the EditorConfig setting to enforce spaces after
control-flow keywords (such as `if`) because, while our codebase is
inconsistent, it is our preferred style going forward.

This replaces #1523.