### PR TITLE
Fix formatting handlers and PSScriptAnalyzer loading

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -72,8 +72,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (formattedScript is null)
             {
-                _logger.LogWarning($"Formatting returned null. Returning original contents for file: {scriptFile.DocumentUri}");
-                formattedScript = scriptFile.Contents;
+                _logger.LogWarning($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
+                return null;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning($"Formatting request canceled for: {scriptFile.DocumentUri}");
+                return null;
             }
 
             return new TextEditContainer(new TextEdit
@@ -152,8 +158,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (formattedScript is null)
             {
-                _logger.LogWarning($"Formatting returned null. Returning original contents for file: {scriptFile.DocumentUri}");
-                formattedScript = scriptFile.Contents;
+                _logger.LogWarning($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
+                return null;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogWarning($"Formatting request canceled for: {scriptFile.DocumentUri}");
+                return null;
             }
 
             return new TextEditContainer(new TextEdit


### PR DESCRIPTION
Now we return `null` per the LSP specification if the formatting request was canceled (such as will happen if the document is modified since the request was sent), and we only load our bundled PSScriptAnalzyer module. Similar to PSReadLine, we should not support loading an arbitrary version of the module, as that leads to difficult to fix bugs and complicates the code.

Should fix https://github.com/PowerShell/vscode-powershell/issues/3928 and https://github.com/PowerShell/vscode-powershell/issues/3926.