### PR TITLE
Fix debugger regression where console needed input to start/continue

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -74,8 +74,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _logger.LogInformation("Debug adapter is shutting down...");
 
 #pragma warning disable CS4014
-            // Trigger the clean up of the debugger. No need to wait for it.
-            Task.Run(_psesDebugServer.OnSessionEnded, cancellationToken);
+            // Trigger the clean up of the debugger. No need to wait for it nor cancel it.
+            Task.Run(_psesDebugServer.OnSessionEnded, CancellationToken.None);
 #pragma warning restore CS4014
 
             return new DisconnectResponse();

--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -765,7 +765,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     }
 
                     // This is the primary reason that ExecuteCommandAsync takes a CancellationToken
-                    cancellationToken.Register(() => shell.Stop());
                     return await Task.Run<IEnumerable<TResult>>(
                         () => shell.Invoke<TResult>(input: null, invocationSettings), cancellationToken)
                         .ConfigureAwait(false);

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/PSReadLinePromptContext.cs
@@ -144,7 +144,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 readLineCommand,
                 errorMessages: null,
                 s_psrlExecutionOptions,
-                cancellationToken).ConfigureAwait(false);
+                // NOTE: This command should always be allowed to complete, as the command itself
+                // has a linked cancellation token such that PSReadLine will be correctly cancelled.
+                CancellationToken.None).ConfigureAwait(false);
 
             string line = readLineResults.FirstOrDefault();
 

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            if (!s_completionHandle.Wait(0, cancellationToken))
+            if (!s_completionHandle.Wait(0, CancellationToken.None))
             {
                 return null;
             }


### PR DESCRIPTION
These needed to be explicitly `None` to indicate that they should not be cancelled (for various reasons). The actual bug fix was the removal of `shell.Stop()`. Fixes https://github.com/PowerShell/vscode-powershell/issues/3513.