### PR TITLE
Re-enable `ExtensionCommandTests.cs`

### DIFF
--- a/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         [Fact]
         public async Task CanCancelExecutionWithToken()
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            await Assert.ThrowsAsync<TaskCanceledException>(() =>
             {
                 return psesHost.ExecutePSCommandAsync(
                     new PSCommand().AddScript("Start-Sleep 10"),
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
             // Wait until our task has started.
             Thread.Sleep(2000);
             psesHost.CancelCurrentTask();
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(() => executeTask).ConfigureAwait(true);
+            await Assert.ThrowsAsync<TaskCanceledException>(() => executeTask).ConfigureAwait(true);
             Assert.True(executeTask.IsCanceled);
         }
 


### PR DESCRIPTION
These tests actually did not require the language server nor the service provider, we just had to manually initialize the extension service itself. Resolves #1444.