### PR TITLE
Add `WorkspaceFolders` and use it when enumerating files

### DIFF
--- a/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Extensions/Api/WorkspaceService.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
     public interface IWorkspaceService
     {
         /// <summary>
-        /// The root path of the workspace.
+        /// The root path of the workspace for the current editor.
         /// </summary>
         string WorkspacePath { get; }
 
@@ -116,7 +116,9 @@ namespace Microsoft.PowerShell.EditorServices.Extensions.Services
             ExcludedFileGlobs = _workspaceService.ExcludeFilesGlob.AsReadOnly();
         }
 
-        public string WorkspacePath => _workspaceService.WorkspacePath;
+        // TODO: This needs to use the associated EditorContext to get the workspace for the current
+        // editor instead of the initial working directory.
+        public string WorkspacePath => _workspaceService.InitialWorkingDirectory;
 
         public bool FollowSymlinks => _workspaceService.FollowSymlinks;
 

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         #region Properties
 
         /// <summary>
-        /// Gets the current workspace path if there is one or null otherwise.
+        /// Gets the current workspace path if there is one for the open editor or null otherwise.
         /// </summary>
         public string Path => editorOperations.GetWorkspacePath();
 

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,6 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.Template;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.JsonRpc;
-using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Serilog;
@@ -130,12 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                             WorkspaceService workspaceService = languageServer.Services.GetService<WorkspaceService>();
                             if (initializeParams.WorkspaceFolders is not null)
                             {
-                                // TODO: Support multi-workspace.
-                                foreach (WorkspaceFolder workspaceFolder in initializeParams.WorkspaceFolders)
-                                {
-                                    workspaceService.InitialWorkingDirectory = workspaceFolder.Uri.GetFileSystemPath();
-                                    break;
-                                }
+                                workspaceService.WorkspaceFolders.AddRange(initializeParams.WorkspaceFolders);
                             }
 
                             // Parse initialization options.
@@ -149,12 +144,18 @@ namespace Microsoft.PowerShell.EditorServices.Server
                                 //
                                 // NOTE: The keys start with a lowercase because OmniSharp's client
                                 // (used for testing) forces it to be that way.
-                                LoadProfiles = initializationOptions?.GetValue("enableProfileLoading")?.Value<bool>() ?? true,
-                                // TODO: Consider deprecating the setting which sets this and
-                                // instead use WorkspacePath exclusively.
-                                InitialWorkingDirectory = initializationOptions?.GetValue("initialWorkingDirectory")?.Value<string>() ?? workspaceService.InitialWorkingDirectory,
-                                ShellIntegrationEnabled = initializationOptions?.GetValue("shellIntegrationEnabled")?.Value<bool>() ?? false
+                                LoadProfiles = initializationOptions?.GetValue("enableProfileLoading")?.Value<bool>()
+                                    ?? true,
+                                // First check the setting, then use the first workspace folder,
+                                // finally fall back to CWD.
+                                InitialWorkingDirectory = initializationOptions?.GetValue("initialWorkingDirectory")?.Value<string>()
+                                    ?? workspaceService.WorkspaceFolders.FirstOrDefault()?.Uri.GetFileSystemPath()
+                                    ?? Directory.GetCurrentDirectory(),
+                                ShellIntegrationEnabled = initializationOptions?.GetValue("shellIntegrationEnabled")?.Value<bool>()
+                                    ?? false
                             };
+
+                            workspaceService.InitialWorkingDirectory = hostStartOptions.InitialWorkingDirectory;
 
                             _psesHost = languageServer.Services.GetService<PsesInternalHost>();
                             return _psesHost.TryStartAsync(hostStartOptions, cancellationToken);

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                                 // TODO: Support multi-workspace.
                                 foreach (WorkspaceFolder workspaceFolder in initializeParams.WorkspaceFolders)
                                 {
-                                    workspaceService.WorkspacePath = workspaceFolder.Uri.GetFileSystemPath();
+                                    workspaceService.InitialWorkingDirectory = workspaceFolder.Uri.GetFileSystemPath();
                                     break;
                                 }
                             }
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                                 LoadProfiles = initializationOptions?.GetValue("enableProfileLoading")?.Value<bool>() ?? true,
                                 // TODO: Consider deprecating the setting which sets this and
                                 // instead use WorkspacePath exclusively.
-                                InitialWorkingDirectory = initializationOptions?.GetValue("initialWorkingDirectory")?.Value<string>() ?? workspaceService.WorkspacePath,
+                                InitialWorkingDirectory = initializationOptions?.GetValue("initialWorkingDirectory")?.Value<string>() ?? workspaceService.InitialWorkingDirectory,
                                 ShellIntegrationEnabled = initializationOptions?.GetValue("shellIntegrationEnabled")?.Value<bool>() ?? false
                             };
 

--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -191,7 +191,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
         }
 
-        public string GetWorkspacePath() => _workspaceService.WorkspacePath;
+        // TODO: This should get the current editor's context and use it to determine which
+        // workspace it's in.
+        public string GetWorkspacePath() => _workspaceService.InitialWorkingDirectory;
 
         public string GetWorkspaceRelativePath(string filePath) => _workspaceService.GetRelativePath(filePath);
 

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolReference.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolReference.cs
@@ -66,5 +66,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
             }
             IsDeclaration = isDeclaration;
         }
+
+        /// <summary>
+        /// This is only used for unit tests!
+        /// </summary>
+        internal SymbolReference(string id, SymbolType type)
+        {
+            Id = id;
+            Type = type;
+            Name = "";
+            NameRegion = new("", "", 0, 0, 0, 0, 0, 0);
+            ScriptRegion = NameRegion;
+            SourceLine = "";
+            FilePath = "";
+        }
     }
 }

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             _configurationService.CurrentSettings.Update(
                 incomingSettings.Powershell,
-                _workspaceService.WorkspacePath,
+                _workspaceService.InitialWorkingDirectory,
                 _logger);
 
             // Run any events subscribed to configuration updates

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -230,6 +230,23 @@ namespace PowerShellEditorServices.Test.Language
         }
 
         [Fact]
+        public async Task FindsReferenceAcrossMultiRootWorkspace()
+        {
+            workspace.WorkspaceFolders = new[] { "Debugging", "ParameterHints", "SymbolDetails" }
+                .Select(i => new WorkspaceFolder
+                {
+                    Uri = DocumentUri.FromFileSystemPath(TestUtilities.GetSharedPath(i))
+                }).ToList();
+
+            SymbolReference symbol = new("fn Get-Process", SymbolType.Function);
+            IEnumerable<SymbolReference> symbols = await symbolsService.ScanForReferencesOfSymbolAsync(symbol).ConfigureAwait(true);
+            Assert.Collection(symbols.OrderBy(i => i.FilePath),
+                i => Assert.EndsWith("VariableTest.ps1", i.FilePath),
+                i => Assert.EndsWith("ParamHints.ps1", i.FilePath),
+                i => Assert.EndsWith("SymbolDetails.ps1", i.FilePath));
+        }
+
+        [Fact]
         public async Task FindsReferencesOnFunctionIncludingAliases()
         {
             // TODO: Same as in FindsFunctionDefinitionForAlias.

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -40,7 +40,7 @@ namespace PowerShellEditorServices.Test.Language
             psesHost = PsesHostFactory.Create(NullLoggerFactory.Instance);
             workspace = new WorkspaceService(NullLoggerFactory.Instance)
             {
-                WorkspacePath = TestUtilities.GetSharedPath("References")
+                InitialWorkingDirectory = TestUtilities.GetSharedPath("References")
             };
             symbolsService = new SymbolsService(
                 NullLoggerFactory.Instance,

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -23,6 +23,8 @@ using Microsoft.PowerShell.EditorServices.Test.Shared.References;
 using Microsoft.PowerShell.EditorServices.Test.Shared.SymbolDetails;
 using Microsoft.PowerShell.EditorServices.Test.Shared.Symbols;
 using Microsoft.PowerShell.EditorServices.Utility;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using Xunit;
 
 namespace PowerShellEditorServices.Test.Language
@@ -38,10 +40,11 @@ namespace PowerShellEditorServices.Test.Language
         public SymbolsServiceTests()
         {
             psesHost = PsesHostFactory.Create(NullLoggerFactory.Instance);
-            workspace = new WorkspaceService(NullLoggerFactory.Instance)
+            workspace = new WorkspaceService(NullLoggerFactory.Instance);
+            workspace.WorkspaceFolders.Add(new WorkspaceFolder
             {
-                InitialWorkingDirectory = TestUtilities.GetSharedPath("References")
-            };
+                Uri = DocumentUri.FromFileSystemPath(TestUtilities.GetSharedPath("References"))
+            });
             symbolsService = new SymbolsService(
                 NullLoggerFactory.Instance,
                 psesHost,

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -39,7 +39,7 @@ namespace PowerShellEditorServices.Test.Session
             string expectedOutsidePath = TestUtilities.NormalizePath("../PeerPath/FilePath.ps1");
 
             // Test with a workspace path
-            workspace.WorkspacePath = workspacePath;
+            workspace.InitialWorkingDirectory = workspacePath;
             Assert.Equal(expectedInsidePath, workspace.GetRelativePath(testPathInside));
             Assert.Equal(expectedOutsidePath, workspace.GetRelativePath(testPathOutside));
             Assert.Equal(testPathAnotherDrive, workspace.GetRelativePath(testPathAnotherDrive));
@@ -49,7 +49,7 @@ namespace PowerShellEditorServices.Test.Session
         {
             return new WorkspaceService(NullLoggerFactory.Instance)
             {
-                WorkspacePath = TestUtilities.NormalizePath("Fixtures/Workspace")
+                InitialWorkingDirectory = TestUtilities.NormalizePath("Fixtures/Workspace")
             };
         }
 
@@ -94,10 +94,10 @@ namespace PowerShellEditorServices.Test.Session
 
             List<string> expected = new()
             {
-                Path.Combine(workspace.WorkspacePath, "nested", "donotfind.ps1"),
-                Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"),
-                Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psm1"),
-                Path.Combine(workspace.WorkspacePath, "rootfile.ps1")
+                Path.Combine(workspace.InitialWorkingDirectory, "nested", "donotfind.ps1"),
+                Path.Combine(workspace.InitialWorkingDirectory, "nested", "nestedmodule.psd1"),
+                Path.Combine(workspace.InitialWorkingDirectory, "nested", "nestedmodule.psm1"),
+                Path.Combine(workspace.InitialWorkingDirectory, "rootfile.ps1")
             };
 
             // .NET Core doesn't appear to use the same three letter pattern matching rule although the docs
@@ -105,7 +105,7 @@ namespace PowerShellEditorServices.Test.Session
             // ref https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=netcore-2.1#System_IO_Directory_GetFiles_System_String_System_String_System_IO_EnumerationOptions_
             if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework"))
             {
-                expected.Insert(3, Path.Combine(workspace.WorkspacePath, "other", "other.ps1xml"));
+                expected.Insert(3, Path.Combine(workspace.InitialWorkingDirectory, "other", "other.ps1xml"));
             }
 
             Assert.Equal(expected, actual);
@@ -122,7 +122,7 @@ namespace PowerShellEditorServices.Test.Session
                 maxDepth: 1,
                 ignoreReparsePoints: s_defaultIgnoreReparsePoints
             );
-            Assert.Equal(new[] { Path.Combine(workspace.WorkspacePath, "rootfile.ps1") }, actual);
+            Assert.Equal(new[] { Path.Combine(workspace.InitialWorkingDirectory, "rootfile.ps1") }, actual);
         }
 
         [Fact]
@@ -138,8 +138,8 @@ namespace PowerShellEditorServices.Test.Session
             );
 
             Assert.Equal(new[] {
-                    Path.Combine(workspace.WorkspacePath, "nested", "nestedmodule.psd1"),
-                    Path.Combine(workspace.WorkspacePath, "rootfile.ps1")
+                    Path.Combine(workspace.InitialWorkingDirectory, "nested", "nestedmodule.psd1"),
+                    Path.Combine(workspace.InitialWorkingDirectory, "rootfile.ps1")
                 }, actual);
         }
 
@@ -181,7 +181,7 @@ namespace PowerShellEditorServices.Test.Session
         public void CanOpenAndCloseFile()
         {
             WorkspaceService workspace = FixturesWorkspace();
-            string filePath = Path.GetFullPath(Path.Combine(workspace.WorkspacePath, "rootfile.ps1"));
+            string filePath = Path.GetFullPath(Path.Combine(workspace.InitialWorkingDirectory, "rootfile.ps1"));
 
             ScriptFile file = workspace.GetFile(filePath);
             Assert.Equal(workspace.GetOpenedFiles(), new[] { file });


### PR DESCRIPTION
Resolves https://github.com/PowerShell/vscode-powershell/issues/2112. Should probably write a test for it, does _not_ yet include updates to the API to handle getting the correct workspace for an open editor.