### PR TITLE
Fix execution of debug prompt commands

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
                 // the latter we must not send through it else they pollute the history as this
                 // PowerShell API does not let us exclude them from it.
                 return _pwsh.Runspace.Debugger.InBreakpoint
-                    && (PowerShellExecutionOptions.AddToHistory || IsPromptCommand(_psCommand))
+                    && (PowerShellExecutionOptions.AddToHistory || IsPromptCommand(_psCommand) || _pwsh.Runspace.RunspaceIsRemote)
                     ? ExecuteInDebugger(cancellationToken)
                     : ExecuteNormally(cancellationToken);
             }


### PR DESCRIPTION
Thanks to a brilliant idea from Patrick, this simplifies how we choose which commands to execute through PowerShell's debugger API, and also fixes an issue where a user's custom prompt function wasn't aware that it was in the debugger.

This fixes https://github.com/PowerShell/vscode-powershell/issues/3980.