### PR TITLE
Implement temporary workaround for race condition in REPL

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -27,6 +27,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         // instead hide from the user with pretty strings (or perhaps not write out at all).
         private static readonly PowerShellExecutionOptions s_debuggerExecutionOptions = new()
         {
+            // NOTE: We want to interrupt the current foreground task because otherwise we won't run
+            // this until the idle handler processes it, but we also don't want it to run under the
+            // idle handler, so both of these are true.
+            InterruptCurrentForeground = true,
             MustRunInForeground = true,
             WriteInputToHost = true,
             WriteOutputToHost = true,

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
@@ -32,7 +32,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
             _psrlProxy.OverrideIdleHandler(onIdleAction);
         }
 
-        public override string ReadLine(CancellationToken cancellationToken) => _psesHost.InvokeDelegate(representation: "ReadLine", new ExecutionOptions { MustRunInForeground = true }, InvokePSReadLine, cancellationToken);
+        public override string ReadLine(CancellationToken cancellationToken) => _psesHost.InvokeDelegate(
+            representation: "ReadLine",
+            new ExecutionOptions { MustRunInForeground = true, InterruptCurrentForeground = true, },
+            InvokePSReadLine,
+            cancellationToken);
 
         protected override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken) => _psesHost.ReadKey(intercept: true, cancellationToken);
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/BlockingConcurrentDeque.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/BlockingConcurrentDeque.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         public IDisposable BlockConsumers() => PriorityQueueBlockLifetime.StartBlocking(_blockConsumersEvent);
 
-        public void Dispose() => ((IDisposable)_blockConsumersEvent).Dispose();
+        public void Dispose() => _blockConsumersEvent.Dispose();
 
         private class PriorityQueueBlockLifetime : IDisposable
         {

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -949,6 +949,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             return runspace;
         }
 
+        // NOTE: This token is received from PSReadLine, and it _is_ the ReadKey cancellation token!
         private void OnPowerShellIdle(CancellationToken idleCancellationToken)
         {
             IReadOnlyList<PSEventSubscriber> eventSubscribers = _mainRunspaceEngineIntrinsics.Events.Subscribers;
@@ -1102,27 +1103,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
             void OnDebuggerStoppedImpl(object sender, DebuggerStopEventArgs debuggerStopEventArgs)
             {
-                    // If the debug server is NOT active, we need to synchronize state and start it.
-                    if (!DebugContext.IsDebugServerActive)
-                    {
-                        _languageServer?.SendNotification("powerShell/startDebugger");
-                    }
+                // If the debug server is NOT active, we need to synchronize state and start it.
+                if (!DebugContext.IsDebugServerActive)
+                {
+                    _languageServer?.SendNotification("powerShell/startDebugger");
+                }
 
-                    DebugContext.SetDebuggerStopped(debuggerStopEventArgs);
+                DebugContext.SetDebuggerStopped(debuggerStopEventArgs);
 
-                    try
-                    {
-                        CurrentPowerShell.WaitForRemoteOutputIfNeeded();
-                        PowerShellFrameType frameBase = CurrentFrame.FrameType & PowerShellFrameType.Remote;
-                        PushPowerShellAndRunLoop(
-                            CreateNestedPowerShell(CurrentRunspace),
-                            frameBase | PowerShellFrameType.Debug | PowerShellFrameType.Nested | PowerShellFrameType.Repl);
-                        CurrentPowerShell.ResumeRemoteOutputIfNeeded();
-                    }
-                    finally
-                    {
-                        DebugContext.SetDebuggerResumed();
-                    }
+                try
+                {
+                    CurrentPowerShell.WaitForRemoteOutputIfNeeded();
+                    PowerShellFrameType frameBase = CurrentFrame.FrameType & PowerShellFrameType.Remote;
+                    PushPowerShellAndRunLoop(
+                        CreateNestedPowerShell(CurrentRunspace),
+                        frameBase | PowerShellFrameType.Debug | PowerShellFrameType.Nested | PowerShellFrameType.Repl);
+                    CurrentPowerShell.ResumeRemoteOutputIfNeeded();
+                }
+                finally
+                {
+                    DebugContext.SetDebuggerResumed();
+                }
             }
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -737,6 +737,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 && !CurrentRunspace.Runspace.Debugger.InBreakpoint)
             {
                 StopDebugContext();
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
             }
 
             // When a task must run in the foreground, we cancel out of the idle loop and return to the top level.

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -683,6 +683,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
                 try
                 {
+                    // TODO: This works around a race condition around executing our interactive
+                    // tasks, and is a HIGH PRIORITY to fix.
+                    Thread.Sleep(200);
                     DoOneRepl(cancellationScope.CancellationToken);
                 }
                 catch (OperationCanceledException)

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -109,8 +109,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
         public void Dispose()
         {
+            // TODO: This is whack. It used to call `Cancel` on the cancellation source, but we
+            // shouldn't do that!
+            _cancellationSource.Dispose();
             _cancellationStack.TryPop(out CancellationScope _);
-            _cancellationSource.Cancel();
         }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/PowerShell/vscode-powershell/issues/3937. It is not a good fix, but it is viable for now. We've identified where the race condition is, and can effectively workaround it with a small sleep in the REPL. Our top priority is to fix up the REPL so this race doesn't occur in the first place, but that will require more invasive changes.