### PR TITLE
Strip scope from function references

### DIFF
--- a/src/PowerShellEditorServices/Services/Symbols/Visitors/SymbolVisitor.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/Visitors/SymbolVisitor.cs
@@ -40,7 +40,7 @@ internal sealed class SymbolVisitor : AstVisitor2
 
         return _action(new SymbolReference(
             SymbolType.Function,
-            "fn " + CommandHelpers.StripModuleQualification(commandName, out _),
+            "fn " + VisitorUtils.GetUnqualifiedFunctionName(CommandHelpers.StripModuleQualification(commandName, out _)),
             commandName,
             commandAst.CommandElements[0].Extent,
             commandAst.Extent,
@@ -64,7 +64,7 @@ internal sealed class SymbolVisitor : AstVisitor2
         IScriptExtent nameExtent = VisitorUtils.GetNameExtent(functionDefinitionAst);
         return _action(new SymbolReference(
             symbolType,
-            "fn " + functionDefinitionAst.Name,
+            "fn " + VisitorUtils.GetUnqualifiedFunctionName(functionDefinitionAst.Name),
             VisitorUtils.GetFunctionDisplayName(functionDefinitionAst),
             nameExtent,
             functionDefinitionAst.Extent,

--- a/src/PowerShellEditorServices/Utility/VisitorUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VisitorUtils.cs
@@ -33,6 +33,20 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             return PSESSymbols.AstOperations.TryGetInferredValue(expandableStringExpressionAst, out string value) ? value : null;
         }
 
+        // Strip the qualification, if there is any, so script:my-function is a reference of my-function etc.
+        internal static string GetUnqualifiedFunctionName(string name)
+        {
+            foreach (string scope in new string[] { "private:", "script:", "global:", "local:" })
+            {
+                if (name.StartsWith(scope, StringComparison.OrdinalIgnoreCase))
+                {
+                    return name.Substring(scope.Length);
+                }
+            }
+
+            return name;
+        }
+
         // Strip the qualification, if there is any, so $var is a reference of $script:var etc.
         internal static string GetUnqualifiedVariableName(VariablePath variablePath)
         {

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/MultipleSymbols.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/MultipleSymbols.ps1
@@ -4,7 +4,7 @@ $Script:ScriptVar2 = 2
 
 "`$Script:ScriptVar2 is $Script:ScriptVar2"
 
-function AFunction {}
+function script:AFunction {}
 
 filter AFilter {$_}
 

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -738,8 +738,9 @@ namespace PowerShellEditorServices.Test.Language
 
             SymbolReference symbol = symbols.First(i => i.Type == SymbolType.Function);
             Assert.Equal("fn AFunction", symbol.Id);
-            Assert.Equal("function AFunction ()", symbol.Name);
+            Assert.Equal("function script:AFunction ()", symbol.Name);
             Assert.True(symbol.IsDeclaration);
+            Assert.Equal(2, GetOccurrences(symbol.NameRegion).Count());
 
             symbol = symbols.First(i => i.Id == "fn AFilter");
             Assert.Equal("filter AFilter ()", symbol.Name);


### PR DESCRIPTION
Like methods we just bucket them as overloads, which means that it works better than before despite not being perfect.

Resolves https://github.com/PowerShell/vscode-powershell/issues/1089.