### PR TITLE
Keep only first assignment as declaration

### DIFF
--- a/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
@@ -94,6 +94,15 @@ internal sealed class ReferenceTable
             _ => new ConcurrentBag<SymbolReference> { symbol },
             (_, existing) =>
             {
+                // Keep only the first variable encountered as a declaration marked as such. This
+                // keeps the first assignment without also counting every reassignment as a
+                // declaration (cleaning up e.g. Code's outline view).
+                if (symbol.Type is SymbolType.Variable && symbol.IsDeclaration
+                    && existing.Any(i => i.IsDeclaration))
+                {
+                    symbol = symbol with { IsDeclaration = false };
+                }
+
                 existing.Add(symbol);
                 return existing;
             });

--- a/test/PowerShellEditorServices.Test.Shared/References/SimpleFile.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/References/SimpleFile.ps1
@@ -5,7 +5,7 @@ function My-Function ($myInput)
 
 $things = 4
 
-$things
+$things = 3
 
 My-Function $things
 

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -263,7 +263,8 @@ namespace PowerShellEditorServices.Test.Language
         [Fact]
         public async Task FindsVariableDefinition()
         {
-            SymbolReference symbol = await GetDefinition(FindsVariableDefinitionData.SourceDetails).ConfigureAwait(true);
+            IEnumerable<SymbolReference> definitions = await GetDefinitions(FindsVariableDefinitionData.SourceDetails).ConfigureAwait(true);
+            SymbolReference symbol = Assert.Single(definitions); // Even though it's re-assigned
             Assert.Equal("var things", symbol.Id);
             Assert.Equal("$things", symbol.Name);
             Assert.Equal(SymbolType.Variable, symbol.Type);


### PR DESCRIPTION
As noted by @fflaten in https://github.com/PowerShell/vscode-powershell/issues/1465#issuecomment-1421401557, our initial logic counted _every_ assignment as a declaration. While there's no true way to determine which is _really_ the declaration, we can make a relatively safe assumption that the first encountered declaration is it. This is efficient, easy, and seems to work quite well.