### PR TITLE
Fix bug with `ExecuteScriptWithArgsAsync` when `script` is a command

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/PowerShellContextService.cs
@@ -1047,8 +1047,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             if (arguments != null)
             {
-                // Add CWD from PowerShell if not an absolute path
-                if (!Path.IsPathRooted(script))
+                // Add CWD from PowerShell if the script is a file (not a command/inline script) and
+                // it's not an absolute path.
+                if (File.Exists(script) && !Path.IsPathRooted(script))
                 {
                     try
                     {


### PR DESCRIPTION
This fixes https://github.com/PowerShell/vscode-powershell/issues/3537.