### PR TITLE
Fix `ShowHelpHandler` by running with `RequiresForeground`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/ShowHelpHandler.cs
@@ -67,7 +67,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             // TODO: Rather than print the help in the console, we should send the string back
             //       to VSCode to display in a help pop-up (or similar)
-            await _executionService.ExecutePSCommandAsync<PSObject>(checkHelpPSCommand, cancellationToken, new PowerShellExecutionOptions { WriteOutputToHost = true, ThrowOnError = false }).ConfigureAwait(false);
+            await _executionService.ExecutePSCommandAsync<PSObject>(
+                checkHelpPSCommand,
+                cancellationToken,
+                new PowerShellExecutionOptions
+                {
+                    RequiresForeground = true,
+                    WriteOutputToHost = true,
+                    ThrowOnError = false
+                }).ConfigureAwait(false);
             return Unit.Value;
         }
     }


### PR DESCRIPTION
This was broken after the rewrite because we'd forgotten to specify that it needs the foreground (which implies too that it must run immediately). Now the script actually executes, either showing the help in the Extension Terminal (or...I guess nowhere for clients without it) or opening the URL it found. This should still be rewritten properly to return the help over LSP and do something better with it, but at least it's no longer broken.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4212.