### PR TITLE
Enable resolution of an alias to its function definition

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -51,8 +51,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
         private static readonly ConcurrentDictionary<string, CommandInfo> s_commandInfoCache = new();
         private static readonly ConcurrentDictionary<string, string> s_synopsisCache = new();
-        private static readonly ConcurrentDictionary<string, List<string>> s_cmdletToAliasCache = new(System.StringComparer.OrdinalIgnoreCase);
-        private static readonly ConcurrentDictionary<string, string> s_aliasToCmdletCache = new(System.StringComparer.OrdinalIgnoreCase);
+        internal static readonly ConcurrentDictionary<string, List<string>> s_cmdletToAliasCache = new(System.StringComparer.OrdinalIgnoreCase);
+        internal static readonly ConcurrentDictionary<string, string> s_aliasToCmdletCache = new(System.StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the CommandInfo instance for a command with a particular name.

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -405,6 +405,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
             Validate.IsNotNull(nameof(sourceFile), sourceFile);
             Validate.IsNotNull(nameof(foundSymbol), foundSymbol);
 
+            // If symbol is an alias, resolve it.
+            (Dictionary<string, List<string>> _, Dictionary<string, string> aliasToCmdlets) =
+                await CommandHelpers.GetAliasesAsync(_executionService).ConfigureAwait(false);
+
+            if (aliasToCmdlets.ContainsKey(foundSymbol.SymbolName))
+            {
+                foundSymbol = new SymbolReference(
+                    foundSymbol.SymbolType,
+                    aliasToCmdlets[foundSymbol.SymbolName],
+                    foundSymbol.ScriptRegion,
+                    foundSymbol.FilePath,
+                    foundSymbol.SourceLine);
+            }
+
             ScriptFile[] referencedFiles =
                 _workspaceService.ExpandScriptReferences(
                     sourceFile);

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/FindDeclarationVisitor.cs
@@ -52,8 +52,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 File = functionDefinitionAst.Extent.File
             };
 
+            // We compare to the SymbolName instead of its text because it may have been resolved
+            // from an alias.
             if (symbolRef.SymbolType.Equals(SymbolType.Function) &&
-                nameExtent.Text.Equals(symbolRef.ScriptRegion.Text, StringComparison.CurrentCultureIgnoreCase))
+                nameExtent.Text.Equals(symbolRef.SymbolName, StringComparison.CurrentCultureIgnoreCase))
             {
                 this.FoundDeclaration =
                     new SymbolReference(

--- a/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionOfAlias.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Definition/FindsFunctionDefinitionOfAlias.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Shared.Definition
+{
+    public static class FindsFunctionDefinitionOfAliasData
+    {
+        public static readonly ScriptRegion SourceDetails = new(
+            file: TestUtilities.NormalizePath("References/SimpleFile.ps1"),
+            text: string.Empty,
+            startLineNumber: 20,
+            startColumnNumber: 4,
+            startOffset: 0,
+            endLineNumber: 0,
+            endColumnNumber: 0,
+            endOffset: 0);
+    }
+}

--- a/test/PowerShellEditorServices.Test.Shared/References/SimpleFile.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/References/SimpleFile.ps1
@@ -16,3 +16,5 @@ gci
 dir
 Write-Host
 Get-ChildItem
+
+My-Alias


### PR DESCRIPTION
Two caveats:

1. The alias must be set in the runspace, which means the script needs
   to have been executed.
2. The definition is the function itself, not the `Set-Alias` command.

Resolves https://github.com/PowerShell/vscode-powershell/issues/2800