### PR TITLE
Don't use `RunContinuationsAsynchronously` for our `TaskCompletionSource`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             CancellationToken cancellationToken)
         {
             Logger = logger;
-            _taskCompletionSource = new TaskCompletionSource<TResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _taskCompletionSource = new TaskCompletionSource<TResult>();
             _taskRequesterCancellationToken = cancellationToken;
             _executionCanceled = false;
         }


### PR DESCRIPTION
Fixes PowerShell/vscode-powershell#4038

It's not a good sign that this slowed everything down, but at least it's
easy to revert. More investigation is required.