### PR TITLE
Print prompt and command when `WriteInputToHost` is true

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
-using Microsoft.PowerShell.EditorServices.Utility;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Remoting;
 using System.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
+using Microsoft.PowerShell.EditorServices.Utility;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
             if (PowerShellExecutionOptions.WriteInputToHost)
             {
-                _psesHost.UI.WriteLine(_psCommand.GetInvocationText());
+                _psesHost.WriteWithPrompt(_psCommand, cancellationToken);
             }
 
             return _pwsh.Runspace.Debugger.InBreakpoint
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
                 foreach (PSObject output in outputCollection)
                 {
-                    if (object.Equals(output?.BaseObject, false))
+                    if (Equals(output?.BaseObject, false))
                     {
                         _psesHost.DebugContext.ProcessDebuggerResult(new DebuggerCommandResults(DebuggerResumeAction.Stop, evaluatedByDebugger: true));
                         _logger.LogWarning("Cancelling debug session due to remote command cancellation causing the end of remote debugging session");

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -674,6 +674,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             return prompt;
         }
 
+        /// <summary>
+        /// This is used to write the invocation text of a command with the user's prompt so that,
+        /// for example, F8 (evaluate selection) appears as if the user typed it. Used when
+        /// 'WriteInputToHost' is true.
+        /// </summary>
+        /// <param name="command">The PSCommand we'll print after the prompt.</param>
+        /// <param name="cancellationToken"></param>
+        public void WriteWithPrompt(PSCommand command, CancellationToken cancellationToken)
+        {
+            UI.Write(GetPrompt(cancellationToken));
+            UI.Write(command.GetInvocationText());
+        }
+
         private string InvokeReadLine(CancellationToken cancellationToken)
         {
             return _readLineProvider.ReadLine.ReadLine(cancellationToken);


### PR DESCRIPTION
This fixes https://github.com/PowerShell/vscode-powershell/issues/3786 by simply printing the prompt before the input of the command run by F8. It's almost cosmetic-only, except it does invoke the user's `prompt` function again which could have side-effects. What's more, we'll still have an empty prompt before the invocation; however, I believe that to be an accurate representation of what's happening because that prompt is canceled per my explanation here: https://github.com/PowerShell/vscode-powershell/issues/3786#issuecomment-1026354061