### PR TITLE
Re-enable stdio clients by fixing initialization sequence

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -208,6 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 #endif
 
             // Add the bundled modules to the PSModulePath
+            // TODO: Why do we do this in addition to passing the bundled module path to the host?
             UpdatePSModulePath();
 
             // Check to see if the configuration we have is valid

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -12,7 +12,7 @@ using SMA = System.Management.Automation;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 
-#if DEBUG
+#if ASSEMBLY_LOAD_STACKTRACE
 using System.Diagnostics;
 #endif
 
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext _, AssemblyName asmName) =>
             {
-#if DEBUG
+#if ASSEMBLY_LOAD_STACKTRACE
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}. Stacktrace:\n{new StackTrace()}");
 #else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}");
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // Unlike in .NET Core, we need to be look for all dependencies in .NET Framework, not just PSES.dll
             AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) =>
             {
-#if DEBUG
+#if ASSEMBLY_LOAD_STACKTRACE
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}. Stacktrace:\n{new StackTrace()}");
 #else
                 logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}");

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -152,6 +152,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                     .AddSerilog()
                     .SetMinimumLevel(LogLevel.Trace)) // TODO: Why randomly set to trace?
                 .AddSingleton<ILanguageServerFacade>(_ => null)
+                // TODO: Why add these for a debug server?!
                 .AddPsesLanguageServices(hostStartupInfo)
                 // For a Temp session, there is no LanguageServer so just set it to null
                 .AddSingleton(

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -24,15 +24,12 @@ namespace Microsoft.PowerShell.EditorServices.Server
     internal class PsesLanguageServer
     {
         internal ILoggerFactory LoggerFactory { get; }
-
         internal ILanguageServer LanguageServer { get; private set; }
-
         private readonly LogLevel _minimumLogLevel;
         private readonly Stream _inputStream;
         private readonly Stream _outputStream;
         private readonly HostStartupInfo _hostDetails;
         private readonly TaskCompletionSource<bool> _serverStart;
-
         private PsesInternalHost _psesHost;
 
         /// <summary>
@@ -156,7 +153,6 @@ namespace Microsoft.PowerShell.EditorServices.Server
         /// <returns>A task that completes when the server is shut down.</returns>
         public async Task WaitForShutdown()
         {
-            Log.Logger.Debug("Shutting down OmniSharp Language Server");
             await _serverStart.Task.ConfigureAwait(false);
             await LanguageServer.WaitForExit.ConfigureAwait(false);
 

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +11,8 @@ using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.Template;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Serilog;
@@ -114,33 +115,32 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     // _Initialize_ request:
                     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize
                     .OnInitialize(
-                        (languageServer, request, _) =>
+                        (languageServer, initializeParams, cancellationToken) =>
                         {
-                            Log.Logger.Debug("Initializing OmniSharp Language Server");
-
-                            IServiceProvider serviceProvider = languageServer.Services;
-
-                            _psesHost = serviceProvider.GetService<PsesInternalHost>();
-
-                            WorkspaceService workspaceService = serviceProvider.GetService<WorkspaceService>();
-
-                            // Grab the workspace path from the parameters
-                            if (request.RootUri != null)
+                            // Set the workspace path from the parameters.
+                            WorkspaceService workspaceService = languageServer.Services.GetService<WorkspaceService>();
+                            if (initializeParams.WorkspaceFolders is not null)
                             {
-                                workspaceService.WorkspacePath = request.RootUri.GetFileSystemPath();
-                            }
-                            else if (request.WorkspaceFolders != null)
-                            {
-                                // If RootUri isn't set, try to use the first WorkspaceFolder.
                                 // TODO: Support multi-workspace.
-                                foreach (OmniSharp.Extensions.LanguageServer.Protocol.Models.WorkspaceFolder workspaceFolder in request.WorkspaceFolders)
+                                foreach (WorkspaceFolder workspaceFolder in initializeParams.WorkspaceFolders)
                                 {
                                     workspaceService.WorkspacePath = workspaceFolder.Uri.GetFileSystemPath();
                                     break;
                                 }
                             }
 
-                            return Task.CompletedTask;
+                            // Parse initialization options.
+                            JObject initializationOptions = initializeParams.InitializationOptions as JObject;
+                            HostStartOptions hostStartOptions = new()
+                            {
+                                LoadProfiles = initializationOptions?.GetValue("EnableProfileLoading")?.Value<bool>() ?? false,
+                                // TODO: Consider deprecating the setting which sets this and
+                                // instead use WorkspacePath exclusively.
+                                InitialWorkingDirectory = initializationOptions?.GetValue("InitialWorkingDirectory")?.Value<string>() ?? workspaceService.WorkspacePath
+                            };
+
+                            _psesHost = languageServer.Services.GetService<PsesInternalHost>();
+                            return _psesHost.TryStartAsync(hostStartOptions, cancellationToken);
                         });
             }).ConfigureAwait(false);
 

--- a/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
+++ b/src/PowerShellEditorServices/Server/PsesServiceCollectionExtensions.cs
@@ -44,11 +44,10 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             provider.GetService<EditorOperationsService>(),
                             provider.GetService<IInternalPowerShellExecutionService>());
 
-                        // This is where we create the $psEditor variable
-                        // so that when the console is ready, it will be available
-                        // TODO: Improve the sequencing here so that:
-                        //  - The variable is guaranteed to be initialized when the console first appears
-                        //  - Any errors that occur are handled rather than lost by the unawaited task
+                        // This is where we create the $psEditor variable so that when the console
+                        // is ready, it will be available. NOTE: We cannot await this because it
+                        // uses a lazy initialization to avoid a race with the dependency injection
+                        // framework, see the EditorObject class for that!
                         extensionService.InitializeAsync();
 
                         return extensionService;

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/NullPSHostRawUI.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/NullPSHostRawUI.cs
@@ -12,44 +12,38 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public NullPSHostRawUI() => _buffer = new BufferCell[0, 0];
 
-        public override ConsoleColor BackgroundColor { get; set; }
-        public override Size BufferSize { get; set; }
-        public override Coordinates CursorPosition { get; set; }
-        public override int CursorSize { get; set; }
-        public override ConsoleColor ForegroundColor { get; set; }
-
-        public override bool KeyAvailable => false;
-
-        public override Size MaxPhysicalWindowSize => MaxWindowSize;
+        public override Coordinates WindowPosition { get; set; }
 
         public override Size MaxWindowSize => new() { Width = _buffer.GetLength(0), Height = _buffer.GetLength(1) };
 
-        public override Coordinates WindowPosition { get; set; }
+        public override Size MaxPhysicalWindowSize => MaxWindowSize;
+
+        public override bool KeyAvailable => false;
+
+        public override ConsoleColor ForegroundColor { get; set; }
+
+        public override int CursorSize { get; set; }
+
+        public override Coordinates CursorPosition { get; set; }
+
+        public override Size BufferSize { get; set; }
+
+        public override ConsoleColor BackgroundColor { get; set; }
+
         public override Size WindowSize { get; set; }
+
         public override string WindowTitle { get; set; }
 
-        public override void FlushInputBuffer()
-        {
-            // Do nothing
-        }
+        public override void FlushInputBuffer() { }
 
         public override BufferCell[,] GetBufferContents(Rectangle rectangle) => _buffer;
 
         public override KeyInfo ReadKey(ReadKeyOptions options) => default;
 
-        public override void ScrollBufferContents(Rectangle source, Coordinates destination, Rectangle clip, BufferCell fill)
-        {
-            // Do nothing
-        }
+        public override void ScrollBufferContents(Rectangle source, Coordinates destination, Rectangle clip, BufferCell fill) { }
 
-        public override void SetBufferContents(Coordinates origin, BufferCell[,] contents)
-        {
-            // Do nothing
-        }
+        public override void SetBufferContents(Coordinates origin, BufferCell[,] contents) { }
 
-        public override void SetBufferContents(Rectangle rectangle, BufferCell fill)
-        {
-            // Do nothing
-        }
+        public override void SetBufferContents(Rectangle rectangle, BufferCell fill) { }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/NullPSHostUI.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/NullPSHostUI.cs
@@ -14,6 +14,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
     {
         public NullPSHostUI() => RawUI = new NullPSHostRawUI();
 
+        public override bool SupportsVirtualTerminal => false;
+
         public override PSHostRawUserInterface RawUI { get; }
 
         public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions) => new();
@@ -29,44 +31,26 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public override SecureString ReadLineAsSecureString() => new();
 
-        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
-        {
-            // Do nothing
-        }
+        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value) { }
 
-        public override void Write(string value)
-        {
-            // Do nothing
-        }
+        public override void Write(string value) { }
 
-        public override void WriteDebugLine(string message)
-        {
-            // Do nothing
-        }
+        public override void WriteDebugLine(string message) { }
 
-        public override void WriteErrorLine(string value)
-        {
-            // Do nothing
-        }
+        public override void WriteErrorLine(string value) { }
 
-        public override void WriteLine(string value)
-        {
-            // Do nothing
-        }
+        public override void WriteInformation(InformationRecord record) { }
 
-        public override void WriteProgress(long sourceId, ProgressRecord record)
-        {
-            // Do nothing
-        }
+        public override void WriteLine() { }
 
-        public override void WriteVerboseLine(string message)
-        {
-            // Do nothing
-        }
+        public override void WriteLine(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value) { }
 
-        public override void WriteWarningLine(string message)
-        {
-            // Do nothing
-        }
+        public override void WriteLine(string value) { }
+
+        public override void WriteProgress(long sourceId, ProgressRecord record) { }
+
+        public override void WriteVerboseLine(string message) { }
+
+        public override void WriteWarningLine(string message) { }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -169,8 +169,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public bool IsRunning => _isRunningLatch.IsSignaled;
 
-        public string InitialWorkingDirectory { get; private set; }
-
         public Task Shutdown => _stopped.Task;
 
         IRunspaceInfo IRunspaceContext.CurrentRunspace => CurrentRunspace;
@@ -442,8 +440,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public Task SetInitialWorkingDirectoryAsync(string path, CancellationToken cancellationToken)
         {
-            InitialWorkingDirectory = path;
-
             return ExecutePSCommandAsync(
                 new PSCommand().AddCommand("Set-Location").AddParameter("LiteralPath", path),
                 cancellationToken);

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             // Respect a user provided bundled module path.
             if (Directory.Exists(hostInfo.BundledModulePath))
             {
-                _logger.LogTrace("Using new bundled module path: {}", hostInfo.BundledModulePath);
+                _logger.LogTrace($"Using new bundled module path: {hostInfo.BundledModulePath}");
                 s_bundledModulePath = hostInfo.BundledModulePath;
             }
 
@@ -236,7 +236,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         /// <returns>A task that resolves when the host has finished startup, with the value true if the caller started the host, and false otherwise.</returns>
         public async Task<bool> TryStartAsync(HostStartOptions startOptions, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Host starting");
+            _logger.LogDebug("Starting host...");
             if (!_isRunningLatch.TryEnter())
             {
                 _logger.LogDebug("Host start requested after already started.");
@@ -248,13 +248,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
             if (startOptions.LoadProfiles)
             {
+                _logger.LogDebug("Loading profiles...");
                 await LoadHostProfilesAsync(cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation("Profiles loaded");
+                _logger.LogDebug("Profiles loaded!");
             }
 
             if (startOptions.InitialWorkingDirectory is not null)
             {
-                await SetInitialWorkingDirectoryAsync(startOptions.InitialWorkingDirectory, CancellationToken.None).ConfigureAwait(false);
+                _logger.LogDebug($"Setting InitialWorkingDirectory to {startOptions.InitialWorkingDirectory}...");
+                await SetInitialWorkingDirectoryAsync(startOptions.InitialWorkingDirectory, cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug("InitialWorkingDirectory set!");
             }
 
             await _started.Task.ConfigureAwait(false);
@@ -269,6 +272,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public void TriggerShutdown()
         {
+            _logger.LogDebug("Shutting down host...");
             if (Interlocked.Exchange(ref _shuttingDown, 1) == 0)
             {
                 _cancellationContext.CancelCurrentTaskStack();
@@ -680,7 +684,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 return;
             }
 
-            _logger.LogInformation("PSES pipeline thread loop shutting down");
+            _logger.LogDebug("PSES pipeline thread loop shutting down");
             _stopped.SetResult(true);
         }
 

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -76,12 +76,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         {
             IScriptPosition cursorPosition = s_clonePositionWithNewOffset(scriptAst.Extent.StartScriptPosition, fileOffset);
 
-            logger.LogTrace(
-                string.Format(
-                    "Getting completions at offset {0} (line: {1}, column: {2})",
-                    fileOffset,
-                    cursorPosition.LineNumber,
-                    cursorPosition.ColumnNumber));
+            logger.LogTrace($"Getting completions at offset {fileOffset} (line: {cursorPosition.LineNumber}, column: {cursorPosition.ColumnNumber})");
 
             Stopwatch stopwatch = new();
 
@@ -103,7 +98,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 .ConfigureAwait(false);
 
             stopwatch.Stop();
-            logger.LogTrace($"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms.");
+            logger.LogTrace($"IntelliSense completed in {stopwatch.ElapsedMilliseconds}ms: {commandCompletion}");
 
             return commandCompletion;
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override Task<CodeLens> Handle(CodeLens request, CancellationToken cancellationToken)
         {
-            // TODO: Catch deserializtion exception on bad object
+            // TODO: Catch deserialization exception on bad object
             CodeLensData codeLensData = request.Data.ToObject<CodeLensData>();
 
             ICodeLensProvider originalProvider = _symbolsService

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -185,7 +185,10 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 // Retain PowerShell's sort order with the given index.
                 SortText = $"{sortIndex:D4}{result.ListItemText}",
                 FilterText = result.CompletionText,
-                TextEdit = textEdit // Used instead of InsertText.
+                // Used instead of Label when TextEdit is unsupported
+                InsertText = result.CompletionText,
+                // Used instead of InsertText when possible
+                TextEdit = textEdit
             };
 
             return result.ResultType switch

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -144,6 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             for (int i = 0; i < result.CompletionMatches.Count; i++)
             {
                 completionItems[i] = CreateCompletionItem(result.CompletionMatches[i], replacedRange, i + 1);
+                _logger.LogTrace("Created completion item: " + completionItems[i] + " with " + completionItems[i].TextEdit);
             }
             return completionItems;
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
@@ -9,9 +12,6 @@ using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
@@ -27,7 +27,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             _logger = loggerFactory.CreateLogger<PsesDocumentHighlightHandler>();
             _workspaceService = workspaceService;
-            _logger.LogInformation("highlight handler loaded");
         }
 
         protected override DocumentHighlightRegistrationOptions CreateRegistrationOptions(DocumentHighlightCapability capability, ClientCapabilities clientCapabilities) => new()
@@ -46,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 request.Position.Line + 1,
                 request.Position.Character + 1);
 
-            if (symbolOccurrences == null)
+            if (symbolOccurrences is null)
             {
                 return Task.FromResult(s_emptyHighlightContainer);
             }
@@ -60,6 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     Range = symbolOccurrences[i].ScriptRegion.ToRange()
                 };
             }
+            _logger.LogDebug("Highlights: " + highlights);
 
             return Task.FromResult(new DocumentHighlightContainer(highlights));
         }

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteAttributeValue.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteAttributeValue.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Property,
             Detail = "System.Boolean ValueFromPipeline",
             FilterText = "ValueFromPipeline",
+            InsertText = "ValueFromPipeline",
             Label = "ValueFromPipeline",
             SortText = "0001ValueFromPipeline",
             TextEdit = new TextEdit
@@ -41,6 +42,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Property,
             Detail = "System.Boolean ValueFromPipelineByPropertyName",
             FilterText = "ValueFromPipelineByPropertyName",
+            InsertText = "ValueFromPipelineByPropertyName",
             Label = "ValueFromPipelineByPropertyName",
             SortText = "0002ValueFromPipelineByPropertyName",
             TextEdit = new TextEdit
@@ -59,6 +61,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Property,
             Detail = "System.Boolean ValueFromRemainingArguments",
             FilterText = "ValueFromRemainingArguments",
+            InsertText = "ValueFromRemainingArguments",
             Label = "ValueFromRemainingArguments",
             SortText = "0003ValueFromRemainingArguments",
             TextEdit = new TextEdit

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandFromModule.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Function,
             Detail = "", // OS-dependent, checked separately.
             FilterText = "Get-Random",
+            InsertText = "Get-Random",
             Label = "Get-Random",
             SortText = "0001Get-Random",
             TextEdit = new TextEdit

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Function,
             Detail = "",
             FilterText = "Get-Something",
+            InsertText = "Get-Something",
             Label = "Get-Something",
             SortText = "0001Get-Something",
             TextEdit = new TextEdit

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteNamespace.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteNamespace.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Module,
             Detail = "Namespace System.Collections",
             FilterText = "System.Collections",
+            InsertText = "System.Collections",
             Label = "Collections",
             SortText = "0001Collections",
             TextEdit = new TextEdit

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteTypeName.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteTypeName.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.TypeParameter,
             Detail = "System.Collections.ArrayList",
             FilterText = "System.Collections.ArrayList",
+            InsertText = "System.Collections.ArrayList",
             Label = "ArrayList",
             SortText = "0001ArrayList",
             TextEdit = new TextEdit

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteVariableInFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteVariableInFile.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             Kind = CompletionItemKind.Variable,
             Detail = "", // Same as label, so not shown.
             FilterText = "$testVar1",
+            InsertText = "$testVar1",
             Label = "testVar1",
             SortText = "0001testVar1",
             TextEdit = new TextEdit


### PR DESCRIPTION
In addition to a few clean-ups, the primary fix here is to start the PowerShell host in the `initialize` request handler, instead of the `onDidChangeConfiguration` handler, which only worked as it relied on a quirk of the VS Code client. In order to do this, we now expect to receive the settings `EnableProfileLoading: bool` and `InitialWorkingDirectory: string` as initialization parameters.

Fixes https://github.com/PowerShell/PowerShellEditorServices/issues/1695.