### PR TITLE
Fix release build

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -45,6 +45,18 @@ steps:
     testResultsFiles: '**/*.trx'
   condition: succeededOrFailed()
 
+- task: PowerShell@2
+  displayName: Assert PowerShellEditorServices release configuration
+  inputs:
+    targetType: inline
+    script: |
+      $assembly = [Reflection.Assembly]::LoadFile("$(Build.SourcesDirectory)/module/PowerShellEditorServices.VSCode/bin/Microsoft.PowerShell.EditorServices.VSCode.dll")
+      if ($assembly.GetCustomAttributes([System.Diagnostics.DebuggableAttribute], $true).IsJITOptimizerDisabled) {
+        Write-Host "##vso[task.LogIssue type=error;] PowerShell Editor Services bits were not built in release configuration!"
+        exit 1
+      }
+    pwsh: ${{ parameters.pwsh }}
+
 # NOTE: We zip the artifacts because they're ~20 MB compressed, but ~300 MB raw,
 # and we have limited pipeline artifact storage space.
 - task: ArchiveFiles@2

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -35,7 +35,7 @@ steps:
   displayName: Test
   inputs:
     targetType: inline
-    script: Invoke-Build Test
+    script: Invoke-Build Test -Configuration Release
     pwsh: ${{ parameters.pwsh }}
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Add assertion to build that bits are built in release configuration and invoke tests in release configuration. Resolves https://github.com/PowerShell/vscode-powershell/issues/4218 by (correctly and how it was expected in the first place) preventing the developer option to wait for debugger to be in the binary.