### PR TITLE
Generalize the execution busy status to all PowerShell tasks

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/ExtensionService.cs
@@ -14,37 +14,6 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 
 namespace Microsoft.PowerShell.EditorServices.Services.Extension
 {
-    /// Enumerates the possible execution results that can occur after
-    /// executing a command or script.
-    /// </summary>
-    internal enum ExecutionStatus
-    {
-        /// <summary>
-        /// Indicates that execution has not yet started.
-        /// </summary>
-        Pending,
-
-        /// <summary>
-        /// Indicates that the command is executing.
-        /// </summary>
-        Running,
-
-        /// <summary>
-        /// Indicates that execution has failed.
-        /// </summary>
-        Failed,
-
-        /// <summary>
-        /// Indicates that execution was aborted by the user.
-        /// </summary>
-        Aborted,
-
-        /// <summary>
-        /// Indicates that execution completed successfully.
-        /// </summary>
-        Completed
-    }
-
     /// <summary>
     /// Provides a high-level service which enables PowerShell scripts
     /// and modules to extend the behavior of the host editor.
@@ -154,7 +123,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         /// <exception cref="KeyNotFoundException">The command being invoked was not registered.</exception>
         public Task InvokeCommandAsync(string commandName, EditorContext editorContext, CancellationToken cancellationToken)
         {
-            _languageServer?.SendNotification("powerShell/executionStatusChanged", ExecutionStatus.Pending);
             if (editorCommands.TryGetValue(commandName, out EditorCommand editorCommand))
             {
                 PSCommand executeCommand = new PSCommand()
@@ -163,7 +131,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                     .AddParameter("ArgumentList", new object[] { editorContext });
 
                 // This API is used for editor command execution so it requires the foreground.
-                _languageServer?.SendNotification("powerShell/executionStatusChanged", ExecutionStatus.Running);
                 return ExecutionService.ExecutePSCommandAsync(
                     executeCommand,
                     cancellationToken,
@@ -173,27 +140,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                         WriteOutputToHost = !editorCommand.SuppressOutput,
                         AddToHistory = !editorCommand.SuppressOutput,
                         ThrowOnError = false,
-                    }).ContinueWith((Task executeTask) =>
-                    {
-                        ExecutionStatus status = ExecutionStatus.Failed;
-                        if (executeTask.IsCompleted)
-                        {
-                            status = ExecutionStatus.Completed;
-                        }
-                        else if (executeTask.IsCanceled)
-                        {
-                            status = ExecutionStatus.Aborted;
-                        }
-                        else if (executeTask.IsFaulted)
-                        {
-                            status = ExecutionStatus.Failed;
-                        }
-
-                        _languageServer?.SendNotification("powerShell/executionStatusChanged", status);
-                    }, TaskScheduler.Default);
+                    });
             }
 
-            _languageServer?.SendNotification("powerShell/executionStatusChanged", ExecutionStatus.Failed);
             throw new KeyNotFoundException($"Editor command not found: '{commandName}'");
         }
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -16,7 +16,14 @@ using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 {
-    internal class SynchronousPowerShellTask<TResult> : SynchronousTask<IReadOnlyList<TResult>>
+    internal interface ISynchronousPowerShellTask
+    {
+        PowerShellExecutionOptions PowerShellExecutionOptions { get; }
+
+        void MaybeAddToHistory();
+    }
+
+    internal class SynchronousPowerShellTask<TResult> : SynchronousTask<IReadOnlyList<TResult>>, ISynchronousPowerShellTask
     {
         private static readonly PowerShellExecutionOptions s_defaultPowerShellExecutionOptions = new();
 
@@ -353,7 +360,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             }
         }
 
-        internal void MaybeAddToHistory()
+        public void MaybeAddToHistory()
         {
             // Do not add PSES internal commands to history. Also exclude input that came from the
             // REPL (e.g. PSReadLine) as it handles history itself in that scenario.


### PR DESCRIPTION
We generalized the "execution busy status" from just editor commands to any running PowerShell task.