### PR TITLE
Make `ExecuteCommandAsync` cancellable 

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -137,6 +137,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
         public void Dispose()
         {
             _powerShellContextService.IsDebugServerActive = false;
+            // TODO: If the debugger has stopped, should we clear the breakpoints?
             _debugAdapterServer.Dispose();
             _inputStream.Dispose();
             _outputStream.Dispose();

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -135,7 +135,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 IEnumerable<Breakpoint> setBreakpoints =
                     await _powerShellContextService.ExecuteCommandAsync<Breakpoint>(psCommand).ConfigureAwait(false);
                 configuredBreakpoints.AddRange(
-                    setBreakpoints.Select(BreakpointDetails.Create));
+                    setBreakpoints.Select((breakpoint) => BreakpointDetails.Create(breakpoint))
+                );
             }
 
             return configuredBreakpoints;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -139,16 +139,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 );
 
                 string reason = (e.UpdateType) switch {
-                    BreakpointUpdateType.Set => "new",
-                    BreakpointUpdateType.Removed => "removed",
-                    BreakpointUpdateType.Enabled => "changed",
-                    BreakpointUpdateType.Disabled => "changed",
-                    _ => "unknown"
+                    BreakpointUpdateType.Set => BreakpointEventReason.New,
+                    BreakpointUpdateType.Removed => BreakpointEventReason.Removed,
+                    BreakpointUpdateType.Enabled => BreakpointEventReason.Changed,
+                    BreakpointUpdateType.Disabled => BreakpointEventReason.Changed,
+                    _ => "InvalidBreakpointUpdateTypeEnum"
                 };
 
                 _debugAdapterServer.SendNotification(
                     EventNames.Breakpoint,
-                    new BreakpointEvent { Reason = reason, Breakpoint = breakpoint }
+                    new BreakpointEvent { Breakpoint = breakpoint, Reason = reason }
                 );
             }
             else if (e.Breakpoint is CommandBreakpoint)

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -77,8 +77,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// PowerShell Breakpoint object.
         /// </summary>
         /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
+        /// <param name="updateType">The BreakpointUpdateType to determine if the breakpoint is verified.</param>
         /// <returns>A new instance of the BreakpointDetails class.</returns>
-        internal static BreakpointDetails Create(Breakpoint breakpoint)
+        internal static BreakpointDetails Create(
+            Breakpoint breakpoint,
+            BreakpointUpdateType updateType = BreakpointUpdateType.Set)
         {
             Validate.IsNotNull("breakpoint", breakpoint);
 
@@ -91,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             var breakpointDetails = new BreakpointDetails
             {
                 Id = breakpoint.Id,
-                Verified = true,
+                Verified = updateType != BreakpointUpdateType.Disabled,
                 Source = lineBreakpoint.Script,
                 LineNumber = lineBreakpoint.Line,
                 ColumnNumber = lineBreakpoint.Column,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -303,11 +303,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             string debugRunspaceCmd;
             if (request.RunspaceName != null)
             {
-                IEnumerable<int?> ids = await _powerShellContextService.ExecuteCommandAsync<int?>(new PSCommand()
-                    .AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace")
-                    .AddParameter("Name", request.RunspaceName)
-                    .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
-                    .AddParameter("ExpandProperty", "Id")).ConfigureAwait(false);
+                IEnumerable<int?> ids = await _powerShellContextService.ExecuteCommandAsync<int?>(
+                    new PSCommand()
+                        .AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace")
+                        .AddParameter("Name", request.RunspaceName)
+                        .AddCommand("Microsoft.PowerShell.Utility\\Select-Object")
+                        .AddParameter("ExpandProperty", "Id"), cancellationToken: cancellationToken).ConfigureAwait(false);
+
                 foreach (var id in ids)
                 {
                     _debugStateService.RunspaceId = id;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ThreadsHandler.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 // TODO: OmniSharp supports multithreaded debugging (where
                 // multiple threads can be debugged at once), but we don't. This
-                // means we always need to set AllThreadsStoppped and
+                // means we always need to set AllThreadsStopped and
                 // AllThreadsContinued in our events. But if we one day support
                 // multithreaded debugging, we'd need a way to associate
                 // debugged runspaces with .NET threads in a consistent way.

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Console/ConsoleReadLine.cs
@@ -208,9 +208,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                                 command.AddParameter("CursorColumn", currentCursorIndex);
                                 command.AddParameter("Options", null);
 
-                                var results = await this.powerShellContext
-                                    .ExecuteCommandAsync<CommandCompletion>(command, sendOutputToHost: false, sendErrorToHost: false)
-                                    .ConfigureAwait(false);
+                                var results = await this.powerShellContext.ExecuteCommandAsync<CommandCompletion>(
+                                    command, sendOutputToHost: false, sendErrorToHost: false, cancellationToken).ConfigureAwait(false);
 
                                 currentCompletion = results.FirstOrDefault();
                             }
@@ -327,8 +326,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                             PSCommand command = new PSCommand();
                             command.AddCommand("Get-History");
 
-                            currentHistory = await this.powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false)
-                                .ConfigureAwait(false)
+                            currentHistory = await this.powerShellContext.ExecuteCommandAsync<PSObject>(
+                                command, sendOutputToHost: false, sendErrorToHost: false, cancellationToken).ConfigureAwait(false)
                                 as Collection<PSObject>;
 
                             if (currentHistory != null)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ExpandAliasHandler.cs
@@ -69,7 +69,8 @@ function __Expand-Alias {
                 .AddStatement()
                 .AddCommand("__Expand-Alias")
                 .AddArgument(request.Text);
-            var result = await _powerShellContextService.ExecuteCommandAsync<string>(psCommand).ConfigureAwait(false);
+            var result = await _powerShellContextService.ExecuteCommandAsync<string>(
+                psCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return new ExpandAliasResult
             {

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/GetCommandHandler.cs
@@ -53,7 +53,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 .AddCommand("Microsoft.PowerShell.Utility\\Sort-Object")
                     .AddParameter("Property", "Name");
 
-            IEnumerable<CommandInfo> result = await _powerShellContextService.ExecuteCommandAsync<CommandInfo>(psCommand).ConfigureAwait(false);
+            IEnumerable<CommandInfo> result = await _powerShellContextService.ExecuteCommandAsync<CommandInfo>(
+                psCommand, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var commandList = new List<PSCommandMessage>();
             if (result != null)

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/PSHostProcessAndRunspaceHandlers.cs
@@ -87,7 +87,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 var psCommand = new PSCommand().AddCommand("Microsoft.PowerShell.Utility\\Get-Runspace");
                 var sb = new StringBuilder();
                 // returns (not deserialized) Runspaces. For simpler code, we use PSObject and rely on dynamic later.
-                runspaces = await _powerShellContextService.ExecuteCommandAsync<PSObject>(psCommand, sb).ConfigureAwait(false);
+                runspaces = await _powerShellContextService.ExecuteCommandAsync<PSObject>(
+                    psCommand, sb, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             var runspaceResponses = new List<RunspaceResponse>();

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Handlers/ShowHelpHandler.cs
@@ -72,7 +72,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // TODO: Rather than print the help in the console, we should send the string back
             //       to VSCode to display in a help pop-up (or similar)
-            await _powerShellContextService.ExecuteCommandAsync<PSObject>(checkHelpPSCommand, sendOutputToHost: true).ConfigureAwait(false);
+            await _powerShellContextService.ExecuteCommandAsync<PSObject>(
+                checkHelpPSCommand, sendOutputToHost: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             return Unit.Value;
         }
     }

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/EditorServicesPSHostUserInterface.cs
@@ -731,7 +731,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
 
             cancellationToken.ThrowIfCancellationRequested();
             string promptString =
-                (await this.powerShellContext.ExecuteCommandAsync<PSObject>(promptCommand, false, false).ConfigureAwait(false))
+                (await this.powerShellContext.ExecuteCommandAsync<PSObject>(
+                    promptCommand, false, false, cancellationToken).ConfigureAwait(false))
                     .Select(pso => pso.BaseObject)
                     .OfType<string>()
                     .FirstOrDefault() ?? "PS> ";

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -143,7 +143,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             IEnumerable<string> readLineResults = await _powerShellContext.ExecuteCommandAsync<string>(
                 readLineCommand,
                 errorMessages: null,
-                s_psrlExecutionOptions).ConfigureAwait(false);
+                s_psrlExecutionOptions,
+                cancellationToken).ConfigureAwait(false);
 
             string line = readLineResults.FirstOrDefault();
 


### PR DESCRIPTION
This hasn't solved the problem where the PowerShell debugger and the VS Code debugger somehow disconnect from each other when `System.Windows.Forms` is added to the PowerShell session, but it does improve the situation somewhat. The debugger can be stopped now (though it cannot be restarted yet).