### PR TITLE
Fix duplicate DiagnosticMarkers when reopening a file

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -373,7 +373,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
 
-                scriptFile.DiagnosticMarkers.Clear();
+                // Clear old PSSA-results, but keeping parser-errors ("PowerShell"-source).
+                scriptFile.DiagnosticMarkers.RemoveAll(m => m.Source == "PSScriptAnalyzer");
                 scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
 
                 PublishScriptDiagnostics(scriptFile);

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -373,7 +373,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
 
-                // Clear old PSSA-results, but keeping parser-errors ("PowerShell"-source).
+                // Clear existing PSScriptAnalyzer markers (but keep parser errors where the source is "PowerShell")
+                // so that they are not duplicated when re-opening files.
                 scriptFile.DiagnosticMarkers.RemoveAll(m => m.Source == "PSScriptAnalyzer");
                 scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
 

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -373,6 +373,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
 
+                scriptFile.DiagnosticMarkers.Clear();
                 scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
 
                 PublishScriptDiagnostics(scriptFile);


### PR DESCRIPTION
# PR Summary

Clears the cached DiagnosticsMarkers for a file before adding new results from full script analysis.

## PR Context

Reopening a file with PSSA-findings will be duplicated each time the file is closed and reopened.

Fix PowerShell/vscode-powershell#3252
