### PR TITLE
Use global `dotnet` and update build dependencies

### DIFF
--- a/.vsts-ci/azure-pipelines-release.yml
+++ b/.vsts-ci/azure-pipelines-release.yml
@@ -29,7 +29,8 @@ stages:
   jobs:
   - job: Build
     pool:
-      vmImage: windows-2019
+      name: 1ES
+      demands: ImageOverride -equals PSMMS2019-Secure
     steps:
     - template: templates/ci-general.yml
 
@@ -39,7 +40,7 @@ stages:
   - job: Sign
     pool:
       name: 1ES
-      demands: ImageOverride -equals MMSWindows2019-Secure
+      demands: ImageOverride -equals PSMMS2019-Secure
     variables:
     - group: ESRP
     steps:
@@ -51,7 +52,8 @@ stages:
   - deployment: Publish
     environment: PowerShellEditorServices
     pool:
-      vmImage: ubuntu-latest
+      name: 1ES
+      demands: ImageOverride -equals PSMMSUbuntu20.04-Secure
     variables:
     - group: Publish
     strategy:

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -11,6 +11,20 @@ steps:
     script: $PSVersionTable
     pwsh: ${{ parameters.pwsh }}
 
+- task: UseDotNet@2
+  displayName: Install .NET 6.0.x SDK
+  inputs:
+    packageType: sdk
+    version: 6.0.x
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  displayName: Install .NET 3.1.x runtime
+  inputs:
+    packageType: runtime
+    version: 3.1.x
+    performMultiLevelLookup: true
+
 - task: PowerShell@2
   displayName: Build and test
   inputs:

--- a/tools/azurePipelinesBuild.ps1
+++ b/tools/azurePipelinesBuild.ps1
@@ -17,7 +17,7 @@ if ($IsWindows -or $PSVersionTable.PSVersion.Major -lt 6) {
 Update-Help -Force -ErrorAction SilentlyContinue
 
 # Needed for build and docs gen.
-Install-Module -Name InvokeBuild -MaximumVersion 5.1.0 -Scope CurrentUser -Force
-Install-Module -Name PlatyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force
+Install-Module -Name InvokeBuild -RequiredVersion 5.9.7 -Scope CurrentUser -Force
+Install-Module -Name platyPS -RequiredVersion 0.14.2 -Scope CurrentUser -Force
 
 Invoke-Build -Configuration Release


### PR DESCRIPTION
This removes our build script's dependency on the `install-dotnet` script (which is only meant for use in CI, but we now use an ADO task for that, and so that we can rely on pre-installed versions of .NET if available). Developers will need to follow .NET Core's instructions to install .NET SDK 6.0, and the 3.1 runtime for the end-to-end tests. Fortunately, this actually eases the developer workflow by no longer being sensitive to a local installation of `dotnet`, so the C# extension in Code now "just works."

This updates the release pipeline to use the `PMMSWindows2019-Secure` for build, sign, and release.

This also updates our required and installed `InvokeBuild` and `platyPS` modules for the build, which is probably the most annoying part of this PR as devs will need to run `Update-Module` for these (and possibly install `playPS` if they had never run the dependent task before).