### PR TITLE
Re-enable line breakpoints for untitled scripts

### DIFF
--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -129,10 +129,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             return sb;
         }
 
-        public static PSCommand BuildCommandFromArguments(string command, IEnumerable<string> arguments)
+        public static PSCommand BuildDotSourceCommandWithArguments(string command, IEnumerable<string> arguments)
         {
+            string args = string.Join(" ", arguments ?? Array.Empty<string>());
+            string script = string.Concat(". ", command, string.IsNullOrEmpty(args) ? "" : " ", args);
             // HACK: We use AddScript instead of AddArgument/AddParameter to reuse Powershell parameter binding logic.
-            string script = string.Concat(". ", command, " ", string.Join(" ", arguments ?? Array.Empty<string>()));
             return new PSCommand().AddScript(script);
         }
     }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
         private Task ExecutePowerShellCommand(string command, params string[] args)
         {
             return psesHost.ExecutePSCommandAsync(
-                PSCommandHelpers.BuildCommandFromArguments(string.Concat('"', command, '"'), args),
+                PSCommandHelpers.BuildDotSourceCommandWithArguments(string.Concat('"', command, '"'), args),
                 CancellationToken.None);
         }
 


### PR DESCRIPTION
We managed to make the previous hack work while continuing to support
passing the users' arguments. As there was demand for this feature to
continue working, despite being a hack, we're keeping it.