### PR TITLE
Explicitly disable implicit namespace imports

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -4,7 +4,7 @@
     <VersionSuffix></VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation.</Copyright>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <PackageTags>PowerShell;editor;development;language;debugging</PackageTags>
     <PackageLicenseUrl>https://raw.githubusercontent.com/PowerShell/PowerShellEditorServices/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -12,7 +12,9 @@
     <RepositoryUrl>https://github.com/PowerShell/PowerShellEditorServices</RepositoryUrl>
     <DebugType>portable</DebugType>
     <!-- See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview -->
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <!-- TODO: Enable `EnforceCodeStyleInBuild` -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <!-- See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This also reverts us back to language version 9.0.

This reverts commit e29979c369efdcb645a681403ae5d380076a85c8.

Fixes #1544.