### PR TITLE
Fix file close in workspace service for Linux

### DIFF
--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -120,9 +120,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             Validate.IsNotNull(nameof(documentUri), documentUri);
 
-            string keyName = VersionUtils.IsLinux
-                ? documentUri.ToString()
-                : documentUri.ToString().ToLower();
+            string keyName = GetFileKey(documentUri);
 
             // Make sure the file isn't already loaded into the workspace
             if (!workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile))
@@ -258,9 +256,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             Validate.IsNotNull(nameof(documentUri), documentUri);
 
-            string keyName = VersionUtils.IsLinux
-                ? documentUri.ToString()
-                : documentUri.ToString().ToLower();
+            string keyName = GetFileKey(documentUri);
 
             // Make sure the file isn't already loaded into the workspace
             if (!workspaceFiles.TryGetValue(keyName, out ScriptFile scriptFile) && initialBuffer != null)
@@ -293,7 +289,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             Validate.IsNotNull(nameof(scriptFile), scriptFile);
 
-            workspaceFiles.TryRemove(scriptFile.Id, out ScriptFile _);
+            string keyName = GetFileKey(scriptFile.DocumentUri);
+            workspaceFiles.TryRemove(keyName, out ScriptFile _);
         }
 
         /// <summary>
@@ -539,6 +536,14 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             return combinedPath;
         }
+
+        /// <summary>
+        /// Returns a normalized string for a given documentUri to be used as key name.
+        /// Case-sensitive uri on Linux and lowercase for other platforms.
+        /// </summary>
+        /// <param name="documentUri">A DocumentUri object to get a normalized key name from</param>
+        private static string GetFileKey(DocumentUri documentUri)
+            => VersionUtils.IsLinux ? documentUri.ToString() : documentUri.ToString().ToLower();
 
         #endregion
     }

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Test.Shared;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Xunit;
 
 namespace PowerShellEditorServices.Test.Session
@@ -174,6 +175,19 @@ namespace PowerShellEditorServices.Test.Session
             };
 
             Assert.All(notInMemoryPaths, (p) => Assert.False(WorkspaceService.IsPathInMemory(p)));
+        }
+
+        [Fact]
+        public void CanOpenAndCloseFile()
+        {
+            WorkspaceService workspace = FixturesWorkspace();
+            string filePath = Path.GetFullPath(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"));
+
+            ScriptFile file = workspace.GetFile(filePath);
+            Assert.Equal(workspace.GetOpenedFiles(), new[] { file });
+
+            workspace.CloseFile(file);
+            Assert.Equal(workspace.GetOpenedFiles(), Array.Empty<ScriptFile>());
         }
     }
 }


### PR DESCRIPTION
# PR Summary

Use a consistent dictionary key for CRUD operations in `WorkspaceService.workspaceFiles`

## PR Context

Fix #1901
