### PR TITLE
Fix New-EditorFile adding content in current file

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -155,7 +155,7 @@ function New-EditorFile {
                     }
 
                     $psEditor.Workspace.OpenFile($fileName, $preview)
-                    $editorContext.CurrentFile.InsertText(($valueList | Out-String))
+                    $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
                 } else {
                     $PSCmdlet.WriteError( (
                         New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
@@ -167,7 +167,7 @@ function New-EditorFile {
             }
         } else {
             $psEditor.Workspace.NewFile()
-            $editorContext.CurrentFile.InsertText(($valueList | Out-String))
+            $psEditor.GetEditorContext().CurrentFile.InsertText(($valueList | Out-String))
         }
     }
 }

--- a/module/PowerShellEditorServices/Commands/Public/Out-CurrentFile.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Out-CurrentFile.ps1
@@ -26,7 +26,7 @@ function Out-CurrentFile {
 
         try {
             # If there is no file open
-            $psEditor.GetEditorContext()
+            $null = $psEditor.GetEditorContext()
         }
         catch {
             # create a new one


### PR DESCRIPTION
# PR Summary

Updates `New-EditorFile` to insert text in the newly created editor as intended.

Also took the liberty to silent the `EditorContext`-object currently being returned from `Out-CurrentFile` after #869. I'm 99% sure that's unintended 🙂 /cc @dfinke 

## PR Context

Fix https://github.com/PowerShell/vscode-powershell/issues/3192
