### PR TITLE
Return a code action for each diagnostic record

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
-using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -21,21 +19,22 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     {
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
-        private readonly WorkspaceService _workspaceService;
 
-        public PsesCodeActionHandler(ILoggerFactory factory, AnalysisService analysisService, WorkspaceService workspaceService)
+        public PsesCodeActionHandler(ILoggerFactory factory, AnalysisService analysisService)
         {
             _logger = factory.CreateLogger<PsesCodeActionHandler>();
             _analysisService = analysisService;
-            _workspaceService = workspaceService;
         }
 
-        protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities) => new CodeActionRegistrationOptions
+        protected override CodeActionRegistrationOptions CreateRegistrationOptions(CodeActionCapability capability, ClientCapabilities clientCapabilities)
+        {
+            return new()
             {
-            // TODO: What do we do with the arguments?
-            DocumentSelector = LspUtils.PowerShellDocumentSelector,
-            CodeActionKinds = new CodeActionKind[] { CodeActionKind.QuickFix }
-        };
+                // TODO: What do we do with the arguments?
+                DocumentSelector = LspUtils.PowerShellDocumentSelector,
+                CodeActionKinds = new CodeActionKind[] { CodeActionKind.QuickFix }
+            };
+        }
 
         // TODO: Either fix or ignore "method lacks 'await'" warning.
         public override async Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
@@ -65,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return Array.Empty<CommandOrCodeAction>();
             }
 
-            var codeActions = new List<CommandOrCodeAction>();
+            List<CommandOrCodeAction> codeActions = new();
 
             // If there are any code fixes, send these commands first so they appear at top of "Code Fix" menu in the client UI.
             foreach (Diagnostic diagnostic in request.Context.Diagnostics)
@@ -108,7 +107,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Add "show documentation" commands last so they appear at the bottom of the client UI.
             // These commands do not require code fixes. Sometimes we get a batch of diagnostics
             // to create commands for. No need to create multiple show doc commands for the same rule.
-            var ruleNamesProcessed = new HashSet<string>();
+            HashSet<string> ruleNamesProcessed = new();
             foreach (Diagnostic diagnostic in request.Context.Diagnostics)
             {
                 if (
@@ -122,8 +121,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 if (string.Equals(diagnostic.Source, "PSScriptAnalyzer", StringComparison.OrdinalIgnoreCase) &&
                     !ruleNamesProcessed.Contains(diagnostic.Code?.String))
                 {
-                    ruleNamesProcessed.Add(diagnostic.Code?.String);
-                    var title = $"Show documentation for: {diagnostic.Code?.String}";
+                    _ = ruleNamesProcessed.Add(diagnostic.Code?.String);
+                    string title = $"Show documentation for: {diagnostic.Code?.String}";
                     codeActions.Add(new CodeAction
                     {
                         Title = title,
@@ -135,7 +134,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         {
                             Title = title,
                             Name = "PowerShell.ShowCodeActionDocumentation",
-                            Arguments = JArray.FromObject(new[] { diagnostic.Code?.String })
+                            Arguments = Newtonsoft.Json.Linq.JArray.FromObject(new[] { diagnostic.Code?.String })
                         }
                     });
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -81,24 +81,27 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 string diagnosticId = AnalysisService.GetUniqueIdFromDiagnostic(diagnostic);
                 if (corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
                 {
-                    codeActions.Add(new CodeAction
+                    foreach (ScriptRegion edit in correction.Edits)
                     {
-                        Title = correction.Name,
-                        Kind = CodeActionKind.QuickFix,
-                        Edit = new WorkspaceEdit
+                        codeActions.Add(new CodeAction
                         {
-                            DocumentChanges = new Container<WorkspaceEditDocumentChange>(
-                                new WorkspaceEditDocumentChange(
-                                    new TextDocumentEdit
-                                    {
-                                        TextDocument = new OptionalVersionedTextDocumentIdentifier
+                            Title = correction.Name,
+                            Kind = CodeActionKind.QuickFix,
+                            Edit = new WorkspaceEdit
+                            {
+                                DocumentChanges = new Container<WorkspaceEditDocumentChange>(
+                                    new WorkspaceEditDocumentChange(
+                                        new TextDocumentEdit
                                         {
-                                            Uri = request.TextDocument.Uri
-                                        },
-                                        Edits = new TextEditContainer(correction.Edits.Select(ScriptRegion.ToTextEdit))
-                                    }))
-                        }
-                    });
+                                            TextDocument = new OptionalVersionedTextDocumentIdentifier
+                                            {
+                                                Uri = request.TextDocument.Uri
+                                            },
+                                            Edits = new TextEditContainer(ScriptRegion.ToTextEdit(edit))
+                                        }))
+                            }
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently, PSSA's `SuggestCorrections` property of the
`DiagnosticRecord` object already is an array, but no built-in rules
return more than one suggested correction, which led to
`PowerShellEditorServices` not correctly translating this array before
returning it as an code action as it only ever displayed one. This fixes
it by making it generic again so it returns a code action for each
suggest correction. It's basically just performing a `foreach` loop and
calling `ToTextEdit` just once.

This is a pre-requisite for an implementation of this, where a built-in
rule will return multiple suggest corrections:
https://github.com/PowerShell/PSScriptAnalyzer/issues/1767

I've manually tested this with a modified version of PSScriptAnalyzer
where I return two suggested corrections. The extension's UI now shows
me the two different suggested code actions and also applies them
correctly.

Replaces #1713.