### PR TITLE
Use `HostInfo.BundledModulePath` to find PSScriptAnalyzer

### DIFF
--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 
@@ -92,7 +93,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public string LogPath { get; }
 
         /// <summary>
-        /// The InitialSessionState will be inherited from the orginal PowerShell process. This will
+        /// The InitialSessionState will be inherited from the original PowerShell process. This will
         /// be used when creating runspaces so that we honor the same InitialSessionState.
         /// </summary>
         public InitialSessionState InitialSessionState { get; }
@@ -167,7 +168,15 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             LogLevel = logLevel;
             ConsoleReplEnabled = consoleReplEnabled;
             UsesLegacyReadLine = usesLegacyReadLine;
-            BundledModulePath = bundledModulePath;
+
+            // Respect a user provided bundled module path.
+            BundledModulePath = Directory.Exists(bundledModulePath)
+                ? bundledModulePath
+                : Path.GetFullPath(Path.Combine(
+                    Path.GetDirectoryName(typeof(HostStartupInfo).Assembly.Location),
+                    "..",
+                    "..",
+                    ".."));
         }
 
         #endregion

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Hosting;
 using Microsoft.PowerShell.EditorServices.Services.Analysis;
 using Microsoft.PowerShell.EditorServices.Services.Configuration;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -52,8 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             .Append(':')
             .Append(end.Character);
 
-            string id = sb.ToString();
-            return id;
+            return sb.ToString();
         }
 
         /// <summary>
@@ -96,20 +96,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private CancellationTokenSource _diagnosticsCancellationTokenSource;
 
+        private readonly string _pssaModulePath;
+
         private string _pssaSettingsFilePath;
 
-        /// <summary>
-        /// Construct a new AnalysisService.
-        /// </summary>
-        /// <param name="loggerFactory">Logger factory to create logger instances with.</param>
-        /// <param name="languageServer">The LSP language server for notifications.</param>
-        /// <param name="configurationService">The configuration service to query for configurations.</param>
-        /// <param name="workspaceService">The workspace service for file handling within a workspace.</param>
         public AnalysisService(
             ILoggerFactory loggerFactory,
             ILanguageServerFacade languageServer,
             ConfigurationService configurationService,
-            WorkspaceService workspaceService)
+            WorkspaceService workspaceService,
+            HostStartupInfo hostInfo)
         {
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<AnalysisService>();
@@ -119,6 +115,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _analysisDelayMillis = 750;
             _mostRecentCorrectionsByFile = new ConcurrentDictionary<ScriptFile, CorrectionTableEntry>();
             _analysisEngineLazy = new Lazy<PssaCmdletAnalysisEngine>(InstantiateAnalysisEngine);
+            _pssaModulePath = Path.Combine(hostInfo.BundledModulePath, "PSScriptAnalyzer");
             _pssaSettingsFilePath = null;
         }
 
@@ -302,7 +299,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 pssaCmdletEngineBuilder.WithIncludedRules(s_defaultRules);
             }
 
-            return pssaCmdletEngineBuilder.Build();
+            return pssaCmdletEngineBuilder.Build(_pssaModulePath);
         }
 
         private PssaCmdletAnalysisEngine RecreateAnalysisEngine(PssaCmdletAnalysisEngine oldAnalysisEngine)

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return null;
             }
 
-            Hashtable commentHelpSettings = AnalysisService.GetCommentHelpRuleSettings(helpLocation, forBlockComment);
+            Hashtable commentHelpSettings = GetCommentHelpRuleSettings(helpLocation, forBlockComment);
 
             ScriptFileMarker[] analysisResults = await AnalysisEngine.AnalyzeScriptAsync(functionText, commentHelpSettings).ConfigureAwait(false);
 
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _analysisEngineLazy = new Lazy<PssaCmdletAnalysisEngine>(() => RecreateAnalysisEngine(currentAnalysisEngine));
         }
 
-        private PssaCmdletAnalysisEngine InstantiateAnalysisEngine()
+        internal PssaCmdletAnalysisEngine InstantiateAnalysisEngine()
         {
             PssaCmdletAnalysisEngine.Builder pssaCmdletEngineBuilder = new(_loggerFactory);
 
@@ -317,7 +317,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private bool TryFindSettingsFile(out string settingsFilePath)
         {
-            string configuredPath = _configurationService.CurrentSettings.ScriptAnalysis.SettingsPath;
+            string configuredPath = _configurationService?.CurrentSettings.ScriptAnalysis.SettingsPath;
 
             if (string.IsNullOrEmpty(configuredPath))
             {
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return false;
             }
 
-            settingsFilePath = _workspaceService.ResolveWorkspacePath(configuredPath);
+            settingsFilePath = _workspaceService?.ResolveWorkspacePath(configuredPath);
 
             if (settingsFilePath == null
                 || !File.Exists(settingsFilePath))

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,34 +66,26 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             /// If PSScriptAnalyzer cannot be found, this will return null.
             /// </summary>
             /// <returns>A newly configured PssaCmdletAnalysisEngine, or null if PSScriptAnalyzer cannot be found.</returns>
-            public PssaCmdletAnalysisEngine Build()
+            public PssaCmdletAnalysisEngine Build(string pssaModulePath)
             {
                 // RunspacePool takes care of queuing commands for us so we do not
                 // need to worry about executing concurrent commands
                 ILogger logger = _loggerFactory.CreateLogger<PssaCmdletAnalysisEngine>();
                 try
                 {
-                    RunspacePool pssaRunspacePool = CreatePssaRunspacePool();
-
-                    PssaCmdletAnalysisEngine cmdletAnalysisEngine = _settingsParameter is not null
-                        ? new PssaCmdletAnalysisEngine(logger, pssaRunspacePool, _settingsParameter)
-                        : new PssaCmdletAnalysisEngine(logger, pssaRunspacePool, _rules);
-
+                    logger.LogDebug("Creating PSScriptAnalyzer runspace with module at: '{Path}'", pssaModulePath);
+                    RunspacePool pssaRunspacePool = CreatePssaRunspacePool(pssaModulePath);
+                    PssaCmdletAnalysisEngine cmdletAnalysisEngine = new(logger, pssaRunspacePool, _settingsParameter ?? _rules);
                     cmdletAnalysisEngine.LogAvailablePssaFeatures();
                     return cmdletAnalysisEngine;
                 }
-                catch (FileNotFoundException e)
+                catch (Exception ex)
                 {
-                    logger.LogError(e, $"Unable to find PSScriptAnalyzer. Disabling script analysis. PSModulePath: '{Environment.GetEnvironmentVariable("PSModulePath")}'");
+                    logger.LogError(ex, "Unable to load PSScriptAnalyzer, disabling script analysis!");
                     return null;
                 }
             }
         }
-
-        // This is a default that can be overriden at runtime by the user or tests.
-        // TODO: Deduplicate this logic with PsesInternalHost.
-        private static readonly string s_pssaModulePath = Path.GetFullPath(Path.Combine(
-            Path.GetDirectoryName(typeof(PssaCmdletAnalysisEngine).Assembly.Location), "..", "..", "..", "PSScriptAnalyzer"));
 
         /// <summary>
         /// The indentation to add when the logger lists errors.
@@ -365,7 +356,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
         /// This looks for the latest version of PSScriptAnalyzer on the path and loads that.
         /// </summary>
         /// <returns>A runspace pool with PSScriptAnalyzer loaded for running script analysis tasks.</returns>
-        private static RunspacePool CreatePssaRunspacePool()
+        private static RunspacePool CreatePssaRunspacePool(string pssaModulePath)
         {
             using PowerShell pwsh = PowerShell.Create(RunspaceMode.NewRunspace);
 
@@ -375,10 +366,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             // We intentionally use `CreateDefault2()` as it loads `Microsoft.PowerShell.Core`
             // only, which is a more minimal and therefore safer state.
             InitialSessionState sessionState = InitialSessionState.CreateDefault2();
-
-            sessionState.ImportPSModulesFromPath(s_pssaModulePath);
-            // pwsh.ImportModule(s_pssaModulePath);
-            // sessionState.ImportPSModule(new[] { pssaModuleInfo.ModuleBase });
+            sessionState.ImportPSModulesFromPath(pssaModulePath);
 
             RunspacePool runspacePool = RunspaceFactory.CreateRunspacePool(sessionState);
 

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -15,10 +15,12 @@ using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
 using Microsoft.PowerShell.EditorServices.Utility;
 using Xunit;
-namespace Microsoft.PowerShell.EditorServices.Test.Debugging
+
+namespace PowerShellEditorServices.Test.Debugging
 {
     [Trait("Category", "DebugService")]
     public class DebugServiceTests : IDisposable

--- a/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/ExtensionCommandTests.cs
@@ -13,10 +13,11 @@ using Microsoft.PowerShell.EditorServices.Extensions.Services;
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Extensions
+namespace PowerShellEditorServices.Test.Extensions
 {
     [Trait("Category", "Extensions")]
     public class ExtensionCommandTests : IDisposable
@@ -59,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
                 BufferRange.None);
 
             EditorCommand commandAdded = null;
-            extensionCommandService.CommandAdded += (object _, EditorCommand command) => commandAdded = command;
+            extensionCommandService.CommandAdded += (_, command) => commandAdded = command;
 
             const string commandName = "test.function";
             const string commandDisplayName = "Function extension";
@@ -95,7 +96,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
                 BufferRange.None);
 
             EditorCommand commandAdded = null;
-            extensionCommandService.CommandAdded += (object _, EditorCommand command) => commandAdded = command;
+            extensionCommandService.CommandAdded += (_, command) => commandAdded = command;
 
             const string commandName = "test.scriptblock";
             const string commandDisplayName = "ScriptBlock extension";
@@ -126,7 +127,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
         public async Task CanUpdateRegisteredCommand()
         {
             EditorCommand updatedCommand = null;
-            extensionCommandService.CommandUpdated += (object _, EditorCommand command) => updatedCommand = command;
+            extensionCommandService.CommandUpdated += (_, command) => updatedCommand = command;
 
             const string commandName = "test.function";
             const string commandDisplayName = "Updated function extension";
@@ -160,7 +161,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Extensions
             const string commandDisplayName = "ScriptBlock extension";
 
             EditorCommand removedCommand = null;
-            extensionCommandService.CommandRemoved += (object _, EditorCommand command) => removedCommand = command;
+            extensionCommandService.CommandRemoved += (_, command) => removedCommand = command;
 
             // Add the command and wait for the add event
             await psesHost.ExecutePSCommandAsync(

--- a/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
@@ -11,13 +11,14 @@ using Microsoft.PowerShell.EditorServices.Handlers;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
 using Microsoft.PowerShell.EditorServices.Test.Shared.Completion;
 using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Language
+namespace PowerShellEditorServices.Test.Language
 {
     [Trait("Category", "Completions")]
     public class CompletionHandlerTests : IDisposable

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation.Language;
-using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Handlers;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Language
+namespace PowerShellEditorServices.Test.Language
 {
     public class SemanticTokenTest
     {

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -14,6 +14,7 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
 using Microsoft.PowerShell.EditorServices.Test.Shared.Definition;
 using Microsoft.PowerShell.EditorServices.Test.Shared.Occurrences;
@@ -23,7 +24,7 @@ using Microsoft.PowerShell.EditorServices.Test.Shared.SymbolDetails;
 using Microsoft.PowerShell.EditorServices.Test.Shared.Symbols;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Language
+namespace PowerShellEditorServices.Test.Language
 {
     [Trait("Category", "Symbols")]
     public class SymbolsServiceTests : IDisposable

--- a/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/TokenOperationsTests.cs
@@ -8,7 +8,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Language
+namespace PowerShellEditorServices.Test.Language
 {
     public class TokenOperationsTests
     {

--- a/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/AstOperationsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Services.Symbols
+namespace PowerShellEditorServices.Test.Services.Symbols
 {
     [Trait("Category", "AstOperations")]
     public class AstOperationsTests

--- a/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.PowerShell.EditorServices.Hosting;
+using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Services.Analysis;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test;
+using Xunit;
+
+namespace PowerShellEditorServices.Test.Services.Symbols
+{
+    [Trait("Category", "PSScriptAnalyzer")]
+    public class PSScriptAnalyzerTests
+    {
+        private readonly AnalysisService analysisService;
+
+        public PSScriptAnalyzerTests() => analysisService = new(
+            NullLoggerFactory.Instance,
+            languageServer: null,
+            configurationService: null,
+            workspaceService: null,
+            new HostStartupInfo(
+                name: "",
+                profileId: "",
+                version: null,
+                psHost: null,
+                profilePaths: null,
+                featureFlags: null,
+                additionalModules: null,
+                initialSessionState: null,
+                logPath: null,
+                logLevel: 0,
+                consoleReplEnabled: false,
+                usesLegacyReadLine: false,
+                bundledModulePath: PsesHostFactory.BundledModulePath));
+
+        [Fact]
+        public async Task CanLoadPSScriptAnalyzer()
+        {
+            PssaCmdletAnalysisEngine engine = analysisService.InstantiateAnalysisEngine();
+            Assert.NotNull(engine);
+            ScriptFileMarker[] violations = await engine.AnalyzeScriptAsync("function Get-Widgets {}").ConfigureAwait(true);
+            Assert.Collection(violations,
+            (actual) =>
+            {
+                Assert.Single(actual.Corrections);
+                Assert.Equal("Singularized correction of 'Get-Widgets'", actual.Corrections.First().Name);
+                Assert.Equal(ScriptFileMarkerLevel.Warning, actual.Level);
+                Assert.Equal("PSUseSingularNouns", actual.RuleName);
+                Assert.Equal("PSScriptAnalyzer", actual.Source);
+            });
+        }
+    }
+}

--- a/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PathEscapingTests.cs
@@ -4,7 +4,7 @@
 using Xunit;
 using Microsoft.PowerShell.EditorServices.Utility;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Session
+namespace PowerShellEditorServices.Test.Session
 {
     public class PathEscapingTests
     {

--- a/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
@@ -11,9 +11,10 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShell.Console;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
+using Microsoft.PowerShell.EditorServices.Test;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Console
+namespace PowerShellEditorServices.Test.Session
 {
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;

--- a/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/ScriptFileTests.cs
@@ -10,7 +10,7 @@ using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Xunit;
 
-namespace PSLanguageService.Test
+namespace PowerShellEditorServices.Test.Session
 {
     public class ScriptFileChangeTests
     {
@@ -194,7 +194,7 @@ namespace PSLanguageService.Test
                     PowerShellVersion);
 
             Assert.Equal(3, scriptFile.ReferencedFiles.Length);
-            System.Console.Write("a" + scriptFile.ReferencedFiles[0]);
+            Console.Write("a" + scriptFile.ReferencedFiles[0]);
             Assert.Equal(TestUtilities.NormalizePath("./athing.ps1"), scriptFile.ReferencedFiles[0]);
         }
 

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -10,7 +10,7 @@ using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
 using Xunit;
 
-namespace Microsoft.PowerShell.EditorServices.Test.Session
+namespace PowerShellEditorServices.Test.Session
 {
     [Trait("Category", "Workspace")]
     public class WorkspaceTests


### PR DESCRIPTION
Also refactor a bit so we're not triplicating this logic.

Resolves https://github.com/PowerShell/vscode-powershell/issues/2697.

I need to add some tests which just ensure PSSA loads and has rules.