### PR TITLE
Reset progress messages at end of REPL

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -662,6 +662,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 UI.WriteErrorLine($"An error occurred while running the REPL loop:{Environment.NewLine}{e}");
                 _logger.LogError(e, "An error occurred while running the REPL loop");
             }
+            finally
+            {
+                // At the end of each REPL we need to complete all progress records so that the
+                // progress indicator is cleared.
+                if (UI is EditorServicesConsolePSHostUserInterface ui)
+                {
+                    ui.ResetProgress();
+                }
+            }
         }
 
         private string GetPrompt(CancellationToken cancellationToken)


### PR DESCRIPTION
This seems to work. We needed to hold onto processed progress records,
and then at the end of the REPL mark each as completed and re-write it
(which uses the underlying host and effectively clears it).

Fixes https://github.com/PowerShell/vscode-powershell/issues/3807