### PR TITLE
Upgrade PSScriptAnalyzer to 1.21.0

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,6 +1,6 @@
 {
     "PSScriptAnalyzer": {
-        "Version": "1.20.0"
+        "Version": "1.21.0"
     },
     "Plaster": {
         "Version": "1.1.3"

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -189,6 +189,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
 
         public bool AddWhitespaceAroundPipe { get; set; }
         public bool AutoCorrectAliases { get; set; }
+        public bool AvoidSemicolonsAsLineTerminators { get; set; }
         public bool UseConstantStrings { get; set; }
         public CodeFormattingPreset Preset { get; set; }
         public bool OpenBraceOnSameLine { get; set; }
@@ -309,6 +310,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                     new Hashtable {
                     { "Enable", UseConstantStrings }
                 }
+                },
+                {
+                    "PSAvoidSemicolonsAsLineTerminators",
+                    new Hashtable {
+                    { "Enable", AvoidSemicolonsAsLineTerminators }
+                    }
                 },
             };
 


### PR DESCRIPTION
# PR Summary

Bump version and expose new setting related to new `AvoidSemicolonsAsLineTerminators` rule.
Impediment of https://github.com/PowerShell/vscode-powershell/pull/4164

## PR Context

PSSA 1.21.0 will release soon.
