### PR TITLE
Replace `_consoleHostUI` with `_underlyingHostUI`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Host;
-using System.Reflection;
 using System.Security;
 using System.Threading;
 using Microsoft.Extensions.Logging;
@@ -20,8 +19,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         private readonly IReadLineProvider _readLineProvider;
 
         private readonly PSHostUserInterface _underlyingHostUI;
-
-        private readonly PSHostUserInterface _consoleHostUI;
 
         /// <summary>
         /// We use a ConcurrentDictionary because ConcurrentHashSet does not exist, hence the value
@@ -37,58 +34,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             _readLineProvider = readLineProvider;
             _underlyingHostUI = underlyingHostUI;
             RawUI = new EditorServicesConsolePSHostRawUserInterface(loggerFactory, underlyingHostUI.RawUI);
-
-            _consoleHostUI = GetConsoleHostUI(_underlyingHostUI);
-
-            if (_consoleHostUI != null)
-            {
-                SetConsoleHostUIToInteractive(_consoleHostUI);
-            }
         }
 
         public override bool SupportsVirtualTerminal => _underlyingHostUI.SupportsVirtualTerminal;
 
         public override PSHostRawUserInterface RawUI { get; }
 
-        public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
-        {
-            if (_consoleHostUI != null)
-            {
-                return _consoleHostUI.Prompt(caption, message, descriptions);
-            }
+        public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions) => _underlyingHostUI.Prompt(caption, message, descriptions);
 
-            return _underlyingHostUI.Prompt(caption, message, descriptions);
-        }
+        public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice) => _underlyingHostUI.PromptForChoice(caption, message, choices, defaultChoice);
 
-        public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
-        {
-            if (_consoleHostUI != null)
-            {
-                return _consoleHostUI.PromptForChoice(caption, message, choices, defaultChoice);
-            }
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options) => _underlyingHostUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
 
-            return _underlyingHostUI.PromptForChoice(caption, message, choices, defaultChoice);
-        }
-
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
-        {
-            if (_consoleHostUI != null)
-            {
-                return _consoleHostUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
-            }
-
-            return _underlyingHostUI.PromptForCredential(caption, message, userName, targetName, allowedCredentialTypes, options);
-        }
-
-        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
-        {
-            if (_consoleHostUI is not null)
-            {
-                return _consoleHostUI.PromptForCredential(caption, message, userName, targetName);
-            }
-
-            return _underlyingHostUI.PromptForCredential(caption, message, userName, targetName);
-        }
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName) => _underlyingHostUI.PromptForCredential(caption, message, userName, targetName);
 
         public override string ReadLine() => _readLineProvider.ReadLine.ReadLine(CancellationToken.None);
 
@@ -138,19 +96,5 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         public override void WriteVerboseLine(string message) => _underlyingHostUI.WriteVerboseLine(message);
 
         public override void WriteWarningLine(string message) => _underlyingHostUI.WriteWarningLine(message);
-
-        private static PSHostUserInterface GetConsoleHostUI(PSHostUserInterface ui)
-        {
-            FieldInfo externalUIField = ui.GetType().GetField("_externalUI", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            if (externalUIField is null)
-            {
-                return null;
-            }
-
-            return (PSHostUserInterface)externalUIField.GetValue(ui);
-        }
-
-        private static void SetConsoleHostUIToInteractive(PSHostUserInterface ui) => ui.GetType().GetProperty("ThrowOnReadAndPrompt", BindingFlags.NonPublic | BindingFlags.Instance)?.SetValue(ui, false);
     }
 }


### PR DESCRIPTION
And stop using reflection to find `_externalUI`. This is not necessary in order to reuse PowerShell's built-in prompt logic (which was its original goal). Unfortunately this doesn't fix the issues it was written in an attempt to fix, but it does remove unnecessary reflection logic.