### PR TITLE
Require .NET 6 SDK and remove other unnecessary SDKs

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -106,8 +106,7 @@ task SetupDotNet -Before Clean, Build, TestServerWinPS, TestServerPS7, TestServe
     $dotnetExePath = if ($script:IsNix) { "$dotnetPath/dotnet" } else { "$dotnetPath/dotnet.exe" }
 
     if (!(Test-Path $dotnetExePath)) {
-        # TODO: Test .NET 5 with PowerShell 7.1
-        Install-Dotnet -Channel '3.1','5.0','6.0'
+        Install-Dotnet -Channel '6.0'
     }
 
     # This variable is used internally by 'dotnet' to know where it's installed

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "allowPrerelease": true
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "6.0",
+    "rollForward": "latestFeature",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
This will make bootstrapping more efficient and avoid potential development environment differences.