### PR TITLE
Resurrect support to resolve aliased references

### DIFF
--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
@@ -34,13 +35,12 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// The CodeLens to resolve.
         /// </param>
         /// <param name="scriptFile">
-        /// A CancellationToken which can be used to cancel the
-        /// request.
+        /// The ScriptFile to resolve it in (sometimes unused).
         /// </param>
         /// <returns>
         /// A Task which returns the resolved CodeLens when completed.
         /// </returns>
-        CodeLens ResolveCodeLens(
+        Task<CodeLens> ResolveCodeLens(
             CodeLens codeLens,
             ScriptFile scriptFile);
     }

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -133,11 +134,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="codeLens">The code lens to resolve.</param>
         /// <param name="scriptFile">The script file.</param>
         /// <returns>The given CodeLens, wrapped in a task.</returns>
-        public CodeLens ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile)
+        public Task<CodeLens> ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile)
         {
             // This provider has no specific behavior for
             // resolving CodeLenses.
-            return codeLens;
+            return Task.FromResult(codeLens);
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -79,10 +80,10 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// Take a codelens and create a new codelens object with updated references.
         /// </summary>
         /// <param name="codeLens">The old code lens to get updated references for.</param>
+        /// <param name="scriptFile"></param>
         /// <returns>A new code lens object describing the same data as the old one but with updated references.</returns>
-        public CodeLens ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile)
+        public async Task<CodeLens> ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile)
         {
-
             ScriptFile[] references = _workspaceService.ExpandScriptReferences(
                 scriptFile);
 
@@ -91,10 +92,10 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                 codeLens.Range.Start.Line + 1,
                 codeLens.Range.Start.Character + 1);
 
-            List<SymbolReference> referencesResult = _symbolsService.FindReferencesOfSymbol(
+            List<SymbolReference> referencesResult = await _symbolsService.FindReferencesOfSymbol(
                 foundSymbol,
                 references,
-                _workspaceService);
+                _workspaceService).ConfigureAwait(false);
 
             Location[] referenceLocations;
             if (referencesResult == null)

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -177,15 +177,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
         /// Gets all aliases found in the runspace
         /// </summary>
         /// <param name="executionService"></param>
-        public static async Task<(ConcurrentDictionary<string, List<string>>, ConcurrentDictionary<string, string>)> GetAliasesAsync(IInternalPowerShellExecutionService executionService)
+        public static async Task<(Dictionary<string, List<string>>, Dictionary<string, string>)> GetAliasesAsync(IInternalPowerShellExecutionService executionService)
         {
             Validate.IsNotNull(nameof(executionService), executionService);
-
-            // TODO: Should we return the caches if they're not empty, or always update?
-            // if (!s_cmdletToAliasCache.IsEmpty || !s_aliasToCmdletCache.IsEmpty)
-            // {
-            //     return (s_cmdletToAliasCache, s_aliasToCmdletCache);
-            // }
 
             IEnumerable<CommandInfo> aliases = await executionService.ExecuteDelegateAsync<IEnumerable<CommandInfo>>(
                 nameof(GetAliasesAsync),
@@ -209,7 +203,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
                 s_aliasToCmdletCache.TryAdd(aliasInfo.Name, aliasInfo.Definition);
             }
 
-            return (s_cmdletToAliasCache, s_aliasToCmdletCache);
+            return (new Dictionary<string, List<string>>(s_cmdletToAliasCache),
+                new Dictionary<string, string>(s_aliasToCmdletCache));
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return null;
             }
 
-            (ConcurrentDictionary<string, List<string>> cmdletToAliases, ConcurrentDictionary<string, string> aliasToCmdlets) = await CommandHelpers.GetAliasesAsync(_executionService).ConfigureAwait(false);
+            (Dictionary<string, List<string>> cmdletToAliases, Dictionary<string, string> aliasToCmdlets) = await CommandHelpers.GetAliasesAsync(_executionService).ConfigureAwait(false);
 
             // We want to look for references first in referenced files, hence we use ordered dictionary
             // TODO: File system case-sensitivity is based on filesystem not OS, but OS is a much cheaper heuristic

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -264,10 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return null;
             }
 
-            return AstOperations.FindReferencesOfSymbol(
-                file.ScriptAst,
-                foundSymbol,
-                needsAliases: false).ToArray();
+            return AstOperations.FindReferencesOfSymbol(file.ScriptAst, foundSymbol).ToArray();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -39,7 +39,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private readonly ConcurrentDictionary<string, ICodeLensProvider> _codeLensProviders;
         private readonly ConcurrentDictionary<string, IDocumentSymbolProvider> _documentSymbolProviders;
-
+        private readonly Dictionary<String, List<String>> _cmdletToAliasDictionary;
+        private readonly Dictionary<String, String> _aliasToCmdletDictionary;
         #endregion
 
         #region Constructors
@@ -84,6 +85,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 _documentSymbolProviders.TryAdd(documentSymbolProvider.ProviderId, documentSymbolProvider);
             }
+
+            _cmdletToAliasDictionary = new Dictionary<String, List<String>>(StringComparer.OrdinalIgnoreCase);
+            _aliasToCmdletDictionary = new Dictionary<String, String>(StringComparer.OrdinalIgnoreCase);
+            GetAliases();
         }
 
         #endregion
@@ -186,8 +191,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return null;
             }
 
-            // NOTE: we use to make sure aliases were loaded but took it out because we needed the pipeline thread.
-
             // We want to look for references first in referenced files, hence we use ordered dictionary
             // TODO: File system case-sensitivity is based on filesystem not OS, but OS is a much cheaper heuristic
             var fileMap = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
@@ -221,7 +224,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 IEnumerable<SymbolReference> references = AstOperations.FindReferencesOfSymbol(
                     file.ScriptAst,
                     foundSymbol,
-                    needsAliases: false);
+                    _cmdletToAliasDictionary,
+                    _aliasToCmdletDictionary);
 
                 foreach (SymbolReference reference in references)
                 {
@@ -488,6 +492,36 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             return foundDefinition;
+        }
+
+        /// <summary>
+        /// Gets all aliases found in the runspace
+        /// </summary>
+        private async void GetAliases()
+        {
+            IEnumerable<CommandInfo> aliases = await _executionService.ExecuteDelegateAsync<IEnumerable<CommandInfo>>(
+                nameof(GetAliases),
+                PowerShell.Execution.ExecutionOptions.Default,
+                (pwsh, _) =>
+                {
+                    CommandInvocationIntrinsics invokeCommand = pwsh.Runspace.SessionStateProxy.InvokeCommand;
+                    return invokeCommand.GetCommands("*", CommandTypes.Alias, nameIsPattern: true);
+                },
+                System.Threading.CancellationToken.None).ConfigureAwait(false);
+
+            foreach (AliasInfo aliasInfo in aliases)
+            {
+                if (!_cmdletToAliasDictionary.ContainsKey(aliasInfo.Definition))
+                {
+                    _cmdletToAliasDictionary.Add(aliasInfo.Definition, new List<String>() { aliasInfo.Name });
+                }
+                else
+                {
+                    _cmdletToAliasDictionary[aliasInfo.Definition].Add(aliasInfo.Name);
+                }
+
+                _aliasToCmdletDictionary.Add(aliasInfo.Name, aliasInfo.Definition);
+            }
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -153,42 +154,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// </summary>
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
         /// <param name="symbolReference">The symbol that we are looking for referneces of</param>
-        /// <param name="CmdletToAliasDictionary">Dictionary maping cmdlets to aliases for finding alias references</param>
-        /// <param name="AliasToCmdletDictionary">Dictionary maping aliases to cmdlets for finding alias references</param>
+        /// <param name="cmdletToAliasDictionary">Dictionary maping cmdlets to aliases for finding alias references</param>
+        /// <param name="aliasToCmdletDictionary">Dictionary maping aliases to cmdlets for finding alias references</param>
         /// <returns></returns>
         public static IEnumerable<SymbolReference> FindReferencesOfSymbol(
             Ast scriptAst,
             SymbolReference symbolReference,
-            Dictionary<String, List<String>> CmdletToAliasDictionary,
-            Dictionary<String, String> AliasToCmdletDictionary)
+            ConcurrentDictionary<string, List<string>> cmdletToAliasDictionary = default,
+            ConcurrentDictionary<string, string> aliasToCmdletDictionary = default)
         {
             // find the symbol evaluators for the node types we are handling
-            FindReferencesVisitor referencesVisitor =
-                new FindReferencesVisitor(
-                    symbolReference,
-                    CmdletToAliasDictionary,
-                    AliasToCmdletDictionary);
-            scriptAst.Visit(referencesVisitor);
+            FindReferencesVisitor referencesVisitor = new(
+                symbolReference,
+                cmdletToAliasDictionary,
+                aliasToCmdletDictionary);
 
-            return referencesVisitor.FoundReferences;
-        }
-
-        /// <summary>
-        /// Finds all references (not including aliases) in a script for the given symbol
-        /// </summary>
-        /// <param name="scriptAst">The abstract syntax tree of the given script</param>
-        /// <param name="foundSymbol">The symbol that we are looking for referneces of</param>
-        /// <param name="needsAliases">If this reference search needs aliases.
-        /// This should always be false and used for occurence requests</param>
-        /// <returns>A collection of SymbolReference objects that are refrences to the symbolRefrence
-        /// not including aliases</returns>
-        public static IEnumerable<SymbolReference> FindReferencesOfSymbol(
-            ScriptBlockAst scriptAst,
-            SymbolReference foundSymbol,
-            bool needsAliases)
-        {
-            FindReferencesVisitor referencesVisitor =
-                new FindReferencesVisitor(foundSymbol);
             scriptAst.Visit(referencesVisitor);
 
             return referencesVisitor.FoundReferences;

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -160,8 +159,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         public static IEnumerable<SymbolReference> FindReferencesOfSymbol(
             Ast scriptAst,
             SymbolReference symbolReference,
-            ConcurrentDictionary<string, List<string>> cmdletToAliasDictionary = default,
-            ConcurrentDictionary<string, string> aliasToCmdletDictionary = default)
+            IDictionary<string, List<string>> cmdletToAliasDictionary = default,
+            IDictionary<string, string> aliasToCmdletDictionary = default)
         {
             // find the symbol evaluators for the node types we are handling
             FindReferencesVisitor referencesVisitor = new(

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 
@@ -12,11 +13,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
     /// </summary>
     internal class FindReferencesVisitor : AstVisitor
     {
-        private SymbolReference symbolRef;
-        private Dictionary<String, List<String>> CmdletToAliasDictionary;
-        private Dictionary<String, String> AliasToCmdletDictionary;
-        private string symbolRefCommandName;
-        private bool needsAliases;
+        private readonly SymbolReference _symbolRef;
+        private readonly ConcurrentDictionary<string, List<string>> _cmdletToAliasDictionary;
+        private readonly ConcurrentDictionary<string, string> _aliasToCmdletDictionary;
+        private readonly string _symbolRefCommandName;
+        private readonly bool _needsAliases;
 
         public List<SymbolReference> FoundReferences { get; set; }
 
@@ -24,36 +25,35 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// Constructor used when searching for aliases is needed
         /// </summary>
         /// <param name="symbolReference">The found symbolReference that other symbols are being compared to</param>
-        /// <param name="CmdletToAliasDictionary">Dictionary maping cmdlets to aliases for finding alias references</param>
-        /// <param name="AliasToCmdletDictionary">Dictionary maping aliases to cmdlets for finding alias references</param>
+        /// <param name="cmdletToAliasDictionary">Dictionary maping cmdlets to aliases for finding alias references</param>
+        /// <param name="aliasToCmdletDictionary">Dictionary maping aliases to cmdlets for finding alias references</param>
         public FindReferencesVisitor(
             SymbolReference symbolReference,
-            Dictionary<String, List<String>> CmdletToAliasDictionary,
-            Dictionary<String, String> AliasToCmdletDictionary)
+            ConcurrentDictionary<string, List<string>> cmdletToAliasDictionary = default,
+            ConcurrentDictionary<string, string> aliasToCmdletDictionary = default)
         {
-            this.symbolRef = symbolReference;
-            this.FoundReferences = new List<SymbolReference>();
-            this.needsAliases = true;
-            this.CmdletToAliasDictionary = CmdletToAliasDictionary;
-            this.AliasToCmdletDictionary = AliasToCmdletDictionary;
+            _symbolRef = symbolReference;
+            FoundReferences = new List<SymbolReference>();
 
-            // Try to get the symbolReference's command name of an alias,
-            // if a command name does not exists (if the symbol isn't an alias to a command)
-            // set symbolRefCommandName to and empty string value
-            AliasToCmdletDictionary.TryGetValue(symbolReference.ScriptRegion.Text, out symbolRefCommandName);
-            if (symbolRefCommandName == null) { symbolRefCommandName = string.Empty; }
+            if (cmdletToAliasDictionary is null || aliasToCmdletDictionary is null)
+            {
+                _needsAliases = false;
+                return;
+            }
 
-        }
+            _needsAliases = true;
+            _cmdletToAliasDictionary = cmdletToAliasDictionary;
+            _aliasToCmdletDictionary = aliasToCmdletDictionary;
 
-        /// <summary>
-        /// Constructor used when searching for aliases is not needed
-        /// </summary>
-        /// <param name="foundSymbol">The found symbolReference that other symbols are being compared to</param>
-        public FindReferencesVisitor(SymbolReference foundSymbol)
-        {
-            this.symbolRef = foundSymbol;
-            this.FoundReferences = new List<SymbolReference>();
-            this.needsAliases = false;
+            // Try to get the symbolReference's command name of an alias. If a command name does not
+            // exists (if the symbol isn't an alias to a command) set symbolRefCommandName to an
+            // empty string.
+            aliasToCmdletDictionary.TryGetValue(symbolReference.ScriptRegion.Text, out _symbolRefCommandName);
+
+            if (_symbolRefCommandName == null)
+            {
+                _symbolRefCommandName = string.Empty;
+            }
         }
 
         /// <summary>
@@ -68,50 +68,44 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             Ast commandNameAst = commandAst.CommandElements[0];
             string commandName = commandNameAst.Extent.Text;
 
-            if(symbolRef.SymbolType.Equals(SymbolType.Function))
+            if (_symbolRef.SymbolType.Equals(SymbolType.Function))
             {
-                if (needsAliases)
+                if (_needsAliases)
                 {
-                    // Try to get the commandAst's name and aliases,
-                    // if a command does not exists (if the symbol isn't an alias to a command)
-                    // set command to and empty string value string command
-                    // if the aliases do not exist (if the symvol isn't a command that has aliases)
+                    // Try to get the commandAst's name and aliases.
+                    //
+                    // If a command does not exist (if the symbol isn't an alias to a command) set
+                    // command to an empty string value string command.
+                    //
+                    // If the aliases do not exist (if the symbol isn't a command that has aliases)
                     // set aliases to an empty List<string>
-                    string command;
-                    List<string> alaises;
-                    CmdletToAliasDictionary.TryGetValue(commandName, out alaises);
-                    AliasToCmdletDictionary.TryGetValue(commandName, out command);
-                    if (alaises == null) { alaises = new List<string>(); }
+                    _cmdletToAliasDictionary.TryGetValue(commandName, out List<string> aliases);
+                    _aliasToCmdletDictionary.TryGetValue(commandName, out string command);
+                    if (aliases == null) { aliases = new List<string>(); }
                     if (command == null) { command = string.Empty; }
 
-                    if (symbolRef.SymbolType.Equals(SymbolType.Function))
+                    // Check if the found symbol's name is the same as the commandAst's name OR
+                    // if the symbol's name is an alias for this commandAst's name (commandAst is a cmdlet) OR
+                    // if the symbol's name is the same as the commandAst's cmdlet name (commandAst is a alias)
+                    if (commandName.Equals(_symbolRef.SymbolName, StringComparison.OrdinalIgnoreCase)
+                        // Note that PowerShell command names and aliases are case insensitive.
+                        || aliases.Exists((match) => string.Equals(match, _symbolRef.ScriptRegion.Text, StringComparison.OrdinalIgnoreCase))
+                        || command.Equals(_symbolRef.ScriptRegion.Text, StringComparison.OrdinalIgnoreCase)
+                        || (!string.IsNullOrEmpty(command)
+                            && command.Equals(_symbolRefCommandName, StringComparison.OrdinalIgnoreCase)))
                     {
-                        // Check if the found symbol's name is the same as the commandAst's name OR
-                        // if the symbol's name is an alias for this commandAst's name (commandAst is a cmdlet) OR
-                        // if the symbol's name is the same as the commandAst's cmdlet name (commandAst is a alias)
-                        if (commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase) ||
-                        alaises.Contains(symbolRef.ScriptRegion.Text.ToLower()) ||
-                        command.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase) ||
-                        (!string.IsNullOrEmpty(command) && command.Equals(symbolRefCommandName, StringComparison.CurrentCultureIgnoreCase)))
-                        {
-                            this.FoundReferences.Add(new SymbolReference(
-                                SymbolType.Function,
-                                commandNameAst.Extent));
-                        }
+                        FoundReferences.Add(new SymbolReference(SymbolType.Function, commandNameAst.Extent));
                     }
-
                 }
                 else // search does not include aliases
                 {
-                    if (commandName.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
+                    if (commandName.Equals(_symbolRef.SymbolName, StringComparison.OrdinalIgnoreCase))
                     {
-                        this.FoundReferences.Add(new SymbolReference(
-                            SymbolType.Function,
-                            commandNameAst.Extent));
+                        FoundReferences.Add(new SymbolReference(SymbolType.Function, commandNameAst.Extent));
                     }
                 }
-
             }
+
             return base.VisitCommand(commandAst);
         }
 
@@ -135,12 +129,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 File = functionDefinitionAst.Extent.File
             };
 
-            if (symbolRef.SymbolType.Equals(SymbolType.Function) &&
-                nameExtent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
+            if (_symbolRef.SymbolType.Equals(SymbolType.Function) &&
+                nameExtent.Text.Equals(_symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
-                this.FoundReferences.Add(new SymbolReference(
-                                          SymbolType.Function,
-                                          nameExtent));
+                FoundReferences.Add(new SymbolReference(SymbolType.Function, nameExtent));
             }
             return base.VisitFunctionDefinition(functionDefinitionAst);
         }
@@ -153,12 +145,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>A visit action that continues the search for references</returns>
         public override AstVisitAction VisitCommandParameter(CommandParameterAst commandParameterAst)
         {
-            if (symbolRef.SymbolType.Equals(SymbolType.Parameter) &&
-                commandParameterAst.Extent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
+            if (_symbolRef.SymbolType.Equals(SymbolType.Parameter) &&
+                commandParameterAst.Extent.Text.Equals(_symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
-                this.FoundReferences.Add(new SymbolReference(
-                                         SymbolType.Parameter,
-                                         commandParameterAst.Extent));
+                FoundReferences.Add(new SymbolReference(SymbolType.Parameter, commandParameterAst.Extent));
             }
             return AstVisitAction.Continue;
         }
@@ -171,12 +161,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>A visit action that continues the search for references</returns>
         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
         {
-            if(symbolRef.SymbolType.Equals(SymbolType.Variable) &&
-                variableExpressionAst.Extent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
+            if (_symbolRef.SymbolType.Equals(SymbolType.Variable)
+                && variableExpressionAst.Extent.Text.Equals(_symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
-                this.FoundReferences.Add(new SymbolReference(
-                                         SymbolType.Variable,
-                                         variableExpressionAst.Extent));
+                FoundReferences.Add(new SymbolReference(SymbolType.Variable, variableExpressionAst.Extent));
             }
             return AstVisitAction.Continue;
         }
@@ -186,7 +174,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         {
             int startColumnNumber = ast.Extent.StartColumnNumber;
             int startLineNumber = ast.Extent.StartLineNumber;
-            int astOffset = 0;
+            int astOffset;
 
             if (ast.IsFilter)
             {

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindReferencesVisitor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 
@@ -14,8 +13,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
     internal class FindReferencesVisitor : AstVisitor
     {
         private readonly SymbolReference _symbolRef;
-        private readonly ConcurrentDictionary<string, List<string>> _cmdletToAliasDictionary;
-        private readonly ConcurrentDictionary<string, string> _aliasToCmdletDictionary;
+        private readonly IDictionary<string, List<string>> _cmdletToAliasDictionary;
+        private readonly IDictionary<string, string> _aliasToCmdletDictionary;
         private readonly string _symbolRefCommandName;
         private readonly bool _needsAliases;
 
@@ -29,8 +28,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <param name="aliasToCmdletDictionary">Dictionary maping aliases to cmdlets for finding alias references</param>
         public FindReferencesVisitor(
             SymbolReference symbolReference,
-            ConcurrentDictionary<string, List<string>> cmdletToAliasDictionary = default,
-            ConcurrentDictionary<string, string> aliasToCmdletDictionary = default)
+            IDictionary<string, List<string>> cmdletToAliasDictionary = default,
+            IDictionary<string, string> aliasToCmdletDictionary = default)
         {
             _symbolRef = symbolReference;
             FoundReferences = new List<SymbolReference>();

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -75,8 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 _workspaceService.GetFile(
                     codeLensData.Uri);
 
-            var resolvedCodeLens = originalProvider.ResolveCodeLens(request, scriptFile);
-            return Task.FromResult(resolvedCodeLens);
+            return originalProvider.ResolveCodeLens(request, scriptFile);
         }
 
         public void SetCapability(CodeLensCapability capability)

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             DocumentSelector = LspUtils.PowerShellDocumentSelector
         };
 
-        public override Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
+        public async override Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
@@ -45,10 +45,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     request.Position.Character + 1);
 
             List<SymbolReference> referencesResult =
-                _symbolsService.FindReferencesOfSymbol(
+                await _symbolsService.FindReferencesOfSymbol(
                     foundSymbol,
                     _workspaceService.ExpandScriptReferences(scriptFile),
-                    _workspaceService);
+                    _workspaceService).ConfigureAwait(false);
 
             var locations = new List<Location>();
 
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            return Task.FromResult(new LocationContainer(locations));
+            return new LocationContainer(locations);
         }
 
         private static Range GetRangeFromScriptRegion(ScriptRegion scriptRegion)

--- a/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnBuiltInCommandWithAlias.cs
+++ b/test/PowerShellEditorServices.Test.Shared/References/FindsReferencesOnBuiltInCommandWithAlias.cs
@@ -17,16 +17,4 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.References
             endColumnNumber: 0,
             endOffset: 0);
     }
-    public static class FindsReferencesOnBuiltInAliasData
-    {
-        public static readonly ScriptRegion SourceDetails = new(
-            file: TestUtilities.NormalizePath("References/SimpleFile.ps1"),
-            text: string.Empty,
-            startLineNumber: 15,
-            startColumnNumber: 2,
-            startOffset: 0,
-            endLineNumber: 0,
-            endColumnNumber: 0,
-            endOffset: 0);
-    }
 }

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -203,20 +203,12 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             Assert.Equal(3, occurrencesResult[occurrencesResult.Count - 1].ScriptRegion.StartLineNumber);
         }
 
-        [Fact(Skip = "TODO Fix this test. A possible bug in PSES product code.")]
+        [Fact]
         public void FindsReferencesOnCommandWithAlias()
         {
             List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnBuiltInCommandWithAliasData.SourceDetails);
             Assert.Equal(4, referencesResult.Count);
             Assert.Equal("gci", referencesResult[1].SymbolName);
-            Assert.Equal("Get-ChildItem", referencesResult[referencesResult.Count - 1].SymbolName);
-        }
-
-        [Fact(Skip = "TODO Fix this test. A possible bug in PSES product code.")]
-        public void FindsReferencesOnAlias()
-        {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnBuiltInCommandWithAliasData.SourceDetails);
-            Assert.Equal(4, referencesResult.Count);
             Assert.Equal("dir", referencesResult[2].SymbolName);
             Assert.Equal("Get-ChildItem", referencesResult[referencesResult.Count - 1].SymbolName);
         }

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
             return symbolsService.GetDefinitionOfSymbolAsync(scriptFile, symbolReference);
         }
 
-        private List<SymbolReference> GetReferences(ScriptRegion scriptRegion)
+        private Task<List<SymbolReference>> GetReferences(ScriptRegion scriptRegion)
         {
             ScriptFile scriptFile = GetScriptFile(scriptRegion);
 
@@ -126,9 +126,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         }
 
         [Fact]
-         public void FindsReferencesOnFunction()
+         public async Task FindsReferencesOnFunction()
         {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnFunctionData.SourceDetails);
+            List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionData.SourceDetails).ConfigureAwait(true);
             Assert.Equal(3, referencesResult.Count);
             Assert.Equal(1, referencesResult[0].ScriptRegion.StartLineNumber);
             Assert.Equal(10, referencesResult[0].ScriptRegion.StartColumnNumber);
@@ -177,9 +177,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         }
 
         [Fact]
-        public void FindsReferencesOnVariable()
+        public async Task FindsReferencesOnVariable()
         {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnVariableData.SourceDetails);
+            List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnVariableData.SourceDetails).ConfigureAwait(true);
             Assert.Equal(3, referencesResult.Count);
             Assert.Equal(10, referencesResult[referencesResult.Count - 1].ScriptRegion.StartLineNumber);
             Assert.Equal(13, referencesResult[referencesResult.Count - 1].ScriptRegion.StartColumnNumber);
@@ -204,9 +204,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         }
 
         [Fact]
-        public void FindsReferencesOnCommandWithAlias()
+        public async Task FindsReferencesOnCommandWithAlias()
         {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnBuiltInCommandWithAliasData.SourceDetails);
+            List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnBuiltInCommandWithAliasData.SourceDetails).ConfigureAwait(true);
             Assert.Equal(4, referencesResult.Count);
             Assert.Equal("gci", referencesResult[1].SymbolName);
             Assert.Equal("dir", referencesResult[2].SymbolName);
@@ -214,16 +214,16 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         }
 
         [Fact]
-        public void FindsReferencesOnFileWithReferencesFileB()
+        public async Task FindsReferencesOnFileWithReferencesFileB()
         {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileB.SourceDetails);
+            List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileB.SourceDetails).ConfigureAwait(true);
             Assert.Equal(4, referencesResult.Count);
         }
 
         [Fact]
-        public void FindsReferencesOnFileWithReferencesFileC()
+        public async Task FindsReferencesOnFileWithReferencesFileC()
         {
-            List<SymbolReference> referencesResult = GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileC.SourceDetails);
+            List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileC.SourceDetails).ConfigureAwait(true);
             Assert.Equal(4, referencesResult.Count);
         }
 

--- a/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
@@ -7,13 +7,13 @@ using System.Management.Automation.Language;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.PowerShell.EditorServices.Test.Services.Symbols
 {
+    [Trait("Category", "AstOperations")]
     public class AstOperationsTests
     {
-        private static string s_scriptString = @"function BasicFunction {}
+        private const string s_scriptString = @"function BasicFunction {}
 BasicFunction
 
 function          FunctionWithExtraSpace
@@ -36,9 +36,8 @@ function
 
     FunctionNameOnDifferentLine
 ";
-        private static ScriptBlockAst s_ast = (ScriptBlockAst) ScriptBlock.Create(s_scriptString).Ast;
+        private static readonly ScriptBlockAst s_ast = (ScriptBlockAst) ScriptBlock.Create(s_scriptString).Ast;
 
-        [Trait("Category", "AstOperations")]
         [Theory]
         [InlineData(2, 3, "BasicFunction")]
         [InlineData(7, 18, "FunctionWithExtraSpace")]
@@ -50,14 +49,13 @@ function
             Assert.Equal(expectedName, reference.SymbolName);
         }
 
-        [Trait("Category", "AstOperations")]
         [Theory]
-        [MemberData(nameof(FindReferencesOfSymbolAtPostionData), parameters: 3)]
+        [MemberData(nameof(FindReferencesOfSymbolAtPostionData))]
         public void CanFindReferencesOfSymbolAtPostion(int lineNumber, int columnNumber, Position[] positions)
         {
             SymbolReference symbol = AstOperations.FindSymbolAtPosition(s_ast, lineNumber, columnNumber);
 
-            IEnumerable<SymbolReference> references = AstOperations.FindReferencesOfSymbol(s_ast, symbol, needsAliases: false);
+            IEnumerable<SymbolReference> references = AstOperations.FindReferencesOfSymbol(s_ast, symbol);
 
             int positionsIndex = 0;
             foreach (SymbolReference reference in references)
@@ -69,9 +67,7 @@ function
             }
         }
 
-        public static object[][] FindReferencesOfSymbolAtPostionData => s_findReferencesOfSymbolAtPostionData;
-
-        private static readonly object[][] s_findReferencesOfSymbolAtPostionData = new object[][]
+        public static object[][] FindReferencesOfSymbolAtPostionData { get; } = new object[][]
         {
             new object[] { 2, 3, new[] { new Position(1, 10), new Position(2, 1) } },
             new object[] { 7, 18, new[] { new Position(4, 19), new Position(7, 3) } },


### PR DESCRIPTION
This work was spawned by a skipped unit test that "indicated a bug in the product code." The bug was that the support was removed, but could be brought back fairly simply now that the pipeline threading work is finished.