### PR TITLE
Add example of starting PSES in a script to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ pwsh -NoLogo -NoProfile -Command "$PSES_BUNDLE_PATH/PowerShellEditorServices/Sta
 > - `$PSES_BUNDLE_PATH` is the root of the PowerShellEditorServices.zip downloaded from the GitHub releases.
 > - `$SESSION_TEMP_PATH` is the folder path that you'll use for this specific editor session.
 
+If you are trying to automate the service in PowerShell, You can also run it under `Start-Process` to prevent hanging your script. It also gives you access to Process/PID automation features like `$process.Close()` or `$process.Kill()`
+
+```powershell
+$command = @(
+    "$PSES_BUNDLE_PATH/PowerShellEditorServices/Start-EditorServices.ps1",
+        "-BundledModulesPath $PSES_BUNDLE_PATH",
+        "-LogPath $SESSION_TEMP_PATH/logs.log",
+        "-SessionDetailsPath $SESSION_TEMP_PATH/session.json",
+        "-FeatureFlags @()",
+        "-AdditionalModules @()",
+        "-HostName 'My Client'",
+        "-HostProfileId 'myclient'",
+        "-HostVersion 1.0.0",
+        "-LogLevel Normal"
+)-join " "
+
+$pwsh_arguments = "-NoLogo -NoProfile -Command $command"
+$process = Start-Process pwsh -ArgumentList $arguments -PassThru
+
+...
+
+$process.Close(); #$process.Kill();
+```
+
 Once the command is run,
 PowerShell Editor Services will wait until the client connects to the Named Pipe.
 The `session.json` will contain the paths of the Named Pipes that you will connect to.


### PR DESCRIPTION
# Problems Solved:

## Shell Hang:

Executing pwsh with the original command (the older one on top) from the readme causes shells to hang.
Not script or automation friendly.

## Poor Doc Readability
The arguments list is also long enough to scroll off the screen on most devices.
Spacing them out over an array is a screen-friendly alternative.

- However, keeping the old one is good for users who just want a quick copy-and-paste one-liner.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Added an automation-friendly powershell script for starting the service that doesn't hang the shell.

## PR Context

The original command is long (longer than the width of most device screens), so it's not great in documentation, since it needs to be readable. The old one is being left there, so that users have access to a quick and easy copy-and-paste one-liner.

It also hangs the shell. If you run it from the command line, you have to wait for the process to exit before running anything else. Since some users may want to automate the service from PowerShell itself, it is a better practice to call the command with `Start-Process` instead.
