### PR TITLE
Add magic value formatting for variable booleans

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/VariableDetails.cs
@@ -168,12 +168,22 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             }
 
             Type objType = value.GetType();
-            typeName = $"[{objType.FullName}]";
+
+            // This is the type format PowerShell users expect and will appear when you hover a variable name
+            typeName = '[' + objType.FullName + ']';
 
             if (value is bool)
             {
                 // Set to identifier recognized by PowerShell to make setVariable from the debug UI more natural.
                 valueString = (bool) value ? "$true" : "$false";
+
+                // We need to use this "magic value" to highlight in vscode properly
+                // These "magic values" are analagous to TypeScript and are visible in VSCode here:
+                // https://github.com/microsoft/vscode/blob/57ca9b99d5b6a59f2d2e0f082ae186559f45f1d8/src/vs/workbench/contrib/debug/browser/baseDebugView.ts#L68-L78
+                // NOTE: we don't do numbers and strings since they (so far) seem to get detected properly by 
+                //serialization, and the original .NET type can be preserved so it shows up in the variable name 
+                //type hover as the original .NET type.
+                typeName = "boolean";
             }
             else if (isExpandable)
             {

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1
@@ -1,22 +1,24 @@
 ﻿class MyClass {
-	[String] $Name;
-	[Int32] $Number; }
+    [String] $Name;
+    [Int32] $Number; }
 [bool]$scriptBool = $false
 $scriptInt = 42
 function Test-Variables {
     $strVar = "Hello"
-	[string]$strVar2 = "Hello2"
-	$arrVar = @(1, 2, $strVar, $objVar)
-	$assocArrVar = @{ firstChild = "Child"; secondChild = 42 }
-	$classVar = [MyClass]::new();
-	$classVar.Name = "Test"
-	$classVar.Number = 42;
+    [string]$strVar2 = "Hello2"
+    $arrVar = @(1, 2, $strVar, $objVar)
+    $assocArrVar = @{ firstChild = "Child"; secondChild = 42 }
+    $classVar = [MyClass]::new();
+    $classVar.Name = "Test"
+    $classVar.Number = 42;
     $enumVar = $ErrorActionPreference
     $nullString = [NullString]::Value
-    $psObjVar = New-Object -TypeName PSObject -Property @{Name = 'John';  Age = 75}
-    $psCustomObjVar = [PSCustomObject] @{Name = 'Paul'; Age = 73}
+    $psObjVar = New-Object -TypeName PSObject -Property @{Name = 'John'; Age = 75 }
+    $psCustomObjVar = [PSCustomObject] @{Name = 'Paul'; Age = 73 }
     $procVar = Get-Process -PID $PID
-	Write-Output "Done"
+    $trueVar = $true
+    $falseVar = $false
+    Write-Output "Done"
 }
 
 Test-Variables

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -534,7 +534,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         {
             await debugService.SetLineBreakpointsAsync(
                 variableScriptFile,
-                new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 14) }).ConfigureAwait(true);
+                new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 21) }).ConfigureAwait(true);
 
             Task _ = ExecuteVariableScriptFile();
             AssertDebuggerStopped(variableScriptFile.FilePath);
@@ -567,6 +567,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
             var classChildren = debugService.GetVariables(classVar.Id);
             Assert.Equal(2, classChildren.Length);
+
+            var trueVar = Array.Find(variables, v => v.Name == "$trueVar");
+            Assert.NotNull(trueVar);
+            Assert.Equal("boolean", trueVar.Type);
+            Assert.Equal("$true", trueVar.ValueString);
+
+            var falseVar = Array.Find(variables, v => v.Name == "$falseVar");
+            Assert.NotNull(falseVar);
+            Assert.Equal("boolean", falseVar.Type);
+            Assert.Equal("$false", falseVar.ValueString);
         }
 
         [Trait("Category", "DebugService")]


### PR DESCRIPTION
This PR fixes https://github.com/PowerShell/vscode-powershell/issues/3703

$true and $false now highlight correctly regardless of vscode bug, and number/string type is still preserved.
![image](https://user-images.githubusercontent.com/15258962/143324109-22134c18-5672-414d-86ac-dfbd988de1ca.png)
