### PR TITLE
Replace superfluous `Default` member with default values

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             // Register the editor object in the runspace
             return ExecutionService.ExecuteDelegateAsync(
                 $"Create ${PSEditorVariableName} object",
-                ExecutionOptions.Default,
+                executionOptions: null,
                 (pwsh, _) => pwsh.Runspace.SessionStateProxy.PSVariable.Set(psEditor),
                 CancellationToken.None);
         }

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/LegacyReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/LegacyReadLine.cs
@@ -84,14 +84,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
                                         .AddParameter("CursorColumn", currentCursorIndex)
                                         .AddParameter("Options", null);
 
-                                    currentCompletion = _psesHost.InvokePSCommand<CommandCompletion>(command, PowerShellExecutionOptions.Default, cancellationToken).FirstOrDefault();
+                                    currentCompletion = _psesHost.InvokePSCommand<CommandCompletion>(command, executionOptions: null, cancellationToken).FirstOrDefault();
                                 }
                                 else
                                 {
                                     currentCompletion = _psesHost.InvokePSDelegate(
                                         "Legacy readline inline command completion",
-                                        ExecutionOptions.Default,
-                                        (pwsh, cancellationToken) => CommandCompletion.CompleteInput(inputAfterCompletion, currentCursorIndex, options: null, pwsh),
+                                        executionOptions: null,
+                                        (pwsh, _) => CommandCompletion.CompleteInput(inputAfterCompletion, currentCursorIndex, options: null, pwsh),
                                         cancellationToken);
 
                                     if (currentCompletion.CompletionMatches.Count > 0)
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
                                 PSCommand command = new PSCommand()
                                     .AddCommand("Get-History");
 
-                                currentHistory = _psesHost.InvokePSCommand<PSObject>(command, PowerShellExecutionOptions.Default, cancellationToken);
+                                currentHistory = _psesHost.InvokePSCommand<PSObject>(command, executionOptions: null, cancellationToken);
 
                                 if (currentHistory != null)
                                 {

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
 
             return psesHost.ExecuteDelegateAsync<DscBreakpointCapability>(
                 nameof(getDscBreakpointCapabilityFunc),
-                ExecutionOptions.Default,
+                executionOptions: null,
                 getDscBreakpointCapabilityFunc,
                 cancellationToken);
         }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
@@ -15,39 +15,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
     // Generally the executor will do the right thing though; some options just priority over others.
     public record ExecutionOptions
     {
-        public static ExecutionOptions Default = new()
-        {
-            Priority = ExecutionPriority.Normal,
-            MustRunInForeground = false,
-            InterruptCurrentForeground = false,
-        };
-
-        public ExecutionPriority Priority { get; init; }
-
+        public ExecutionPriority Priority { get; init; } = ExecutionPriority.Normal;
         public bool MustRunInForeground { get; init; }
-
         public bool InterruptCurrentForeground { get; init; }
     }
 
     public record PowerShellExecutionOptions : ExecutionOptions
     {
-        public static new PowerShellExecutionOptions Default = new()
-        {
-            Priority = ExecutionPriority.Normal,
-            MustRunInForeground = false,
-            InterruptCurrentForeground = false,
-            WriteOutputToHost = false,
-            WriteInputToHost = false,
-            ThrowOnError = true,
-            AddToHistory = false,
-        };
-
         public bool WriteOutputToHost { get; init; }
-
         public bool WriteInputToHost { get; init; }
-
-        public bool ThrowOnError { get; init; }
-
+        public bool ThrowOnError { get; init; } = true;
         public bool AddToHistory { get; init; }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousDelegateTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousDelegateTask.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             CancellationToken cancellationToken)
             : base(logger, cancellationToken)
         {
-            ExecutionOptions = executionOptions;
+            ExecutionOptions = executionOptions ?? new ExecutionOptions();
             _representation = representation;
             _action = action;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
         {
             _func = func;
             _representation = representation;
-            ExecutionOptions = executionOptions;
+            ExecutionOptions = executionOptions ?? new ExecutionOptions();
         }
 
         public override ExecutionOptions ExecutionOptions { get; }
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _psesHost = psesHost;
             _action = action;
             _representation = representation;
-            ExecutionOptions = executionOptions;
+            ExecutionOptions = executionOptions ?? new ExecutionOptions();
         }
 
         public override ExecutionOptions ExecutionOptions { get; }
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _psesHost = psesHost;
             _func = func;
             _representation = representation;
-            ExecutionOptions = executionOptions;
+            ExecutionOptions = executionOptions ?? new ExecutionOptions();
         }
 
         public override ExecutionOptions ExecutionOptions { get; }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _logger = logger;
             _psesHost = psesHost;
             _psCommand = command;
-            PowerShellExecutionOptions = executionOptions;
+            PowerShellExecutionOptions = executionOptions ?? new PowerShellExecutionOptions();
         }
 
         public PowerShellExecutionOptions PowerShellExecutionOptions { get; }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -307,7 +307,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             Func<PowerShell, CancellationToken, TResult> func,
             CancellationToken cancellationToken)
         {
-            return InvokeTaskOnPipelineThreadAsync(new SynchronousPSDelegateTask<TResult>(_logger, this, representation, executionOptions ?? ExecutionOptions.Default, func, cancellationToken));
+            return InvokeTaskOnPipelineThreadAsync(
+                new SynchronousPSDelegateTask<TResult>(_logger, this, representation, executionOptions, func, cancellationToken));
         }
 
         public Task ExecuteDelegateAsync(
@@ -316,7 +317,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             Action<PowerShell, CancellationToken> action,
             CancellationToken cancellationToken)
         {
-            return InvokeTaskOnPipelineThreadAsync(new SynchronousPSDelegateTask(_logger, this, representation, executionOptions ?? ExecutionOptions.Default, action, cancellationToken));
+            return InvokeTaskOnPipelineThreadAsync(
+                new SynchronousPSDelegateTask(_logger, this, representation, executionOptions, action, cancellationToken));
         }
 
         public Task<TResult> ExecuteDelegateAsync<TResult>(
@@ -325,7 +327,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             Func<CancellationToken, TResult> func,
             CancellationToken cancellationToken)
         {
-            return InvokeTaskOnPipelineThreadAsync(new SynchronousDelegateTask<TResult>(_logger, representation, executionOptions ?? ExecutionOptions.Default, func, cancellationToken));
+            return InvokeTaskOnPipelineThreadAsync(
+                new SynchronousDelegateTask<TResult>(_logger, representation, executionOptions, func, cancellationToken));
         }
 
         public Task ExecuteDelegateAsync(
@@ -334,7 +337,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             Action<CancellationToken> action,
             CancellationToken cancellationToken)
         {
-            return InvokeTaskOnPipelineThreadAsync(new SynchronousDelegateTask(_logger, representation, executionOptions ?? ExecutionOptions.Default, action, cancellationToken));
+            return InvokeTaskOnPipelineThreadAsync(
+                new SynchronousDelegateTask(_logger, representation, executionOptions, action, cancellationToken));
         }
 
         public Task<IReadOnlyList<TResult>> ExecutePSCommandAsync<TResult>(
@@ -342,18 +346,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             CancellationToken cancellationToken,
             PowerShellExecutionOptions executionOptions = null)
         {
-            return InvokeTaskOnPipelineThreadAsync(new SynchronousPowerShellTask<TResult>(
-                _logger,
-                this,
-                psCommand,
-                executionOptions ?? PowerShellExecutionOptions.Default,
-                cancellationToken));
+            return InvokeTaskOnPipelineThreadAsync(
+                new SynchronousPowerShellTask<TResult>(_logger, this, psCommand, executionOptions, cancellationToken));
         }
 
         public Task ExecutePSCommandAsync(
             PSCommand psCommand,
             CancellationToken cancellationToken,
-            PowerShellExecutionOptions executionOptions = null) => ExecutePSCommandAsync<PSObject>(psCommand, cancellationToken, executionOptions);
+            PowerShellExecutionOptions executionOptions = null)
+        {
+            return ExecutePSCommandAsync<PSObject>(psCommand, cancellationToken, executionOptions);
+        }
 
         public TResult InvokeDelegate<TResult>(string representation, ExecutionOptions executionOptions, Func<CancellationToken, TResult> func, CancellationToken cancellationToken)
         {
@@ -374,7 +377,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         }
 
         public void InvokePSCommand(PSCommand psCommand, PowerShellExecutionOptions executionOptions, CancellationToken cancellationToken)
-            => InvokePSCommand<PSObject>(psCommand, executionOptions, cancellationToken);
+        {
+            InvokePSCommand<PSObject>(psCommand, executionOptions, cancellationToken);
+        }
 
         public TResult InvokePSDelegate<TResult>(string representation, ExecutionOptions executionOptions, Func<PowerShell, CancellationToken, TResult> func, CancellationToken cancellationToken)
         {
@@ -662,7 +667,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         private string GetPrompt(CancellationToken cancellationToken)
         {
             var command = new PSCommand().AddCommand("prompt");
-            IReadOnlyList<string> results = InvokePSCommand<string>(command, PowerShellExecutionOptions.Default, cancellationToken);
+            IReadOnlyList<string> results = InvokePSCommand<string>(command, executionOptions: null, cancellationToken);
             string prompt = results.Count > 0 ? results[0] : DefaultPrompt;
 
             if (CurrentRunspace.RunspaceOrigin != RunspaceOrigin.Local)
@@ -846,7 +851,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             // to force event processing
             if (runPipelineForEventProcessing)
             {
-                InvokePSCommand(new PSCommand().AddScript("0", useLocalScope: true), PowerShellExecutionOptions.Default, CancellationToken.None);
+                InvokePSCommand(new PSCommand().AddScript("0", useLocalScope: true), executionOptions: null, CancellationToken.None);
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -183,7 +183,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
             IEnumerable<CommandInfo> aliases = await executionService.ExecuteDelegateAsync<IEnumerable<CommandInfo>>(
                 nameof(GetAliasesAsync),
-                Execution.ExecutionOptions.Default,
+                executionOptions: null,
                 (pwsh, _) =>
                 {
                     CommandInvocationIntrinsics invokeCommand = pwsh.Runspace.SessionStateProxy.InvokeCommand;

--- a/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
@@ -657,8 +657,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         private Task RegisterPSEditFunctionAsync()
             => _executionService.ExecuteDelegateAsync(
                 "Register psedit function",
-                ExecutionOptions.Default,
-                (pwsh, cancellationToken) => RegisterPSEditFunction(pwsh.Runspace),
+                executionOptions: null,
+                (pwsh, _) => RegisterPSEditFunction(pwsh.Runspace),
                 CancellationToken.None);
 
         private void RegisterPSEditFunction(Runspace runspace)


### PR DESCRIPTION
I think this was a case of premature optimization. We're using C#
records, which should be as cheap as an object as they come, especially
when we can rely on the compiler for default values. Now we're passing
fewer objects around too.