### PR TITLE
Support Run/Debug tests in PSKoans-files

### DIFF
--- a/module/PowerShellEditorServices/InvokePesterStub.ps1
+++ b/module/PowerShellEditorServices/InvokePesterStub.ps1
@@ -59,10 +59,24 @@ param(
     [string] $OutputPath
 )
 
-$pesterModule = Microsoft.PowerShell.Core\Get-Module Pester
 # add one line, so the subsequent output is not shifted to the side
 Write-Output ''
 
+# checking and importing PSKoans first as it will import the required Pester-version (v4 vs v5)
+if ($ScriptPath -match '\.Koans\.ps1$') {
+    $psKoansModule = Microsoft.PowerShell.Core\Get-Module PSKoans
+    if (!$psKoansModule) {
+        Write-Output "Importing PSKoans module..."
+        $psKoansModule = Microsoft.PowerShell.Core\Import-Module PSKoans -ErrorAction Ignore -PassThru
+    }
+
+    if (!$psKoansModule) {
+        Write-Warning "Failed to import PSKoans. You must install PSKoans module to run or debug tests in *.Koans.ps1 files."
+        return
+    }
+}
+
+$pesterModule = Microsoft.PowerShell.Core\Get-Module Pester
 if (!$pesterModule) {
     Write-Output "Importing Pester module..."
     if ($MinimumVersion5) {

--- a/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
@@ -20,9 +20,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         IEnumerable<SymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(
             ScriptFile scriptFile)
         {
-            if (!scriptFile.FilePath.EndsWith(
-                    "tests.ps1",
-                    StringComparison.OrdinalIgnoreCase))
+            if (!scriptFile.FilePath.EndsWith(".tests.ps1", StringComparison.OrdinalIgnoreCase) &&
+                !scriptFile.FilePath.EndsWith(".Koans.ps1", StringComparison.OrdinalIgnoreCase))
             {
                 return Enumerable.Empty<SymbolReference>();
             }

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPSKoansFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/FindSymbolsInPSKoansFile.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+
+namespace Microsoft.PowerShell.EditorServices.Test.Shared.Symbols
+{
+    public static class FindSymbolsInPSKoansFile
+    {
+        public static readonly ScriptRegion SourceDetails =
+            new(
+                file: TestUtilities.NormalizePath("Symbols/PesterFile.Koans.ps1"),
+                text: string.Empty,
+                startLineNumber: 0,
+                startColumnNumber: 0,
+                startOffset: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                endOffset: 0);
+    }
+}

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.Koans.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/PesterFile.Koans.ps1
@@ -1,0 +1,23 @@
+﻿Describe "Testing Pester symbols in a PSKoans-file" {
+    Context "Simple demo" {
+        BeforeAll {
+
+        }
+
+        BeforeEach {
+
+        }
+
+        It "Should return Pester symbols" {
+
+        }
+
+        AfterEach {
+
+        }
+    }
+
+    AfterAll {
+
+    }
+}

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -890,6 +890,15 @@ namespace PowerShellEditorServices.Test.Language
         }
 
         [Fact]
+        public void FindsSymbolsInPSKoansFile()
+        {
+            IEnumerable<PesterSymbolReference> symbols = FindSymbolsInFile(FindSymbolsInPSKoansFile.SourceDetails).OfType<PesterSymbolReference>();
+
+            // Pester symbols are properly tested in FindsSymbolsInPesterFile so only counting to make sure they appear
+            Assert.Equal(7, symbols.Count(i => i.Type == SymbolType.Function));
+        }
+
+        [Fact]
         public void FindsSymbolsInPSDFile()
         {
             IEnumerable<SymbolReference> symbols = FindSymbolsInFile(FindSymbolsInPSDFile.SourceDetails);


### PR DESCRIPTION
# PR Summary

Adds support for using Run/Debug Tests codelens and Run/Debug Pester Tests commands with `*.Koans.ps1`-files used by [PSKoans](https://github.com/vexx32/PSKoans).

Manually testing only for `InvokePesterStub.ps1` to avoid extra dependency for a simple feature.

## PR Context

Fix PowerShell/vscode-powershell#4363