### PR TITLE
Add artificial stack frame to represent contexts without one

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/StackFrameDetails.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <summary>
         /// Gets the name of the function where the stack frame occurred.
         /// </summary>
-        public string FunctionName { get; private set; }
+        public string FunctionName { get; internal init; }
 
         /// <summary>
         /// Gets the start line number of the script where the stack frame occurred.
@@ -62,12 +62,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <summary>
         /// Gets or sets the VariableContainerDetails that contains the auto variables.
         /// </summary>
-        public VariableContainerDetails AutoVariables { get; private set; }
+        public VariableContainerDetails AutoVariables { get; internal init; }
 
         /// <summary>
         /// Gets or sets the VariableContainerDetails that contains the call stack frame variables.
         /// </summary>
-        public VariableContainerDetails CommandVariables { get; private set; }
+        public VariableContainerDetails CommandVariables { get; internal init; }
 
         #endregion
 

--- a/src/PowerShellEditorServices/Utility/PathUtils.cs
+++ b/src/PowerShellEditorServices/Utility/PathUtils.cs
@@ -30,6 +30,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         internal static readonly char AlternatePathSeparator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '/' : '\\';
 
+        /// <summary>
+        /// The <see cref="StringComparison" /> value to be used when comparing paths. Will be
+        /// <see cref="StringComparison.Ordinal" /> for case sensitive file systems and <see cref="StringComparison.OrdinalIgnoreCase" />
+        /// in case insensitive file systems.
+        /// </summary>
         internal static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
             ? StringComparison.Ordinal
             : StringComparison.OrdinalIgnoreCase;
@@ -41,6 +46,15 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <returns>The normalized path.</returns>
         public static string NormalizePathSeparators(string path) => string.IsNullOrWhiteSpace(path) ? path : path.Replace(AlternatePathSeparator, DefaultPathSeparator);
 
+        /// <summary>
+        /// Determines whether two specified strings represent the same path.
+        /// </summary>
+        /// <param name="left">The first path to compare, or <see langword="null" />.</param>
+        /// <param name="right">The second path to compare, or <see langword="null" />.</param>
+        /// <returns>
+        /// <see langword="true" /> if the value of <paramref name="left" /> represents the same
+        /// path as the value of <paramref name="right" />; otherwise, <see langword="false" />.
+        /// </returns>
         internal static bool IsPathEqual(string left, string right)
         {
             if (string.IsNullOrEmpty(left))

--- a/src/PowerShellEditorServices/Utility/PathUtils.cs
+++ b/src/PowerShellEditorServices/Utility/PathUtils.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Management.Automation;
 using System.Runtime.InteropServices;
@@ -29,12 +30,33 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// </summary>
         internal static readonly char AlternatePathSeparator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? '/' : '\\';
 
+        internal static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase;
+
         /// <summary>
         /// Converts all alternate path separators to the current platform's main path separators.
         /// </summary>
         /// <param name="path">The path to normalize.</param>
         /// <returns>The normalized path.</returns>
         public static string NormalizePathSeparators(string path) => string.IsNullOrWhiteSpace(path) ? path : path.Replace(AlternatePathSeparator, DefaultPathSeparator);
+
+        internal static bool IsPathEqual(string left, string right)
+        {
+            if (string.IsNullOrEmpty(left))
+            {
+                return string.IsNullOrEmpty(right);
+            }
+
+            if (string.IsNullOrEmpty(right))
+            {
+                return false;
+            }
+
+            left = Path.GetFullPath(left).TrimEnd(DefaultPathSeparator);
+            right = Path.GetFullPath(right).TrimEnd(DefaultPathSeparator);
+            return left.Equals(right, PathComparison);
+        }
 
         /// <summary>
         /// Return the given path with all PowerShell globbing characters escaped,


### PR DESCRIPTION
Fixes #1897 
Fixes PowerShell/vscode-powershell#4103

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When stepping into certain contexts like a `param` block's default value expression, the engine does not provide a call stack frame to represent it. In this scenario we want to create an artificial call stack frame to represent the context we've stepped into.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
