### PR TITLE
Add regression tests for F5 and F8 saving to history

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Console/ReadLineProvider.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Console/ReadLineProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Console
 
         public ReadLineProvider(ILoggerFactory loggerFactory) => _logger = loggerFactory.CreateLogger<ReadLineProvider>();
 
-        public IReadLine ReadLine { get; private set; }
+        public IReadLine ReadLine { get; internal set; }
 
         public void OverrideReadLine(IReadLine readLine)
         {

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         private readonly CancellationContext _cancellationContext;
 
-        private readonly ReadLineProvider _readLineProvider;
+        internal readonly ReadLineProvider _readLineProvider;
 
         private readonly Thread _pipelineThread;
 


### PR DESCRIPTION
This tests both the PowerShell history and the PSReadLine history via a stub, since we can't load PSReadLine itself in these tests.

Covers https://github.com/PowerShell/vscode-powershell/issues/3683 and https://github.com/PowerShell/PowerShellEditorServices/pull/1823.