### PR TITLE
Added check to see if PSModulePath already contained BundledModulePath

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -269,9 +269,13 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             }
 
             string psModulePath = Environment.GetEnvironmentVariable("PSModulePath").TrimEnd(Path.PathSeparator);
+            if ($"{psModulePath}{Path.PathSeparator}".Contains($"{_hostConfig.BundledModulePath}{Path.PathSeparator}"))
+            {
+                _logger.Log(PsesLogLevel.Diagnostic, "BundledModulePath already set, skipping");
+                return;
+            }
             psModulePath = $"{psModulePath}{Path.PathSeparator}{_hostConfig.BundledModulePath}";
             Environment.SetEnvironmentVariable("PSModulePath", psModulePath);
-
             _logger.Log(PsesLogLevel.Verbose, $"Updated PSModulePath to: '{psModulePath}'");
         }
 


### PR DESCRIPTION
This prevents PSModulePath from having BundledModulePath added each time PSES is started and shutdown in the same process.