### PR TITLE
Don't cancel on disposal of `CancellationScope`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CancellationContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -109,8 +109,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
         public void Dispose()
         {
+            // TODO: This is whack. It used to call `Cancel` on the cancellation source, but we
+            // shouldn't do that!
+            _cancellationSource.Dispose();
             _cancellationStack.TryPop(out CancellationScope _);
-            _cancellationSource.Cancel();
         }
     }
 }


### PR DESCRIPTION
This eliminates an extra cancellation on tokens that are getting disposed.