### PR TITLE
Bring back `WriteWithPrompt()`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
                 if (PowerShellExecutionOptions.WriteInputToHost)
                 {
-                    _psesHost.UI.WriteLine(_psCommand.GetInvocationText());
+                    _psesHost.WriteWithPrompt(_psCommand, cancellationToken);
                 }
 
                 return _pwsh.Runspace.Debugger.InBreakpoint

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -76,6 +76,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         private CancellationToken _readKeyCancellationToken;
 
         private bool _resettingRunspace;
+
+        private (int x, int y)? _lastPromptPosition;
 
         public PsesInternalHost(
             ILoggerFactory loggerFactory,
@@ -757,7 +759,20 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             try
             {
                 string prompt = GetPrompt(cancellationToken);
+
+                // Check cursor position to see if we're in the exact same spot as the last time we
+                // wrote the prompt. If we are, write a new line.
+                if (_lastPromptPosition is not null)
+                {
+                    (int x, int y) current = (System.Console.CursorLeft, System.Console.CursorTop);
+                    if (current == _lastPromptPosition.Value)
+                    {
+                        UI.WriteLine();
+                    }
+                }
+
                 UI.Write(prompt);
+                _lastPromptPosition = (System.Console.CursorLeft, System.Console.CursorTop);
                 string userInput = InvokeReadLine(cancellationToken);
 
                 // If the user input was empty it's because:

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -76,8 +76,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         private CancellationToken _readKeyCancellationToken;
 
         private bool _resettingRunspace;
-
-        private (int x, int y)? _lastPromptPosition;
 
         public PsesInternalHost(
             ILoggerFactory loggerFactory,
@@ -759,20 +757,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             try
             {
                 string prompt = GetPrompt(cancellationToken);
-
-                // Check cursor position to see if we're in the exact same spot as the last time we
-                // wrote the prompt. If we are, write a new line.
-                if (_lastPromptPosition is not null)
-                {
-                    (int x, int y) current = (System.Console.CursorLeft, System.Console.CursorTop);
-                    if (current == _lastPromptPosition.Value)
-                    {
-                        UI.WriteLine();
-                    }
-                }
-
                 UI.Write(prompt);
-                _lastPromptPosition = (System.Console.CursorLeft, System.Console.CursorTop);
                 string userInput = InvokeReadLine(cancellationToken);
 
                 // If the user input was empty it's because:

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -770,7 +770,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 // one, but we do not want to print one if the ReadLine task was canceled.
                 if (string.IsNullOrEmpty(userInput))
                 {
-                    if (LastKeyWasCtrlC())
+                    if (cancellationToken.IsCancellationRequested || LastKeyWasCtrlC())
                     {
                         UI.WriteLine();
                     }
@@ -834,6 +834,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             }
 
             return prompt;
+        }
+
+        /// <summary>
+        /// This is used to write the invocation text of a command with the user's prompt so that,
+        /// for example, F8 (evaluate selection) appears as if the user typed it. Used when
+        /// 'WriteInputToHost' is true.
+        /// </summary>
+        /// <param name="command">The PSCommand we'll print after the prompt.</param>
+        /// <param name="cancellationToken"></param>
+        public void WriteWithPrompt(PSCommand command, CancellationToken cancellationToken)
+        {
+            UI.Write(GetPrompt(cancellationToken));
+            UI.WriteLine(command.GetInvocationText());
         }
 
         private string InvokeReadLine(CancellationToken cancellationToken)


### PR DESCRIPTION
We were running into a situation where we'd print the prompt on the same line that we had previously printed it. This was especially noticable when stepping through the debugger.

This change ensures that we always write a new line if that situation occurs.

Examples:

![image](https://user-images.githubusercontent.com/24977523/165795176-e6a736ef-f8cf-435d-b646-fe6aa27aec53.png)

![image](https://user-images.githubusercontent.com/24977523/165795192-d0189a9f-81fb-413a-86e0-da3b620f7fec.png)
