### PR TITLE
Create `$psEditor` as a constant

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -104,15 +104,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
 
             // Assign the new EditorObject to be the static instance available to binary APIs
             EditorObject.SetAsStaticInstance();
+            // This is constant so Remove-Variable cannot remove it.
+            PSVariable psEditor = new(PSEditorVariableName, EditorObject, ScopedItemOptions.Constant);
 
             // Register the editor object in the runspace
             return ExecutionService.ExecuteDelegateAsync(
                 $"Create ${PSEditorVariableName} object",
                 ExecutionOptions.Default,
-                (pwsh, cancellationToken) =>
-                {
-                    pwsh.Runspace.SessionStateProxy.PSVariable.Set(PSEditorVariableName, EditorObject);
-                },
+                (pwsh, _) => pwsh.Runspace.SessionStateProxy.PSVariable.Set(psEditor),
                 CancellationToken.None);
         }
 


### PR DESCRIPTION
This prevents accidental removal (and breakage of the extension) by disallowing `Remove-Variable` from removing `$psEditor`. While it's not expected anyone would do this, glob expressions may include the variable name and when piped to `Remove-Variable` resulted in a user-reported breakage.

Fixes https://github.com/PowerShell/vscode-powershell/issues/3718.