### PR TITLE
Fix incorrect ErrorAction values

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Session/Capabilities/DscBreakpointCapability.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                     powerShell.AddCommand("Import-Module");
                     powerShell.AddArgument(@"C:\Program Files\DesiredStateConfiguration\1.0.0.0\Modules\PSDesiredStateConfiguration\PSDesiredStateConfiguration.psd1");
                     powerShell.AddParameter("PassThru");
-                    powerShell.AddParameter("ErrorAction", "Ignore");
+                    powerShell.AddParameter("ErrorAction", "SilentlyContinue");
 
                     PSObject moduleInfo = null;
 

--- a/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShellContext/Utilities/CommandHelpers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
             PSCommand command = new PSCommand();
             command.AddCommand(@"Microsoft.PowerShell.Core\Get-Command");
             command.AddArgument(commandName);
-            command.AddParameter("ErrorAction", "Ignore");
+            command.AddParameter("ErrorAction", "SilentlyContinue");
 
             CommandInfo commandInfo = (await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false))
                 .Select(o => o.BaseObject)
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShellContext
                 // CommandInfo.ToString() duplicates the Prefix if one exists.
                 .AddParameter("Name", commandInfo.Name)
                 .AddParameter("Online", false)
-                .AddParameter("ErrorAction", "Ignore");
+                .AddParameter("ErrorAction", "SilentlyContinue");
 
             var results = await powerShellContext.ExecuteCommandAsync<PSObject>(command, sendOutputToHost: false, sendErrorToHost: false).ConfigureAwait(false);
             PSObject helpObject = results.FirstOrDefault();


### PR DESCRIPTION
I noticed in the logs of my editor's Language Server Protocol client that PowerShellEditorServices was throwing errors from commands with `-ErrorAction Ignore` in them. I checked to be sure, and `Ignore` isn't the correct value; `SilentlyContinue` does that.

I searched the codebase and fixed the three instances of the `Ignore` value I found.