### PR TITLE
Update `Microsoft.PowerShell.SDK` with workaround

### DIFF
--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -14,7 +14,9 @@
 
   <!-- Latest PowerShell -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-      <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.0" />
+      <!-- TODO: Remove this workaround with the 7.3.2 update. -->
+      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="7.0.0-preview.2.22152.2" NoWarn="NU1605" />
+      <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.1" />
   </ItemGroup>
 
   <!-- PowerShell LTS -->


### PR DESCRIPTION
This should let us take the update with a temporary workaround suggested by @TravisEz13 in https://github.com/PowerShell/PowerShell/issues/18782.