### PR TITLE
Fix `Write-Host -NoNewLine` and `-*Color`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Console;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -11,13 +9,13 @@ using System.Management.Automation.Host;
 using System.Reflection;
 using System.Security;
 using System.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Console;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 {
     internal class EditorServicesConsolePSHostUserInterface : PSHostUserInterface
     {
-        private readonly ILogger _logger;
-
         private readonly IReadLineProvider _readLineProvider;
 
         private readonly PSHostUserInterface _underlyingHostUI;
@@ -29,21 +27,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             IReadLineProvider readLineProvider,
             PSHostUserInterface underlyingHostUI)
         {
-            _logger = loggerFactory.CreateLogger<EditorServicesConsolePSHostUserInterface>();
             _readLineProvider = readLineProvider;
             _underlyingHostUI = underlyingHostUI;
             RawUI = new EditorServicesConsolePSHostRawUserInterface(loggerFactory, underlyingHostUI.RawUI);
 
             _consoleHostUI = GetConsoleHostUI(_underlyingHostUI);
+
             if (_consoleHostUI != null)
             {
                 SetConsoleHostUIToInteractive(_consoleHostUI);
             }
         }
 
-        public override PSHostRawUserInterface RawUI { get; }
-
         public override bool SupportsVirtualTerminal => _underlyingHostUI.SupportsVirtualTerminal;
+
+        public override PSHostRawUserInterface RawUI { get; }
 
         public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
         {
@@ -77,7 +75,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
         {
-            if (_consoleHostUI != null)
+            if (_consoleHostUI is not null)
             {
                 return _consoleHostUI.PromptForCredential(caption, message, userName, targetName);
             }
@@ -85,58 +83,37 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             return _underlyingHostUI.PromptForCredential(caption, message, userName, targetName);
         }
 
-        public override string ReadLine()
-        {
-            return _readLineProvider.ReadLine.ReadLine(CancellationToken.None);
-        }
+        public override string ReadLine() => _readLineProvider.ReadLine.ReadLine(CancellationToken.None);
 
-        public override SecureString ReadLineAsSecureString()
-        {
-            return _readLineProvider.ReadLine.ReadSecureLine(CancellationToken.None);
-        }
+        public override SecureString ReadLineAsSecureString() => _readLineProvider.ReadLine.ReadSecureLine(CancellationToken.None);
 
-        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
-        {
-            _underlyingHostUI.Write(foregroundColor, backgroundColor, value);
-        }
+        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value) => _underlyingHostUI.Write(foregroundColor, backgroundColor, value);
 
-        public override void Write(string value)
-        {
-            _underlyingHostUI.Write(value);
-        }
+        public override void Write(string value) => _underlyingHostUI.Write(value);
 
-        public override void WriteDebugLine(string message)
-        {
-            _underlyingHostUI.WriteDebugLine(message);
-        }
+        public override void WriteDebugLine(string message) => _underlyingHostUI.WriteDebugLine(message);
 
-        public override void WriteErrorLine(string value)
-        {
-            _underlyingHostUI.WriteErrorLine(value);
-        }
+        public override void WriteErrorLine(string value) => _underlyingHostUI.WriteErrorLine(value);
 
-        public override void WriteLine(string value)
-        {
-            _underlyingHostUI.WriteLine(value);
-        }
+        public override void WriteInformation(InformationRecord record) => _underlyingHostUI.WriteInformation(record);
+
+        public override void WriteLine() => _underlyingHostUI.WriteLine();
+
+        public override void WriteLine(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value) => _underlyingHostUI.WriteLine(foregroundColor, backgroundColor, value);
+
+        public override void WriteLine(string value) => _underlyingHostUI.WriteLine(value);
 
         public override void WriteProgress(long sourceId, ProgressRecord record) => _underlyingHostUI.WriteProgress(sourceId, record);
 
-        public override void WriteVerboseLine(string message)
-        {
-            _underlyingHostUI.WriteVerboseLine(message);
-        }
+        public override void WriteVerboseLine(string message) => _underlyingHostUI.WriteVerboseLine(message);
 
-        public override void WriteWarningLine(string message)
-        {
-            _underlyingHostUI.WriteWarningLine(message);
-        }
+        public override void WriteWarningLine(string message) => _underlyingHostUI.WriteWarningLine(message);
 
         private static PSHostUserInterface GetConsoleHostUI(PSHostUserInterface ui)
         {
             FieldInfo externalUIField = ui.GetType().GetField("_externalUI", BindingFlags.NonPublic | BindingFlags.Instance);
 
-            if (externalUIField == null)
+            if (externalUIField is null)
             {
                 return null;
             }

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -66,7 +66,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
                 // We need to do merge errors and output before rendering with an Out- cmdlet
                 Command lastCommand = psCommand.Commands[psCommand.Commands.Count - 1];
                 lastCommand.MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
-                lastCommand.MergeMyResults(PipelineResultTypes.Information, PipelineResultTypes.Output);
             }
             return psCommand;
         }


### PR DESCRIPTION
Fixes #1667, PowerShell/vscode-powershell#3651

When we merge the `Information` stream into output it causes all information messages to be written directly to the output stream. This ignores `InformationAction` and also strips `Write-Host` of it's extra color/new line metadata.

This also fixes PowerShell/vscode-powershell#3705 (I would assume anyway)