### PR TITLE
Fix build for Apple M1 when running PowerShell 7.2 (arm64)

### DIFF
--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -17,12 +17,14 @@
     <ProjectReference Include="..\PowerShellEditorServices.Test.Shared\PowerShellEditorServices.Test.Shared.csproj" />
   </ItemGroup>
 
+  <!-- This is for testing PowerShell 7.2 LTS -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0-preview.3" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.0" />
   </ItemGroup>
 
+  <!-- This is for testing PowerShell 7.0 LTS -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">


### PR DESCRIPTION
The previous fix assumed PowerShell was always running in an emulated mode (i.e. running PowerShell (x64) but on an Apple M1). Now that PowerShell 7.2 has a native build for Apple M1 (arm64) the check needs to handle both cases.

We must also skip asking `dotnet-install` to install the 3.1 or 5.0 .NET Runtimes on an Apple M1 because they don't exist, but their installer tries to get them anyway. This was a non-breaking bug previously where the macOS x64 runtimes would be installed, but not used.