### PR TITLE
Catch `OperationCanceledException` in both command loops

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -228,8 +228,10 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
                 using EditorServicesLoader psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, sessionFileWriter, _loggerUnsubscribers);
                 _logger.Log(PsesLogLevel.Verbose, "Loading EditorServices");
-                // Start editor services and wait here until it shuts down
+                // Synchronously start editor services and wait here until it shuts down.
+#pragma warning disable VSTHRD002
                 psesLoader.LoadAndRunEditorServicesAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
             }
             catch (Exception e)
             {

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -769,7 +769,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                     && !cancellationScope.CancellationToken.IsCancellationRequested
                     && _taskQueue.TryTake(out ISynchronousTask task))
                 {
-                    task.ExecuteSynchronously(cancellationScope.CancellationToken);
+                    try
+                    {
+                        task.ExecuteSynchronously(cancellationScope.CancellationToken);
+                    }
+                    catch (OperationCanceledException e)
+                    {
+                        _logger.LogDebug(e, "Task {Task} was canceled!", task);
+                    }
                 }
 
                 if (_shouldExit

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
@@ -33,7 +33,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
                 serviceProvider: null,
                 editorOperations: null,
                 executionService: psesHost);
+#pragma warning disable VSTHRD002
             extensionService.InitializeAsync().Wait();
+#pragma warning restore VSTHRD002
             extensionCommandService = new(extensionService);
         }
 
@@ -110,7 +112,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             Assert.Equal(commandName, commandAdded.Name);
             Assert.Equal(commandDisplayName, commandAdded.DisplayName);
 
-            // Invoke the command
+            // Invoke the command.
+            // TODO: What task was this cancelling?
             await extensionCommandService.InvokeCommandAsync("test.scriptblock", editorContext).ConfigureAwait(true);
 
             // Assert the expected value


### PR DESCRIPTION
Our flaky extension command test seems to be flaky because sometimes another task gets queued, and since it runs in the foreground it cancels that task. Interactively, this happens in the first loop (with `DoOneRepl`) which catches the cancellation exception; but when under tests that is a no-op, so it happens in the second loop. Hence we should duplicate the same logic and so catch that exception.