### PR TITLE
Correctly map `SuggestedCorrection` to `MarkerCorrection`

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -402,7 +402,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 Diagnostic diagnostic = GetDiagnosticFromMarker(marker);
 
-                if (marker.Corrections != null)
+                if (marker.Corrections is not null)
                 {
                     string diagnosticId = GetUniqueIdFromDiagnostic(diagnostic);
                     fileCorrections.Corrections[diagnosticId] = marker.Corrections;

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -208,7 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             ScriptFileMarker[] analysisResults = await AnalysisEngine.AnalyzeScriptAsync(functionText, commentHelpSettings).ConfigureAwait(false);
 
-            if (analysisResults.Length == 0 || analysisResults[0].Corrections.Any())
+            if (analysisResults.Length == 0 || !analysisResults[0].Corrections.Any())
             {
                 return null;
             }

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -208,14 +208,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             ScriptFileMarker[] analysisResults = await AnalysisEngine.AnalyzeScriptAsync(functionText, commentHelpSettings).ConfigureAwait(false);
 
-            if (analysisResults.Length == 0
-                || analysisResults[0]?.Correction?.Edits == null
-                || analysisResults[0].Correction.Edits.Length == 0)
+            if (analysisResults.Length == 0 || analysisResults[0].Corrections.Any())
             {
                 return null;
             }
 
-            return analysisResults[0].Correction.Edits[0].Text;
+            return analysisResults[0].Corrections.First().Edit.Text;
         }
 
         /// <summary>
@@ -223,7 +221,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="documentUri">The URI string of the file to get code actions for.</param>
         /// <returns>A threadsafe readonly dictionary of the code actions of the particular file.</returns>
-        public async Task<IReadOnlyDictionary<string, MarkerCorrection>> GetMostRecentCodeActionsForFileAsync(DocumentUri uri)
+        public async Task<IReadOnlyDictionary<string, IEnumerable<MarkerCorrection>>> GetMostRecentCodeActionsForFileAsync(DocumentUri uri)
         {
             if (!_workspaceService.TryGetFile(uri, out ScriptFile file)
                 || !_mostRecentCorrectionsByFile.TryGetValue(file, out CorrectionTableEntry corrections))
@@ -404,10 +402,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
                 Diagnostic diagnostic = GetDiagnosticFromMarker(marker);
 
-                if (marker.Correction != null)
+                if (marker.Corrections != null)
                 {
                     string diagnosticId = GetUniqueIdFromDiagnostic(diagnostic);
-                    fileCorrections.Corrections[diagnosticId] = marker.Correction;
+                    fileCorrections.Corrections[diagnosticId] = marker.Corrections;
                 }
 
                 diagnostics[i] = diagnostic;
@@ -511,11 +509,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             public CorrectionTableEntry()
             {
-                Corrections = new ConcurrentDictionary<string, MarkerCorrection>();
+                Corrections = new ConcurrentDictionary<string, IEnumerable<MarkerCorrection>>();
                 DiagnosticPublish = Task.CompletedTask;
             }
 
-            public ConcurrentDictionary<string, MarkerCorrection> Corrections { get; }
+            public ConcurrentDictionary<string, IEnumerable<MarkerCorrection>> Corrections { get; }
 
             public Task DiagnosticPublish { get; set; }
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return Array.Empty<CommandOrCodeAction>();
             }
 
-            IReadOnlyDictionary<string, MarkerCorrection> corrections = await _analysisService.GetMostRecentCodeActionsForFileAsync(
+            IReadOnlyDictionary<string, IEnumerable<MarkerCorrection>> corrections = await _analysisService.GetMostRecentCodeActionsForFileAsync(
                 request.TextDocument.Uri)
                 .ConfigureAwait(false);
 
@@ -75,13 +75,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
 
                 string diagnosticId = AnalysisService.GetUniqueIdFromDiagnostic(diagnostic);
-                if (corrections.TryGetValue(diagnosticId, out MarkerCorrection correction))
+                if (corrections.TryGetValue(diagnosticId, out IEnumerable<MarkerCorrection> markerCorrections))
                 {
-                    foreach (ScriptRegion edit in correction.Edits)
+                    foreach (MarkerCorrection markerCorrection in markerCorrections)
                     {
                         codeActions.Add(new CodeAction
                         {
-                            Title = correction.Name,
+                            Title = markerCorrection.Name,
                             Kind = CodeActionKind.QuickFix,
                             Edit = new WorkspaceEdit
                             {
@@ -93,7 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                                             {
                                                 Uri = request.TextDocument.Uri
                                             },
-                                            Edits = new TextEditContainer(ScriptRegion.ToTextEdit(edit))
+                                            Edits = new TextEditContainer(ScriptRegion.ToTextEdit(markerCorrection.Edit))
                                         }))
                             }
                         });

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
@@ -136,9 +136,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                                 suggestedCorrection.Text,
                                 startLineNumber: suggestedCorrection.StartLineNumber,
                                 startColumnNumber: suggestedCorrection.StartColumnNumber,
+                                startOffset: -1,
                                 endLineNumber: suggestedCorrection.EndLineNumber,
                                 endColumnNumber: suggestedCorrection.EndColumnNumber,
-                                startOffset: -1,
                                 endOffset: -1),
                     });
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs
@@ -21,9 +21,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of ScriptRegions that define the edits to be made by the correction.
+        /// Gets or sets the ScriptRegion that define the edit to be made by the correction.
         /// </summary>
-        public ScriptRegion[] Edits { get; set; }
+        public ScriptRegion Edit { get; set; }
     }
 
     /// <summary>
@@ -79,9 +79,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         public ScriptRegion ScriptRegion { get; set; }
 
         /// <summary>
-        /// Gets or sets an optional code correction that can be applied based on this marker.
+        /// Gets or sets a optional code corrections that can be applied based on its marker.
         /// </summary>
-        public MarkerCorrection Correction { get; set; }
+        public IEnumerable<MarkerCorrection> Corrections { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the marker's source like "PowerShell"
@@ -110,7 +110,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         internal static ScriptFileMarker FromDiagnosticRecord(PSObject psObject)
         {
             Validate.IsNotNull(nameof(psObject), psObject);
-            MarkerCorrection correction = null;
 
             // make sure psobject is of type DiagnosticRecord
             if (!psObject.TypeNames.Contains(
@@ -124,32 +123,25 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             // the diagnostic record's properties directly i.e. <instance>.<propertyName>
             // without having to go through PSObject's Members property.
             dynamic diagnosticRecord = psObject;
-
+            List<MarkerCorrection> markerCorrections = new();
             if (diagnosticRecord.SuggestedCorrections != null)
             {
-                List<ScriptRegion> editRegions = new();
-                string correctionMessage = null;
                 foreach (dynamic suggestedCorrection in diagnosticRecord.SuggestedCorrections)
                 {
-                    editRegions.Add(
-                        new ScriptRegion(
-                            diagnosticRecord.ScriptPath,
-                            suggestedCorrection.Text,
-                            startLineNumber: suggestedCorrection.StartLineNumber,
-                            startColumnNumber: suggestedCorrection.StartColumnNumber,
-                            endLineNumber: suggestedCorrection.EndLineNumber,
-                            endColumnNumber: suggestedCorrection.EndColumnNumber,
-                            startOffset: -1,
-                            endOffset: -1));
-
-                    correctionMessage = suggestedCorrection.Description;
+                    markerCorrections.Add(new MarkerCorrection
+                    {
+                        Name = suggestedCorrection.Description ?? diagnosticRecord.Message,
+                        Edit = new ScriptRegion(
+                                diagnosticRecord.ScriptPath,
+                                suggestedCorrection.Text,
+                                startLineNumber: suggestedCorrection.StartLineNumber,
+                                startColumnNumber: suggestedCorrection.StartColumnNumber,
+                                endLineNumber: suggestedCorrection.EndLineNumber,
+                                endColumnNumber: suggestedCorrection.EndColumnNumber,
+                                startOffset: -1,
+                                endOffset: -1),
+                    });
                 }
-
-                correction = new MarkerCorrection
-                {
-                    Name = correctionMessage ?? diagnosticRecord.Message,
-                    Edits = editRegions.ToArray()
-                };
             }
 
             string severity = diagnosticRecord.Severity.ToString();
@@ -166,7 +158,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
                 RuleName = diagnosticRecord.RuleName as string ?? string.Empty,
                 Level = level,
                 ScriptRegion = ScriptRegion.Create(diagnosticRecord.Extent as IScriptExtent),
-                Correction = correction,
+                Corrections = markerCorrections,
                 Source = "PSScriptAnalyzer"
             };
         }


### PR DESCRIPTION
With the recent fix in PR #1718, PSES processes now all Correction objects from PSSA but the message specifically was just taken from the last correction [here](https://github.com/PowerShell/PowerShellEditorServices/blob/e555dc050d3ef36272ba6f84925086cb7abc048a/src/PowerShellEditorServices/Services/TextDocument/ScriptFileMarker.cs#L150). I did not notice this at first because I thought I had to tweak my rule first to emit two different messages until I realized it was another bug in PSES.
Related: https://github.com/PowerShell/PSScriptAnalyzer/pull/1782
Proof here that the message of each correction is associated to it as well (the actual code fix already was)

BEFORE
![image](https://user-images.githubusercontent.com/9250262/160922634-06e98358-3970-424e-8c51-81bc861b239e.png)

AFTER
![image](https://user-images.githubusercontent.com/9250262/160921940-6e0c49a1-6d7a-41d3-a15a-a0cdf6d903e2.png)