### PR TITLE
Wrap script paths with single instead of double quotes

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
         public StartEditorServicesCommand()
         {
-            //Sets the distribution channel to "PSES" so starts can be distinguished in PS7+ telemetry
+            // Sets the distribution channel to "PSES" so starts can be distinguished in PS7+ telemetry
             Environment.SetEnvironmentVariable("POWERSHELL_DISTRIBUTION_CHANNEL", "PSES");
             _disposableResources = new List<IDisposable>();
             _loggerUnsubscribers = new List<IDisposable>();

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 // For a saved file we just execute its path (after escaping it).
                 command = PSCommandHelpers.BuildDotSourceCommandWithArguments(
-                    string.Concat('"', scriptToLaunch, '"'), _debugStateService?.Arguments);
+                    string.Concat("'", scriptToLaunch, "'"), _debugStateService?.Arguments);
             }
             else // It's a URI to an untitled script, or a raw script.
             {

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -190,7 +190,7 @@ namespace PowerShellEditorServices.Test.E2E
             ConfigurationDoneResponse configDoneResponse = await PsesDebugAdapterClient.RequestConfigurationDone(new ConfigurationDoneArguments()).ConfigureAwait(true);
             Assert.NotNull(configDoneResponse);
             Assert.Collection(await GetLog().ConfigureAwait(true),
-                (i) => Assert.StartsWith(". \"", i));
+                (i) => Assert.StartsWith(". '", i));
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -583,11 +583,11 @@ namespace PowerShellEditorServices.Test.Debugging
 
             // Check the PowerShell history
             Assert.Single(historyResult);
-            Assert.Equal(". \"" + debugScriptFile.FilePath + "\"", historyResult[0]);
+            Assert.Equal(". '" + debugScriptFile.FilePath + "'", historyResult[0]);
 
             // Check the stubbed PSReadLine history
             Assert.Single(testReadLine.history);
-            Assert.Equal(". \"" + debugScriptFile.FilePath + "\"", testReadLine.history[0]);
+            Assert.Equal(". '" + debugScriptFile.FilePath + "'", testReadLine.history[0]);
         }
 
         [Fact]


### PR DESCRIPTION
In order to support funny path names with dollar signs. Also this is what PowerShell does by default (e.g. through tab-completion).

Resolves https://github.com/PowerShell/vscode-powershell/issues/4238.