### PR TITLE
Replace backtick-e with `$([char]0x1b)`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -531,12 +531,12 @@ function Global:Prompt() {
 	if ($Global:__LastHistoryId -ne -1) {
 		if ($LastHistoryEntry.Id -eq $Global:__LastHistoryId) {
 			# Don't provide a command line or exit code if there was no history entry (eg. ctrl+c, enter on no command)
-			$Result  = ""`e]633;E`a""
-			$Result += ""`e]633;D`a""
+			$Result  = ""$([char]0x1b)]633;E`a""
+			$Result += ""$([char]0x1b)]633;D`a""
 		} else {
 			# Command finished command line
 			# OSC 633 ; A ; <CommandLine?> ST
-			$Result  = ""`e]633;E;""
+			$Result  = ""$([char]0x1b)]633;E;""
 			# Sanitize the command line to ensure it can get transferred to the terminal and can be parsed
 			# correctly. This isn't entirely safe but good for most cases, it's important for the Pt parameter
 			# to only be composed of _printable_ characters as per the spec.
@@ -549,27 +549,27 @@ function Global:Prompt() {
 			$Result += ""`a""
 			# Command finished exit code
 			# OSC 633 ; D [; <ExitCode>] ST
-			$Result += ""`e]633;D;$FakeCode`a""
+			$Result += ""$([char]0x1b)]633;D;$FakeCode`a""
 		}
 	}
 	# Prompt started
 	# OSC 633 ; A ST
-	$Result += ""`e]633;A`a""
+	$Result += ""$([char]0x1b)]633;A`a""
 	# Current working directory
 	# OSC 633 ; <Property>=<Value> ST
-	$Result += if($pwd.Provider.Name -eq 'FileSystem'){""`e]633;P;Cwd=$($pwd.ProviderPath)`a""}
+	$Result += if($pwd.Provider.Name -eq 'FileSystem'){""$([char]0x1b)]633;P;Cwd=$($pwd.ProviderPath)`a""}
 	# Before running the original prompt, put $? back to what it was:
 	if ($FakeCode -ne 0) { Write-Error ""failure"" -ea ignore }
 	# Run the original prompt
 	$Result += $Global:__VSCodeOriginalPrompt.Invoke()
 	# Write command started
-	$Result += ""`e]633;B`a""
+	$Result += ""$([char]0x1b)]633;B`a""
 	$Global:__LastHistoryId = $LastHistoryEntry.Id
 	return $Result
 }
 
 # Set IsWindows property
-Write-Host -NoNewLine ""`e]633;P;IsWindows=$($IsWindows)`a""
+Write-Host -NoNewLine ""$([char]0x1b)]633;P;IsWindows=$($IsWindows)`a""
 
 # Set always on key handlers which map to default VS Code keybindings
 function Set-MappedKeyHandler {


### PR DESCRIPTION
By replacing backtick-e with `$([char]0x1b)`, we allow shell integration to work with Windows PowerShell, as the only problem seemed to be use of backtick-e, which was an escape character added only to PowerShell Core, but the `[char]` equivalent works fine.

Same change as proposed upstream in https://github.com/microsoft/vscode/pull/167023, resolves https://github.com/PowerShell/vscode-powershell/issues/4279.