### PR TITLE
Add regression test for untitled scripts in Windows PowerShell

### DIFF
--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -427,13 +427,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
             SymbolReference foundDefinition = null;
             foreach (ScriptFile scriptFile in referencedFiles)
             {
-                foundDefinition =
-                    AstOperations.FindDefinitionOfSymbol(
-                        scriptFile.ScriptAst,
-                        foundSymbol);
+                foundDefinition = AstOperations.FindDefinitionOfSymbol(scriptFile.ScriptAst, foundSymbol);
 
                 filesSearched.Add(scriptFile.FilePath);
-                if (foundDefinition != null)
+                if (foundDefinition is not null)
                 {
                     foundDefinition.FilePath = scriptFile.FilePath;
                     break;
@@ -453,7 +450,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // if the definition the not found in referenced files
             // look for it in all the files in the workspace
-            if (foundDefinition == null)
+            if (foundDefinition is null)
             {
                 // Get a list of all powershell files in the workspace path
                 foreach (string file in _workspaceService.EnumeratePSFiles())
@@ -469,7 +466,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                             foundSymbol);
 
                     filesSearched.Add(file);
-                    if (foundDefinition != null)
+                    if (foundDefinition is not null)
                     {
                         foundDefinition.FilePath = file;
                         break;
@@ -480,7 +477,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // if the definition is not found in a file in the workspace
             // look for it in the builtin commands but only if the symbol
             // we are looking at is possibly a Function.
-            if (foundDefinition == null
+            if (foundDefinition is null
                 && (foundSymbol.SymbolType == SymbolType.Function
                     || foundSymbol.SymbolType == SymbolType.Unknown))
             {

--- a/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Vistors/AstOperations.cs
@@ -215,11 +215,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             Ast scriptAst,
             SymbolReference symbolReference)
         {
-            FindDeclarationVisitor declarationVisitor =
-                new(
-                    symbolReference);
+            FindDeclarationVisitor declarationVisitor = new(symbolReference);
             scriptAst.Visit(declarationVisitor);
-
             return declarationVisitor.FoundDeclaration;
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         }
 
         /// <summary>
-        /// Deterines whether the supplied path indicates the file is an "untitled:Unitled-X"
+        /// Determines whether the supplied path indicates the file is an "untitled:Untitled-X"
         /// which has not been saved to file.
         /// </summary>
         /// <param name="path">The path to check.</param>
@@ -203,10 +203,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         internal static bool IsUntitledPath(string path)
         {
             Validate.IsNotNull(nameof(path), path);
-            return !string.Equals(
-                DocumentUri.From(path).Scheme,
-                Uri.UriSchemeFile,
-                StringComparison.OrdinalIgnoreCase);
+            // This may not have been given a URI, so return false instead of throwing.
+            return Uri.IsWellFormedUriString(path, UriKind.RelativeOrAbsolute) &&
+                !string.Equals(DocumentUri.From(path).Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -152,8 +152,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         /// <param name="filePath">The file path at which the script resides.</param>
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
-        public bool TryGetFile(string filePath, out ScriptFile scriptFile) =>
-            TryGetFile(new Uri(filePath), out scriptFile);
+        public bool TryGetFile(string filePath, out ScriptFile scriptFile)
+        {
+            scriptFile = null;
+            return Uri.IsWellFormedUriString(filePath, UriKind.RelativeOrAbsolute)
+                && TryGetFile(new Uri(filePath), out scriptFile);
+        }
 
         /// <summary>
         /// Tries to get an open file in the workspace. Returns true if it succeeds, false otherwise.

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -2,17 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Security;
 using System.Text;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Utility;
-using Microsoft.PowerShell.EditorServices.Services.Workspace;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
-using System.Collections.Concurrent;
+using Microsoft.PowerShell.EditorServices.Services.Workspace;
+using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 
 namespace Microsoft.PowerShell.EditorServices.Services
@@ -154,9 +154,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="scriptFile">The out parameter that will contain the ScriptFile object.</param>
         public bool TryGetFile(string filePath, out ScriptFile scriptFile)
         {
-            scriptFile = null;
-            return Uri.IsWellFormedUriString(filePath, UriKind.RelativeOrAbsolute)
-                && TryGetFile(new Uri(filePath), out scriptFile);
+            // This might not have been given a file path, in which case the Uri constructor barfs.
+            try
+            {
+                return TryGetFile(new Uri(filePath), out scriptFile);
+            }
+            catch (UriFormatException)
+            {
+                scriptFile = null;
+                return false;
+            }
         }
 
         /// <summary>
@@ -305,7 +312,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             referencedScriptFiles.Add(scriptFile.Id, scriptFile);
             RecursivelyFindReferences(scriptFile, referencedScriptFiles);
 
-            // remove original file from referened file and add it as the first element of the
+            // remove original file from referenced file and add it as the first element of the
             // expanded referenced list to maintain order so the original file is always first in the list
             referencedScriptFiles.Remove(scriptFile.Id);
             expandedReferences.Add(scriptFile);

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
@@ -12,13 +12,13 @@ namespace PowerShellEditorServices.Test.E2E
 {
     public static class DebugAdapterClientExtensions
     {
-        public static async Task LaunchScript(this DebugAdapterClient debugAdapterClient, string filePath, TaskCompletionSource<object> started)
+        public static async Task LaunchScript(this DebugAdapterClient debugAdapterClient, string script, TaskCompletionSource<object> started)
         {
             LaunchResponse launchResponse = await debugAdapterClient.Launch(
                 new PsesLaunchRequestArguments
                 {
                     NoDebug = false,
-                    Script = filePath,
+                    Script = script,
                     Cwd = "",
                     CreateTemporaryIntegratedConsole = false
                 }).ConfigureAwait(true);

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -127,7 +127,13 @@ namespace PowerShellEditorServices.Test.E2E
                 throw new ArgumentNullException(nameof(logStatements), "Expected at least one argument.");
             }
 
-            // Have script create/overwrite file first with `>`.
+            // Clean up side effects from other test runs.
+            if (File.Exists(s_testOutputPath))
+            {
+                File.Delete(s_testOutputPath);
+            }
+
+            // Have script create file first with `>` (but don't rely on overwriting).
             StringBuilder builder = new StringBuilder().Append('\'').Append(logStatements[0]).Append("' > '").Append(s_testOutputPath).AppendLine("'");
             for (int i = 1; i < logStatements.Length; i++)
             {

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -183,7 +183,7 @@ namespace PowerShellEditorServices.Test.E2E
         public async Task CanSetBreakpointsAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode,
+                PsesStdioProcess.RunningInConstrainedLanguageMode,
                 "You can't set breakpoints in ConstrainedLanguage mode.");
 
             string filePath = NewTestFile(GenerateScriptFromLoggingStatements(
@@ -260,7 +260,7 @@ namespace PowerShellEditorServices.Test.E2E
         public async Task CanStepPastSystemWindowsForms()
         {
             Skip.IfNot(PsesStdioProcess.IsWindowsPowerShell);
-            Skip.If(PsesStdioProcess.RunningInConstainedLanguageMode);
+            Skip.If(PsesStdioProcess.RunningInConstrainedLanguageMode);
 
             string filePath = NewTestFile(string.Join(Environment.NewLine, new[]
                 {

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -155,7 +155,7 @@ function CanSendWorkspaceSymbolRequest {
         public async Task CanReceiveDiagnosticsFromFileOpenAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             NewTestFile("$a = 4");
@@ -178,7 +178,7 @@ function CanSendWorkspaceSymbolRequest {
         public async Task CanReceiveDiagnosticsFromFileChangedAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string filePath = NewTestFile("$a = 4");
@@ -230,7 +230,7 @@ function CanSendWorkspaceSymbolRequest {
         public async Task CanReceiveDiagnosticsFromConfigurationChangeAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             NewTestFile("gci | % { $_ }");
@@ -331,7 +331,7 @@ $_
         public async Task CanSendFormattingRequestAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string scriptPath = NewTestFile(@"
@@ -368,7 +368,7 @@ Get-Process
         public async Task CanSendRangeFormattingRequestAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string scriptPath = NewTestFile(@"
@@ -892,7 +892,7 @@ CanSendReferencesCodeLensRequest
         public async Task CanSendCodeActionRequestAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string filePath = NewTestFile("gci");
@@ -1090,7 +1090,7 @@ CanSendDefinitionRequest
         [SkippableFact]
         public async Task CanSendGetProjectTemplatesRequestAsync()
         {
-            Skip.If(PsesStdioProcess.RunningInConstainedLanguageMode, "Plaster doesn't work in ConstrainedLanguage mode.");
+            Skip.If(PsesStdioProcess.RunningInConstrainedLanguageMode, "Plaster doesn't work in ConstrainedLanguage mode.");
 
             GetProjectTemplatesResponse getProjectTemplatesResponse =
                 await PsesLanguageClient
@@ -1110,7 +1110,7 @@ CanSendDefinitionRequest
         public async Task CanSendGetCommentHelpRequestAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
+                PsesStdioProcess.RunningInConstrainedLanguageMode && PsesStdioProcess.IsWindowsPowerShell,
                 "Windows PowerShell doesn't trust PSScriptAnalyzer by default so it won't load.");
 
             string scriptPath = NewTestFile(@"
@@ -1183,7 +1183,7 @@ function CanSendGetCommentHelpRequest {
         public async Task CanSendExpandAliasRequestAsync()
         {
             Skip.If(
-                PsesStdioProcess.RunningInConstainedLanguageMode,
+                PsesStdioProcess.RunningInConstrainedLanguageMode,
                 "This feature currently doesn't support ConstrainedLanguage Mode.");
 
             ExpandAliasResult expandAliasResult =

--- a/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
@@ -43,9 +43,10 @@ namespace PowerShellEditorServices.Test.E2E
 
         #region public static properties
 
+        // NOTE: Just hard-code this to "powershell" when testing with the code lens.
         public static string PwshExe { get; } = Environment.GetEnvironmentVariable("PWSH_EXE_NAME") ?? "pwsh";
         public static bool IsWindowsPowerShell { get; } = PwshExe.Contains("powershell");
-        public static bool RunningInConstainedLanguageMode { get; } =
+        public static bool RunningInConstrainedLanguageMode { get; } =
             Environment.GetEnvironmentVariable("__PSLockdownPolicy", EnvironmentVariableTarget.Machine) != null;
 
         #endregion

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         [Fact]
         public async Task FindsFunctionDefinitionForAlias()
         {
-            // TODO: Eventually we should get the alises through the AST instead of relying on them
+            // TODO: Eventually we should get the aliases through the AST instead of relying on them
             // being defined in the runspace.
             await psesHost.ExecutePSCommandAsync(
                 new PSCommand().AddScript("Set-Alias -Name My-Alias -Value My-Function"),
@@ -184,6 +184,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Language
         public async Task FindsDotSourcedFile()
         {
             SymbolReference definitionResult = await GetDefinition(FindsDotSourcedFileData.SourceDetails).ConfigureAwait(true);
+            Assert.NotNull(definitionResult);
             Assert.True(
                 definitionResult.FilePath.EndsWith(Path.Combine("References", "ReferenceFileE.ps1")),
                 "Unexpected reference file: " + definitionResult.FilePath);

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -651,6 +651,7 @@ First line
         [InlineData("vscode-notebook-cell:/Users/me/Documents/test.ps1#0001", true)]
         [InlineData("https://microsoft.com", true)]
         [InlineData("Untitled:Untitled-1", true)]
+        [InlineData("'a log statement' > 'c:\\Users\\me\\Documents\\test.txt'\r\n", false)]
         public void IsUntitledFileIsCorrect(string path, bool expected) => Assert.Equal(expected, ScriptFile.IsUntitledPath(path));
     }
 }


### PR DESCRIPTION
Specifically targeting the edge case where the last line of the script is a comment. Covers https://github.com/PowerShell/vscode-powershell/issues/3965