### PR TITLE
Implement `LengthInBufferCells` to fix ANSI formatting

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Host/TerminalPSHostRawUserInterface.cs
@@ -265,6 +265,53 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             this.internalRawUI.SetBufferContents(origin, contents);
         }
 
+        /// <summary>
+        /// Determines the number of BufferCells a character occupies.
+        /// </summary>
+        /// <param name="source">
+        /// The character whose length we want to know.
+        /// </param>
+        /// <returns>
+        /// The length in buffer cells according to the original host
+        /// implementation for the process.
+        /// </returns>
+        public override int LengthInBufferCells(char source)
+        {
+            return this.internalRawUI.LengthInBufferCells(source);
+        }
+        /// <summary>
+        /// Determines the number of BufferCells a string occupies.
+        /// </summary>
+        /// <param name="source">
+        /// The string whose length we want to know.
+        /// </param>
+        /// <returns>
+        /// The length in buffer cells according to the original host
+        /// implementation for the process.
+        /// </returns>
+        public override int LengthInBufferCells(string source)
+        {
+            return this.internalRawUI.LengthInBufferCells(source);
+        }
+
+        /// <summary>
+        /// Determines the number of BufferCells a substring of a string occupies.
+        /// </summary>
+        /// <param name="source">
+        /// The string whose substring length we want to know.
+        /// </param>
+        /// <param name="offset">
+        /// Offset where the substring begins in <paramref name="source"/>
+        /// </param>
+        /// <returns>
+        /// The length in buffer cells according to the original host
+        /// implementation for the process.
+        /// </returns>
+        public override int LengthInBufferCells(string source, int offset)
+        {
+            return this.internalRawUI.LengthInBufferCells(source, offset);
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Without redirecting this call to `internalRawUI` any formatting with ANSI escapes will likely be truncated in the wrong spot.

## Before fix

![image](https://user-images.githubusercontent.com/24977523/132235242-6371bdb9-9c4a-48c0-ad3b-0a93d29c0edf.png)

## After fix

![image](https://user-images.githubusercontent.com/24977523/132235165-363b1461-8eac-4bb3-9869-a80019f32230.png)

Fixes #840

