### PR TITLE
Catch exceptions within completion handler

### DIFF
--- a/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LSPTestsFixures.cs
@@ -33,8 +33,9 @@ namespace PowerShellEditorServices.Test.E2E
         private const bool IsDebugAdapterTests = false;
 
         public ILanguageClient PsesLanguageClient { get; private set; }
-        public List<Diagnostic> Diagnostics { get; set; }
-        internal List<PsesTelemetryEvent> TelemetryEvents { get; set; }
+        public List<LogMessageParams> Messages = new();
+        public List<Diagnostic> Diagnostics = new();
+        internal List<PsesTelemetryEvent> TelemetryEvents = new();
         public ITestOutputHelper Output { get; set; }
 
         protected PsesStdioProcess _psesProcess;
@@ -46,9 +47,7 @@ namespace PowerShellEditorServices.Test.E2E
             _psesProcess = new PsesStdioProcess(factory, IsDebugAdapterTests);
             await _psesProcess.Start().ConfigureAwait(false);
 
-            Diagnostics = new List<Diagnostic>();
-            TelemetryEvents = new List<PsesTelemetryEvent>();
-            DirectoryInfo testdir =
+            DirectoryInfo testDir =
                 Directory.CreateDirectory(Path.Combine(s_binDir, Path.GetRandomFileName()));
 
             PsesLanguageClient = LanguageClient.PreInit(options =>
@@ -56,10 +55,13 @@ namespace PowerShellEditorServices.Test.E2E
                 options
                     .WithInput(_psesProcess.OutputStream)
                     .WithOutput(_psesProcess.InputStream)
-                    .WithWorkspaceFolder(DocumentUri.FromFileSystemPath(testdir.FullName), "testdir")
+                    .WithWorkspaceFolder(DocumentUri.FromFileSystemPath(testDir.FullName), "testdir")
                     .WithInitializationOptions(new { EnableProfileLoading = false })
                     .OnPublishDiagnostics(diagnosticParams => Diagnostics.AddRange(diagnosticParams.Diagnostics.Where(d => d != null)))
-                    .OnLogMessage(logMessageParams => Output?.WriteLine($"{logMessageParams.Type}: {logMessageParams.Message}"))
+                    .OnLogMessage(logMessageParams => {
+                        Output?.WriteLine($"{logMessageParams.Type}: {logMessageParams.Message}");
+                        Messages.Add(logMessageParams);
+                    })
                     .OnTelemetryEvent(telemetryEventParams => TelemetryEvents.Add(
                         new PsesTelemetryEvent
                         {


### PR DESCRIPTION
We'll still see the same error in the log, but as a warning and not as an exception bubbled up over LSP that causes some clients, like Kate, to crash. We can't do anything about PowerShell's completion failing.

Fixes #1926.