### PR TITLE
Fix regression around `OnIdle` handler

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1085,7 +1085,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
         }
 
         // NOTE: This token is received from PSReadLine, and it _is_ the ReadKey cancellation token!
-        private void OnPowerShellIdle(CancellationToken idleCancellationToken)
+        internal void OnPowerShellIdle(CancellationToken idleCancellationToken)
         {
             IReadOnlyList<PSEventSubscriber> eventSubscribers = _mainRunspaceEngineIntrinsics.Events.Subscribers;
 

--- a/test/PowerShellEditorServices.Test.Shared/Profile/Test.PowerShellEditorServices_profile.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Profile/Test.PowerShellEditorServices_profile.ps1
@@ -5,3 +5,5 @@
 function Assert-ProfileLoaded {
 	return $true
 }
+
+Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -MaxTriggerCount 1 -Action { $global:handledInProfile = $true }

--- a/test/PowerShellEditorServices.Test/PsesHostFactory.cs
+++ b/test/PowerShellEditorServices.Test/PsesHostFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
 
         public static readonly string BundledModulePath = Path.GetFullPath(TestUtilities.NormalizePath("../../../../../module"));
 
-        public static PsesInternalHost Create(ILoggerFactory loggerFactory)
+        public static PsesInternalHost Create(ILoggerFactory loggerFactory, bool loadProfiles = false)
         {
             // We intentionally use `CreateDefault2()` as it loads `Microsoft.PowerShell.Core` only,
             // which is a more minimal and therefore safer state.
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
             PsesInternalHost psesHost = new(loggerFactory, null, testHostDetails);
 
             // NOTE: Because this is used by constructors it can't use await.
-            if (psesHost.TryStartAsync(new HostStartOptions { LoadProfiles = false }, CancellationToken.None).GetAwaiter().GetResult())
+            if (psesHost.TryStartAsync(new HostStartOptions { LoadProfiles = loadProfiles }, CancellationToken.None).GetAwaiter().GetResult())
             {
                 return psesHost;
             }


### PR DESCRIPTION
Unfortunately the (admittedly hairy) change made in https://github.com/PowerShell/PowerShellEditorServices/pull/1918 to fix:

> System.Management.Automation.PSInvalidOperationException: The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.

has resulted in https://github.com/PowerShell/vscode-powershell/issues/4219:

> System.Management.Automation.PSInvalidOperationException: You should only run a nested pipeline from within a running pipeline.

because we had hacked in that _all_ our pipelines are nested (to allow the concurrency check to pass), but when loading profiles, we do not actually have a running pipeline, so our  lie about being nested fails another check.

So I think what happened was that https://github.com/PowerShell/vscode-powershell/issues/4048 was already no longer reproducing by happenstance (as the Az.Tools.Predictor module presumably updated and removed their `OnIdle` handler). I failed to check that _before_ attempting to fix it following the last result of our investigation. The "fix" inadvertently caused nearly the same `PSInvalidOperationException`, and by mistake I confused the two scenarios. With this PR, and regression tests, I can confirm that the `OnIdle` handler works both in a profile and at the regular prompt after reverting the breaking change. Furthermore, I can no longer repro the original issue with Az.Tools.Predictor whatsoever, in any version, hence my conclusion their module updated.

Resolves https://github.com/PowerShell/vscode-powershell/issues/4219