### PR TITLE
Pin .NET to 6.0.302 and 3.1.27

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -15,14 +15,14 @@ steps:
   displayName: Install .NET 6.0.x SDK
   inputs:
     packageType: sdk
-    version: 6.0.x
+    version: 6.0.302
     performMultiLevelLookup: true
 
 - task: UseDotNet@2
   displayName: Install .NET 3.1.x runtime
   inputs:
     packageType: runtime
-    version: 3.1.x
+    version: 3.1.27
     performMultiLevelLookup: true
 
 - task: PowerShell@2


### PR DESCRIPTION
The latest update has blocked the CI/CD pipeline, and so while we investigate that, we'll pin to the last known working version.

Works around https://github.com/PowerShell/PowerShellEditorServices/issues/1877 for now.