### PR TITLE
Enable IDE0005 (unneccessary using statements) as error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,12 @@ dotnet_diagnostic.CS0414.severity = error
 dotnet_diagnostic.CS0618.severity = suggestion
 # CS0649: Uninitialized private or internal field declaration that is never assigned a value
 dotnet_diagnostic.CS0649.severity = error
+# CS1570: Parameter has no matching param tag in the XML comment
+dotnet_diagnostic.CS1570.severity = silent
+# CS1574: XML comment has cref attribute that could not be resolved.
+dotnet_diagnostic.CS1574.severity = suggestion
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = silent
 # CS1998: This async method lacks 'await' operators and will run synchronously
 dotnet_diagnostic.CS1998.severity = suggestion
 # CS4014: Consider applying the await operator to the result of the call

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -14,6 +14,8 @@
     <!-- See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview -->
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Required to enable IDE0005 as error -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TODO: Enable <AnalysisMode>All</AnalysisMode> -->
     <!-- See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -15,9 +15,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
     /// User-facing log level for editor services configuration.
     /// </summary>
     /// <remarks>
-    /// The underlying values of this enum attempt to align to both <see
-    /// cref="Microsoft.Logging.Extensions.LogLevel"</see> and <see
-    /// cref="Serilog.Events.LogEventLevel"</see>.
+    /// The underlying values of this enum attempt to align to both
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel" /> and
+    /// <see cref="Serilog.Events.LogEventLevel" />.
     /// </remarks>
     public enum PsesLogLevel
     {

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="logger">The host logger to use.</param>
         /// <param name="hostConfig">The host configuration to start editor services with.</param>
         /// <param name="sessionFileWriter">The session file writer to write the session file with.</param>
+        /// <param name="loggersToUnsubscribe">The loggers to unsubscribe form writing to the terminal.</param>
         /// <returns></returns>
         public static EditorServicesLoader Create(
             HostLogger logger,

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -12,6 +11,10 @@ using System.Runtime.InteropServices;
 using SMA = System.Management.Automation;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+
+#if DEBUG
+using System.Diagnostics;
+#endif
 
 #if CoreCLR
 using System.Runtime.Loader;

--- a/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorExtensionServiceProvider.cs
@@ -55,11 +55,6 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         public ILanguageServerService LanguageServer { get; }
 
         /// <summary>
-        /// Service providing document symbol provider registration.
-        /// </summary>
-        // public IDocumentSymbolService DocumentSymbols { get; }
-
-        /// <summary>
         /// Service providing extension command registration and functionality.
         /// </summary>
         public IExtensionCommandService ExtensionCommands { get; }
@@ -93,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
         /// <summary>
         /// Get an underlying service object from PSES by type name.
         /// </summary>
-        /// <param name="psesServiceFullTypeName">The full type name of the service to get.</param>
+        /// <param name="fullTypeName">The full type name of the service to get.</param>
         /// <param name="assemblyName">The assembly name from which the service comes.</param>
         /// <returns>The service object requested, or null if no service of that type name exists.</returns>
         /// <remarks>

--- a/src/PowerShellEditorServices/Extensions/EditorObject.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorObject.cs
@@ -73,6 +73,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Creates a new instance of the EditorObject class.
         /// </summary>
+        /// <param name="serviceProvider">The service provider?</param>
         /// <param name="extensionService">An ExtensionService which handles command registration.</param>
         /// <param name="editorOperations">An IEditorOperations implementation which handles operations in the host editor.</param>
         internal EditorObject(

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Gets the file content in the specified range as an array of strings.
         /// </summary>
-        /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
+        /// <param name="fileRange">The buffer range for which content will be extracted.</param>
         /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
         public string[] GetTextLines(FileRange fileRange) => scriptFile.GetLinesInRange(fileRange.ToBufferRange());
 

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -14,6 +13,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 
 #if DEBUG
+using System.Diagnostics;
 using Serilog.Debugging;
 #endif
 

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <remarks>
         /// <para>
         /// This can only be called once because it sets global state (the logger) and that call is
-        /// in <see cref="EditorServicesRunner"/>.
+        /// in <see cref="Hosting.EditorServicesRunner" />.
         /// </para>
         /// <para>
         /// TODO: Why is this a static function wrapping a constructor instead of just a
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// </remarks>
         /// <param name="logPath">The path of the log file to use.</param>
         /// <param name="minimumLogLevel">The minimum log level to use.</param>
-        /// <returns></returns>
+        /// <param name="hostLogger">The host logger?</param>
         public static EditorServicesServerFactory Create(string logPath, int minimumLogLevel, IObservable<(int logLevel, string message)> hostLogger)
         {
             Log.Logger = new LoggerConfiguration()
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// Create the LSP server.
         /// </summary>
         /// <remarks>
-        /// This is only called once and that's in <see cref="EditorServicesRunner"/>.
+        /// This is only called once and that's in <see cref="Hosting.EditorServicesRunner"/>.
         /// </remarks>
         /// <param name="inputStream">The protocol transport input stream.</param>
         /// <param name="outputStream">The protocol transport output stream.</param>
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// Create the debug server given a language server instance.
         /// </summary>
         /// <remarks>
-        /// This is only called once and that's in <see cref="EditorServicesRunner"/>.
+        /// This is only called once and that's in <see cref="Hosting.EditorServicesRunner"/>.
         /// </remarks>
         /// <param name="inputStream">The protocol transport input stream.</param>
         /// <param name="outputStream">The protocol transport output stream.</param>
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// Create a new debug server based on an old one in an ended session.
         /// </summary>
         /// <remarks>
-        /// This is only called once and that's in <see cref="EditorServicesRunner"/>.
+        /// This is only called once and that's in <see cref="Hosting.EditorServicesRunner"/>.
         /// </remarks>
         /// <param name="inputStream">The protocol transport input stream.</param>
         /// <param name="outputStream">The protocol transport output stream.</param>

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// The minimum log level of log events to be logged.
         /// </summary>
         /// <remarks>
-        /// This is cast to all of <see cref="PsesLogLevel"/>, <see
+        /// This is cast to all of <see cref="Hosting.PsesLogLevel"/>, <see
         /// cref="Microsoft.Extensions.Logging.LogLevel"/>, and <see
         /// cref="Serilog.Events.LogEventLevel"/>, hence it is an <c>int</c>.
         /// </remarks>
@@ -131,8 +131,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// </param>
         /// <param name="version">The host application's version.</param>
         /// <param name="psHost">The PowerShell host to use.</param>
-        /// <param name="allUsersProfilePath">The path to the shared profile.</param>
-        /// <param name="currentUsersProfilePath">The path to the user specific profile.</param>
+        /// <param name="profilePaths">The set of profile paths.</param>
         /// <param name="featureFlags">Flags of features to enable.</param>
         /// <param name="additionalModules">Names or paths of additional modules to import.</param>
         /// <param name="initialSessionState">The language mode inherited from the orginal PowerShell process. This will be used when creating runspaces so that we honor the same initialSessionState including allowed modules, cmdlets and language mode.</param>

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -131,10 +131,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Sets up a script analysis run, eventually returning the result.
         /// </summary>
         /// <param name="filesToAnalyze">The files to run script analysis on.</param>
-        /// <param name="cancellationToken">A cancellation token to cancel this call with.</param>
         /// <returns>A task that finishes when script diagnostics have been published.</returns>
-        public void StartScriptDiagnostics(
-            ScriptFile[] filesToAnalyze)
+        public void StartScriptDiagnostics(ScriptFile[] filesToAnalyze)
         {
             if (!_configurationService.CurrentSettings.ScriptAnalysis.Enable)
             {
@@ -219,7 +217,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <summary>
         /// Get the most recent corrections computed for a given script file.
         /// </summary>
-        /// <param name="documentUri">The URI string of the file to get code actions for.</param>
+        /// <param name="uri">The URI string of the file to get code actions for.</param>
         /// <returns>A threadsafe readonly dictionary of the code actions of the particular file.</returns>
         public async Task<IReadOnlyDictionary<string, IEnumerable<MarkerCorrection>>> GetMostRecentCodeActionsForFileAsync(DocumentUri uri)
         {
@@ -245,7 +243,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <summary>
         /// Event subscription method to be run when PSES configuration has been updated.
         /// </summary>
-        /// <param name="sender">The sender of the configuration update event.</param>
+        /// <param name="_">The sender of the configuration update event.</param>
         /// <param name="settings">The new language server settings.</param>
         public void OnConfigurationUpdated(object _, LanguageServerSettings settings)
         {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -167,6 +167,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="condition">The expression that needs to be true for the breakpoint to be triggered.</param>
         /// <param name="hitCondition">The amount of times this line should be hit til the breakpoint is triggered.</param>
         /// <param name="logMessage">The log message to write instead of calling 'break'. In VS Code, this is called a 'logPoint'.</param>
+        /// <param name="errorMessage">The error message we might return.</param>
         /// <returns>ScriptBlock</returns>
         public static ScriptBlock GetBreakpointActionScriptBlock(string condition, string hitCondition, string logMessage, out string errorMessage)
         {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -49,6 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="column"></param>
         /// <param name="condition"></param>
         /// <param name="hitCondition"></param>
+        /// <param name="logMessage"></param>
         /// <returns></returns>
         internal static BreakpointDetails Create(
             string source,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/DebuggerStoppedEventArgs.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// Creates a new instance of the DebuggerStoppedEventArgs class.
         /// </summary>
         /// <param name="originalEvent">The original DebuggerStopEventArgs instance from which this instance is based.</param>
-        /// <param name="runspaceDetails">The RunspaceDetails of the runspace which raised this event.</param>
+        /// <param name="runspaceInfo">The RunspaceDetails of the runspace which raised this event.</param>
         public DebuggerStoppedEventArgs(
             DebuggerStopEventArgs originalEvent,
             IRunspaceInfo runspaceInfo)
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// Creates a new instance of the DebuggerStoppedEventArgs class.
         /// </summary>
         /// <param name="originalEvent">The original DebuggerStopEventArgs instance from which this instance is based.</param>
-        /// <param name="runspaceDetails">The RunspaceDetails of the runspace which raised this event.</param>
+        /// <param name="runspaceInfo">The RunspaceDetails of the runspace which raised this event.</param>
         /// <param name="localScriptPath">The local path of the remote script being debugged.</param>
         public DebuggerStoppedEventArgs(
             DebuggerStopEventArgs originalEvent,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
@@ -83,6 +83,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="autoVariables">
         /// A variable container with all the filtered, auto variables for this stack frame.
         /// </param>
+        /// <param name="commandVariables">
+        /// A variable container with all the command variables for this stack frame.
+        /// </param>
         /// <returns>A new instance of the StackFrameDetails class.</returns>
         internal static StackFrameDetails Create(
             PSObject callStackFrameObject,

--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -117,6 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         /// </summary>
         /// <param name="commandName">The unique name of the command to be invoked.</param>
         /// <param name="editorContext">The context in which the command is being invoked.</param>
+        /// <param name="cancellationToken">The token used to cancel this.</param>
         /// <returns>A Task that can be awaited for completion.</returns>
         /// <exception cref="KeyNotFoundException">The command being invoked was not registered.</exception>
         public Task InvokeCommandAsync(string commandName, EditorContext editorContext, CancellationToken cancellationToken)

--- a/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellContextFrame.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellContextFrame.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Diagnostics;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
 using SMA = System.Management.Automation;
+
+#if DEBUG
+using System.Text;
+#endif
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Context
 {

--- a/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellVersionDetails.cs
@@ -91,6 +91,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Context
         /// Gets the PowerShell version details for the given runspace.
         /// </summary>
         /// <param name="logger">An ILogger implementation used for writing log messages.</param>
+        /// <param name="pwsh">The PowerShell instance for which to to get the version.</param>
         /// <returns>A new PowerShellVersionDetails instance.</returns>
         public static PowerShellVersionDetails GetVersionDetails(ILogger logger, PowerShell pwsh)
         {

--- a/src/PowerShellEditorServices/Services/PowerShell/Runspace/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Runspace/SessionDetails.cs
@@ -43,7 +43,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace
         /// contained in the PSObject which was obtained using the
         /// PSCommand returned by GetDetailsCommand.
         /// </summary>
-        /// <param name="detailsObject"></param>
         public SessionDetails(
             int processId,
             string computerName,

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -59,6 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
         /// <param name="commandName">The name of the command.</param>
         /// <param name="currentRunspace">The current runspace.</param>
         /// <param name="executionService">The execution service.</param>
+        /// <param name="cancellationToken">The token used to cancel this.</param>
         /// <returns>A CommandInfo object with details about the specified command.</returns>
         public static async Task<CommandInfo> GetCommandInfoAsync(
             string commandName,
@@ -117,6 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
         /// </summary>
         /// <param name="commandInfo">The CommandInfo instance for the command.</param>
         /// <param name="executionService">The execution service to use for getting command documentation.</param>
+        /// <param name="cancellationToken">The token used to cancel this.</param>
         /// <returns>The synopsis.</returns>
         public static async Task<string> GetCommandSynopsisAsync(
             CommandInfo commandInfo,

--- a/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ScriptDocumentSymbolProvider.cs
@@ -30,7 +30,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// Finds all symbols in a script
         /// </summary>
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
-        /// <param name="powerShellVersion">The PowerShell version the Ast was generated from</param>
         /// <returns>A collection of SymbolReference objects</returns>
         public static IEnumerable<SymbolReference> FindSymbolsInDocument(Ast scriptAst)
         {

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <param name="fileOffset">
         /// The 1-based file offset at which a symbol will be located.
         /// </param>
-        /// <param name="powerShellContext">
+        /// <param name="executionService">
         /// The PowerShellContext to use for gathering completions.
         /// </param>
         /// <param name="logger">An ILogger implementation used for writing log messages.</param>
@@ -195,7 +195,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// Finds all symbols in a script
         /// </summary>
         /// <param name="scriptAst">The abstract syntax tree of the given script</param>
-        /// <param name="powerShellVersion">The PowerShell version the Ast was generated from</param>
         /// <returns>A collection of SymbolReference objects</returns>
         public static IEnumerable<SymbolReference> FindSymbolsInDocument(Ast scriptAst)
         {

--- a/src/PowerShellEditorServices/Services/Template/TemplateService.cs
+++ b/src/PowerShellEditorServices/Services/Template/TemplateService.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Template
         /// <summary>
         /// Creates a new instance of the TemplateService class.
         /// </summary>
-        /// <param name="powerShellContext">The PowerShellContext to use for this service.</param>
+        /// <param name="executionService">The PowerShellContext to use for this service.</param>
         /// <param name="factory">An ILoggerFactory implementation used for writing log messages.</param>
         public TemplateService(IInternalPowerShellExecutionService executionService, ILoggerFactory factory)
         {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -109,6 +109,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// <param name="columnNumber">
         /// The 1-based column number at which completions will be gathered.
         /// </param>
+        /// <param name="cancellationToken">The token used to cancel this.</param>
         /// <returns>
         /// A CommandCompletion instance completions for the identified statement.
         /// </returns>

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -209,6 +209,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         /// </summary>
         /// <param name="tabSize">The tab size in the number spaces.</param>
         /// <param name="insertSpaces">If true, insert spaces otherwise insert tabs for indentation.</param>
+        /// <param name="logger">The logger instance.</param>
         public Hashtable GetPSSASettingsHashtable(
             int tabSize,
             bool insertSpaces,

--- a/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
@@ -245,7 +245,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Creates a new instance of the RemoteFileManagerService class.
         /// </summary>
         /// <param name="factory">An ILoggerFactory implementation used for writing log messages.</param>
-        /// <param name="powerShellContext">
+        /// <param name="runspaceContext">The runspace we're using.</param>
+        /// <param name="executionService">
         /// The PowerShellContext to use for file loading operations.
         /// </param>
         /// <param name="editorOperations">

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -80,8 +80,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <summary>
         /// Creates a new instance of the Workspace class.
         /// </summary>
-        /// <param name="powerShellVersion">The version of PowerShell for which scripts will be parsed.</param>
-        /// <param name="logger">An ILogger implementation used for writing log messages.</param>
         public WorkspaceService(ILoggerFactory factory)
         {
             powerShellVersion = VersionUtils.PSVersion;
@@ -108,18 +106,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </exception>
         public ScriptFile GetFile(string filePath) => GetFile(new Uri(filePath));
 
-        /// <summary>
-        /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.
-        /// <para>IMPORTANT: Not all documents have a backing file e.g. untitled: scheme documents.  Consider using
-        /// <see cref="TryGetFile(string, out ScriptFile)"/> instead.</para>
-        /// </summary>
-        /// <param name="fileUri">The file URI at which the script resides.</param>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filePath"/> is not found.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="filePath"/> contains a null or empty string.
-        /// </exception>
         public ScriptFile GetFile(Uri fileUri) => GetFile(DocumentUri.From(fileUri));
 
         /// <summary>
@@ -128,12 +114,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <see cref="TryGetFile(string, out ScriptFile)"/> instead.</para>
         /// </summary>
         /// <param name="documentUri">The document URI at which the script resides.</param>
-        /// <exception cref="FileNotFoundException">
-        /// <paramref name="filePath"/> is not found.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="filePath"/> contains a null or empty string.
-        /// </exception>
+        /// <exception cref="FileNotFoundException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         public ScriptFile GetFile(DocumentUri documentUri)
         {
             Validate.IsNotNull(nameof(documentUri), documentUri);
@@ -349,7 +331,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 resolvedPath = workspaceUri.MakeRelativeUri(fileUri).ToString();
 
                 // Convert the directory separators if necessary
-                if (System.IO.Path.DirectorySeparatorChar == '\\')
+                if (Path.DirectorySeparatorChar == '\\')
                 {
                     resolvedPath = resolvedPath.Replace('/', '\\');
                 }


### PR DESCRIPTION
Due to a quirk in how `msbuild` runs rules, documentation generation
must be enabled for this rule (and presumably others) to be respected.

See https://github.com/dotnet/roslyn/issues/22579.

Fixes https://github.com/PowerShell/PowerShellEditorServices/issues/1479.