### PR TITLE
Overhaul workspace search for symbol references

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -119,6 +119,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     .WithHandler<ShowHelpHandler>()
                     .WithHandler<ExpandAliasHandler>()
                     .WithHandler<PsesSemanticTokensHandler>()
+                    .WithHandler<DidChangeWatchedFilesHandler>()
                     // NOTE: The OnInitialize delegate gets run when we first receive the
                     // _Initialize_ request:
                     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
                 return invocationName;
             }
 
-            // Storing moduleName as ROMemory safes a string allocation in the common case where it
+            // Storing moduleName as ROMemory saves a string allocation in the common case where it
             // is not needed.
             moduleName = invocationName.AsMemory().Slice(0, slashIndex);
             return invocationName.Substring(slashIndex + 1);

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
         /// <summary>
         /// Gets the actual command behind a fully module qualified command invocation, e.g.
-        /// <c>Microsoft.PowerShell.Management\Get-ChildItem</c> will return <c>Get-ChilddItem</c>
+        /// <c>Microsoft.PowerShell.Management\Get-ChildItem</c> will return <c>Get-ChildItem</c>
         /// </summary>
         /// <param name="invocationName">
         /// The potentially module qualified command name at the site of invocation.

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
         /// <returns>The actual command name.</returns>
         public static string StripModuleQualification(string invocationName, out ReadOnlyMemory<char> moduleName)
         {
-            int slashIndex = invocationName.IndexOf('\\');
+            int slashIndex = invocationName.LastIndexOfAny(new[] { '\\', '/' });
             if (slashIndex is -1)
             {
                 moduleName = default;

--- a/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Management.Automation.Language;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
+
+namespace Microsoft.PowerShell.EditorServices.Services;
+
+/// <summary>
+/// Represents the symbols that are referenced and their locations within a single document.
+/// </summary>
+internal sealed class ReferenceTable
+{
+    private readonly ScriptFile _parent;
+
+    private readonly ConcurrentDictionary<string, ConcurrentBag<IScriptExtent>> _symbolReferences = new(StringComparer.OrdinalIgnoreCase);
+
+    private bool _isInited;
+
+    public ReferenceTable(ScriptFile parent) => _parent = parent;
+
+    /// <summary>
+    /// Clears the reference table causing it to rescan the source AST when queried.
+    /// </summary>
+    public void TagAsChanged()
+    {
+        _symbolReferences.Clear();
+        _isInited = false;
+    }
+
+    // Prefer checking if the dictionary has contents to determine if initialized. The field
+    // `_isInited` is to guard against rescanning files with no command references, but will
+    // generally be less reliable of a check.
+    private bool IsInitialized => !_symbolReferences.IsEmpty || _isInited;
+
+    internal bool TryGetReferences(string command, out ConcurrentBag<IScriptExtent>? references)
+    {
+        EnsureInitialized();
+        return _symbolReferences.TryGetValue(command, out references);
+    }
+
+    internal void EnsureInitialized()
+    {
+        if (IsInitialized)
+        {
+            return;
+        }
+
+        _parent.ScriptAst.Visit(new ReferenceVisitor(this));
+    }
+
+    private void AddReference(string symbol, IScriptExtent extent)
+    {
+        _symbolReferences.AddOrUpdate(
+            symbol,
+            _ => new ConcurrentBag<IScriptExtent> { extent },
+            (_, existing) =>
+            {
+                existing.Add(extent);
+                return existing;
+            });
+    }
+
+    private sealed class ReferenceVisitor : AstVisitor
+    {
+        private readonly ReferenceTable _references;
+
+        public ReferenceVisitor(ReferenceTable references) => _references = references;
+
+        public override AstVisitAction VisitCommand(CommandAst commandAst)
+        {
+            string commandName = commandAst.GetCommandName();
+            if (string.IsNullOrEmpty(commandName))
+            {
+                return AstVisitAction.Continue;
+            }
+
+            _references.AddReference(
+                CommandHelpers.StripModuleQualification(commandName, out _),
+                commandAst.CommandElements[0].Extent);
+            return AstVisitAction.Continue;
+        }
+
+        public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
+        {
+            // TODO: Consider tracking unscoped variable references only when they declared within
+            // the same function definition.
+            _references.AddReference(
+                $"${variableExpressionAst.VariablePath.UserPath}",
+                variableExpressionAst.Extent);
+
+            return AstVisitAction.Continue;
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         continue;
                     }
 
-                    foreach (IScriptExtent extent in references)
+                    foreach (IScriptExtent extent in references.OrderBy(e => e.StartOffset))
                     {
                         SymbolReference reference = new(
                             SymbolType.Function,

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DidChangeWatchedFilesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DidChangeWatchedFilesHandler.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Services.Configuration;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+
+// Using an alias since this is conflicting with System.IO.FileSystemWatcher and ends up really finicky.
+using OmniSharpFileSystemWatcher = OmniSharp.Extensions.LanguageServer.Protocol.Models.FileSystemWatcher;
+
+namespace Microsoft.PowerShell.EditorServices.Handlers;
+
+/// <summary>
+/// Receives file change notifications from the client for any file in the workspace, including those
+/// that are not considered opened by the client. This handler is used to allow us to scan the
+/// workspace only once when the language server starts.
+/// </summary>
+internal class DidChangeWatchedFilesHandler : IDidChangeWatchedFilesHandler
+{
+    private readonly WorkspaceService _workspaceService;
+
+    private readonly ConfigurationService _configurationService;
+
+    public DidChangeWatchedFilesHandler(
+        WorkspaceService workspaceService,
+        ConfigurationService configurationService)
+    {
+        _workspaceService = workspaceService;
+        _configurationService = configurationService;
+    }
+
+    public DidChangeWatchedFilesRegistrationOptions GetRegistrationOptions(
+        DidChangeWatchedFilesCapability capability,
+        ClientCapabilities clientCapabilities)
+        => new()
+        {
+            Watchers = new[]
+            {
+                new OmniSharpFileSystemWatcher()
+                {
+                    GlobPattern = "**/*.{ps1,psm1}",
+                    Kind = WatchKind.Create | WatchKind.Delete | WatchKind.Change,
+                },
+            },
+        };
+
+    public Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
+    {
+        LanguageServerSettings currentSettings = _configurationService.CurrentSettings;
+        if (currentSettings.AnalyzeOpenDocumentsOnly)
+        {
+            return Task.FromResult(Unit.Value);
+        }
+
+        // Honor `search.exclude` settings in the watcher.
+        Matcher matcher = new();
+        matcher.AddExcludePatterns(_workspaceService.ExcludeFilesGlob);
+        foreach (FileEvent change in request.Changes)
+        {
+            if (matcher.Match(change.Uri.GetFileSystemPath()).HasMatches)
+            {
+                continue;
+            }
+
+            if (!_workspaceService.TryGetFile(change.Uri, out ScriptFile scriptFile))
+            {
+                continue;
+            }
+
+            if (change.Type is FileChangeType.Created)
+            {
+                // We've already triggered adding the file to `OpenedFiles` via `TryGetFile`.
+                continue;
+            }
+
+            if (change.Type is FileChangeType.Deleted)
+            {
+                _workspaceService.CloseFile(scriptFile);
+                continue;
+            }
+
+            if (change.Type is FileChangeType.Changed)
+            {
+                // If the file is opened by the editor (rather than by us in the background), let
+                // DidChangeTextDocument handle changes.
+                if (scriptFile.IsOpen)
+                {
+                    continue;
+                }
+
+                string fileContents;
+                try
+                {
+                    fileContents = WorkspaceService.ReadFileContents(change.Uri);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                scriptFile.SetFileContents(fileContents);
+                scriptFile.References.TagAsChanged();
+            }
+        }
+
+        return Task.FromResult(Unit.Value);
+    }
+}

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -120,6 +120,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         }
 
         internal ReferenceTable References { get; }
+
+        internal bool IsOpen { get; set; }
 
         #endregion
 
@@ -523,7 +525,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
         #region Private Methods
 
-        private void SetFileContents(string fileContents)
+        internal void SetFileContents(string fileContents)
         {
             // Split the file contents into lines and trim
             // any carriage returns from the strings.

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -119,6 +119,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
             private set;
         }
 
+        internal ReferenceTable References { get; }
+
         #endregion
 
         #region Constructors
@@ -149,6 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             // SetFileContents() calls ParseFileContents() which initializes the rest of the properties.
             SetFileContents(textReader.ReadToEnd());
+            References = new ReferenceTable(this);
         }
 
         /// <summary>
@@ -383,6 +386,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
 
             // Parse the script again to be up-to-date
             ParseFileContents();
+            References.TagAsChanged();
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         public PesterSettings Pester { get; set; }
         public string Cwd { get; set; }
         public bool EnableReferencesCodeLens { get; set; } = true;
+        public bool AnalyzeOpenDocumentsOnly { get; set; }
 
         public LanguageServerSettings()
         {
@@ -48,6 +49,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                     Pester.Update(settings.Pester, logger);
                     Cwd = settings.Cwd;
                     EnableReferencesCodeLens = settings.EnableReferencesCodeLens;
+                    AnalyzeOpenDocumentsOnly = settings.AnalyzeOpenDocumentsOnly;
                 }
             }
         }

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -478,17 +478,9 @@ CanSendReferencesRequest
                 .Returning<LocationContainer>(CancellationToken.None).ConfigureAwait(true);
 
             Assert.Collection(locations,
-                location1 =>
+                location =>
                 {
-                    Range range = location1.Range;
-                    Assert.Equal(1, range.Start.Line);
-                    Assert.Equal(9, range.Start.Character);
-                    Assert.Equal(1, range.End.Line);
-                    Assert.Equal(33, range.End.Character);
-                },
-                location2 =>
-                {
-                    Range range = location2.Range;
+                    Range range = location.Range;
                     Assert.Equal(5, range.Start.Line);
                     Assert.Equal(0, range.Start.Character);
                     Assert.Equal(5, range.End.Line);

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -152,9 +152,9 @@ namespace PowerShellEditorServices.Test.Language
         public async Task FindsReferencesOnFunction()
         {
             List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionData.SourceDetails).ConfigureAwait(true);
-            Assert.Equal(3, referencesResult.Count);
-            Assert.Equal(1, referencesResult[0].ScriptRegion.StartLineNumber);
-            Assert.Equal(10, referencesResult[0].ScriptRegion.StartColumnNumber);
+            Assert.Equal(2, referencesResult.Count);
+            Assert.Equal(3, referencesResult[0].ScriptRegion.StartLineNumber);
+            Assert.Equal(2, referencesResult[0].ScriptRegion.StartColumnNumber);
         }
 
         [Fact]
@@ -166,9 +166,9 @@ namespace PowerShellEditorServices.Test.Language
                 CancellationToken.None).ConfigureAwait(true);
 
             List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionData.SourceDetails).ConfigureAwait(true);
-            Assert.Equal(4, referencesResult.Count);
-            Assert.Equal(1, referencesResult[0].ScriptRegion.StartLineNumber);
-            Assert.Equal(10, referencesResult[0].ScriptRegion.StartColumnNumber);
+            Assert.Equal(3, referencesResult.Count);
+            Assert.Equal(3, referencesResult[0].ScriptRegion.StartLineNumber);
+            Assert.Equal(2, referencesResult[0].ScriptRegion.StartColumnNumber);
         }
 
         [Fact]
@@ -246,8 +246,8 @@ namespace PowerShellEditorServices.Test.Language
         {
             List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnBuiltInCommandWithAliasData.SourceDetails).ConfigureAwait(true);
             Assert.Equal(4, referencesResult.Count);
-            Assert.Equal("gci", referencesResult[1].SymbolName);
-            Assert.Equal("dir", referencesResult[2].SymbolName);
+            Assert.Equal("Get-ChildItem", referencesResult[1].SymbolName);
+            Assert.Equal("Get-ChildItem", referencesResult[2].SymbolName);
             Assert.Equal("Get-ChildItem", referencesResult[referencesResult.Count - 1].SymbolName);
         }
 
@@ -255,14 +255,14 @@ namespace PowerShellEditorServices.Test.Language
         public async Task FindsReferencesOnFileWithReferencesFileB()
         {
             List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileB.SourceDetails).ConfigureAwait(true);
-            Assert.Equal(4, referencesResult.Count);
+            Assert.Equal(3, referencesResult.Count);
         }
 
         [Fact]
         public async Task FindsReferencesOnFileWithReferencesFileC()
         {
             List<SymbolReference> referencesResult = await GetReferences(FindsReferencesOnFunctionMultiFileDotSourceFileC.SourceDetails).ConfigureAwait(true);
-            Assert.Equal(4, referencesResult.Count);
+            Assert.Equal(3, referencesResult.Count);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Dependent on PowerShell/vscode-powershell#4170

Significantly reduce performance overhead of reference finding in large workspaces.

<!-- Summarize your PR between here and the checklist. -->

## PR Context

This PR has the following changes:

1. Adds a reference cache to every `ScriptFile`
2. Workspace scan is performed only once on first request
3. An LSP file system watcher provides updates for files not changed via `Did*TextDocument` notifications
4. Adds a setting to only search "open documents" for references. This disables both the initial workspace scan and the file system watcher, relying only on `Did*TextDocument` notifications.

---

As a stress test I opened up my profile directory (which has ~3k script files in total in the `Modules` directory) and created a file with a function definition on every line. I then tabbed to a different file, and then tabbed back to the new file. Before the changes, the references code lens took ~10 seconds to populate and my CPU spiked to ~50% usage. After the changes, they populated instantly and CPU spiked to ~2% usage.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
