### PR TITLE
Add stack trace to resolve event handler on debug

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -93,7 +94,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext defaultLoadContext, AssemblyName asmName) =>
             {
+#if DEBUG
+                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}. Stacktrace:\n{new StackTrace()}");
+#else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}");
+#endif
 
                 // We only want the Editor Services DLL; the new ALC will lazily load its dependencies automatically
                 if (!string.Equals(asmName.Name, "Microsoft.PowerShell.EditorServices", StringComparison.Ordinal))
@@ -124,7 +129,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // Unlike in .NET Core, we need to be look for all dependencies in .NET Framework, not just PSES.dll
             AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) =>
             {
+#if DEBUG
+                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}. Stacktrace:\n{new StackTrace()}");
+#else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}");
+#endif
 
                 var asmName = new AssemblyName(args.Name);
                 var dllName = $"{asmName.Name}.dll";


### PR DESCRIPTION
Allows us to work out why an assembly is being loaded in debug builds