### PR TITLE
With a fix in PSReadLine, we don't have to return a "null" key press

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -6,6 +6,6 @@
         "Version": "1.1.3"
     },
     "PSReadLine": {
-        "Version": "2.2.2"
+        "Version": "2.2.3"
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1022,13 +1022,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             }
         }
 
-        private static readonly ConsoleKeyInfo s_nullKeyInfo = new(
-            keyChar: ' ',
-            ConsoleKey.DownArrow,
-            shift: false,
-            alt: false,
-            control: false);
-
         private ConsoleKeyInfo ReadKey(bool intercept)
         {
             // PSRL doesn't tell us when CtrlC was sent.
@@ -1047,11 +1040,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
             // TODO: We may want to allow users of PSES to override this method call.
             _lastKey = System.Console.ReadKey(intercept);
-
-            // TODO: After fixing PSReadLine so that when canceled it doesn't read a key, we can
-            // stop using s_nullKeyInfo (which is a down arrow so we don't change the buffer
-            // content). Without this, the sent key press is translated to an @ symbol.
-            return _readKeyCancellationToken.IsCancellationRequested ? s_nullKeyInfo : _lastKey.Value;
+            return _lastKey.Value;
         }
 
         internal ConsoleKeyInfo ReadKey(bool intercept, CancellationToken cancellationToken)


### PR DESCRIPTION
Which wasn't reliable anyway, because it could be translated to different things depending on the system and encodings in use. PSReadLine now just discards any key input after cancellation.

Requires https://github.com/PowerShell/PSReadLine/pull/3274 and fixes https://github.com/PowerShell/PowerShellEditorServices/issues/1754.