### PR TITLE
Add Emacs regression tests for PSES

### DIFF
--- a/.github/workflows/emacs-test.yml
+++ b/.github/workflows/emacs-test.yml
@@ -1,0 +1,30 @@
+name: "Emacs"
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ v* ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+    paths-ignore: [ '**/*.md' ]
+
+jobs:
+  test:
+    name: Test PSES with Emacs via Eglot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build PSES
+        shell: pwsh
+        run: tools/azurePipelinesBuild.ps1
+
+      - name: Install Emacs
+        uses: purcell/setup-emacs@v3.0
+        with:
+          version: '28.1'
+
+      - name: Run ERT
+        run: emacs -batch -l ert -l test/emacs-test.el -f ert-run-tests-batch-and-exit

--- a/test/emacs-test.el
+++ b/test/emacs-test.el
@@ -1,0 +1,70 @@
+;;; emacs-test.el --- Integration testing script          -*- lexical-binding: t; -*-
+
+;; Copyright (c) Microsoft Corporation.
+;; Licensed under the MIT License.
+
+;; Author: Andy Schwartzmeyer <andschwa@microsoft.com>
+;; Keywords: PowerShell, LSP
+
+;;; Code:
+
+(require 'ert)
+
+;; Improved TLS Security.
+(with-eval-after-load 'gnutls
+  (custom-set-variables
+   '(gnutls-verify-error t)
+   '(gnutls-min-prime-bits 3072)))
+
+;; Package setup.
+(require 'package)
+(add-to-list 'package-archives
+             '("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+
+(require 'flymake)
+
+(unless (package-installed-p 'powershell)
+  (package-refresh-contents)
+  (package-install 'powershell))
+(require 'powershell)
+
+(unless (package-installed-p 'eglot)
+  (package-refresh-contents)
+  (package-install 'eglot))
+(require 'eglot)
+
+(ert-deftest powershell-editor-services ()
+  "Eglot should connect to PowerShell Editor Services."
+  (let* ((repo (project-root (project-current)))
+         (start-script (expand-file-name "module/PowerShellEditorServices/Start-EditorServices.ps1" repo))
+         (module-path (expand-file-name "module" repo))
+         (log-path (expand-file-name "test/emacs-test.log" repo))
+         (session-path (expand-file-name "test/emacs-session.json" repo))
+         (test-script (expand-file-name "test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1" repo))
+         (eglot-sync-connect t))
+    (add-to-list
+     'eglot-server-programs
+     `(powershell-mode
+       . ("pwsh" "-NoLogo" "-NoProfile" "-Command" ,start-script
+          "-HostName" "Emacs" "-HostProfileId" "Emacs" "-HostVersion" "1.0.0"
+          "-BundledModulesPath" ,module-path
+          "-LogPath" ,log-path "-LogLevel" "Diagnostic"
+          "-SessionDetailsPath" ,session-path
+          "-Stdio")))
+    (with-current-buffer (find-file-noselect test-script)
+      (should (eq major-mode 'powershell-mode))
+      (should (apply #'eglot--connect (eglot--guess-contact)))
+      (should (eglot-current-server))
+      (let ((lsp (eglot-current-server)))
+        (should (string= (oref lsp project-nickname) "PowerShellEditorServices"))
+        (should (eq (oref lsp major-mode) 'powershell-mode))
+        (should (string= (oref lsp language-id) "powershell")))
+      (sleep-for 3) ; TODO: Wait for "textDocument/publishDiagnostics" instead
+      (flymake-start)
+      (goto-char (point-min))
+      (flymake-goto-next-error)
+      (should (eq 'flymake-warning (face-at-point))))))
+
+(provide 'emacs-test)
+;;; emacs-test.el ends here


### PR DESCRIPTION
This adds regression tests written in Emacs to validate that PSES can be connected (and reports diagnostics) with a client that isn't VS Code, namely [Eglot](https://github.com/joaotavora/eglot), and Emacs LSP client.