### PR TITLE
Utilize the `AddToHistory` delegate from PSRL proxy

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Console/IReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/IReadLine.cs
@@ -9,5 +9,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
     internal interface IReadLine
     {
         string ReadLine(CancellationToken cancellationToken);
+
+        void AddToHistory(string historyEntry);
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/PsrlReadLine.cs
@@ -38,6 +38,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
             InvokePSReadLine,
             cancellationToken);
 
+        public override void AddToHistory(string historyEntry) => _psrlProxy.AddToHistory(historyEntry);
+
         protected override ConsoleKeyInfo ReadKey(CancellationToken cancellationToken) => _psesHost.ReadKey(intercept: true, cancellationToken);
 
         private string InvokePSReadLine(CancellationToken cancellationToken)

--- a/src/PowerShellEditorServices/Services/PowerShell/Console/TerminalReadLine.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/TerminalReadLine.cs
@@ -9,6 +9,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
 
     internal abstract class TerminalReadLine : IReadLine
     {
+        public virtual void AddToHistory(string historyEntry)
+        {
+            // No-op by default. If the ReadLine provider is not PSRL then history is automatically
+            // added as part of the invocation process.
+        }
+
         public abstract string ReadLine(CancellationToken cancellationToken);
 
         protected abstract ConsoleKeyInfo ReadKey(CancellationToken cancellationToken);

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/ExecutionOptions.cs
@@ -34,5 +34,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
         public bool WriteInputToHost { get; init; }
         public bool ThrowOnError { get; init; } = true;
         public bool AddToHistory { get; init; }
+        internal bool FromRepl { get; init; }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -446,6 +446,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             task.ExecuteAndGetResult(cancellationToken);
         }
 
+        internal void AddToHistory(string historyEntry) => _readLineProvider.ReadLine.AddToHistory(historyEntry);
+
         internal Task LoadHostProfilesAsync(CancellationToken cancellationToken)
         {
             // NOTE: This is a special task run on startup!
@@ -918,7 +920,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 {
                     AddToHistory = true,
                     ThrowOnError = false,
-                    WriteOutputToHost = true
+                    WriteOutputToHost = true,
+                    FromRepl = true,
                 },
                 cancellationToken);
         }


### PR DESCRIPTION
Fixes PowerShell/vscode-powershell#3683

This PR just fixes the regression of history not including <kbd>F5</kbd>/<kbd>F8</kbd>. Opened #1822 to track making this configurable