### PR TITLE
Fix off-by-one error in validation within `GetOffsetAtPosition`

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -411,7 +411,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// <returns>The zero-based offset for the given file position.</returns>
         public int GetOffsetAtPosition(int lineNumber, int columnNumber)
         {
-            Validate.IsWithinRange("lineNumber", lineNumber, 1, this.FileLines.Count);
+            Validate.IsWithinRange("lineNumber", lineNumber, 1, this.FileLines.Count + 1);
             Validate.IsGreaterThan("columnNumber", columnNumber, 0);
 
             int offset = 0;


### PR DESCRIPTION
The incoming line number is 1-indexed (not 0-indexed), so while the
lower limit was correctly set to 1, the upper limit was set to
`FileLines.Count` which could be 0, but 0 lines implies an upper limit
of 1 with this indexing. See `ScriptFile.GetLine` for the only other use
of this 1-index range validation.

Fixes #1663.