### PR TITLE
Add symbols for Pester setup and teardown blocks

### DIFF
--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -113,12 +113,19 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
             List<CodeLens> lenses = new();
             foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (symbol is not PesterSymbolReference pesterSymbol)
                 {
                     continue;
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
+                // Skip codelense for setup/teardown block
+                if (!PesterSymbolReference.IsPesterTestCommand(pesterSymbol.Command))
+                {
+                    continue;
+                }
+
                 if (_configurationService.CurrentSettings.Pester.UseLegacyCodeLens
                         && pesterSymbol.Command != PesterCommandType.Describe)
                 {

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/WorkspaceSymbolsHandler.cs
@@ -56,6 +56,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         continue;
                     }
 
+                    // Exclude Pester setup/teardown symbols as they're unnamed
+                    if (foundOccurrence is PesterSymbolReference pesterSymbol &&
+                        !PesterSymbolReference.IsPesterTestCommand(pesterSymbol.Command))
+                    {
+                        continue;
+                    }
+
                     Location location = new()
                     {
                         Uri = DocumentUri.From(foundOccurrence.FilePath),

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.tests.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.tests.ps1
@@ -1,5 +1,21 @@
-﻿Describe "A dummy test" {
-    Context "When a pester file is given" {
+﻿BeforeDiscovery {
+
+}
+
+BeforeAll {
+
+}
+
+Describe "Testing Pester symbols" {
+    Context "When a Pester file is given" {
+        BeforeAll {
+
+        }
+
+        BeforeEach {
+
+        }
+
         It "Should return it symbols" {
 
         }
@@ -11,5 +27,17 @@
         It "Should return describe symbols" {
 
         }
+
+        It "Should return setup and teardown symbols" {
+
+        }
+
+        AfterEach {
+
+        }
+    }
+
+    AfterAll {
+
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -315,25 +315,55 @@ namespace PowerShellEditorServices.Test.Language
         public void FindsSymbolsInPesterFile()
         {
             List<PesterSymbolReference> symbolsResult = FindSymbolsInFile(FindSymbolsInPesterFile.SourceDetails).OfType<PesterSymbolReference>().ToList();
-            Assert.Equal(5, symbolsResult.Count(r => r.SymbolType == SymbolType.Function));
+            Assert.Equal(12, symbolsResult.Count(r => r.SymbolType == SymbolType.Function));
 
             Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.Describe));
             SymbolReference firstDescribeSymbol = symbolsResult.First(r => r.Command == PesterCommandType.Describe);
-            Assert.Equal("Describe \"A dummy test\"", firstDescribeSymbol.SymbolName);
-            Assert.Equal(1, firstDescribeSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal("Describe \"Testing Pester symbols\"", firstDescribeSymbol.SymbolName);
+            Assert.Equal(9, firstDescribeSymbol.ScriptRegion.StartLineNumber);
             Assert.Equal(1, firstDescribeSymbol.ScriptRegion.StartColumnNumber);
 
             Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.Context));
             SymbolReference firstContextSymbol = symbolsResult.First(r => r.Command == PesterCommandType.Context);
-            Assert.Equal("Context \"When a pester file is given\"", firstContextSymbol.SymbolName);
-            Assert.Equal(2, firstContextSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal("Context \"When a Pester file is given\"", firstContextSymbol.SymbolName);
+            Assert.Equal(10, firstContextSymbol.ScriptRegion.StartLineNumber);
             Assert.Equal(5, firstContextSymbol.ScriptRegion.StartColumnNumber);
 
-            Assert.Equal(3, symbolsResult.Count(r => r.Command == PesterCommandType.It));
+            Assert.Equal(4, symbolsResult.Count(r => r.Command == PesterCommandType.It));
             SymbolReference lastItSymbol = symbolsResult.Last(r => r.Command == PesterCommandType.It);
-            Assert.Equal("It \"Should return describe symbols\"", lastItSymbol.SymbolName);
-            Assert.Equal(11, lastItSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal("It \"Should return setup and teardown symbols\"", lastItSymbol.SymbolName);
+            Assert.Equal(31, lastItSymbol.ScriptRegion.StartLineNumber);
             Assert.Equal(9, lastItSymbol.ScriptRegion.StartColumnNumber);
+
+            Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.BeforeDiscovery));
+            SymbolReference firstBeforeDisocverySymbol = symbolsResult.First(r => r.Command == PesterCommandType.BeforeDiscovery);
+            Assert.Equal("BeforeDiscovery", firstBeforeDisocverySymbol.SymbolName);
+            Assert.Equal(1, firstBeforeDisocverySymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal(1, firstBeforeDisocverySymbol.ScriptRegion.StartColumnNumber);
+
+            Assert.Equal(2, symbolsResult.Count(r => r.Command == PesterCommandType.BeforeAll));
+            SymbolReference lastBeforeAllSymbol = symbolsResult.Last(r => r.Command == PesterCommandType.BeforeAll);
+            Assert.Equal("BeforeAll", lastBeforeAllSymbol.SymbolName);
+            Assert.Equal(11, lastBeforeAllSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal(9, lastBeforeAllSymbol.ScriptRegion.StartColumnNumber);
+
+            Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.BeforeEach));
+            SymbolReference firstBeforeEachSymbol = symbolsResult.First(r => r.Command == PesterCommandType.BeforeEach);
+            Assert.Equal("BeforeEach", firstBeforeEachSymbol.SymbolName);
+            Assert.Equal(15, firstBeforeEachSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal(9, firstBeforeEachSymbol.ScriptRegion.StartColumnNumber);
+
+            Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.AfterEach));
+            SymbolReference firstAfterEachSymbol = symbolsResult.First(r => r.Command == PesterCommandType.AfterEach);
+            Assert.Equal("AfterEach", firstAfterEachSymbol.SymbolName);
+            Assert.Equal(35, firstAfterEachSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal(9, firstAfterEachSymbol.ScriptRegion.StartColumnNumber);
+
+            Assert.Equal(1, symbolsResult.Count(r => r.Command == PesterCommandType.AfterAll));
+            SymbolReference firstAfterAllSymbol = symbolsResult.First(r => r.Command == PesterCommandType.AfterAll);
+            Assert.Equal("AfterAll", firstAfterAllSymbol.SymbolName);
+            Assert.Equal(40, firstAfterAllSymbol.ScriptRegion.StartLineNumber);
+            Assert.Equal(5, firstAfterAllSymbol.ScriptRegion.StartColumnNumber);
         }
 
         [Fact]


### PR DESCRIPTION
# PR Summary

Adds document symbols for setup and teardown blocks used in Pester to improve navigation using outline and sticky scroll (experimental VSCode feature).

Sticky scroll and breadcrumbs:
![image](https://user-images.githubusercontent.com/3436158/185172441-63fa6325-70cc-481a-82a4-9d73aa4f34d1.png)

Outline:
![image](https://user-images.githubusercontent.com/3436158/185172679-5af7092e-6e4a-4cc1-8e40-efae8cc2658c.png)
![image](https://user-images.githubusercontent.com/3436158/185173393-be2787ab-70e6-4bf7-b8d0-45c52c8a7e9e.png)


Setup/teardown symbols are excluded from workspace symbol search to avoid filling it up with thousand identical symbols like "BeforeAll { }".

## PR Context

Fix #1892
