### PR TITLE
Add `Directory.Exists()` check to `SetInitialWorkingDirectoryAsync()`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -475,9 +475,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public Task SetInitialWorkingDirectoryAsync(string path, CancellationToken cancellationToken)
         {
-            return ExecutePSCommandAsync(
-                new PSCommand().AddCommand("Set-Location").AddParameter("LiteralPath", path),
-                cancellationToken);
+            return Directory.Exists(path)
+                ? ExecutePSCommandAsync(
+                    new PSCommand().AddCommand("Set-Location").AddParameter("LiteralPath", path),
+                    cancellationToken)
+                : Task.CompletedTask;
         }
 
         private void Run()


### PR DESCRIPTION
There was an edge case where, after setting and un-setting the `powershell.cwd` property in the VS Code client, instead of being `null` the setting would be the empty string `""`. The client did not care about this, and so left the server to silently crash on startup. We previously assumed that by the time the server started, the directory would be validated by the client, but this was wrong. So now we check its existence first.

Resolves #1849 (with a regression test too).