### PR TITLE
Send `stopDebugger` during REPL if no longer debugging

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
@@ -15,22 +15,22 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Debugging through a PowerShell Host is implemented by registering a handler
-    /// for the <see cref="System.Management.Automation.Debugger.DebuggerStop"/> event.
-    /// Registering that handler causes debug actions in PowerShell like Set-PSBreakpoint
-    /// and Wait-Debugger to drop into the debugger and trigger the handler.
-    /// The handler is passed a mutable <see cref="System.Management.Automation.DebuggerStopEventArgs"/> object
-    /// and the debugger stop lasts for the duration of the handler call.
-    /// The handler sets the <see cref="System.Management.Automation.DebuggerStopEventArgs.ResumeAction"/> property
-    /// when after it returns, the PowerShell debugger uses that as the direction on how to proceed.
+    /// Debugging through a PowerShell Host is implemented by registering a handler for the <see
+    /// cref="Debugger.DebuggerStop"/> event. Registering that handler causes debug actions in
+    /// PowerShell like Set-PSBreakpoint and Wait-Debugger to drop into the debugger and trigger the
+    /// handler. The handler is passed a mutable <see cref="DebuggerStopEventArgs"/> object and the
+    /// debugger stop lasts for the duration of the handler call. The handler sets the <see
+    /// cref="DebuggerStopEventArgs.ResumeAction"/> property when after it returns, the PowerShell
+    /// debugger uses that as the direction on how to proceed.
     /// </para>
     /// <para>
-    /// When we handle the <see cref="System.Management.Automation.Debugger.DebuggerStop"/> event,
-    /// we drop into a nested debug prompt and execute things in the debugger with <see cref="System.Management.Automation.Debugger.ProcessCommand(PSCommand, PSDataCollection{PSObject})"/>,
-    /// which enables debugger commands like <c>l</c>, <c>c</c>, <c>s</c>, etc.
-    /// <see cref="Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging.PowerShellDebugContext"/> saves the event args object in its state,
-    /// and when one of the debugger commands is used, the result returned is used to set <see cref="System.Management.Automation.DebuggerStopEventArgs.ResumeAction"/>
-    /// on the saved event args object so that when the event handler returns, the PowerShell debugger takes the correct action.
+    /// When we handle the <see cref="Debugger.DebuggerStop"/> event, we drop into a nested debug
+    /// prompt and execute things in the debugger with <see cref="Debugger.ProcessCommand(PSCommand,
+    /// PSDataCollection{PSObject})"/>, which enables debugger commands like <c>l</c>, <c>c</c>,
+    /// <c>s</c>, etc. <see cref="PowerShellDebugContext"/> saves the event args object in its
+    /// state, and when one of the debugger commands is used, the result returned is used to set
+    /// <see cref="DebuggerStopEventArgs.ResumeAction"/> on the saved event args object so that when
+    /// the event handler returns, the PowerShell debugger takes the correct action.
     /// </para>
     /// </remarks>
     internal class PowerShellDebugContext : IPowerShellDebugContext
@@ -72,42 +72,24 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
             return _psesHost.CurrentRunspace.GetDscBreakpointCapabilityAsync(_logger, _psesHost, cancellationToken);
         }
 
+        // This is required by the PowerShell API so that remote debugging works. Without it, a
+        // runspace may not have these options set and attempting to set breakpoints remotely fails.
         public void EnableDebugMode()
         {
-            // This is required by the PowerShell API so that remote debugging works.
-            // Without it, a runspace may not have these options set and attempting to set breakpoints remotely can fail.
             _psesHost.Runspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
         }
 
-        public void Abort()
-        {
-            SetDebugResuming(DebuggerResumeAction.Stop);
-        }
+        public void Abort() => SetDebugResuming(DebuggerResumeAction.Stop);
 
-        public void BreakExecution()
-        {
-            _psesHost.Runspace.Debugger.SetDebuggerStepMode(enabled: true);
-        }
+        public void BreakExecution() => _psesHost.Runspace.Debugger.SetDebuggerStepMode(enabled: true);
 
-        public void Continue()
-        {
-            SetDebugResuming(DebuggerResumeAction.Continue);
-        }
+        public void Continue() => SetDebugResuming(DebuggerResumeAction.Continue);
 
-        public void StepInto()
-        {
-            SetDebugResuming(DebuggerResumeAction.StepInto);
-        }
+        public void StepInto() => SetDebugResuming(DebuggerResumeAction.StepInto);
 
-        public void StepOut()
-        {
-            SetDebugResuming(DebuggerResumeAction.StepOut);
-        }
+        public void StepOut() => SetDebugResuming(DebuggerResumeAction.StepOut);
 
-        public void StepOver()
-        {
-            SetDebugResuming(DebuggerResumeAction.StepOver);
-        }
+        public void StepOver() => SetDebugResuming(DebuggerResumeAction.StepOver);
 
         public void SetDebugResuming(DebuggerResumeAction debuggerResumeAction)
         {
@@ -132,27 +114,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
         }
 
         // This must be called AFTER the new PowerShell has been pushed
-        public void EnterDebugLoop()
-        {
-            RaiseDebuggerStoppedEvent();
-        }
+        public void EnterDebugLoop() => RaiseDebuggerStoppedEvent();
 
         // This must be called BEFORE the debug PowerShell has been popped
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "This method may acquire an implementation later, at which point it will need instance data")]
-        public void ExitDebugLoop()
-        {
-        }
+        public void ExitDebugLoop() { }
 
-        public void SetDebuggerStopped(DebuggerStopEventArgs debuggerStopEventArgs)
+        public void SetDebuggerStopped(DebuggerStopEventArgs args)
         {
             IsStopped = true;
-            LastStopEventArgs = debuggerStopEventArgs;
+            LastStopEventArgs = args;
         }
 
-        public void SetDebuggerResumed()
-        {
-            IsStopped = false;
-        }
+        public void SetDebuggerResumed() { IsStopped = false; }
 
         public void ProcessDebuggerResult(DebuggerCommandResults debuggerResult)
         {
@@ -163,19 +137,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
             }
         }
 
-        public void HandleBreakpointUpdated(BreakpointUpdatedEventArgs breakpointUpdatedEventArgs)
-        {
-            BreakpointUpdated?.Invoke(this, breakpointUpdatedEventArgs);
-        }
+        public void HandleBreakpointUpdated(BreakpointUpdatedEventArgs args) => BreakpointUpdated?.Invoke(this, args);
 
-        private void RaiseDebuggerStoppedEvent()
-        {
-            DebuggerStopped?.Invoke(this, LastStopEventArgs);
-        }
+        private void RaiseDebuggerStoppedEvent() => DebuggerStopped?.Invoke(this, LastStopEventArgs);
 
-        private void RaiseDebuggerResumingEvent(DebuggerResumingEventArgs debuggerResumingEventArgs)
-        {
-            DebuggerResuming?.Invoke(this, debuggerResumingEventArgs);
-        }
+        private void RaiseDebuggerResumingEvent(DebuggerResumingEventArgs args) => DebuggerResuming?.Invoke(this, args);
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -599,6 +599,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             if (!_hostInfo.ConsoleReplEnabled)
             {
                 return;
+            }
+
+            // If we started the debug server, then on each REPL we need to check if we're still
+            // actively debugging, and if not, stop the server.
+            if (DebugContext.OwnsDebugServerState && !CurrentRunspace.Runspace.Debugger.InBreakpoint)
+            {
+                DebugContext.OwnsDebugServerState = false;
+                _languageServer?.SendNotification("powerShell/stopDebugger");
             }
 
             // When a task must run in the foreground, we cancel out of the idle loop and return to the top level.


### PR DESCRIPTION
This finishes #1677 by resurrecting the bug-fix originally implemented in #1570. This allows the user to start a debug session within the integrated console and then have the VS Code debugger stop when the PowerShell debug session stops.