### PR TITLE
Avoid recording debugger commands in the history

### DIFF
--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -586,10 +586,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             VariableDetailsBase[] variables = GetVariables(VariableContainerDetails.LocalScopeName);
 
             // Test set of a local string variable (not strongly typed)
-            const string newStrValue = "Goodbye";
+            const string newStrValue = "\"Goodbye\"";
             VariableScope localScope = Array.Find(scopes, s => s.Name == VariableContainerDetails.LocalScopeName);
-            // TODO: Fix this so it has the second quotes again?
-            string setStrValue = await debugService.SetVariableAsync(localScope.Id, "$strVar", '"' + newStrValue + '"').ConfigureAwait(true);
+            string setStrValue = await debugService.SetVariableAsync(localScope.Id, "$strVar", newStrValue).ConfigureAwait(true);
             Assert.Equal(newStrValue, setStrValue);
 
             // Test set of script scope int variable (not strongly typed)


### PR DESCRIPTION
This changes how we decide to run a given command through
`ExecuteInDebugger` or `ExecuteNormally`. It now restricts the former
such that it is only used for PowerShell's intrinsic debugger commands
(like `s`, `c`, etc.) and the latter is used for any other user command
or, more importantly, our own implementation's debugger commands (like
when we call `Get-Variable`).