### PR TITLE
Add `Thread.Sleep(100)` to throttle REPL when it's non-interactive

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -595,7 +595,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                         task.ExecuteSynchronously(cancellationScope.CancellationToken);
                     }
                 }
-                Thread.Sleep(100);
             }
         }
 
@@ -603,6 +602,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         {
             if (!_hostInfo.ConsoleReplEnabled)
             {
+                // Throttle the REPL loop with a sleep because we're not interactively reading input from the user.
+                Thread.Sleep(100);
                 return;
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -595,6 +595,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                         task.ExecuteSynchronously(cancellationScope.CancellationToken);
                     }
                 }
+                Thread.Sleep(100);
             }
         }
 


### PR DESCRIPTION
We integrated PSES into our project and noticed a considerable increase in CPU usage while PSES is running.

I downloaded the PSES project and was able to step through the code and see it is executing a `while` loop with zero throttling.

Adding a `Thread.Sleep(100)` brought down the CPU of my application considerably when PSES was running.  I did not notice any increase in latency when using PSES itself either.

Here are the parameters we are using:

```c#
powershell.AddCommand("Start-EditorServices")
        .AddParameter("HostName", "monaco")
        .AddParameter("HostProfileId", "0")
        .AddParameter("HostVersion", "1.0.0")
        .AddParameter("LogPath", Path.ChangeExtension(Path.GetTempFileName(), ".log"))
        .AddParameter("LogLevel", "Normal")
        .AddParameter("FeatureFlags", Array.Empty<string>())
        .AddParameter("BundledModulesPath", BundledModulesPath)
        .AddParameter("SessionDetailsPath", _sessionInfoFilePath)
        .AddParameter("LanguageServiceOnly");
```

Using `Thread.Sleep(100)` is heavy handed, so the solution can likely be expanded to either take in a variable that specifies the sleep amount, or better yet, remove the `while` loop entirely and refactor it into an even-driven approach and execute only when we have data in ` _taskQueue`.


This solution works for us, but I am not at all familiar with the rest of this project.  So please let me know if there are any obvious disadvantages with making this change. Thanks!
