### PR TITLE
Update C# language version to 10.0 to fix bug with .NET SDK 6 Preview 7

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -4,7 +4,7 @@
     <VersionSuffix></VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/PowerShell/PowerShellEditorServices/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Our build started failing this morning because .NET SDK 6 moved from Preview 6 to Preview 7 and its generated code now throws an error with language version 9.0, but is allowed with 10.0. Issue is documented upstream in https://github.com/dotnet/sdk/issues/19702