### PR TITLE
Revert manual pin of Newtonsoft.Json

### DIFF
--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <!-- Manually pull in the updated version of Newtonsoft.Json. -->
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <!-- TODO: Manually pull in the updated version of Newtonsoft.Json after OmniSharp updates. -->
+    <!-- PackageReference Include="Newtonsoft.Json" Version="13.0.1" -->
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.6" />
     <PackageReference Include="OmniSharp.Extensions.DebugAdapter.Server" Version="0.19.6" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />

--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -89,6 +89,8 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     {
                         // Start the host if not already started, and enable debug mode (required
                         // for remote debugging).
+                        //
+                        // TODO: We might need to fill in HostStartOptions here.
                         _startedPses = !await _psesHost.TryStartAsync(new HostStartOptions(), cancellationToken).ConfigureAwait(false);
                         _psesHost.DebugContext.EnableDebugMode();
 

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -154,9 +154,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
                     Title = GetReferenceCountHeader(referenceLocations.Length),
                     Arguments = JArray.FromObject(new object[]
                     {
-                    scriptFile.DocumentUri,
-                    codeLens.Range.Start,
-                    referenceLocations
+                        scriptFile.DocumentUri,
+                        codeLens.Range.Start,
+                        referenceLocations
                     },
                     LspSerializer.Instance.JsonSerializer)
                 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeActionHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -12,6 +13,7 @@ using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Serialization;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
@@ -131,7 +133,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         {
                             Title = title,
                             Name = "PowerShell.ShowCodeActionDocumentation",
-                            Arguments = Newtonsoft.Json.Linq.JArray.FromObject(new[] { diagnostic.Code?.String })
+                            Arguments = JArray.FromObject(new object[]
+                            {
+                                diagnostic.Code?.String
+                            },
+                            LspSerializer.Instance.JsonSerializer)
                         }
                     });
                 }

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -506,6 +506,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         internal string ResolveRelativeScriptPath(string baseFilePath, string relativePath)
         {
+            // TODO: Sometimes the `baseFilePath` (even when its `WorkspacePath`) is null.
             string combinedPath = null;
             Exception resolveException = null;
 


### PR DESCRIPTION
Pinning this in https://github.com/PowerShell/PowerShellEditorServices/pull/1947 before getting our transitive dependencies in order seems to be the root cause of https://github.com/PowerShell/vscode-powershell/issues/4278 and possibly also https://github.com/PowerShell/vscode-powershell/issues/4283. We're going to revert until we get OmniSharp's dependency sorted, and test in preview with users if those issues are resolved.