### PR TITLE
Remove unnecessary `PowerShellProcessArchitecture`

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -354,6 +354,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 ");
         }
 
+        // TODO: Deduplicate this with VersionUtils.
         private static string GetOSArchitecture()
         {
 #if CoreCLR

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/GetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/GetVersionHandler.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell;
@@ -13,35 +12,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     {
         public async Task<PowerShellVersion> Handle(GetVersionParams request, CancellationToken cancellationToken)
         {
-            PowerShellProcessArchitecture architecture = PowerShellProcessArchitecture.Unknown;
-            // This should be changed to using a .NET call sometime in the future... but it's just for logging purposes.
-            string arch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
-            if (arch != null)
-            {
-                if (string.Equals(arch, "AMD64", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    architecture = PowerShellProcessArchitecture.X64;
-                }
-                else if (string.Equals(arch, "x86", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    architecture = PowerShellProcessArchitecture.X86;
-                }
-            }
-
             return new PowerShellVersion
             {
                 Version = VersionUtils.PSVersionString,
                 Edition = VersionUtils.PSEdition,
                 DisplayVersion = VersionUtils.PSVersion.ToString(2),
-                Architecture = architecture.ToString()
+                Architecture = VersionUtils.Architecture
             };
-        }
-
-        private enum PowerShellProcessArchitecture
-        {
-            Unknown,
-            X86,
-            X64
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/IGetVersionHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/IGetVersionHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using MediatR;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Context;
 using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell
@@ -12,29 +11,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell
 
     internal class GetVersionParams : IRequest<PowerShellVersion> { }
 
-    internal class PowerShellVersion
+    internal record PowerShellVersion
     {
-        public string Version { get; set; }
-        public string DisplayVersion { get; set; }
-        public string Edition { get; set; }
-        public string Architecture { get; set; }
-
-        public PowerShellVersion()
-        {
-        }
-
-        public PowerShellVersion(PowerShellVersionDetails versionDetails)
-        {
-            Version = versionDetails.VersionString;
-            DisplayVersion = $"{versionDetails.Version.Major}.{versionDetails.Version.Minor}";
-            Edition = versionDetails.Edition;
-
-            Architecture = versionDetails.Architecture switch
-            {
-                PowerShellProcessArchitecture.X64 => "x64",
-                PowerShellProcessArchitecture.X86 => "x86",
-                _ => "Architecture Unknown",
-            };
-        }
+        public string Version { get; init; }
+        public string DisplayVersion { get; init; }
+        public string Edition { get; init; }
+        public string Architecture { get; init; }
     }
 }

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -61,6 +61,11 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// True if we are running on Linux, false otherwise.
         /// </summary>
         public static bool IsLinux { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+        /// <summary>
+        /// The .NET Architecture as a string.
+        /// </summary>
+        public static string Architecture { get; } = PowerShellReflectionUtils.GetOSArchitecture();
     }
 
     internal static class PowerShellReflectionUtils
@@ -96,5 +101,24 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static string PSVersionString { get; } = s_psCurrentVersionProperty != null
             ? s_psCurrentVersionProperty.GetValue(null).ToString()
             : s_psVersionProperty.GetValue(null).ToString();
+
+        public static string GetOSArchitecture()
+        {
+#if CoreCLR
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return RuntimeInformation.OSArchitecture.ToString();
+            }
+#endif
+            // If on win7 (version 6.1.x), avoid System.Runtime.InteropServices.RuntimeInformation
+            if (Environment.OSVersion.Version < new Version(6, 2))
+            {
+                return Environment.Is64BitProcess
+                    ? "X64"
+                    : "X86";
+            }
+
+            return RuntimeInformation.OSArchitecture.ToString();
+        }
     }
 }


### PR DESCRIPTION
This simply wasn't being used and was overly complicated. The only time we want the architecture is when queried via LSP so that the VS Code client can determine which installer to download for its auto-update feature. If we can, we should deduplicate version logic in the loader and the `VersionUtils` class.

Simplification found when investigating https://github.com/PowerShell/vscode-powershell/issues/3435.