### PR TITLE
Remove bad UX of commit characters for paths

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -384,7 +384,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 InsertText = completionText,
                 FilterText = completionText,
                 InsertTextFormat = insertFormat,
-                CommitCharacters = MaybeAddCommitCharacters("\\", "/", "'", "\""),
             };
         }
 


### PR DESCRIPTION
Pressing a quote character at the start of a string and committing to a
path accidently is really annoying.