### PR TITLE
Remove Windows Server 2016 from CI

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -9,15 +9,6 @@ variables:
     value: 'true'
 
 jobs:
-- job: PS51_Win2016
-  displayName: PowerShell 5.1 - Windows Server 2016
-  pool:
-    vmImage: vs2017-win2016
-  steps:
-  - template: templates/ci-general.yml
-    parameters:
-      pwsh: false
-
 - job: PS51_Win2019
   displayName: PowerShell 5.1 - Windows Server 2019
   pool:


### PR DESCRIPTION
The image has been deprecated and will soon be removed from Azure DevOps. Furthermore Microsoft's support for Windows Server 2016 itself ends in January 2022 (less than two months away).