### PR TITLE
Display prompt after `F8` finishes

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
@@ -47,10 +47,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (isFromRepl)
             {
-                _executionService.ExecutePSCommandAsync(
+                await _executionService.ExecutePSCommandAsync(
                     new PSCommand().AddScript(request.Expression),
                     CancellationToken.None,
-                    new PowerShellExecutionOptions { WriteOutputToHost = true, ThrowOnError = false, AddToHistory = true }).HandleErrorsAsync(_logger);
+                    new PowerShellExecutionOptions { WriteOutputToHost = true, ThrowOnError = false, AddToHistory = true }).HandleErrorsAsync(_logger).ConfigureAwait(false);
             }
             else
             {

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
@@ -55,10 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
                     throw new OperationCanceledException();
                 }
 
-                if (_exceptionInfo is not null)
-                {
-                    _exceptionInfo.Throw();
-                }
+                _exceptionInfo?.Throw();
 
                 return _result;
             }
@@ -79,27 +76,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
                 return;
             }
 
-            using (var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(_taskRequesterCancellationToken, executorCancellationToken))
+            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(_taskRequesterCancellationToken, executorCancellationToken);
+            if (cancellationSource.IsCancellationRequested)
             {
-                if (cancellationSource.IsCancellationRequested)
-                {
-                    SetCanceled();
-                    return;
-                }
+                SetCanceled();
+                return;
+            }
 
-                try
-                {
-                    TResult result = Run(cancellationSource.Token);
-                    SetResult(result);
-                }
-                catch (OperationCanceledException)
-                {
-                    SetCanceled();
-                }
-                catch (Exception e)
-                {
-                    SetException(e);
-                }
+            try
+            {
+                TResult result = Run(cancellationSource.Token);
+                SetResult(result);
+            }
+            catch (OperationCanceledException)
+            {
+                SetCanceled();
+            }
+            catch (Exception e)
+            {
+                SetException(e);
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
@@ -28,23 +28,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _executionService = executionService;
         }
 
-        public Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
+        public async Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
         {
             // TODO: Understand why we currently handle this asynchronously and why we return a dummy result value
             //       instead of awaiting the execution and returing a real result of some kind
 
             // This API is mostly used for F8 execution, so needs to interrupt the command prompt
-            _executionService.ExecutePSCommandAsync(
+            await _executionService.ExecutePSCommandAsync(
                 new PSCommand().AddScript(request.Expression),
                 CancellationToken.None,
-                new PowerShellExecutionOptions { WriteInputToHost = true, WriteOutputToHost = true, AddToHistory = true, ThrowOnError = false, InterruptCurrentForeground = true })
-                .HandleErrorsAsync(_logger);
+                new PowerShellExecutionOptions { WriteInputToHost = true, WriteOutputToHost = true, AddToHistory = true, ThrowOnError = false, InterruptCurrentForeground = true }).ConfigureAwait(false);
 
-            return Task.FromResult(new EvaluateResponseBody
+            return new EvaluateResponseBody
             {
                 Result = "",
                 VariablesReference = 0
-            });
+            };
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -270,11 +270,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 //  - block the consumer thread from mutating the queue
                 //  - cancel any running task on the consumer thread
                 //  - place our task on the front of the queue
+                //  - skip the next prompt so the task runs instead
                 //  - unblock the consumer thread
                 using (_taskQueue.BlockConsumers())
                 {
                     CancelCurrentTask();
                     _taskQueue.Prepend(task);
+                    _skipNextPrompt = true;
                 }
 
                 return task.Task;


### PR DESCRIPTION
This fixes https://github.com/PowerShell/vscode-powershell/issues/3685 by awaiting the task spawned by the evaluate handler (triggered by F8) and skipping the "next" prompt that actually should have been interrupted by that foreground task.