### PR TITLE
Fix piping to native commands for Windows PowerShell

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -33,7 +33,7 @@ $script:IsNix = $IsLinux -or $IsMacOS
 # For Apple M1, pwsh might be getting emulated, in which case we need to check
 # for the proc_translated flag, otherwise we can check the architecture.
 $script:IsAppleM1 = $IsMacOS -and ((sysctl -n sysctl.proc_translated) -eq 1 -or (uname -m) -eq "arm64")
-$script:IsArm64 = $IsWindows -and @("ARM64", "AMD64") -contains $env:PROCESSOR_ARCHITECTURE
+$script:IsArm64 = -not $script:IsNix -and @("ARM64", "AMD64") -contains $env:PROCESSOR_ARCHITECTURE
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")
 $script:PsesCommonProps = [xml](Get-Content -Raw "$PSScriptRoot/PowerShellEditorServices.Common.props")
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Management.Automation.Host;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -981,8 +980,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
                 readLineProvider.OverrideReadLine(readLine);
                 System.Console.CancelKeyPress += OnCancelKeyPress;
-                System.Console.InputEncoding = Encoding.UTF8;
-                System.Console.OutputEncoding = Encoding.UTF8;
             }
 
             if (VersionUtils.IsWindows)

--- a/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
@@ -172,5 +172,15 @@ namespace Microsoft.PowerShell.EditorServices.Test.Console
                     out IReadLine readLine),
                 CancellationToken.None).ConfigureAwait(true));
         }
+
+        // This test asserts that we do not mess up the console encoding, which leads to native
+        // commands receiving piped input failing.
+        [Fact]
+        public async Task ExecutesNativeCommandsCorrectly()
+        {
+            await psesHost.ExecutePSCommandAsync(
+                new PSCommand().AddScript("\"protocol=https`nhost=myhost.com`nusername=john`npassword=doe`n`n\" | git.exe credential approve; if ($LastExitCode) { throw }"),
+                CancellationToken.None).ConfigureAwait(true);
+        }
     }
 }


### PR DESCRIPTION
For an unknown reason, we were explicitly overriding `Console.InputEncoding`, which led to a bug where input piped to a
native command in Windows PowerShell (where the default encoding is different than our override) would fail. Instead, we just don't override the encodings at all, which lets PSES be closer to the expected experience.

The regression test covers this, though to test the failure I had to move that override outside its guard (as it wasn't being set during tests).

Also fix building on ARM64 in Windows PowerShell, which doesn't have `$IsWindows`.

Thanks @SeeminglyScience for so quickly figuring out the problem.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4021