### PR TITLE
Fix a lot of IntelliSense issues

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -12,6 +12,7 @@ using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.Template;
+using OmniSharp.Extensions.JsonRpc;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Serilog;
@@ -102,7 +103,14 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     .WithHandler<PsesCodeLensHandlers>()
                     .WithHandler<PsesCodeActionHandler>()
                     .WithHandler<InvokeExtensionCommandHandler>()
-                    .WithHandler<PsesCompletionHandler>()
+                    // If PsesCompletionHandler is not marked as serial, then DidChangeTextDocument
+                    // notifications will end up cancelling completion. So quickly typing `Get-`
+                    // would result in no completions.
+                    //
+                    // This also lets completion requests interrupt time consuming background tasks
+                    // like the references code lens.
+                    .WithHandler<PsesCompletionHandler>(
+                        new JsonRpcHandlerOptions() { RequestProcessType = RequestProcessType.Serial })
                     .WithHandler<PsesHoverHandler>()
                     .WithHandler<PsesSignatureHelpHandler>()
                     .WithHandler<PsesDefinitionHandler>()

--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -25,8 +26,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="scriptFile">
         /// The document for which CodeLenses should be provided.
         /// </param>
+        /// <param name="cancellationToken"></param>
         /// <returns>An array of CodeLenses.</returns>
-        CodeLens[] ProvideCodeLenses(ScriptFile scriptFile);
+        CodeLens[] ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resolves a CodeLens that was created without a Command.
@@ -37,11 +39,13 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="scriptFile">
         /// The ScriptFile to resolve it in (sometimes unused).
         /// </param>
+        /// <param name="cancellationToken"></param>
         /// <returns>
         /// A Task which returns the resolved CodeLens when completed.
         /// </returns>
         Task<CodeLens> ResolveCodeLens(
             CodeLens codeLens,
-            ScriptFile scriptFile);
+            ScriptFile scriptFile,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
@@ -99,8 +100,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// Get all Pester CodeLenses for a given script file.
         /// </summary>
         /// <param name="scriptFile">The script file to get Pester CodeLenses for.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>All Pester CodeLenses for the given script file.</returns>
-        public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile)
+        public CodeLens[] ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken)
         {
             // Don't return anything if codelens setting is disabled
             if (!_configurationService.CurrentSettings.Pester.CodeLens)
@@ -116,6 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     continue;
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
                 if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {
@@ -133,8 +136,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         /// <param name="codeLens">The code lens to resolve.</param>
         /// <param name="scriptFile">The script file.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>The given CodeLens, wrapped in a task.</returns>
-        public Task<CodeLens> ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile) =>
+        public Task<CodeLens> ResolveCodeLens(CodeLens codeLens, ScriptFile scriptFile, CancellationToken cancellationToken) =>
             // This provider has no specific behavior for
             // resolving CodeLenses.
             Task.FromResult(codeLens);

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             CancellationToken cancellationToken)
         {
             Logger = logger;
-            _taskCompletionSource = new TaskCompletionSource<TResult>();
+            _taskCompletionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             _taskRequesterCancellationToken = cancellationToken;
             _executionCanceled = false;
         }
@@ -76,6 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
         {
             if (IsCanceled)
             {
+                SetCanceled();
                 return;
             }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             // Treat completions trigged by space as incomplete so that `gci `
             // and then typing `-` doesn't just filter the list of parameter values
             // (typically files) returned by the space completion
-            return new CompletionList(completionResults, isIncomplete || request.Context.TriggerCharacter is " ");
+            return new CompletionList(completionResults, isIncomplete || request?.Context?.TriggerCharacter is " ");
         }
 
         // Handler for "completionItem/resolve". In VSCode this is fired when a completion item is highlighted in the completion list.

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -22,6 +22,8 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
+    internal record CompletionResults(bool IsIncomplete, IReadOnlyList<CompletionItem> Matches);
+
     internal class PsesCompletionHandler : CompletionHandlerBase
     {
         private readonly ILogger _logger;
@@ -116,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// <returns>
         /// A CommandCompletion instance completions for the identified statement.
         /// </returns>
-        internal async Task<(bool isIncomplete, IReadOnlyList<CompletionItem> matches)> GetCompletionsInFileAsync(
+        internal async Task<CompletionResults> GetCompletionsInFileAsync(
             ScriptFile scriptFile,
             int lineNumber,
             int columnNumber,
@@ -134,7 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (result.CompletionMatches.Count == 0)
             {
-                return (true, Array.Empty<CompletionItem>());
+                return new CompletionResults(IsIncomplete: true, Array.Empty<CompletionItem>());
             }
 
             BufferRange replacedRange = scriptFile.GetRangeBetweenOffsets(
@@ -159,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 completionItems[i] = CreateCompletionItem(result.CompletionMatches[i], replacedRange, i + 1);
             }
-            return (isIncomplete, completionItems);
+            return new CompletionResults(isIncomplete, completionItems);
         }
 
         internal static CompletionItem CreateCompletionItem(

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -45,7 +45,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 await _symbolsService.FindReferencesOfSymbol(
                     foundSymbol,
                     _workspaceService.ExpandScriptReferences(scriptFile),
-                    _workspaceService).ConfigureAwait(false);
+                    _workspaceService,
+                    cancellationToken).ConfigureAwait(false);
 
             List<Location> locations = new();
 

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         protected override WorkspaceSymbolRegistrationOptions CreateRegistrationOptions(WorkspaceSymbolCapability capability, ClientCapabilities clientCapabilities) => new() { };
 
-        public override Task<Container<SymbolInformation>> Handle(WorkspaceSymbolParams request, CancellationToken cancellationToken)
+        public override async Task<Container<SymbolInformation>> Handle(WorkspaceSymbolParams request, CancellationToken cancellationToken)
         {
             List<SymbolInformation> symbols = new();
 
@@ -47,6 +47,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 foreach (SymbolReference foundOccurrence in foundSymbols)
                 {
+                    // This async method is pretty dense with synchronous code
+                    // so it's helpful to add some yields.
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (!IsQueryMatch(request.Query, foundOccurrence.SymbolName))
                     {
                         continue;
@@ -68,8 +72,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 }
             }
             _logger.LogWarning("Logging in a handler works now.");
-
-            return Task.FromResult(new Container<SymbolInformation>(symbols));
+            return new Container<SymbolInformation>(symbols);
         }
 
         #region private Methods

--- a/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
 
         private ScriptFile GetScriptFile(ScriptRegion scriptRegion) => workspace.GetFile(TestUtilities.GetSharedPath(scriptRegion.File));
 
-        private Task<IEnumerable<CompletionItem>> GetCompletionResultsAsync(ScriptRegion scriptRegion)
+        private Task<CompletionResults> GetCompletionResultsAsync(ScriptRegion scriptRegion)
         {
             return completionHandler.GetCompletionsInFileAsync(
                 GetScriptFile(scriptRegion),
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesCommandInFile()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteCommandInFile.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteCommandInFile.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteCommandInFile.ExpectedCompletion, actual);
         }
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesCommandFromModule()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteCommandFromModule.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteCommandFromModule.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             // NOTE: The tooltip varies across PowerShell and OS versions, so we ignore it.
             Assert.Equal(CompleteCommandFromModule.ExpectedCompletion, actual with { Detail = "" });
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesTypeName()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteTypeName.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteTypeName.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             if (VersionUtils.IsNetCore)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesNamespace()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteNamespace.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteNamespace.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteNamespace.ExpectedCompletion, actual);
         }
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesVariableInFile()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteVariableInFile.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteVariableInFile.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteVariableInFile.ExpectedCompletion, actual);
         }
@@ -108,7 +108,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesAttributeValue()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteAttributeValue.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteAttributeValue.SourceDetails).ConfigureAwait(true);
             Assert.Collection(results.OrderBy(c => c.SortText),
                 actual => Assert.Equal(actual, CompleteAttributeValue.ExpectedCompletion1),
                 actual => Assert.Equal(actual, CompleteAttributeValue.ExpectedCompletion2),
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task CompletesFilePath()
         {
-            IEnumerable<CompletionItem> results = await GetCompletionResultsAsync(CompleteFilePath.SourceDetails).ConfigureAwait(true);
+            (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteFilePath.SourceDetails).ConfigureAwait(true);
             Assert.NotEmpty(results);
             CompletionItem actual = results.First();
             // Paths are system dependent so we ignore the text and just check the type and range.


### PR DESCRIPTION
## Changes:

(each section is it's own commit for easier review)

### Mark completion request handler as `Serial`

This stops completion from being cancelled whenever a `DidChangeTextDocument` notification is sent. So previously, if you typed `Get-` very quickly, you'd get no results at all. It also lets completion cancel some other expensive requests like code lens.

**Note:** the one *not fantastic* down side of this is it makes "missing" code lenses more likely. By missing I mean:

![image](https://user-images.githubusercontent.com/24977523/168149033-394c5082-8ced-4bda-adde-136fc8c09e6f.png)

I have not yet figured out a way to tell VSCode to just try again next time it's able. Also we were already getting this sometimes, but this change does make it at least a bit more likely.

### Fix tasks never completing if cancelled quickly

We were exiting `SynchronousTask.ExecuteSynchronously` early if the cancellation was already requested. This was not setting our tcs state correctly, causing the caller to just fall off without warning. This made some things like `finally` and `using` disposals never happen.

### Make alias discovery possible on idle

The use of `Runspace.SessionStateProxy` while the pipeline thread is busy (even if you are **on** the pipeline thread) results in an exception.

This also allows us to cancel `GetAliasesAsync`. This was really the main reason I was in there, but I also remembered a report from @ninmonkey about an exception here so two birds one stone.

### Add space to completion trigger characters

**Note:** We should be on the look out for feedback about this change and let it sit in preview slightly longer than we'd normally like to. It's possible this may need to be opt in, but I think the entire intellisense experience is now optimized enough to that the behavior is ideal.

Adding space to completion triggers lets us automatically give completion results for parameter values. This also required building in some support for marking completion results as "Incomplete". This means that the client will not cache results when standard identifier characters are typed.

Mainly, this solves the scenario where you type space, get file completion results, and then type `-`. You expect to then get parameter names, but without marking "Incomplete", it will instead filter the file results.

Also fixed a scenario where you type `$script:` and on typing the `:` it would not update to available script scope variables.

### Make completion requests cancellable

That way any completion results from custom argument completers can be cancelled if they take too long and the user keeps typing. `TabExpansion2` is a callback-like function similar to `prompt`, partially for customizing tab completion but also for providing a command to get completion results.

In non-remote runspaces, we can also use it as a completion source that we can cancel by way of issuing a pipeline stop request.