### PR TITLE
Do not exit from `DebuggerStop` unless resuming

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -702,7 +702,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                             PopPowerShell(RunspaceChangeAction.Exit);
                         }
 
-                        return;
+                        if (ShouldExitExecutionLoop)
+                        {
+                            return;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes PowerShell/vscode-powershell#3944

This fixes an issue reported by @PrzemyslawKlys on discord:

![F8_continue](
https://cdn.discordapp.com/attachments/447579065877266454/970295608797704212/F8_continue.gif)