### PR TITLE
Implemented -LanguageServiceOnly switch.

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -66,6 +66,9 @@ param(
     [switch]
     $DebugServiceOnly,
 
+    [switch]
+    $LanguageServiceOnly,
+
     [string[]]
     $AdditionalModules,
 

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -471,11 +471,12 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         {
             _logger.Log(PsesLogLevel.Diagnostic, "Configuring debug transport");
 
-            if(LanguageServiceOnly)
+            if (LanguageServiceOnly)
             {
                 _logger.Log(PsesLogLevel.Diagnostic, "No Debug transport: PSES is language service only");
                 return null;
             }
+
             if (Stdio)
             {
                 if (DebugServiceOnly)

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         public SwitchParameter DebugServiceOnly { get; set; }
 
         /// <summary>
-        /// When set, do not enable debug adapter, only the LSP service.
+        /// When set, do not enable debug adapter, only the language service.
         /// </summary>
         [Parameter]
         public SwitchParameter LanguageServiceOnly { get; set; }

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -183,6 +183,12 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         public SwitchParameter DebugServiceOnly { get; set; }
 
         /// <summary>
+        /// When set, do not enable debug adapter, only the LSP service.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter LanguageServiceOnly { get; set; }
+
+        /// <summary>
         /// When set with a debug build, startup will wait for a debugger to attach.
         /// </summary>
         [Parameter]
@@ -465,6 +471,11 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         {
             _logger.Log(PsesLogLevel.Diagnostic, "Configuring debug transport");
 
+            if(LanguageServiceOnly)
+            {
+                _logger.Log(PsesLogLevel.Diagnostic, "No Debug transport: PSES is language service only");
+                return null;
+            }
             if (Stdio)
             {
                 if (DebugServiceOnly)


### PR DESCRIPTION
In situations where the Debug server is not necessary, it is not possible to shutdown PSES as it hangs here:
https://github.com/PowerShell/PowerShellEditorServices/blob/96a8207db0ad3d692a8429de3373e65d0fa0624b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs#L186

