### PR TITLE
Created a nested PowerShell for the top-level loop

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -475,8 +475,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 (PowerShell pwsh, RunspaceInfo localRunspaceInfo, EngineIntrinsics engineIntrinsics) = CreateInitialPowerShellSession();
                 _mainRunspaceEngineIntrinsics = engineIntrinsics;
                 _localComputerName = localRunspaceInfo.SessionDetails.ComputerName;
-                _runspaceStack.Push(new RunspaceFrame(pwsh.Runspace, localRunspaceInfo));
-                PushPowerShellAndRunLoop(pwsh, PowerShellFrameType.Normal | PowerShellFrameType.Repl, localRunspaceInfo);
+
+                // NOTE: In order to support running events registered to PowerShell's OnIdle
+                // handler, we have to have our top-level PowerShell instance be nested (otherwise
+                // we get a PSInvalidOperationException because pipelines cannot be run
+                // concurrently). Specifically this bug cropped up when a profile loaded code which
+                // registered (and subsequently ran) on the OnIdle handler since it was hitting the
+                // non-nested PowerShell instance. So now we just start with a nested instance.
+                // While the PowerShell object is nested, as a frame type, this is our top-level
+                // frame and therefore NOT nested in that sense.
+                PowerShell nestedPwsh = CreateNestedPowerShell(localRunspaceInfo);
+                _runspaceStack.Push(new RunspaceFrame(nestedPwsh.Runspace, localRunspaceInfo));
+                PushPowerShellAndRunLoop(nestedPwsh, PowerShellFrameType.Normal | PowerShellFrameType.Repl, localRunspaceInfo);
             }
             catch (Exception e)
             {
@@ -964,9 +974,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             // PowerShell.CreateNestedPowerShell() sets IsNested but not IsChild
             // This means it throws due to the parent pipeline not running...
             // So we must use the RunspaceMode.CurrentRunspace option on PowerShell.Create() instead
-            PowerShell pwsh = PowerShell.Create(RunspaceMode.CurrentRunspace);
-            pwsh.Runspace.ThreadOptions = PSThreadOptions.UseCurrentThread;
-            return pwsh;
+            return PowerShell.Create(RunspaceMode.CurrentRunspace);
         }
 
         private static PowerShell CreatePowerShellForRunspace(Runspace runspace)


### PR DESCRIPTION
So that events registered with the `OnIdle` engine event handler will always work.

Resolves https://github.com/PowerShell/vscode-powershell/issues/4048

I added the following code to my profile:

```powershell
Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 10 -Action {
  Write-Host "OnIdle"
}
```
and was able to repro the linked issue before this change, and cannot repro it afterwards.

There may be other ramifications that we're not seeing though, and I'd be curious about a regression test for this.