### PR TITLE
Fix editor commands to interrupt current prompt

### DIFF
--- a/src/PowerShellEditorServices/Extensions/Api/ExtensionCommandService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/ExtensionCommandService.cs
@@ -4,6 +4,7 @@
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Extensions.Services
@@ -78,7 +79,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
 
         public IReadOnlyList<EditorCommand> GetCommands() => _extensionService.GetCommands();
 
-        public Task InvokeCommandAsync(string commandName, EditorContext editorContext) => _extensionService.InvokeCommandAsync(commandName, editorContext);
+        public Task InvokeCommandAsync(string commandName, EditorContext editorContext) => _extensionService.InvokeCommandAsync(commandName, editorContext, CancellationToken.None);
 
         public bool RegisterCommand(EditorCommand editorCommand) => _extensionService.RegisterCommand(editorCommand);
 

--- a/src/PowerShellEditorServices/Services/Extension/Handlers/InvokeExtensionCommandHandler.cs
+++ b/src/PowerShellEditorServices/Services/Extension/Handlers/InvokeExtensionCommandHandler.cs
@@ -4,40 +4,28 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Extensions;
 
 namespace Microsoft.PowerShell.EditorServices.Services.Extension
 {
     internal class InvokeExtensionCommandHandler : IInvokeExtensionCommandHandler
     {
-        private readonly ILogger<InvokeExtensionCommandHandler> _logger;
         private readonly ExtensionService _extensionService;
         private readonly EditorOperationsService _editorOperationsService;
 
         public InvokeExtensionCommandHandler(
-            ILoggerFactory factory,
             ExtensionService extensionService,
-            EditorOperationsService editorOperationsService
-            )
+            EditorOperationsService editorOperationsService)
         {
-            _logger = factory.CreateLogger<InvokeExtensionCommandHandler>();
             _extensionService = extensionService;
             _editorOperationsService = editorOperationsService;
         }
 
         public async Task<Unit> Handle(InvokeExtensionCommandParams request, CancellationToken cancellationToken)
         {
-            // We can now await here because we handle asynchronous message handling.
-            EditorContext editorContext =
-                _editorOperationsService.ConvertClientEditorContext(
-                    request.Context);
-
-            await _extensionService.InvokeCommandAsync(
-                request.Name,
-                editorContext).ConfigureAwait(false);
-
-            return await Unit.Task.ConfigureAwait(false);
+            EditorContext editorContext = _editorOperationsService.ConvertClientEditorContext(request.Context);
+            await _extensionService.InvokeCommandAsync(request.Name, editorContext, cancellationToken).ConfigureAwait(false);
+            return Unit.Value;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
@@ -30,15 +30,21 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
         {
-            // TODO: Understand why we currently handle this asynchronously and why we return a dummy result value
-            //       instead of awaiting the execution and returing a real result of some kind
-
-            // This API is mostly used for F8 execution, so needs to interrupt the command prompt
+            // This API is mostly used for F8 execution, so it needs to interrupt the command prompt
+            // (or other foreground task).
             await _executionService.ExecutePSCommandAsync(
                 new PSCommand().AddScript(request.Expression),
                 CancellationToken.None,
-                new PowerShellExecutionOptions { WriteInputToHost = true, WriteOutputToHost = true, AddToHistory = true, ThrowOnError = false, InterruptCurrentForeground = true }).ConfigureAwait(false);
+                new PowerShellExecutionOptions
+                {
+                    WriteInputToHost = true,
+                    WriteOutputToHost = true,
+                    AddToHistory = true,
+                    ThrowOnError = false,
+                    InterruptCurrentForeground = true
+                }).ConfigureAwait(false);
 
+            // TODO: Should we return a more informative result?
             return new EvaluateResponseBody
             {
                 Result = "",


### PR DESCRIPTION
Also refactored it slightly to accept the existing `cancellationToken` send to the handler, and removed an unused logger service. This fixes https://github.com/PowerShell/vscode-powershell/issues/3691.