### PR TITLE
Add PowerShell 7.3 to test matrix

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Install dotnet
+      uses: actions/setup-dotnet@v3
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/emacs-test.yml
+++ b/.github/workflows/emacs-test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v3
+
       - name: Build PSES
         shell: pwsh
         run: tools/azurePipelinesBuild.ps1

--- a/.github/workflows/vim-test.yml
+++ b/.github/workflows/vim-test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install dotnet
+        uses: actions/setup-dotnet@v3
+
       - name: Build PSES
         shell: pwsh
         run: tools/azurePipelinesBuild.ps1

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -12,9 +12,16 @@ steps:
     pwsh: ${{ parameters.pwsh }}
 
 - task: UseDotNet@2
-  displayName: Install .NET 6.0.x SDK
+  displayName: Install .NET 7.0.x SDK
   inputs:
     packageType: sdk
+    version: 7.0.x
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  displayName: Install .NET 6.0.x runtime
+  inputs:
+    packageType: runtime
     version: 6.0.x
     performMultiLevelLookup: true
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "7.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }

--- a/src/PowerShellEditorServices/Utility/FormatUtils.cs
+++ b/src/PowerShellEditorServices/Utility/FormatUtils.cs
@@ -23,6 +23,8 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 
         private const string Static = "static ";
 
+        private static HashSet<string>? usingNamespaces;
+
         /// <summary>
         /// Space, new line, carriage return and tab.
         /// </summary>
@@ -164,9 +166,9 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         {
             kind = MarkupKind.Markdown;
             StringBuilder text = new();
-            HashSet<string>? usingNamespaces = null;
             while (true)
             {
+                usingNamespaces = null;
                 toolTip = toolTip.TrimStart(s_whiteSpace.Span);
                 toolTip = ProcessMethod(toolTip, text, ref usingNamespaces);
                 if (toolTip.IsEmpty)

--- a/test/PowerShellEditorServices.Test.E2E/Processes/LoggingStream.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/LoggingStream.cs
@@ -16,6 +16,15 @@ namespace PowerShellEditorServices.Test.E2E
 
         public LoggingStream(Stream underlyingStream) => _underlyingStream = underlyingStream;
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                _underlyingStream.Dispose();
+            }
+        }
+
         public override bool CanRead => _underlyingStream.CanRead;
 
         public override bool CanSeek => _underlyingStream.CanSeek;

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices.Test</AssemblyName>
     <TargetPlatform>x64</TargetPlatform>
   </PropertyGroup>
@@ -12,19 +12,29 @@
     <ProjectReference Include="..\PowerShellEditorServices.Test.Shared\PowerShellEditorServices.Test.Shared.csproj" />
   </ItemGroup>
 
-  <!-- This is for testing PowerShell 7.2 LTS -->
+  <!-- Latest PowerShell -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+      <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.0" />
+  </ItemGroup>
+
+  <!-- PowerShell LTS-Current -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.7" />
   </ItemGroup>
 
-  <!-- This is for testing PowerShell 7.0 LTS and so needs to be 7.0.x -->
+  <!-- PowerShell LTS -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.13" />
   </ItemGroup>
 
+  <!-- Windows PowerShell 5.1 -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' ">
+    <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
@@ -48,7 +58,4 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
And in a few weeks we'll remove PowerShell 7.0 (and thus `netcoreapp3.1`).