### PR TITLE
Fix `DebuggerSetsVariablesWithConversion` test

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -400,8 +400,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             VariableDetailsBase variable = variableContainer.Children[name];
-            // Determine scope in which the variable lives so we can pass it to `Get-Variable -Scope`.
-            string scope = null; // TODO: Can this use a fancy pattern matcher?
+
+            // Determine scope in which the variable lives so we can pass it to `Get-Variable
+            // -Scope`. The default is scope 0 which is safe because if a user is able to see a
+            // variable in the debugger and so change it through this interface, it's either in the
+            // top-most scope or in one of the following named scopes. The default scope is most
+            // likely in the case of changing from the "auto variables" container.
+            string scope = "0";
+            // NOTE: This can't use a switch because the IDs aren't constant.
             if (variableContainerReferenceId == localScopeVariables.Id)
             {
                 scope = VariableContainerDetails.LocalScopeName;
@@ -413,11 +419,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
             else if (variableContainerReferenceId == globalScopeVariables.Id)
             {
                 scope = VariableContainerDetails.GlobalScopeName;
-            }
-            else
-            {
-                // Hmm, this would be unexpected. No scope means do not pass GO, do not collect $200.
-                throw new Exception("Could not find the scope for this variable.");
             }
 
             // Now that we have the scope, get the associated PSVariable object for the variable to be set.

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -613,7 +613,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal(newGlobalIntValue, intGlobalVar.ValueString);
         }
 
-        [Fact(Skip = "Variable conversion is broken")]
+        [Fact]
         public async Task DebuggerSetsVariablesWithConversion()
         {
             await debugService.SetLineBreakpointsAsync(
@@ -628,7 +628,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             VariableDetailsBase[] variables = GetVariables(VariableContainerDetails.LocalScopeName);
 
             // Test set of a local string variable (not strongly typed but force conversion)
-            const string newStrValue = "False";
+            const string newStrValue = "\"False\"";
             const string newStrExpr = "$false";
             VariableScope localScope = Array.Find(scopes, s => s.Name == VariableContainerDetails.LocalScopeName);
             string setStrValue = await debugService.SetVariableAsync(localScope.Id, "$strVar2", newStrExpr).ConfigureAwait(true);
@@ -657,8 +657,6 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             variables = GetVariables(VariableContainerDetails.LocalScopeName);
             var strVar = Array.Find(variables, v => v.Name == "$strVar2");
             Assert.Equal(newStrValue, strVar.ValueString);
-
-            scopes = debugService.GetVariableScopes(0);
 
             // Test set of script scope bool variable (strongly typed)
             variables = GetVariables(VariableContainerDetails.ScriptScopeName);

--- a/test/PowerShellEditorServices.Test/PsesHostFactory.cs
+++ b/test/PowerShellEditorServices.Test/PsesHostFactory.cs
@@ -20,21 +20,13 @@ namespace Microsoft.PowerShell.EditorServices.Test
         // NOTE: These paths are arbitrarily chosen just to verify that the profile paths can be set
         // to whatever they need to be for the given host.
 
-        public static readonly ProfilePathInfo TestProfilePaths =
-            new(
-                    Path.GetFullPath(
-                        TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Profile/Test.PowerShellEditorServices_profile.ps1")),
-                    Path.GetFullPath(
-                        TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Profile/ProfileTest.ps1")),
-                    Path.GetFullPath(
-                        TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Test.PowerShellEditorServices_profile.ps1")),
-                    Path.GetFullPath(
-                        TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/ProfileTest.ps1")));
+        public static readonly ProfilePathInfo TestProfilePaths = new(
+            Path.GetFullPath(TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Profile/Test.PowerShellEditorServices_profile.ps1")),
+            Path.GetFullPath(TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Profile/ProfileTest.ps1")),
+            Path.GetFullPath(TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/Test.PowerShellEditorServices_profile.ps1")),
+            Path.GetFullPath(TestUtilities.NormalizePath("../../../../PowerShellEditorServices.Test.Shared/ProfileTest.ps1")));
 
-        public static readonly string BundledModulePath = Path.GetFullPath(
-            TestUtilities.NormalizePath("../../../../../module"));
-
-        public static System.Management.Automation.Runspaces.Runspace InitialRunspace;
+        public static readonly string BundledModulePath = Path.GetFullPath(TestUtilities.NormalizePath("../../../../../module"));
 
         public static PsesInternalHost Create(ILoggerFactory loggerFactory)
         {
@@ -53,16 +45,16 @@ namespace Microsoft.PowerShell.EditorServices.Test
             }
 
             HostStartupInfo testHostDetails = new(
-                "PowerShell Editor Services Test Host",
-                "Test.PowerShellEditorServices",
-                new Version("1.0.0"),
+                name: "PowerShell Editor Services Test Host",
+                profileId: "Test.PowerShellEditorServices",
+                version: new Version("1.0.0"),
                 psHost: new NullPSHost(),
-                TestProfilePaths,
+                profilePaths: TestProfilePaths,
                 featureFlags: Array.Empty<string>(),
                 additionalModules: Array.Empty<string>(),
-                initialSessionState,
+                initialSessionState: initialSessionState,
                 logPath: null,
-                (int)LogLevel.None,
+                logLevel: (int)LogLevel.None,
                 consoleReplEnabled: false,
                 usesLegacyReadLine: false,
                 bundledModulePath: BundledModulePath);
@@ -70,8 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
             var psesHost = new PsesInternalHost(loggerFactory, null, testHostDetails);
 
             // NOTE: Because this is used by constructors it can't use await.
-            // TODO: Should we actually load profiles here?
-            if (psesHost.TryStartAsync(new HostStartOptions { LoadProfiles = true }, CancellationToken.None).GetAwaiter().GetResult())
+            if (psesHost.TryStartAsync(new HostStartOptions { LoadProfiles = false }, CancellationToken.None).GetAwaiter().GetResult())
             {
                 return psesHost;
             }

--- a/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
@@ -94,6 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
         }
 
         [Fact]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Explicitly checking task cancellation status.")]
         public async Task CanCancelExecutionWithMethod()
         {
             var executeTask = psesHost.ExecutePSCommandAsync(


### PR DESCRIPTION
With these two bugs fixed, we can now set variables which are strongly typed (and so need a conversion) through the debugger. This was a great unit test that indicated a bug, and it was easily reproducible.

While testing manually, the scope bug revealed itself when I attempted to set a variable in the "automatic variables" container (the test is using the local variables container). I think assuming a default scope of "0" is sane because if it's an automatic variable, it must be in the local scope, and every other container is mapped to a named scope. As we learned previously, we cannot "guess" at a scope because they do not map one-to-one with stack frames.

The conversion bug was due to `SessionStateProxy.GetVariable("ExecutionContext")` throwing [`NoSessionStateProxyWhenPipelineInProgress`](https://github.com/PowerShell/PowerShell/blob/7dc4587014bfa22919c933607bf564f0ba53db2e/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs#L1187). Initially I thought it could be solved by running it forcibly in the foreground (as the stack-trace showed it was being run via `OnIdle`); however, the same exception was thrown even then. I am not certain, but I think it is because the debugger is currently in a stopped state, which has left the pipeline running, and so this concurrency check fails. I don't know why it can't work concurrently, because this alternative means to get the `EngineIntrinsics` value works, and indeed, was the way we did it previously:

https://github.com/PowerShell/PowerShellEditorServices/blob/99b5b7e1a50f334bb0654e801484802c345a9cdf/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs#L499-L521 

Fixes #1661