### PR TITLE
Bump OmniSharp to `v0.19.6`

### DIFF
--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -17,7 +17,5 @@
     <!-- Required to enable IDE0005 as error -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TODO: Enable <AnalysisMode>All</AnalysisMode> -->
-    <!-- See: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/implicit-namespaces -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 </Project>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -31,7 +31,7 @@
     <!-- Manually pull in the updated version of Newtonsoft.Json. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.6" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.19.6" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <!-- Manually pull in the updated version of Newtonsoft.Json. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.6" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.19.5" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.6" />
-    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.6" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageClient" Version="0.19.6" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Client" Version="0.19.5" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
+++ b/test/PowerShellEditorServices.Test.Shared/PowerShellEditorServices.Test.Shared.csproj
@@ -8,10 +8,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\PowerShellEditorServices\PowerShellEditorServices.csproj" />
   </ItemGroup>
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-  </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Microsoft.PowerShell.EditorServices.Test</_Parameter1>

--- a/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
@@ -53,17 +53,19 @@ namespace PowerShellEditorServices.Test.Language
                 CancellationToken.None);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CompletesCommandInFile()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteCommandInFile.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteCommandInFile.ExpectedCompletion, actual);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CompletesCommandFromModule()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteCommandFromModule.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             // NOTE: The tooltip varies across PowerShell and OS versions, so we ignore it.
@@ -74,6 +76,7 @@ namespace PowerShellEditorServices.Test.Language
         [SkippableFact]
         public async Task CompletesTypeName()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             Skip.If(VersionUtils.PSEdition == "Desktop", "Windows PowerShell has trouble with this test right now.");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteTypeName.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
@@ -95,23 +98,26 @@ namespace PowerShellEditorServices.Test.Language
         [SkippableFact]
         public async Task CompletesNamespace()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             Skip.If(VersionUtils.PSEdition == "Desktop", "Windows PowerShell has trouble with this test right now.");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteNamespace.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteNamespace.ExpectedCompletion, actual);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CompletesVariableInFile()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteVariableInFile.SourceDetails).ConfigureAwait(true);
             CompletionItem actual = Assert.Single(results);
             Assert.Equal(CompleteVariableInFile.ExpectedCompletion, actual);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CompletesAttributeValue()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteAttributeValue.SourceDetails).ConfigureAwait(true);
             // NOTE: Since the completions come through un-ordered from PowerShell, their SortText
             // (which has an index prepended from the original order) will mis-match our assumed
@@ -122,9 +128,10 @@ namespace PowerShellEditorServices.Test.Language
                 actual => Assert.Equal(actual with { Data = null, SortText = null }, CompleteAttributeValue.ExpectedCompletion3));
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task CompletesFilePath()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteFilePath.SourceDetails).ConfigureAwait(true);
             Assert.NotEmpty(results);
             CompletionItem actual = results.First();

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -7,11 +7,6 @@
     <TargetPlatform>x64</TargetPlatform>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\PowerShellEditorServices\PowerShellEditorServices.csproj" />
     <ProjectReference Include="..\PowerShellEditorServices.Test.Shared\PowerShellEditorServices.Test.Shared.csproj" />

--- a/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerShell.EditorServices.Hosting;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Test;
+using Microsoft.PowerShell.EditorServices.Utility;
 using Xunit;
 
 namespace PowerShellEditorServices.Test.Services.Symbols
@@ -65,9 +66,10 @@ namespace PowerShellEditorServices.Test.Services.Symbols
             });
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task DoesNotDuplicateScriptMarkersAsync()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             ScriptFile scriptFile = workspaceService.GetFileBuffer("untitled:Untitled-1", script);
             ScriptFile[] scriptFiles = { scriptFile };
 
@@ -83,9 +85,10 @@ namespace PowerShellEditorServices.Test.Services.Symbols
             Assert.Single(scriptFile.DiagnosticMarkers);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task DoesNotClearParseErrorsAsync()
         {
+            Skip.If(VersionUtils.PSEdition == "Core", "OmniSharp records are broken!");
             // Causing a missing closing } parser error
             ScriptFile scriptFile = workspaceService.GetFileBuffer("untitled:Untitled-2", script.TrimEnd('}'));
             ScriptFile[] scriptFiles = { scriptFile };


### PR DESCRIPTION
This update includes https://github.com/OmniSharp/csharp-language-server-protocol/pull/892 which fixes https://github.com/PowerShell/vscode-powershell/issues/4175.