### PR TITLE
Redirect `EditorServicesConsolePSHost.PrivateData` to `_internalHost`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHost.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public override string Name => _internalHost.Name;
 
+        public override System.Management.Automation.PSObject PrivateData => _internalHost.PrivateData;
+
         public override PSHostUserInterface UI => _internalHost.UI;
 
         public override Version Version => _internalHost.Version;


### PR DESCRIPTION
This may fix color formatting for old version of PowerShell.

Fixes #1607