### PR TITLE
Rename "Integrated Console" to "Extension Terminal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The functionality in PowerShell Editor Services is already available in the foll
   - Real-time semantic analysis of scripts using PowerShell Script Analyzer
 - The Debugging Service simplifies interaction with the PowerShell debugger (breakpoints, variables, call stack, etc.)
 - The [$psEditor API](http://powershell.github.io/PowerShellEditorServices/guide/extensions.html) enables scripting of the host editor
-- A full, terminal-based Integrated Console experience for interactive development and debugging
+- A full, Extension Terminal experience for interactive development and debugging
 
 ## Usage
 
@@ -37,7 +37,7 @@ If you're looking for a more feature-rich experience,
 Named Pipes are the way to go.
 They give you all the benefits of the Language Server Protocol with extra capabilities that you can take advantage of:
 
-- The PowerShell Integrated Console
+- The PowerShell Extension Terminal
 - Debugging using the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
 
 The typical command to start PowerShell Editor Services using named pipes is as follows:
@@ -59,20 +59,20 @@ and once you connect to when you launch the debugger for Debug Adapter Protocol 
 
 The Visual Studio Code, Vim, and IntelliJ extensions currently use Named Pipes.
 
-#### PowerShell Integrated Console
+#### PowerShell Extension Terminal
 
 ![image](https://user-images.githubusercontent.com/2644648/66245084-6985da80-e6c0-11e9-9c7b-4c8476190df5.png)
 
-The PowerShell Integrated Console uses the host process' Stdio streams for console input and output. Please note that this is mutually exclusive from using Stdio for the language server protocol messages.
+The PowerShell Extension Terminal uses the host process' Stdio streams for console input and output. Please note that this is mutually exclusive from using Stdio for the language server protocol messages.
 
-If you want to take advantage of the PowerShell Integrated Console which automatically shares state with the editor-side,
+If you want to take advantage of the PowerShell Extension Terminal which automatically shares state with the editor-side,
 you must include the `-EnableConsoleRepl` switch when called `Start-EditorServices.ps1`.
 
 This is typically used if your client can create arbitrary terminals in the editor like below:
 
-![integrated console in vscode](https://user-images.githubusercontent.com/2644648/66245018-04ca8000-e6c0-11e9-808c-b86144149444.png)
+![Extension Terminal in vscode](https://user-images.githubusercontent.com/2644648/66245018-04ca8000-e6c0-11e9-808c-b86144149444.png)
 
-The Visual Studio Code, Vim, and IntelliJ extensions currently use the PowerShell Integrated Console.
+The Visual Studio Code, Vim, and IntelliJ extensions currently use the PowerShell Extension Terminal.
 
 #### Debugging
 
@@ -87,9 +87,9 @@ Currently, only the Visual Studio Code extension supports debugging.
 
 ### Stdio
 
-Stdio is a simpler and more universal mechanism for the Language Server Protocol. We recommend using it if your editor/client doesn't need to support the PowerShell Integrated Console or debugging.
+Stdio is a simpler and more universal mechanism for the Language Server Protocol. We recommend using it if your editor/client doesn't need to support the PowerShell Extension Terminal or debugging.
 
-> NOTE: Debugging and the Integrated Console are not features of the Stdio channel because each feature requires its own IO streams and since the Stdio model only provides a single set of streams (Stdio),
+> NOTE: Debugging and the Extension Terminal are not features of the Stdio channel because each feature requires its own IO streams and since the Stdio model only provides a single set of streams (Stdio),
 > these features cannot be leveraged.
 
 The typical command to start PowerShell Editor Services using stdio is as follows:

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -149,7 +149,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         public string[] FeatureFlags { get; set; }
 
         /// <summary>
-        /// When set, enables the integrated console.
+        /// When set, enables the Extension Terminal.
         /// </summary>
         [Parameter]
         public SwitchParameter EnableConsoleRepl { get; set; }
@@ -186,7 +186,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         public SwitchParameter SplitInOutPipes { get; set; }
 
         /// <summary>
-        /// The banner/logo to display when the Integrated Console is first started.
+        /// The banner/logo to display when the extension terminal is first started.
         /// </summary>
         [Parameter]
         public string StartupBanner { get; set; }

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -8,7 +8,7 @@ using System.Management.Automation.Runspaces;
 namespace Microsoft.PowerShell.EditorServices.Hosting
 {
     /// <summary>
-    /// Describes the desired console REPL for the integrated console.
+    /// Describes the desired console REPL for the Extension Terminal.
     /// </summary>
     public enum ConsoleReplKind
     {
@@ -84,8 +84,8 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public IReadOnlyList<string> FeatureFlags { get; set; }
 
         /// <summary>
-        /// The console REPL experience to use in the integrated console
-        /// (including none to disable the integrated console).
+        /// The console REPL experience to use in the Extension Terminal
+        /// (including none to disable the Extension Terminal).
         /// </summary>
         public ConsoleReplKind ConsoleRepl { get; set; } = ConsoleReplKind.None;
 
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public string StartupBanner { get; set; } = @"
 
-                  =====> PowerShell Integrated Console <=====
+                  =====> PowerShell Editor Services <=====
 
 ";
     }

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 //  - Possibly start the debug server
                 //  - Wait for the LSP server to finish
 
-                // Unsubscribe the host logger here so that the integrated console is not polluted with input after the first prompt
+                // Unsubscribe the host logger here so that the Extension Terminal is not polluted with input after the first prompt
                 _logger.Log(PsesLogLevel.Verbose, "Starting server, deregistering host logger and registering shutdown listener");
                 if (_loggersToUnsubscribe != null)
                 {

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             // This gets the ExtensionService which triggers the creation of the `$psEditor` variable.
             // (because services are created only when they are first retrieved)
             // Keep in mind, for Temp sessions, the `$psEditor` API is a no-op and the user is warned
-            // to run the command in the main PS Integrated Console.
+            // to run the command in the main extension terminal.
             serviceProvider.GetService<ExtensionService>();
 
             return new PsesDebugServer(

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public IReadOnlyList<string> AdditionalModules { get; }
 
         /// <summary>
-        /// True if the integrated console is to be enabled.
+        /// True if the Extension Terminal is to be enabled.
         /// </summary>
         public bool ConsoleReplEnabled { get; }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         /// <summary>
         /// Gets or sets a boolean value that determines whether to create a temporary
-        /// integrated console for the debug session. Default is false.
+        /// Extension Terminal for the debug session. Default is false.
         /// </summary>
         public bool CreateTemporaryIntegratedConsole { get; set; }
 
@@ -190,7 +190,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 && !string.IsNullOrEmpty(request.Script)
                 && ScriptFile.IsUntitledPath(request.Script))
             {
-                throw new RpcErrorException(0, "Running an Untitled file in a temporary integrated console is currently not supported.");
+                throw new RpcErrorException(0, "Running an Untitled file in a temporary Extension Terminal is currently not supported.");
             }
 
             // If the current session is remote, map the script path to the remote

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -24,14 +24,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 {
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
-    // NOTE: These last three are for a workaround for temporary integrated consoles.
+    // NOTE: These last three are for a workaround for temporary Extension Terminals.
     using Microsoft.PowerShell.EditorServices.Handlers;
     using Microsoft.PowerShell.EditorServices.Server;
     using OmniSharp.Extensions.DebugAdapter.Protocol.Server;
 
     internal class PsesInternalHost : PSHost, IHostSupportsInteractiveSession, IRunspaceContext, IInternalPowerShellExecutionService
     {
-        private const string DefaultPrompt = "PSIC> ";
+        private const string DefaultPrompt = "> ";
         // This is a default that can be overriden at runtime by the user or tests.
         private static string s_bundledModulePath = Path.GetFullPath(Path.Combine(
             Path.GetDirectoryName(typeof(PsesInternalHost).Assembly.Location), "..", "..", ".."));
@@ -1119,12 +1119,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             using CancellationTokenRegistration registration = _readKeyCancellationToken.Register(
                 () =>
                 {
-                    // For the regular integrated console, we have an associated language server on
+                    // For the regular Extension Terminal, we have an associated language server on
                     // which we can send a notification, and have the client subscribe an action to
                     // send a key press.
                     _languageServer?.SendNotification("powerShell/sendKeyPress");
 
-                    // When temporary integrated consoles are spawned, there will be no associated
+                    // When temporary Extension Terminals are spawned, there will be no associated
                     // language server, but instead a debug adaptor server. In this case, the
                     // notification sent here will come across as a DebugSessionCustomEvent to which
                     // we can subscribe in the same way.

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -162,7 +162,7 @@ namespace PowerShellEditorServices.Test.E2E
 
         private static async Task<string[]> GetLog()
         {
-            for (int i = 0; !File.Exists(s_testOutputPath) && i < 10; i++)
+            for (int i = 0; !File.Exists(s_testOutputPath) && i < 60; i++)
             {
                 await Task.Delay(1000).ConfigureAwait(true);
             }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
 
         private void AssertDebuggerPaused()
         {
-            using CancellationTokenSource cts = new(10000);
+            using CancellationTokenSource cts = new(60000);
             DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(cts.Token);
             Assert.Empty(eventArgs.OriginalEvent.Breakpoints);
         }
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Debugging
             int lineNumber = -1,
             CommandBreakpointDetails commandBreakpointDetails = default)
         {
-            using CancellationTokenSource cts = new(10000);
+            using CancellationTokenSource cts = new(60000);
             DebuggerStoppedEventArgs eventArgs = debuggerStoppedQueue.Take(cts.Token);
 
             Assert.True(psesHost.DebugContext.IsStopped);

--- a/test/emacs-test.el
+++ b/test/emacs-test.el
@@ -60,7 +60,7 @@
         (should (string= (oref lsp project-nickname) "PowerShellEditorServices"))
         (should (eq (oref lsp major-mode) 'powershell-mode))
         (should (string= (oref lsp language-id) "powershell")))
-      (sleep-for 3) ; TODO: Wait for "textDocument/publishDiagnostics" instead
+      (sleep-for 5) ; TODO: Wait for "textDocument/publishDiagnostics" instead
       (flymake-start)
       (goto-char (point-min))
       (flymake-goto-next-error)


### PR DESCRIPTION
Except the startup banner as its the default, and may not be for the VS Code extension but for any client that connects to PSES and supports a terminal.

Part of https://github.com/PowerShell/vscode-powershell/issues/4053.