### PR TITLE
Add document symbols for `#region`

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -70,7 +70,9 @@ namespace Microsoft.PowerShell.EditorServices.Server
         /// cref="PsesServiceCollectionExtensions.AddPsesLanguageServices"/>.
         /// </remarks>
         /// <returns>A task that completes when the server is ready and listening.</returns>
+#pragma warning disable CA1506 // Coupling complexity we don't care about
         public async Task StartAsync()
+#pragma warning restore CA1506
         {
             LanguageServer = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
             {

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -123,6 +123,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         /// <summary>
         /// Format a script given its contents.
+        /// TODO: This needs to be cancellable.
         /// </summary>
         /// <param name="scriptDefinition">The full text of a script.</param>
         /// <param name="formatSettings">The formatter settings to use.</param>

--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -27,8 +28,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// The document for which CodeLenses should be provided.
         /// </param>
         /// <param name="cancellationToken"></param>
-        /// <returns>An array of CodeLenses.</returns>
-        CodeLens[] ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken);
+        /// <returns>An IEnumerable of CodeLenses.</returns>
+        IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken);
 
         /// <summary>
         /// Resolves a CodeLens that was created without a Command.

--- a/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ICodeLensProvider.cs
@@ -27,9 +27,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <param name="scriptFile">
         /// The document for which CodeLenses should be provided.
         /// </param>
-        /// <param name="cancellationToken"></param>
         /// <returns>An IEnumerable of CodeLenses.</returns>
-        IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken);
+        IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile);
 
         /// <summary>
         /// Resolves a CodeLens that was created without a Command.

--- a/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/PesterCodeLensProvider.cs
@@ -96,9 +96,8 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// Get all Pester CodeLenses for a given script file.
         /// </summary>
         /// <param name="scriptFile">The script file to get Pester CodeLenses for.</param>
-        /// <param name="cancellationToken"></param>
         /// <returns>All Pester CodeLenses for the given script file.</returns>
-        public IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken)
+        public IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile)
         {
             // Don't return anything if codelens setting is disabled
             if (!_configurationService.CurrentSettings.Pester.CodeLens)
@@ -108,11 +107,6 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
 
             foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    yield break;
-                }
-
                 if (symbol is not PesterSymbolReference pesterSymbol)
                 {
                     continue;

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -52,17 +52,11 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// Get all reference code lenses for a given script file.
         /// </summary>
         /// <param name="scriptFile">The PowerShell script file to get code lenses for.</param>
-        /// <param name="cancellationToken"></param>
         /// <returns>An IEnumerable of CodeLenses describing all functions, classes and enums in the given script file.</returns>
-        public IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken)
+        public IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile)
         {
             foreach (SymbolReference symbol in _symbolProvider.ProvideDocumentSymbols(scriptFile))
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    yield break;
-                }
-
                 // TODO: Can we support more here?
                 if (symbol.IsDeclaration &&
                     symbol.Type is

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/CommandHelpers.cs
@@ -244,6 +244,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
 
             foreach (AliasInfo aliasInfo in aliases.Cast<AliasInfo>())
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 // TODO: When we move to netstandard2.1, we can use another overload which generates
                 // static delegates and thus reduces allocations.
                 s_cmdletToAliasCache.AddOrUpdate(

--- a/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/PesterDocumentSymbolProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// <returns>true if the CommandAst represents a Pester command, false otherwise</returns>
         private static bool IsPesterCommand(CommandAst commandAst)
         {
-            if (commandAst == null)
+            if (commandAst is null)
             {
                 return false;
             }
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
             string commandName = CommandHelpers.StripModuleQualification(pesterCommandAst.GetCommandName(), out _);
             PesterCommandType? commandType = PesterSymbolReference.GetCommandType(commandName);
-            if (commandType == null)
+            if (commandType is null)
             {
                 return null;
             }
@@ -247,10 +247,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
         internal static PesterCommandType? GetCommandType(string commandName)
         {
-            if (commandName == null || !PesterKeywords.TryGetValue(commandName, out PesterCommandType pesterCommandType))
+            if (commandName is null || !PesterKeywords.TryGetValue(commandName, out PesterCommandType pesterCommandType))
             {
                 return null;
             }
+
             return pesterCommandType;
         }
 

--- a/src/PowerShellEditorServices/Services/Symbols/RegionDocumentSymbolProvider.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/RegionDocumentSymbolProvider.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+
+namespace Microsoft.PowerShell.EditorServices.Services.Symbols
+{
+    /// <summary>
+    /// Provides an IDocumentSymbolProvider implementation for
+    /// enumerating regions as symbols in script (.psd1, .psm1) files.
+    /// </summary>
+    internal class RegionDocumentSymbolProvider : IDocumentSymbolProvider
+    {
+        string IDocumentSymbolProvider.ProviderId => nameof(RegionDocumentSymbolProvider);
+
+        IEnumerable<SymbolReference> IDocumentSymbolProvider.ProvideDocumentSymbols(ScriptFile scriptFile)
+        {
+            Stack<Token> tokenCommentRegionStack = new();
+            Token[] tokens = scriptFile.ScriptTokens;
+
+            for (int i = 0; i < tokens.Length; i++)
+            {
+                Token token = tokens[i];
+
+                // Exclude everything but single-line comments
+                if (token.Kind != TokenKind.Comment ||
+                    token.Extent.StartLineNumber != token.Extent.EndLineNumber ||
+                    !TokenOperations.IsBlockComment(i, tokens))
+                {
+                    continue;
+                }
+
+                // Processing for #region -> #endregion
+                if (TokenOperations.s_startRegionTextRegex.IsMatch(token.Text))
+                {
+                    tokenCommentRegionStack.Push(token);
+                    continue;
+                }
+
+                if (TokenOperations.s_endRegionTextRegex.IsMatch(token.Text))
+                {
+                    // Mismatched regions in the script can cause bad stacks.
+                    if (tokenCommentRegionStack.Count > 0)
+                    {
+                        Token regionStart = tokenCommentRegionStack.Pop();
+                        Token regionEnd = token;
+
+                        BufferRange regionRange = new(
+                            regionStart.Extent.StartLineNumber,
+                            regionStart.Extent.StartColumnNumber,
+                            regionEnd.Extent.EndLineNumber,
+                            regionEnd.Extent.EndColumnNumber);
+
+                        yield return new SymbolReference(
+                            SymbolType.Region,
+                            regionStart.Extent.Text.Trim().TrimStart('#'),
+                            regionStart.Extent.Text.Trim(),
+                            regionStart.Extent,
+                            new ScriptExtent()
+                            {
+                                Text = string.Join(System.Environment.NewLine, scriptFile.GetLinesInRange(regionRange)),
+                                StartLineNumber = regionStart.Extent.StartLineNumber,
+                                StartColumnNumber = regionStart.Extent.StartColumnNumber,
+                                StartOffset = regionStart.Extent.StartOffset,
+                                EndLineNumber = regionEnd.Extent.EndLineNumber,
+                                EndColumnNumber = regionEnd.Extent.EndColumnNumber,
+                                EndOffset = regionEnd.Extent.EndOffset,
+                                File = regionStart.Extent.File
+                            },
+                            scriptFile,
+                            isDeclaration: true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
         #region Constructors
 
+        // TODO: This should take a cancellation token!
         internal static async Task<SymbolDetails> CreateAsync(
             SymbolReference symbolReference,
             IRunspaceInfo currentRunspace,

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolDetails.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Management.Automation;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace;
@@ -34,11 +35,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
 
         #region Constructors
 
-        // TODO: This should take a cancellation token!
         internal static async Task<SymbolDetails> CreateAsync(
             SymbolReference symbolReference,
             IRunspaceInfo currentRunspace,
-            IInternalPowerShellExecutionService executionService)
+            IInternalPowerShellExecutionService executionService,
+            CancellationToken cancellationToken)
         {
             SymbolDetails symbolDetails = new()
             {
@@ -50,14 +51,16 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 CommandInfo commandInfo = await CommandHelpers.GetCommandInfoAsync(
                     symbolReference.Id,
                     currentRunspace,
-                    executionService).ConfigureAwait(false);
+                    executionService,
+                    cancellationToken).ConfigureAwait(false);
 
                 if (commandInfo is not null)
                 {
                     symbolDetails.Documentation =
                         await CommandHelpers.GetCommandSynopsisAsync(
                             commandInfo,
-                            executionService).ConfigureAwait(false);
+                            executionService,
+                            cancellationToken).ConfigureAwait(false);
 
                     if (commandInfo.CommandType == CommandTypes.Application)
                     {

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolType.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolType.cs
@@ -79,6 +79,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
         /// The symbol is a type reference
         /// </summary>
         Type,
+
+        /// <summary>
+        /// The symbol is a region. Only used for navigation-features.
+        /// </summary>
+        Region
     }
 
     internal static class SymbolTypeUtils
@@ -97,6 +102,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Symbols
                 SymbolType.Variable or SymbolType.Parameter => SymbolKind.Variable,
                 SymbolType.HashtableKey => SymbolKind.Key,
                 SymbolType.Type => SymbolKind.TypeParameter,
+                SymbolType.Region => SymbolKind.String,
                 SymbolType.Unknown or _ => SymbolKind.Object,
             };
         }

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -77,13 +77,13 @@ namespace Microsoft.PowerShell.EditorServices.Services
             PesterCodeLensProvider pesterProvider = new(configurationService);
             _ = _codeLensProviders.TryAdd(pesterProvider.ProviderId, pesterProvider);
 
-            // TODO: Is this complication so necessary?
             _documentSymbolProviders = new ConcurrentDictionary<string, IDocumentSymbolProvider>();
             IDocumentSymbolProvider[] documentSymbolProviders = new IDocumentSymbolProvider[]
             {
                 new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
-                new PesterDocumentSymbolProvider(),
+                new PesterDocumentSymbolProvider()
+                // NOTE: This specifically does not include RegionDocumentSymbolProvider.
             };
 
             foreach (IDocumentSymbolProvider documentSymbolProvider in documentSymbolProviders)

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -187,7 +187,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 foreach (string targetIdentifier in allIdentifiers)
                 {
                     await Task.Yield();
-                    cancellationToken.ThrowIfCancellationRequested();
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
                     symbols.AddRange(file.References.TryGetReferences(symbol with { Id = targetIdentifier }));
                 }
             }

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -222,12 +222,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// Finds the details of the symbol at the given script file location.
         /// </summary>
         public Task<SymbolDetails?> FindSymbolDetailsAtLocationAsync(
-            ScriptFile scriptFile, int line, int column)
+            ScriptFile scriptFile, int line, int column, CancellationToken cancellationToken)
         {
             SymbolReference? symbol = FindSymbolAtLocation(scriptFile, line, column);
             return symbol is null
                 ? Task.FromResult<SymbolDetails?>(null)
-                : SymbolDetails.CreateAsync(symbol, _runspaceContext.CurrentRunspace, _executionService);
+                : SymbolDetails.CreateAsync(
+                    symbol,
+                    _runspaceContext.CurrentRunspace,
+                    _executionService,
+                    cancellationToken);
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CodeLensHandlers.cs
@@ -42,9 +42,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _logger.LogDebug($"Handling code lens request for {request.TextDocument.Uri}");
 
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
-            IEnumerable<CodeLens> codeLensResults = ProvideCodeLenses(scriptFile, cancellationToken);
+            IEnumerable<CodeLens> codeLensResults = ProvideCodeLenses(scriptFile);
 
-            return !codeLensResults.Any()
+            return cancellationToken.IsCancellationRequested
                 ? Task.FromResult(s_emptyCodeLensContainer)
                 : Task.FromResult(new CodeLensContainer(codeLensResults));
         }
@@ -66,19 +66,13 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// Get all the CodeLenses for a given script file.
         /// </summary>
         /// <param name="scriptFile">The PowerShell script file to get CodeLenses for.</param>
-        /// <param name="cancellationToken"></param>
         /// <returns>All generated CodeLenses for the given script file.</returns>
-        private IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile, CancellationToken cancellationToken)
+        private IEnumerable<CodeLens> ProvideCodeLenses(ScriptFile scriptFile)
         {
             foreach (ICodeLensProvider provider in _symbolsService.GetCodeLensProviders())
             {
-                foreach (CodeLens codeLens in provider.ProvideCodeLenses(scriptFile, cancellationToken))
+                foreach (CodeLens codeLens in provider.ProvideCodeLenses(scriptFile))
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        yield break;
-                    }
-
                     yield return codeLens;
                 }
             }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DefinitionHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class PsesDefinitionHandler : DefinitionHandlerBase
     {
+        private static readonly LocationOrLocationLinks s_emptyLocationOrLocationLinks = new();
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
 
@@ -45,20 +46,19 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (foundSymbol is null)
             {
-                return new LocationOrLocationLinks();
+                return s_emptyLocationOrLocationLinks;
             }
 
             // Short-circuit if we're already on the definition.
             if (foundSymbol.IsDeclaration)
             {
-                return new LocationOrLocationLinks(
-                    new LocationOrLocationLink[] {
-                        new LocationOrLocationLink(
-                            new Location
-                            {
-                                Uri = DocumentUri.From(foundSymbol.FilePath),
-                                Range = foundSymbol.NameRegion.ToRange()
-                            })});
+                return new LocationOrLocationLink[] {
+                    new LocationOrLocationLink(
+                        new Location
+                        {
+                            Uri = DocumentUri.From(foundSymbol.FilePath),
+                            Range = foundSymbol.NameRegion.ToRange()
+                        })};
             }
 
             List<LocationOrLocationLink> definitionLocations = new();
@@ -74,7 +74,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         }));
             }
 
-            return new LocationOrLocationLinks(definitionLocations);
+            return definitionLocations.Count == 0
+                ? s_emptyLocationOrLocationLinks
+                : definitionLocations;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -46,11 +45,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 request.Position.Line + 1,
                 request.Position.Character + 1);
 
-            if (!occurrences.Any())
-            {
-                return Task.FromResult(s_emptyHighlightContainer);
-            }
-
             List<DocumentHighlight> highlights = new();
             foreach (SymbolReference occurrence in occurrences)
             {
@@ -63,7 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             _logger.LogDebug("Highlights: " + highlights);
 
-            return highlights.Count == 0
+            return cancellationToken.IsCancellationRequested || highlights.Count == 0
                 ? Task.FromResult(s_emptyHighlightContainer)
                 : Task.FromResult(new DocumentHighlightContainer(highlights));
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentHighlightHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -45,7 +46,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 request.Position.Line + 1,
                 request.Position.Character + 1);
 
-            if (occurrences is null)
+            if (!occurrences.Any())
             {
                 return Task.FromResult(s_emptyHighlightContainer);
             }
@@ -62,7 +63,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             _logger.LogDebug("Highlights: " + highlights);
 
-            return Task.FromResult(new DocumentHighlightContainer(highlights));
+            return highlights.Count == 0
+                ? Task.FromResult(s_emptyHighlightContainer)
+                : Task.FromResult(new DocumentHighlightContainer(highlights));
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -1,15 +1,11 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -23,6 +19,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class PsesDocumentSymbolHandler : DocumentSymbolHandlerBase
     {
+        private static readonly SymbolInformationOrDocumentSymbolContainer s_emptySymbolInformationOrDocumentSymbolContainer = new();
         private readonly ILogger _logger;
         private readonly WorkspaceService _workspaceService;
         private readonly IDocumentSymbolProvider[] _providers;
@@ -48,23 +45,21 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         // AKA the outline feature
         public override async Task<SymbolInformationOrDocumentSymbolContainer> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
         {
+            _logger.LogDebug($"Handling document symbols for {request.TextDocument.Uri}");
+
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
-
-            IEnumerable<SymbolReference> foundSymbols = ProvideDocumentSymbols(scriptFile);
-            if (foundSymbols is null)
-            {
-                return null;
-            }
-
             string containerName = Path.GetFileNameWithoutExtension(scriptFile.FilePath);
-
             List<SymbolInformationOrDocumentSymbol> symbols = new();
-            foreach (SymbolReference r in foundSymbols)
+
+            foreach (SymbolReference r in ProvideDocumentSymbols(scriptFile))
             {
                 // This async method is pretty dense with synchronous code
                 // so it's helpful to add some yields.
                 await Task.Yield();
-                cancellationToken.ThrowIfCancellationRequested();
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
 
                 // Outline view should only include declarations.
                 //
@@ -93,58 +88,27 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     Location = new Location
                     {
                         Uri = DocumentUri.From(r.FilePath),
-                        Range = new Range(r.NameRegion.ToRange().Start, r.ScriptRegion.ToRange().End) // Jump to name start, but keep whole range to support symbol tree in outline
+                        // Jump to name start, but keep whole range to support symbol tree in outline
+                        Range = new Range(r.NameRegion.ToRange().Start, r.ScriptRegion.ToRange().End)
                     },
                     Name = r.Name
                 }));
             }
 
-            return new SymbolInformationOrDocumentSymbolContainer(symbols);
+            return symbols.Count == 0
+                ? s_emptySymbolInformationOrDocumentSymbolContainer
+                : new SymbolInformationOrDocumentSymbolContainer(symbols);
         }
 
         private IEnumerable<SymbolReference> ProvideDocumentSymbols(ScriptFile scriptFile)
         {
-            return InvokeProviders(p => p.ProvideDocumentSymbols(scriptFile))
-                    .SelectMany(r => r);
-        }
-
-        /// <summary>
-        /// Invokes the given function synchronously against all
-        /// registered providers.
-        /// </summary>
-        /// <param name="invokeFunc">The function to be invoked.</param>
-        /// <returns>
-        /// An IEnumerable containing the results of all providers
-        /// that were invoked successfully.
-        /// </returns>
-        protected IEnumerable<TResult> InvokeProviders<TResult>(
-            Func<IDocumentSymbolProvider, TResult> invokeFunc)
-        {
-            Stopwatch invokeTimer = new();
-            List<TResult> providerResults = new();
-
             foreach (IDocumentSymbolProvider provider in _providers)
             {
-                try
+                foreach (SymbolReference symbol in provider.ProvideDocumentSymbols(scriptFile))
                 {
-                    invokeTimer.Restart();
-
-                    providerResults.Add(invokeFunc(provider));
-
-                    invokeTimer.Stop();
-
-                    _logger.LogTrace(
-                        $"Invocation of provider '{provider.GetType().Name}' completed in {invokeTimer.ElapsedMilliseconds}ms.");
-                }
-                catch (Exception e)
-                {
-                    _logger.LogException(
-                        $"Exception caught while invoking provider {provider.GetType().Name}:",
-                        e);
+                    yield return symbol;
                 }
             }
-
-            return providerResults;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/DocumentSymbolHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -35,7 +35,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 new ScriptDocumentSymbolProvider(),
                 new PsdDocumentSymbolProvider(),
-                new PesterDocumentSymbolProvider()
+                new PesterDocumentSymbolProvider(),
+                new RegionDocumentSymbolProvider()
             };
         }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FoldingRangeHandler.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class PsesFoldingRangeHandler : FoldingRangeHandlerBase
     {
+        private static readonly Container<FoldingRange> s_emptyFoldingRangeContainer = new();
         private readonly ILogger _logger;
         private readonly ConfigurationService _configurationService;
         private readonly WorkspaceService _workspaceService;
@@ -37,27 +38,36 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             if (cancellationToken.IsCancellationRequested)
             {
                 _logger.LogDebug("FoldingRange request canceled for file: {Uri}", request.TextDocument.Uri);
-                return Task.FromResult(new Container<FoldingRange>());
+                return Task.FromResult(s_emptyFoldingRangeContainer);
             }
 
-            // TODO Should be using dynamic registrations
-            if (!_configurationService.CurrentSettings.CodeFolding.Enable) { return Task.FromResult(new Container<FoldingRange>()); }
+            // TODO: Should be using dynamic registrations
+            if (!_configurationService.CurrentSettings.CodeFolding.Enable)
+            {
+                return Task.FromResult(s_emptyFoldingRangeContainer);
+            }
 
             // Avoid crash when using untitled: scheme or any other scheme where the document doesn't
             // have a backing file.  https://github.com/PowerShell/vscode-powershell/issues/1676
             // Perhaps a better option would be to parse the contents of the document as a string
             // as opposed to reading a file but the scenario of "no backing file" probably doesn't
             // warrant the extra effort.
-            if (!_workspaceService.TryGetFile(request.TextDocument.Uri, out ScriptFile scriptFile)) { return Task.FromResult(new Container<FoldingRange>()); }
-
-            List<FoldingRange> result = new();
+            if (!_workspaceService.TryGetFile(request.TextDocument.Uri, out ScriptFile scriptFile))
+            {
+                return Task.FromResult(s_emptyFoldingRangeContainer);
+            }
 
             // If we're showing the last line, decrement the Endline of all regions by one.
             int endLineOffset = _configurationService.CurrentSettings.CodeFolding.ShowLastLine ? -1 : 0;
-
+            List<FoldingRange> folds = new();
             foreach (FoldingReference fold in TokenOperations.FoldableReferences(scriptFile.ScriptTokens).References)
             {
-                result.Add(new FoldingRange
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                folds.Add(new FoldingRange
                 {
                     EndCharacter = fold.EndCharacter,
                     EndLine = fold.EndLine + endLineOffset,
@@ -67,7 +77,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 });
             }
 
-            return Task.FromResult(new Container<FoldingRange>(result));
+            return folds.Count == 0
+                ? Task.FromResult(s_emptyFoldingRangeContainer)
+                : Task.FromResult(new Container<FoldingRange>(folds));
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/FormattingHandlers.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     // TODO: Add IDocumentOnTypeFormatHandler to support on-type formatting.
     internal class PsesDocumentFormattingHandler : DocumentFormattingHandlerBase
     {
+        private static readonly TextEditContainer s_emptyTextEditContainer = new();
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
         private readonly ConfigurationService _configurationService;
@@ -39,6 +40,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<TextEditContainer> Handle(DocumentFormattingParams request, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug($"Formatting request canceled for: {request.TextDocument.Uri}");
+                return s_emptyTextEditContainer;
+            }
+
             Services.TextDocument.ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
             System.Collections.Hashtable pssaSettings = _configurationService.CurrentSettings.CodeFormatting.GetPSSASettingsHashtable(
                 request.Options.TabSize,
@@ -72,14 +79,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (formattedScript is null)
             {
-                _logger.LogWarning($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
-                return null;
+                _logger.LogDebug($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
+                return s_emptyTextEditContainer;
             }
 
+            // Just in case the user really requested a cancellation.
             if (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogWarning($"Formatting request canceled for: {scriptFile.DocumentUri}");
-                return null;
+                _logger.LogDebug($"Formatting request canceled for: {scriptFile.DocumentUri}");
+                return s_emptyTextEditContainer;
             }
 
             return new TextEditContainer(new TextEdit
@@ -92,6 +100,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
     internal class PsesDocumentRangeFormattingHandler : DocumentRangeFormattingHandlerBase
     {
+        private static readonly TextEditContainer s_emptyTextEditContainer = new();
         private readonly ILogger _logger;
         private readonly AnalysisService _analysisService;
         private readonly ConfigurationService _configurationService;
@@ -116,6 +125,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<TextEditContainer> Handle(DocumentRangeFormattingParams request, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug($"Formatting request canceled for: {request.TextDocument.Uri}");
+                return s_emptyTextEditContainer;
+            }
+
             Services.TextDocument.ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
             System.Collections.Hashtable pssaSettings = _configurationService.CurrentSettings.CodeFormatting.GetPSSASettingsHashtable(
                 request.Options.TabSize,
@@ -158,14 +173,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (formattedScript is null)
             {
-                _logger.LogWarning($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
-                return null;
+                _logger.LogDebug($"Formatting returned null. Not formatting: {scriptFile.DocumentUri}");
+                return s_emptyTextEditContainer;
             }
 
+            // Just in case the user really requested a cancellation.
             if (cancellationToken.IsCancellationRequested)
             {
-                _logger.LogWarning($"Formatting request canceled for: {scriptFile.DocumentUri}");
-                return null;
+                _logger.LogDebug($"Formatting request canceled for: {scriptFile.DocumentUri}");
+                return s_emptyTextEditContainer;
             }
 
             return new TextEditContainer(new TextEdit

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -50,7 +50,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 await _symbolsService.FindSymbolDetailsAtLocationAsync(
                         scriptFile,
                         request.Position.Line + 1,
-                        request.Position.Character + 1).ConfigureAwait(false);
+                        request.Position.Character + 1,
+                        cancellationToken).ConfigureAwait(false);
 
             if (symbolDetails is null)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/ReferencesHandler.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class PsesReferencesHandler : ReferencesHandlerBase
     {
+        private static readonly LocationContainer s_emptyLocationContainer = new();
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
 
@@ -33,6 +34,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override async Task<LocationContainer> Handle(ReferenceParams request, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return s_emptyLocationContainer;
+            }
+
             ScriptFile scriptFile = _workspaceService.GetFile(request.TextDocument.Uri);
 
             SymbolReference foundSymbol =
@@ -45,6 +51,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             foreach (SymbolReference foundReference in await _symbolsService.ScanForReferencesOfSymbolAsync(
                     foundSymbol, cancellationToken).ConfigureAwait(false))
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
                 // Respect the request's setting to include declarations.
                 if (!request.Context.IncludeDeclaration && foundReference.IsDeclaration)
                 {
@@ -58,7 +69,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 });
             }
 
-            return new LocationContainer(locations);
+            return locations.Count == 0
+                ? s_emptyLocationContainer
+                : locations;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/TokenOperations.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         // script. They are based on the defaults in the VS Code Language Configuration at;
         // https://github.com/Microsoft/vscode/blob/64186b0a26/extensions/powershell/language-configuration.json#L26-L31
         // https://github.com/Microsoft/vscode/issues/49070
-        private static readonly Regex s_startRegionTextRegex = new(
+        internal static readonly Regex s_startRegionTextRegex = new(
            @"^\s*#[rR]egion\b", RegexOptions.Compiled);
-        private static readonly Regex s_endRegionTextRegex = new(
+        internal static readonly Regex s_endRegionTextRegex = new(
            @"^\s*#[eE]nd[rR]egion\b", RegexOptions.Compiled);
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// - Token text must start with a '#'.false  This is because comment regions
         ///   start with '&lt;#' but have the same TokenKind
         /// </summary>
-        private static bool IsBlockComment(int index, Token[] tokens)
+        internal static bool IsBlockComment(int index, Token[] tokens)
         {
             Token thisToken = tokens[index];
             if (thisToken.Kind != TokenKind.Comment) { return false; }

--- a/test/PowerShellEditorServices.Test.Shared/Symbols/MultipleSymbols.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Symbols/MultipleSymbols.ps1
@@ -41,3 +41,16 @@ enum AEnum {
 AFunction
 1..3 | AFilter
 AnAdvancedFunction
+
+<#
+#region don't find me inside comment block
+abc
+#endregion
+#>
+
+#region find me outer
+#region find me inner
+
+#endregion
+#endregion
+#region ignore this unclosed region

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -821,6 +821,35 @@ namespace PowerShellEditorServices.Test.Language
             Assert.Equal("prop AValue", symbol.Id);
             Assert.Equal("AValue", symbol.Name);
             Assert.True(symbol.IsDeclaration);
+
+            // There should be no region symbols unless the provider has been registered.
+            Assert.Empty(symbols.Where(i => i.Type == SymbolType.Region));
+        }
+
+        [Fact]
+        public void FindsRegionsInFile()
+        {
+            symbolsService.TryRegisterDocumentSymbolProvider(new RegionDocumentSymbolProvider());
+            IEnumerable<SymbolReference> symbols = FindSymbolsInFile(FindSymbolsInMultiSymbolFile.SourceDetails);
+            Assert.Collection(symbols.Where(i => i.Type == SymbolType.Region),
+                 (i) =>
+                 {
+                     Assert.Equal("region find me outer", i.Id);
+                     Assert.Equal("#region find me outer", i.Name);
+                     Assert.Equal(SymbolType.Region, i.Type);
+                     Assert.True(i.IsDeclaration);
+                     AssertIsRegion(i.NameRegion, 51, 1, 51, 22);
+                     AssertIsRegion(i.ScriptRegion, 51, 1, 55, 11);
+                 },
+                 (i) =>
+                 {
+                     Assert.Equal("region find me inner", i.Id);
+                     Assert.Equal("#region find me inner", i.Name);
+                     Assert.Equal(SymbolType.Region, i.Type);
+                     Assert.True(i.IsDeclaration);
+                     AssertIsRegion(i.NameRegion, 52, 1, 52, 22);
+                     AssertIsRegion(i.ScriptRegion, 52, 1, 54, 11);
+                 });
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -755,7 +755,8 @@ namespace PowerShellEditorServices.Test.Language
             SymbolDetails symbolDetails = await symbolsService.FindSymbolDetailsAtLocationAsync(
                 GetScriptFile(FindsDetailsForBuiltInCommandData.SourceDetails),
                 FindsDetailsForBuiltInCommandData.SourceDetails.StartLineNumber,
-                FindsDetailsForBuiltInCommandData.SourceDetails.StartColumnNumber).ConfigureAwait(true);
+                FindsDetailsForBuiltInCommandData.SourceDetails.StartColumnNumber,
+                CancellationToken.None).ConfigureAwait(true);
 
             Assert.Equal("Gets the processes that are running on the local computer.", symbolDetails.Documentation);
         }


### PR DESCRIPTION
And some technical debt clean-ups.

Replaces (and re-uses!) @fflaten's https://github.com/PowerShell/PowerShellEditorServices/pull/1911.

Resolves https://github.com/PowerShell/vscode-powershell/issues/3604 and https://github.com/PowerShell/vscode-powershell/issues/3210.