### PR TITLE
Use an empty array instead of `null`

### DIFF
--- a/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/EditorUIService.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
                     Caption = string.Empty,
                     Message = message,
                     Choices = choiceDetails,
-                    DefaultChoices = defaultChoiceIndex > -1 ? new[] { defaultChoiceIndex } : null,
+                    DefaultChoices = defaultChoiceIndex > -1 ? new[] { defaultChoiceIndex } : Array.Empty<int>(),
                 })
                 .Returning<ShowChoicePromptResponse>(CancellationToken.None)
                 .ConfigureAwait(false);


### PR DESCRIPTION
Fixes #1959

The code on the client expects `DefaultChoices` to never be `null`. If you send `null`, it tries to access the property `length` on what would be an array.
