### PR TITLE
Fix prompt spam and general debugger reliability improvements

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         private void CancelNormalExecution()
         {
-            if (_pwsh.Runspace.RunspaceStateInfo.IsUsable())
+            if (!_pwsh.Runspace.RunspaceStateInfo.IsUsable())
             {
                 return;
             }


### PR DESCRIPTION
This should make default prompt spam significantly less likely or impossible. Also fixes a scenario here if the REPL loop is evaluating and in an attached process, closing the attachee would dead lock.

Also fixed a logic bug that probably caused some not yet seen issues.