### PR TITLE
Handle `debuggerResult` being null in `ProcessDebuggerResult`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
 
         public void ProcessDebuggerResult(DebuggerCommandResults debuggerResult)
         {
-            if (debuggerResult.ResumeAction is not null)
+            if (debuggerResult?.ResumeAction is not null)
             {
                 SetDebugResuming(debuggerResult.ResumeAction.Value);
                 RaiseDebuggerResumingEvent(new DebuggerResumingEventArgs(debuggerResult.ResumeAction.Value));


### PR DESCRIPTION
Not entirely sure why this can be the case, but a stacktrace from a null
dereference crash indicates it can be null. Since the existing logic is
only doing something if the `ResumeAction` field is not null, I assume
we similarly do nothing if the entire object is also null (since that
implies the former, too).

Fixes #1672