### PR TITLE
Allow multiple code actions if there is more than one SuggestedCorrection of a diagnostic record returned by PSSA

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 string diagnosticId = AnalysisService.GetUniqueIdFromDiagnostic(diagnostic);
                 if (corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
                 {
-                    foreach(ScriptRegion edit in correction.Edits)
+                    foreach (ScriptRegion edit in correction.Edits)
                     {
                         codeActions.Add(new CodeAction
                         {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -81,24 +81,27 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 string diagnosticId = AnalysisService.GetUniqueIdFromDiagnostic(diagnostic);
                 if (corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
                 {
-                    codeActions.Add(new CodeAction
+                    foreach(ScriptRegion edit in correction.Edits)
                     {
-                        Title = correction.Name,
-                        Kind = CodeActionKind.QuickFix,
-                        Edit = new WorkspaceEdit
+                        codeActions.Add(new CodeAction
                         {
-                            DocumentChanges = new Container<WorkspaceEditDocumentChange>(
-                                new WorkspaceEditDocumentChange(
-                                    new TextDocumentEdit
-                                    {
-                                        TextDocument = new OptionalVersionedTextDocumentIdentifier
+                            Title = correction.Name,
+                            Kind = CodeActionKind.QuickFix,
+                            Edit = new WorkspaceEdit
+                            {
+                                DocumentChanges = new Container<WorkspaceEditDocumentChange>(
+                                    new WorkspaceEditDocumentChange(
+                                        new TextDocumentEdit
                                         {
-                                            Uri = request.TextDocument.Uri
-                                        },
-                                        Edits = new TextEditContainer(correction.Edits.Select(ScriptRegion.ToTextEdit))
-                                    }))
-                        }
-                    });
+                                            TextDocument = new OptionalVersionedTextDocumentIdentifier
+                                            {
+                                                Uri = request.TextDocument.Uri
+                                            },
+                                            Edits = new TextEditContainer(ScriptRegion.ToTextEdit(edit))
+                                        }))
+                            }
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently, PSSA's `SuggestCorrections` property of the `DiagnosticRecord` object already is an array but no built-in rules return more than one suggested correction, which lead to `PowerShellEditorServices` not correctly translating this array before returning it as an code action but it only ever displayed one. This fixes it makes it generic again so it returns a code action for each suggest correction. It's basically just performing a foreach loop and calling `ToTextEdit` just once, a diff that ignored whitespace due to increased indentation will make this much clearer
This is a pre-requisite for an implementation of this, where a built-inrule will return multiple suggest corrections: https://github.com/PowerShell/PSScriptAnalyzer/issues/1767

I've manually tested this with a modified version of PSSA where I return 2 suggested corrections and when I build the PS extension with this change, the UI shows me the two different suggested code actions and also applies them correctly (as in they are different as they should be by design)