### PR TITLE
Fix regression with `F5` to use `.` instead of `&` operator

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -372,7 +372,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Evaluate the expression to get back a PowerShell object from the expression string.
             // This may throw, in which case the exception is propagated to the caller
             PSCommand evaluateExpressionCommand = new PSCommand().AddScript(value);
-            var expressionResults = await _executionService.ExecutePSCommandAsync<object>(evaluateExpressionCommand, CancellationToken.None).ConfigureAwait(false);
+            IReadOnlyList<object> expressionResults = await _executionService.ExecutePSCommandAsync<object>(evaluateExpressionCommand, CancellationToken.None).ConfigureAwait(false);
             if (expressionResults.Count == 0)
             {
                 throw new InvalidPowerShellExpressionException("Expected an expression result.");
@@ -426,7 +426,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 .AddParameter("Name", name.TrimStart('$'))
                 .AddParameter("Scope", scope);
 
-            var psVariables = await _executionService.ExecutePSCommandAsync<PSVariable>(getVariableCommand, CancellationToken.None).ConfigureAwait(false);
+            IReadOnlyList<PSVariable> psVariables = await _executionService.ExecutePSCommandAsync<PSVariable>(getVariableCommand, CancellationToken.None).ConfigureAwait(false);
             if (psVariables.Count == 0)
             {
                 throw new Exception("Failed to retrieve PSVariables");

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         private int nextVariableId;
         private string temporaryScriptListingPath;
         private List<VariableDetailsBase> variables;
-        internal VariableContainerDetails globalScopeVariables; // Internal for unit testing.
+        private VariableContainerDetails globalScopeVariables;
         private VariableContainerDetails scriptScopeVariables;
         private VariableContainerDetails localScopeVariables;
         private StackFrameDetails[] stackFrameDetails;
@@ -372,9 +372,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Evaluate the expression to get back a PowerShell object from the expression string.
             // This may throw, in which case the exception is propagated to the caller
             PSCommand evaluateExpressionCommand = new PSCommand().AddScript(value);
-            object expressionResult =
-                (await _executionService.ExecutePSCommandAsync<object>(evaluateExpressionCommand, CancellationToken.None)
-                .ConfigureAwait(false)).FirstOrDefault();
+            var expressionResults = await _executionService.ExecutePSCommandAsync<object>(evaluateExpressionCommand, CancellationToken.None).ConfigureAwait(false);
+            if (expressionResults.Count == 0)
+            {
+                throw new InvalidPowerShellExpressionException("Expected an expression result.");
+            }
+            object expressionResult = expressionResults[0];
 
             // If PowerShellContext.ExecuteCommand returns an ErrorRecord as output, the expression failed evaluation.
             // Ideally we would have a separate means from communicating error records apart from normal output.
@@ -423,7 +426,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 .AddParameter("Name", name.TrimStart('$'))
                 .AddParameter("Scope", scope);
 
-            PSVariable psVariable = (await _executionService.ExecutePSCommandAsync<PSVariable>(getVariableCommand, CancellationToken.None).ConfigureAwait(false)).FirstOrDefault();
+            var psVariables = await _executionService.ExecutePSCommandAsync<PSVariable>(getVariableCommand, CancellationToken.None).ConfigureAwait(false);
+            if (psVariables.Count == 0)
+            {
+                throw new Exception("Failed to retrieve PSVariables");
+            }
+
+            PSVariable psVariable = psVariables[0];
             if (psVariable is null)
             {
                 throw new Exception($"Failed to retrieve PSVariable object for '{name}' from scope '{scope}'.");
@@ -449,6 +458,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 _logger.LogTrace($"Setting variable '{name}' using conversion to value: {expressionResult ?? "<null>"}");
 
+                // TODO: This is throwing a 'PSInvalidOperationException' thus causing
+                // 'DebuggerSetsVariablesWithConversion' to fail.
                 psVariable.Value = await _executionService.ExecuteDelegateAsync(
                     "PS debugger argument converter",
                     ExecutionOptions.Default,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -135,6 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
             else
             {
+                // TODO: Fix this so the added script doesn't show up.
                 await _executionService
                     .ExecutePSCommandAsync(
                         PSCommandHelpers.BuildCommandFromArguments(scriptToLaunch, _debugStateService.Arguments),

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -129,21 +129,16 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 
         public static PSCommand BuildCommandFromArguments(string command, IReadOnlyList<string> arguments)
         {
-            if (arguments is null or { Count: 0 })
-            {
-                return new PSCommand().AddCommand(command);
-            }
-
             // HACK: We use AddScript instead of AddArgument/AddParameter to reuse Powershell parameter binding logic.
             // We quote the command parameter so that expressions can still be used in the arguments.
             var sb = new StringBuilder()
-                .Append('&')
+                .Append('.')
                 .Append(' ')
                 .Append('"')
                 .Append(command)
                 .Append('"');
 
-            foreach (string arg in arguments)
+            foreach (string arg in arguments ?? System.Linq.Enumerable.Empty<string>())
             {
                 sb
                 .Append(' ')


### PR DESCRIPTION
This also corrects the scope of the script's parameter variables to be `Local` instead of `Command` in the `DebuggerAcceptsScriptArgs` test, and `Local` instead of `Auto` for most of the rest of the tests (as they
were previous to the pipeline work). Excitingly, this even fixes the `DebuggerSetsVariablesNoConversion` test, although
`DebuggerSetsVariablesWithConversion` is still broken (for a different reason).

Fixes https://github.com/PowerShell/vscode-powershell/issues/3715.