### PR TITLE
Convert PSRL OnIdle handler to take a CancellationToken

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Console/ConsoleReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/ConsoleReadLine.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
             return true;
         }
 
-        public bool TryOverrideIdleHandler(Action idleHandler)
+        public bool TryOverrideIdleHandler(Action<CancellationToken> idleHandler)
         {
             _psrlProxy.OverrideIdleHandler(idleHandler);
             return true;

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/IReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/IReadLine.cs
@@ -15,6 +15,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
 
         bool TryOverrideReadKey(Func<bool, ConsoleKeyInfo> readKeyOverride);
 
-        bool TryOverrideIdleHandler(Action idleHandler);
+        bool TryOverrideIdleHandler(Action<CancellationToken> idleHandler);
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/PSReadLineProxy.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/PSReadLineProxy.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
             _readKeyOverrideField.SetValue(null, readKeyFunc);
         }
 
-        internal void OverrideIdleHandler(Action idleAction)
+        internal void OverrideIdleHandler(Action<CancellationToken> idleAction)
         {
             _handleIdleOverrideField.SetValue(null, idleAction);
         }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -616,7 +616,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             return pwsh;
         }
 
-        public (PowerShell, EngineIntrinsics) CreateInitialPowerShell(
+        private (PowerShell, EngineIntrinsics) CreateInitialPowerShell(
             HostStartupInfo hostStartupInfo,
             ReadLineProvider readLineProvider)
         {
@@ -669,7 +669,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             return runspace;
         }
 
-        private void OnPowerShellIdle()
+        private void OnPowerShellIdle(CancellationToken idleCancellationToken)
         {
             IReadOnlyList<PSEventSubscriber> eventSubscribers = _mainRunspaceEngineIntrinsics.Events.Subscribers;
 
@@ -696,7 +696,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 return;
             }
 
-            using (CancellationScope cancellationScope = _cancellationContext.EnterScope(isIdleScope: true))
+            using (CancellationScope cancellationScope = _cancellationContext.EnterScope(isIdleScope: true, idleCancellationToken))
             {
                 while (!cancellationScope.CancellationToken.IsCancellationRequested
                     && _taskQueue.TryTake(out ISynchronousTask task))

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
@@ -33,14 +33,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
             _cancellationSourceStack = new ConcurrentStack<CancellationScope>();
         }
 
-        public CancellationScope EnterScope(bool isIdleScope)
+        public CancellationScope EnterScope(bool isIdleScope, CancellationToken cancellationToken)
         {
             CancellationTokenSource newScopeCancellationSource = _cancellationSourceStack.TryPeek(out CancellationScope parentScope)
-                ? CancellationTokenSource.CreateLinkedTokenSource(parentScope.CancellationToken)
-                : new CancellationTokenSource();
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, parentScope.CancellationToken)
+                : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             return EnterScope(isIdleScope, newScopeCancellationSource);
         }
+
+        public CancellationScope EnterScope(bool isIdleScope) => EnterScope(isIdleScope, CancellationToken.None);
 
         public void CancelCurrentTask()
         {


### PR DESCRIPTION
Adds cancellation token support to the idle handler in PSES, to align with https://github.com/PowerShell/PSReadLine/pull/1679/files