### PR TITLE
WIP: Wrap `ReadLine` with lock and fallback to legacy when re-entering

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -86,6 +86,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
                 var invocationSettings = new PSInvocationSettings
                 {
                     AddToHistory = PowerShellExecutionOptions.AddToHistory,
+                    Host = _psesHost
                 };
 
                 if (PowerShellExecutionOptions.ThrowOnError)


### PR DESCRIPTION
Just me trying things. So, weird thing, but in the repro for https://github.com/PowerShell/vscode-powershell/issues/3751, while we're in the debugger, things can't print. Like if you run `Get-Process` at the debug prompt it shows nothing, and if you're debugging the pwsh process you see a million exceptions. This gets resolved when I set the host explicitly in the new `PSInvocationSettings`. When we either don't create the linked cancellation token source, or when we move its scope outside the function its currently created in, the repro issue goes away. The monitor logic I guess is useless 🥲

Play around with it @SeeminglyScience?