### PR TITLE
Add regression test for debugging script with dot-source operator

### DIFF
--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -162,7 +162,7 @@ namespace PowerShellEditorServices.Test.E2E
 
         private static async Task<string[]> GetLog()
         {
-            while (!File.Exists(s_testOutputPath))
+            for (int i = 0; !File.Exists(s_testOutputPath) && i < 10; i++)
             {
                 await Task.Delay(1000).ConfigureAwait(true);
             }

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -19,7 +19,7 @@ using Xunit.Abstractions;
 namespace PowerShellEditorServices.Test.E2E
 {
     [Trait("Category", "DAP")]
-    public class DebugAdapterProtocolMessageTests : IAsyncLifetime
+    public class DebugAdapterProtocolMessageTests : IAsyncLifetime, IDisposable
     {
         private const string TestOutputFileName = "__dapTestOutputFile.txt";
         private static readonly bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -104,7 +104,13 @@ namespace PowerShellEditorServices.Test.E2E
                 TerminateDebuggee = true
             }).ConfigureAwait(true);
             await _psesProcess.Stop().ConfigureAwait(true);
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
             PsesDebugAdapterClient?.Dispose();
+            _psesProcess?.Dispose();
         }
 
         private static string NewTestFile(string script, bool isPester = false)

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -136,11 +136,23 @@ namespace PowerShellEditorServices.Test.E2E
             }
 
             // Have script create file first with `>` (but don't rely on overwriting).
-            StringBuilder builder = new StringBuilder().Append('\'').Append(logStatements[0]).Append("' > '").Append(s_testOutputPath).AppendLine("'");
+            // NOTE: We uses double quotes so that we can use PowerShell variables.
+            StringBuilder builder = new StringBuilder()
+                .Append("Write-Output \"")
+                .Append(logStatements[0])
+                .Append("\" > '")
+                .Append(s_testOutputPath)
+                .AppendLine("'");
+
             for (int i = 1; i < logStatements.Length; i++)
             {
                 // Then append to that script with `>>`.
-                builder.Append('\'').Append(logStatements[i]).Append("' >> '").Append(s_testOutputPath).AppendLine("'");
+                builder
+                    .Append("Write-Output \"")
+                    .Append(logStatements[i])
+                    .Append("\" >> '")
+                    .Append(s_testOutputPath)
+                    .AppendLine("'");
             }
 
             _output.WriteLine("Script is:");

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -183,6 +183,17 @@ namespace PowerShellEditorServices.Test.E2E
         }
 
         [Fact]
+        public async Task UsesDotSourceOperatorAndQuotesAsync()
+        {
+            string filePath = NewTestFile(GenerateScriptFromLoggingStatements("$($MyInvocation.Line)"));
+            await PsesDebugAdapterClient.LaunchScript(filePath, Started).ConfigureAwait(true);
+            ConfigurationDoneResponse configDoneResponse = await PsesDebugAdapterClient.RequestConfigurationDone(new ConfigurationDoneArguments()).ConfigureAwait(true);
+            Assert.NotNull(configDoneResponse);
+            Assert.Collection(await GetLog().ConfigureAwait(true),
+                (i) => Assert.StartsWith(". \"", i));
+        }
+
+        [Fact]
         public async Task CanLaunchScriptWithNoBreakpointsAsync()
         {
             string filePath = NewTestFile(GenerateScriptFromLoggingStatements("works"));

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -103,7 +103,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         private void AssertDebuggerPaused()
         {
-            DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(CancellationToken.None);
+            using CancellationTokenSource cts = new(10000);
+            DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(cts.Token);
             Assert.Empty(eventArgs.OriginalEvent.Breakpoints);
         }
 
@@ -112,7 +113,8 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             int lineNumber = -1,
             CommandBreakpointDetails commandBreakpointDetails = default)
         {
-            DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(CancellationToken.None);
+            using CancellationTokenSource cts = new(10000);
+            DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(cts.Token);
 
             Assert.True(psesHost.DebugContext.IsStopped);
 
@@ -587,10 +589,9 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             Assert.Equal("$false", falseVar.ValueString);
         }
 
-        [SkippableFact]
+        [Fact]
         public async Task DebuggerSetsVariablesNoConversion()
         {
-            Skip.If(VersionUtils.IsLinux, "Test hangs on Linux for some reason");
             await debugService.SetLineBreakpointsAsync(
                 variableScriptFile,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 14) }).ConfigureAwait(true);


### PR DESCRIPTION
Covers regression in https://github.com/PowerShell/vscode-powershell/issues/3715.