### PR TITLE
Remove `BinClean` dependency from build task

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -210,7 +210,7 @@ task SetupHelpForTests {
     }
 }
 
-task Build BinClean,{
+Task Build {
     exec { & $script:dotnetExe publish -c $Configuration .\src\PowerShellEditorServices\PowerShellEditorServices.csproj -f $script:NetRuntime.Standard }
     exec { & $script:dotnetExe publish -c $Configuration .\src\PowerShellEditorServices.Hosting\PowerShellEditorServices.Hosting.csproj -f $script:NetRuntime.PS7 }
     if (-not $script:IsNix)


### PR DESCRIPTION
MSBuild does incremental builds by nature, it is not necessary to do a clean and slows down subsequent builds. "Clean" task should be called if a clean is in fact required.