### PR TITLE
Use `static readonly` for default `ExecutionOptions`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousDelegateTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousDelegateTask.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using System;
 using System.Threading;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             CancellationToken cancellationToken)
             : base(logger, cancellationToken)
         {
-            ExecutionOptions = executionOptions ?? new ExecutionOptions();
+            ExecutionOptions = executionOptions ?? s_defaultExecutionOptions;
             _representation = representation;
             _action = action;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
         {
             _func = func;
             _representation = representation;
-            ExecutionOptions = executionOptions ?? new ExecutionOptions();
+            ExecutionOptions = executionOptions ?? s_defaultExecutionOptions;
         }
 
         public override ExecutionOptions ExecutionOptions { get; }
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _psesHost = psesHost;
             _action = action;
             _representation = representation;
-            ExecutionOptions = executionOptions ?? new ExecutionOptions();
+            ExecutionOptions = executionOptions ?? s_defaultExecutionOptions;
         }
 
         public override ExecutionOptions ExecutionOptions { get; }
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _psesHost = psesHost;
             _func = func;
             _representation = representation;
-            ExecutionOptions = executionOptions ?? new ExecutionOptions();
+            ExecutionOptions = executionOptions ?? s_defaultExecutionOptions;
         }
 
         public override ExecutionOptions ExecutionOptions { get; }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         private SMA.PowerShell _pwsh;
 
+        private readonly static PowerShellExecutionOptions s_defaultPowerShellExecutionOptions = new();
+
         public SynchronousPowerShellTask(
             ILogger logger,
             PsesInternalHost psesHost,
@@ -36,7 +38,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             _logger = logger;
             _psesHost = psesHost;
             _psCommand = command;
-            PowerShellExecutionOptions = executionOptions ?? new PowerShellExecutionOptions();
+            PowerShellExecutionOptions = executionOptions ?? s_defaultPowerShellExecutionOptions;
         }
 
         public PowerShellExecutionOptions PowerShellExecutionOptions { get; }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
@@ -65,6 +65,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         public abstract ExecutionOptions ExecutionOptions { get; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "RCS1158", Justification = "Field is not type-dependent")]
+        internal static readonly ExecutionOptions s_defaultExecutionOptions = new();
+
         public abstract TResult Run(CancellationToken cancellationToken);
 
         public abstract override string ToString();


### PR DESCRIPTION
But at the `SynchronousTask` level. Now we get the best of both worlds:
the records have the correct default values on initialization, and we
only heap allocate a single static instance of `ExecutionOptions` for
the default case.