### PR TITLE
Fix creation of `InitialSessionState` to use `CreateDefault2()`

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -51,18 +51,6 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
     git update-index --assume-unchanged "$PSScriptRoot/src/PowerShellEditorServices.Hosting/BuildInfo.cs"
 }
 
-function Invoke-WithCreateDefaultHook {
-    param([scriptblock]$ScriptBlock)
-
-    try
-    {
-        $env:PSES_TEST_USE_CREATE_DEFAULT = 1
-        & $ScriptBlock
-    } finally {
-        Remove-Item env:PSES_TEST_USE_CREATE_DEFAULT
-    }
-}
-
 function Install-Dotnet {
     param (
         [string[]]$Channel
@@ -246,16 +234,12 @@ task TestServerWinPS -If (-not $script:IsNix) {
 
 task TestServerPS7 -If (-not $script:IsRosetta) {
     Set-Location .\test\PowerShellEditorServices.Test\
-    Invoke-WithCreateDefaultHook -NewModulePath $script:PSCoreModulePath {
-        exec { & $script:dotnetExe $script:dotnetTestArgs $script:NetRuntime.PS7 }
-    }
+    exec { & $script:dotnetExe $script:dotnetTestArgs $script:NetRuntime.PS7 }
 }
 
 task TestServerPS72 {
     Set-Location .\test\PowerShellEditorServices.Test\
-    Invoke-WithCreateDefaultHook -NewModulePath $script:PSCoreModulePath {
-        exec { & $script:dotnetExe $script:dotnetTestArgs $script:NetRuntime.PS72 }
-    }
+    exec { & $script:dotnetExe $script:dotnetTestArgs $script:NetRuntime.PS72 }
 }
 
 task TestE2E {

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -468,15 +468,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
                     throw new FileNotFoundException("Unable to find PSScriptAnalyzer module on the module path");
                 }
 
-                // Now that we know where the PSScriptAnalyzer we want to use is,
-                // create a base session state with PSScriptAnalyzer loaded
-#if DEBUG
-                InitialSessionState sessionState = Environment.GetEnvironmentVariable("PSES_TEST_USE_CREATE_DEFAULT") == "1"
-                    ? InitialSessionState.CreateDefault()
-                    : InitialSessionState.CreateDefault2();
-#else
+                // Now that we know where the PSScriptAnalyzer we want to use is, create a base
+                // session state with PSScriptAnalyzer loaded
+                //
+                // We intentionally use `CreateDefault2()` as it loads `Microsoft.PowerShell.Core`
+                // only, which is a more minimal and therefore safer state.
                 InitialSessionState sessionState = InitialSessionState.CreateDefault2();
-#endif
 
                 sessionState.ImportPSModule(new [] { pssaModuleInfo.ModuleBase });
 

--- a/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
+++ b/test/PowerShellEditorServices.Test/PowerShellContextFactory.cs
@@ -41,7 +41,11 @@ namespace Microsoft.PowerShell.EditorServices.Test
         public static PowerShellContextService Create(ILogger logger)
         {
             PowerShellContextService powerShellContext = new PowerShellContextService(logger, null, isPSReadLineEnabled: false);
-            var initialSessionState = InitialSessionState.CreateDefault();
+
+            // We intentionally use `CreateDefault2()` as it loads `Microsoft.PowerShell.Core` only,
+            // which is a more minimal and therefore safer state.
+            var initialSessionState = InitialSessionState.CreateDefault2();
+
             // We set the process scope's execution policy (which is really the runspace's scope) to
             // `Bypass` so we can import our bundled modules. This is equivalent in scope to the CLI
             // argument `-ExecutionPolicy Bypass`, which (for instance) the extension passes. Thus


### PR DESCRIPTION
We erroneously changed our code to use `CreateDefault` instead of `CreateDefault2`. There existed old but defunct code for testing the use of `CreateDefault` instead, but it was never intentionally moved into production. The latter function loads only `Microsoft.PowerShell.Core`, leaving us to load the exact modules we intend to load ourselves, which is the safer behavior (and the previous behavior).