### PR TITLE
 Send `stopDebugger` notification when appropriate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 csharp_space_before_open_square_brackets = true
 csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_before_open_square_brackets = false
 
 # CS0168: The variable 'var' is declared but never used
 dotnet_diagnostic.CS0168.severity = error

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private void DebugServer_OnSessionEnded(object sender, EventArgs args)
         {
-            _logger.Log(PsesLogLevel.Verbose, "Debug session ended. Restarting debug service");
+            _logger.Log(PsesLogLevel.Verbose, "Debug session ended, restarting debug service...");
             var oldServer = (PsesDebugServer)sender;
             oldServer.Dispose();
             _alreadySubscribedDebug = false;

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -260,12 +260,7 @@ namespace PowerShellEditorServices.Test.E2E
                 new SetFunctionBreakpointsArguments
                 {
                     Breakpoints = new FunctionBreakpoint[]
-                    {
-                        new FunctionBreakpoint
-                        {
-                            Name = "Write-Host",
-                        }
-                    }
+                        { new FunctionBreakpoint { Name = "Write-Host", } }
                 }).ConfigureAwait(false);
 
             var breakpoint = setBreakpointsResponse.Breakpoints.First();

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await executeTask.ConfigureAwait(false);
 
             StackFrameDetails[] stackFrames = debugService.GetStackFrames();
-            Assert.Equal(StackFrameDetails.NoFileScriptPath, stackFrames [0].ScriptPath);
+            Assert.Equal(StackFrameDetails.NoFileScriptPath, stackFrames[0].ScriptPath);
 
             VariableDetailsBase[] variables =
                 debugService.GetVariables(stackFrames[0].LocalVariables.Id);
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             await this.debugService.SetLineBreakpointsAsync(
                 debugWithParamsFile,
-                new [] { BreakpointDetails.Create(debugWithParamsFile.FilePath, 3) }).ConfigureAwait(false);
+                new[] { BreakpointDetails.Create(debugWithParamsFile.FilePath, 3) }).ConfigureAwait(false);
 
             string arguments = string.Join(" ", args);
 
@@ -580,8 +580,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
                 PowerShellContextState.Ready,
                 PowerShellExecutionResult.Stopped).ConfigureAwait(false);
 
-            // Abort script execution early and wait for completion
-            this.debugService.Abort();
             await executeTask.ConfigureAwait(false);
         }
 
@@ -872,7 +870,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal("[1]", childVars[1].Name);
 
             var childVarStrs = new HashSet<string>(childVars.Select(v => v.ValueString));
-            var expectedVars = new [] {
+            var expectedVars = new[] {
                 "[firstChild, \"Child\"]",
                 "[secondChild, 42]"
             };
@@ -1026,7 +1024,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             await executeTask.ConfigureAwait(false);
         }
 
-        public async Task AssertDebuggerPaused()
+        private async Task AssertDebuggerPaused()
         {
             DebuggerStoppedEventArgs eventArgs =
                 await this.debuggerStoppedQueue.DequeueAsync(new CancellationTokenSource(10000).Token).ConfigureAwait(false);
@@ -1034,7 +1032,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Empty(eventArgs.OriginalEvent.Breakpoints);
         }
 
-        public async Task AssertDebuggerStopped(
+        private async Task AssertDebuggerStopped(
             string scriptPath,
             int lineNumber = -1)
         {


### PR DESCRIPTION
This is the edge case where the debug server is running because it was started by PowerShell (and not by an LSP event), and we're no longer in the debugger within PowerShell, so since we own the state we need to stop the debug server too.

Along with https://github.com/PowerShell/vscode-powershell/pull/3542, this resolves one of the main issues brought up in https://github.com/PowerShell/vscode-powershell/issues/3522.