### PR TITLE
Avoid stopping the debugger when canceling other tasks in a debug session

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -861,8 +861,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             _cancellationContext.CancelCurrentTask();
 
             // If the current task was running under the debugger, we need to synchronize the
-            // cancelation with our debug context (and likely the debug server).
-            StopDebugContext();
+            // cancelation with our debug context (and likely the debug server). Note that if we're
+            // currently stopped in a breakpoint, that means the task is _not_ under the debugger.
+            if (!CurrentRunspace.Runspace.Debugger.InBreakpoint)
+            {
+                StopDebugContext();
+            }
         }
 
         private ConsoleKeyInfo ReadKey(bool intercept)


### PR DESCRIPTION
While we need to cancel the debugger if a debugged task is running and
Ctrl-C is issued, we explicitly are not running the debugged task when
we're stopped in a breakpoint. Instead, the user can be running
unrelated tasks and may wish to cancel them without stopping the
debugger.

Fixes https://github.com/PowerShell/vscode-powershell/issues/3832 and https://github.com/PowerShell/PowerShellEditorServices/issues/1708