### PR TITLE
Fix stepping while watch expressions or interactive pipeline is running

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -497,10 +497,22 @@ namespace Microsoft.PowerShell.EditorServices.Services
             bool writeResultAsOutput)
         {
             PSCommand command = new PSCommand().AddScript(expressionString);
-            IReadOnlyList<PSObject> results = await _executionService.ExecutePSCommandAsync<PSObject>(
-                command,
-                CancellationToken.None,
-                new PowerShellExecutionOptions { WriteOutputToHost = writeResultAsOutput, ThrowOnError = !writeResultAsOutput }).ConfigureAwait(false);
+            IReadOnlyList<PSObject> results;
+            try
+            {
+                results = await _executionService.ExecutePSCommandAsync<PSObject>(
+                    command,
+                    CancellationToken.None,
+                    new PowerShellExecutionOptions { WriteOutputToHost = writeResultAsOutput, ThrowOnError = !writeResultAsOutput }).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                // If a watch expression throws we want to show the exception.
+                // TODO: Show the exception as an expandable object.
+                return new VariableDetails(
+                    expressionString,
+                    $"{e.GetType().Name}: {e.Message}");
+            }
 
             // Since this method should only be getting invoked in the debugger,
             // we can assume that Out-String will be getting used to format results

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -382,7 +382,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
         private void CancelDebugExecution()
         {
-            if (_pwsh.Runspace.RunspaceStateInfo.IsUsable())
+            if (!_pwsh.Runspace.RunspaceStateInfo.IsUsable())
             {
                 return;
             }


### PR DESCRIPTION
# PR Summary

<!-- Summarize your PR between here and the checklist. -->

Trying to step when any nested command that wasn't PSRL was running caused us to essentially ignore the request. This caused VSCode to think we were "running" while we didn't actually cancel anything.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
