### PR TITLE
Fix ordering of startup tasks so `psEditor` is defined before profiles are loaded

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -104,10 +104,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             // This is constant so Remove-Variable cannot remove it.
             PSVariable psEditor = new(PSEditorVariableName, EditorObject, ScopedItemOptions.Constant);
 
-            // Register the editor object in the runspace
+            // NOTE: This is a special task run on startup! Register the editor object in the
+            // runspace. It has priority next so it goes before LoadProfiles.
             return ExecutionService.ExecuteDelegateAsync(
                 $"Create ${PSEditorVariableName} object",
-                executionOptions: null,
+                new ExecutionOptions { Priority = ExecutionPriority.Next },
                 (pwsh, _) => pwsh.Runspace.SessionStateProxy.PSVariable.Set(psEditor),
                 CancellationToken.None);
         }

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
@@ -15,12 +15,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
     // Generally the executor will do the right thing though; some options just priority over others.
     public record ExecutionOptions
     {
+        // This determines which underlying queue the task is added to.
         public ExecutionPriority Priority { get; init; } = ExecutionPriority.Normal;
+        // This implies `ExecutionPriority.Next` because foreground tasks are prepended.
         public bool RequiresForeground { get; init; }
     }
 
     public record PowerShellExecutionOptions : ExecutionOptions
     {
+        // TODO: Because of the above, this is actually unnecessary.
         internal static PowerShellExecutionOptions ImmediateInteractive = new()
         {
             Priority = ExecutionPriority.Next,

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -97,7 +97,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
 
-            // TODO: Load profiles when the host is already running
+            // TODO: Load profiles when the host is already running? Note that this might mess up
+            // the ordering and require the foreground.
             if (!_cwdSet)
             {
                 if (!string.IsNullOrEmpty(_configurationService.CurrentSettings.Cwd)
@@ -124,6 +125,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 _cwdSet = true;
             }
 
+            // This is another place we call this to setup $psEditor, which really needs to be done
+            // _before_ profiles. In current testing, this has already been done by the call to
+            // InitializeAsync when the ExtensionService class is injected.
+            //
+            // TODO: Remove this.
             await _extensionService.InitializeAsync().ConfigureAwait(false);
 
             // Run any events subscribed to configuration updates

--- a/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
@@ -645,9 +645,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
+        // NOTE: This is a special task run on startup!
         private Task RegisterPSEditFunctionAsync()
             => _executionService.ExecuteDelegateAsync(
-                "Register psedit function",
+                "Register PSEdit function",
                 executionOptions: null,
                 (pwsh, _) => RegisterPSEditFunction(pwsh.Runspace),
                 CancellationToken.None);
@@ -673,7 +674,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
             catch (Exception e)
             {
-                logger.LogException("Could not create psedit function.", e);
+                logger.LogException("Could not create PSEdit function.", e);
             }
             finally
             {


### PR DESCRIPTION
The thing is, `RequiresForeground` necessarily implies an execution
priority of `Next`. So instead we set that priority explicitly for
`psEditor` and mark none of the startup tasks as requiring foreground,
because they're all started before we enter the REPL where that matters.