### PR TITLE
Fix printing of command with F5

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -684,7 +684,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         public void WriteWithPrompt(PSCommand command, CancellationToken cancellationToken)
         {
             UI.Write(GetPrompt(cancellationToken));
-            UI.Write(command.GetInvocationText());
+            UI.WriteLine(command.GetInvocationText());
         }
 
         private string InvokeReadLine(CancellationToken cancellationToken)


### PR DESCRIPTION
Small regression: accidentally called `Write...Write` instead of `Write...WriteLine`.