### PR TITLE
Send `sendKeyPress` event across DAP for temporary integrated consoles

### DIFF
--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -169,7 +169,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 _loggerFactory,
                 inputStream,
                 outputStream,
-                serviceProvider);
+                serviceProvider,
+                isTemp: true);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                         // notifications (specifically for sendKeyPress).
                         if (_isTemp)
                         {
-                            _psesHost._debugServer = server;
+                            _psesHost.DebugServer = server;
                         }
 
                         // Ensure the debugger mode is set correctly - this is required for remote debugging to work

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         /// is true can also receive the required 'sendKeyPress' notification to return from a
         /// canceled <see cref="System.Console.ReadKey()" />.
         /// </summary>
-        internal IDebugAdapterServerFacade _debugServer;
+        internal IDebugAdapterServerFacade DebugServer;
 
         private readonly HostStartupInfo _hostInfo;
 
@@ -1078,11 +1078,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                     // which we can send a notification, and have the client subscribe an action to
                     // send a key press.
                     _languageServer?.SendNotification("powerShell/sendKeyPress");
+
                     // When temporary integrated consoles are spawned, there will be no associated
                     // language server, but instead a debug adaptor server. In this case, the
                     // notification sent here will come across as a DebugSessionCustomEvent to which
                     // we can subscribe in the same way.
-                    _debugServer?.SendNotification("powerShell/sendKeyPress");
+                    DebugServer?.SendNotification("powerShell/sendKeyPress");
                 });
 
             // PSReadLine doesn't tell us when CtrlC was sent. So instead we keep track of the last


### PR DESCRIPTION
This is kind of messy, but it fixes https://github.com/PowerShell/vscode-powershell/issues/3950.