### PR TITLE
Consolidate `InterruptCurrentForeground` and `MustRunInForeground`

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -25,9 +25,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         // TODO: We currently set `WriteInputToHost` as true, which writes our debugged commands'
         // `GetInvocationText` and that reveals some obscure implementation details we should
         // instead hide from the user with pretty strings (or perhaps not write out at all).
+        //
+        // This API is mostly used for F5 execution so it requires the foreground.
         private static readonly PowerShellExecutionOptions s_debuggerExecutionOptions = new()
         {
-            MustRunInForeground = true,
+            RequiresForeground = true,
             WriteInputToHost = true,
             WriteOutputToHost = true,
             ThrowOnError = false,

--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -129,17 +129,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                     .AddParameter("ScriptBlock", editorCommand.ScriptBlock)
                     .AddParameter("ArgumentList", new object[] { editorContext });
 
-                // This API is used for editor command execution, so it needs to interrupt the
-                // current prompt (or other foreground task).
+                // This API is used for editor command execution so it requires the foreground.
                 return ExecutionService.ExecutePSCommandAsync(
                     executeCommand,
                     cancellationToken,
                     new PowerShellExecutionOptions
                     {
+                        RequiresForeground = true,
                         WriteOutputToHost = !editorCommand.SuppressOutput,
                         AddToHistory = !editorCommand.SuppressOutput,
                         ThrowOnError = false,
-                        InterruptCurrentForeground = true
                     });
             }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
@@ -32,7 +32,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
             _psrlProxy.OverrideIdleHandler(onIdleAction);
         }
 
-        public override string ReadLine(CancellationToken cancellationToken) => _psesHost.InvokeDelegate(representation: "ReadLine", new ExecutionOptions { MustRunInForeground = true }, InvokePSReadLine, cancellationToken);
+        public override string ReadLine(CancellationToken cancellationToken) => _psesHost.InvokeDelegate(
+            representation: "ReadLine",
+            new ExecutionOptions { RequiresForeground = true },
+            InvokePSReadLine,
+            cancellationToken);
 
         protected override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken) => _psesHost.ReadKey(intercept: true, cancellationToken);
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/BlockingConcurrentDeque.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/BlockingConcurrentDeque.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         public IDisposable BlockConsumers() => PriorityQueueBlockLifetime.StartBlocking(_blockConsumersEvent);
 
-        public void Dispose() => ((IDisposable)_blockConsumersEvent).Dispose();
+        public void Dispose() => _blockConsumersEvent.Dispose();
 
         private class PriorityQueueBlockLifetime : IDisposable
         {

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
@@ -16,8 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
     public record ExecutionOptions
     {
         public ExecutionPriority Priority { get; init; } = ExecutionPriority.Normal;
-        public bool MustRunInForeground { get; init; }
-        public bool InterruptCurrentForeground { get; init; }
+        public bool RequiresForeground { get; init; }
     }
 
     public record PowerShellExecutionOptions : ExecutionOptions
@@ -25,8 +24,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
         internal static PowerShellExecutionOptions ImmediateInteractive = new()
         {
             Priority = ExecutionPriority.Next,
-            MustRunInForeground = true,
-            InterruptCurrentForeground = true,
+            RequiresForeground = true,
         };
 
         public bool WriteOutputToHost { get; init; }

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
@@ -21,18 +21,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
         {
-            // This API is mostly used for F8 execution, so it needs to interrupt the command prompt
-            // (or other foreground task).
+            // This API is mostly used for F8 execution so it requires the foreground.
             await _executionService.ExecutePSCommandAsync(
                 new PSCommand().AddScript(request.Expression),
                 CancellationToken.None,
                 new PowerShellExecutionOptions
                 {
+                    RequiresForeground = true,
                     WriteInputToHost = true,
                     WriteOutputToHost = true,
                     AddToHistory = true,
                     ThrowOnError = false,
-                    InterruptCurrentForeground = true
                 }).ConfigureAwait(false);
 
             // TODO: Should we return a more informative result?

--- a/src/PowerShellEditorServices/Services/Template/TemplateService.cs
+++ b/src/PowerShellEditorServices/Services/Template/TemplateService.cs
@@ -158,15 +158,21 @@ namespace Microsoft.PowerShell.EditorServices.Services.Template
             _logger.LogTrace(
                 $"Invoking Plaster...\n\n    TemplatePath: {templatePath}\n    DestinationPath: {destinationPath}");
 
-            PSCommand command = new();
-            command.AddCommand("Invoke-Plaster");
-            command.AddParameter("TemplatePath", templatePath);
-            command.AddParameter("DestinationPath", destinationPath);
+            PSCommand command = new PSCommand()
+                .AddCommand("Invoke-Plaster")
+                .AddParameter("TemplatePath", templatePath)
+                .AddParameter("DestinationPath", destinationPath);
 
+            // This command is interactive so it requires the foreground.
             await _executionService.ExecutePSCommandAsync(
                 command,
                 CancellationToken.None,
-                new PowerShellExecutionOptions { WriteOutputToHost = true, InterruptCurrentForeground = true, ThrowOnError = false }).ConfigureAwait(false);
+                new PowerShellExecutionOptions
+                {
+                    RequiresForeground = true,
+                    WriteOutputToHost = true,
+                    ThrowOnError = false
+                }).ConfigureAwait(false);
 
             // If any errors were written out, creation was not successful
             return true;


### PR DESCRIPTION
And set them consistently. If the task needs to interrupt or run in the foreground, it really needs to do both. Also fixes some indentation.