### PR TITLE
Remove supposedly unnecessary lambdas from `Task.Run`

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
                 // TODO: We need to assign cancellation tokens to each frame, because the current
                 // logic results in a deadlock here when we try to cancel the scopes...which
                 // includes ourself (hence running it in a separate thread).
-                _ = Task.Run(() => _psesHost.UnwindCallStack());
+                _ = Task.Run(_psesHost.UnwindCallStack);
                 return;
             }
 

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -496,7 +496,7 @@ namespace PowerShellEditorServices.Test.Debugging
             Assert.Equal(0, confirmedBreakpoints.Count);
             Task _ = ExecuteDebugFileAsync();
             // NOTE: This must be run on a separate thread so the async event handlers can fire.
-            await Task.Run(() => debugService.Break()).ConfigureAwait(true);
+            await Task.Run(debugService.Break).ConfigureAwait(true);
             AssertDebuggerPaused();
         }
 
@@ -505,7 +505,7 @@ namespace PowerShellEditorServices.Test.Debugging
         {
             Task _ = ExecuteDebugFileAsync();
             // NOTE: This must be run on a separate thread so the async event handlers can fire.
-            await Task.Run(() => debugService.Break()).ConfigureAwait(true);
+            await Task.Run(debugService.Break).ConfigureAwait(true);
             AssertDebuggerPaused();
 
             // Try running a command from outside the pipeline thread
@@ -723,7 +723,7 @@ namespace PowerShellEditorServices.Test.Debugging
 
             // The above just tests that the debug service returns the correct new value string.
             // Let's step the debugger and make sure the values got set to the new values.
-            await Task.Run(() => debugService.StepOver()).ConfigureAwait(true);
+            await Task.Run(debugService.StepOver).ConfigureAwait(true);
             AssertDebuggerStopped(variableScriptFile.FilePath);
 
             // Test set of a local string variable (not strongly typed)
@@ -779,7 +779,7 @@ namespace PowerShellEditorServices.Test.Debugging
 
             // The above just tests that the debug service returns the correct new value string.
             // Let's step the debugger and make sure the values got set to the new values.
-            await Task.Run(() => debugService.StepOver()).ConfigureAwait(true);
+            await Task.Run(debugService.StepOver).ConfigureAwait(true);
             AssertDebuggerStopped(variableScriptFile.FilePath);
 
             // Test set of a local string variable (not strongly typed but force conversion)

--- a/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/PsesInternalHostTests.cs
@@ -180,7 +180,7 @@ namespace PowerShellEditorServices.Test.Session
                 new PSCommand().AddScript("$handled"),
                 CancellationToken.None).ConfigureAwait(true);
 
-            Assert.Collection(handled, (p) => Assert.False(p));
+            Assert.Collection(handled, Assert.False);
 
             await psesHost.ExecuteDelegateAsync(
                 nameof(psesHost.OnPowerShellIdle),
@@ -195,7 +195,7 @@ namespace PowerShellEditorServices.Test.Session
                 new PSCommand().AddScript("$handled"),
                 CancellationToken.None).ConfigureAwait(true);
 
-            Assert.Collection(handled, (p) => Assert.True(p));
+            Assert.Collection(handled, Assert.True);
         }
 
         [Fact]
@@ -301,7 +301,7 @@ namespace PowerShellEditorServices.Test.Session
                 new PSCommand().AddScript("$handledInProfile"),
                 CancellationToken.None).ConfigureAwait(true);
 
-            Assert.Collection(handled, (p) => Assert.True(p));
+            Assert.Collection(handled, Assert.True);
         }
     }
 }


### PR DESCRIPTION
Except I think this might be causing Windows PowerShell to fail.