### PR TITLE
Make `Set-ScriptExtent` not slow

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Set-ScriptExtent.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Set-ScriptExtent.ps1
@@ -5,27 +5,29 @@ function Set-ScriptExtent {
     <#
     .EXTERNALHELP ..\PowerShellEditorServices.Commands-help.xml
     #>
-    [CmdletBinding(PositionalBinding=$false, DefaultParameterSetName='__AllParameterSets')]
+    [CmdletBinding(PositionalBinding = $false, DefaultParameterSetName = '__AllParameterSets')]
     param(
-        [Parameter(Position=0, Mandatory)]
-        [psobject]
-        $Text,
+        [Parameter(Position = 0, Mandatory)]
+        [psobject] $Text,
 
-        [Parameter(Mandatory, ParameterSetName='AsString')]
+        [Parameter(Mandatory, ParameterSetName = 'AsString')]
         [switch]
         $AsString,
 
-        [Parameter(Mandatory, ParameterSetName='AsArray')]
-        [switch]
-        $AsArray,
+        [Parameter(Mandatory, ParameterSetName = 'AsArray')]
+        [switch] $AsArray,
 
         [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
-        [System.Management.Automation.Language.IScriptExtent]
-        $Extent = (Find-Ast -AtCursor).Extent
+        [System.Management.Automation.Language.IScriptExtent] $Extent = (Find-Ast -AtCursor).Extent
     )
     begin {
         $fileContext = $psEditor.GetEditorContext().CurrentFile
-        $extentList = [System.Collections.Generic.List[[Microsoft.PowerShell.EditorServices.Extensions.FileScriptExtent, Microsoft.PowerShell.EditorServices]]]::new()
+        $descendingComparer = [System.Collections.Generic.Comparer[int]]::Create{
+            param($x, $y) return $y.CompareTo($x)
+        }
+
+        $extentList = [System.Collections.Generic.SortedList[int, System.Management.Automation.Language.IScriptExtent]]::new(
+            $descendingComparer)
     }
     process {
         if ($Extent -isnot [Microsoft.PowerShell.EditorServices.Extensions.FileScriptExtent, Microsoft.PowerShell.EditorServices]) {
@@ -34,11 +36,11 @@ function Set-ScriptExtent {
                 $Extent.StartOffset,
                 $Extent.EndOffset)
         }
-        $extentList.Add($Extent)
+
+        $extentList.Add($Extent.StartOffset, $Extent)
     }
-    # Currently this kills the pipeline because we need to keep track and edit all extents for position tracking.
-    # TODO: Consider queueing changes in a static property and adding a PassThru switch.
     end {
+        $needsIndentFix = $false
         switch ($PSCmdlet.ParameterSetName) {
             # Insert text as a single string expression.
             AsString {
@@ -55,41 +57,16 @@ function Set-ScriptExtent {
             }
         }
 
-        foreach ($aExtent in $extentList) {
+        foreach ($kvp in $extentList.GetEnumerator()) {
+            $aExtent = $kvp.Value
             $aText = $Text
 
             if ($needsIndentFix) {
-                # I'd rather let PSSA handle this when there are more formatting options.
                 $indentOffset = ' ' * ($aExtent.StartColumnNumber - 1)
-                $aText = $aText -split '\r?\n' `
-                                -join ([Environment]::NewLine + $indentOffset)
+                $aText = $aText -split '\r?\n' -join ([Environment]::NewLine + $indentOffset)
             }
-            $differenceOffset = $aText.Length - $aExtent.Text.Length
-            $scriptText       = $fileContext.GetText()
 
             $fileContext.InsertText($aText, $aExtent)
-
-            $newText = $scriptText.Remove($aExtent.StartOffset, $aExtent.Text.Length).Insert($aExtent.StartOffset, $aText)
-
-            $timeoutLoop = 0
-            while ($fileContext.GetText() -ne $newText) {
-                Start-Sleep -Milliseconds 30
-                $timeoutLoop++
-
-                if ($timeoutLoop -gt 20) {
-                    $PSCmdlet.WriteDebug(('Timed out waiting for change at range {0}, {1}' -f $aExtent.StartOffset,
-                                                                                              $aExtent.EndOffset))
-                    break
-                }
-            }
-
-            if ($differenceOffset) {
-                $extentList.ForEach({
-                    if ($args[0].StartOffset -ge $aExtent.EndOffset) {
-                        $args[0].AddOffset($differenceOffset)
-                    }
-                })
-            }
         }
     }
 }


### PR DESCRIPTION
This was some of the first code I ever contributed...and it shows. It's actually really easy to solve the problem of "when editing many parts of the same document, offsets no longer match up". You just go in reverse, and then you don't have that problem anymore.

So this gets rid of the "waiting for the document" to update which takes forever.