### PR TITLE
Update build documentation to include platyPS requirement

### DIFF
--- a/.github/workflows/emacs-test.yml
+++ b/.github/workflows/emacs-test.yml
@@ -25,9 +25,11 @@ jobs:
         run: tools/azurePipelinesBuild.ps1
 
       - name: Install Emacs
-        uses: purcell/setup-emacs@v4.0
+        uses: purcell/setup-emacs@master
         with:
-          version: '28.1'
+          version: '28.2'
 
       - name: Run ERT
-        run: emacs -batch -l ert -l test/emacs-test.el -f ert-run-tests-batch-and-exit
+        run: |
+          emacs -Q --batch -f package-refresh-contents --eval "(package-install 'eglot)"
+          emacs -Q --batch -l test/emacs-test.el -f ert-run-tests-batch-and-exit

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ App_Data
 *.sln.cache
 *.suo
 TestResults
+test/emacs-session.json
 [Tt]humbs.db
 buildd.*
 release/

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -42,7 +42,8 @@ $script:dotnetTestArgs = @("test") + $script:dotnetBuildArgs + $TestArgs + @(
 $script:IsNix = $IsLinux -or $IsMacOS
 # For Apple M1, pwsh might be getting emulated, in which case we need to check
 # for the proc_translated flag, otherwise we can check the architecture.
-$script:IsAppleM1 = $IsMacOS -and ((sysctl -n sysctl.proc_translated) -eq 1 -or (uname -m) -eq "arm64")
+$script:IsAppleM1 = $IsMacOS -and ((sysctl -n sysctl.proc_translated 2> $null) -eq 1 -or
+    [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "Arm64")
 $script:IsArm64 = -not $script:IsNix -and @("ARM64") -contains $env:PROCESSOR_ARCHITECTURE
 $script:BuildInfoPath = [System.IO.Path]::Combine($PSScriptRoot, "src", "PowerShellEditorServices.Hosting", "BuildInfo.cs")
 $script:PsesCommonProps = [xml](Get-Content -Raw "$PSScriptRoot/PowerShellEditorServices.Common.props")
@@ -272,7 +273,6 @@ Task LayoutModule -After Build {
     }
 
     # Assemble the PowerShellEditorServices.VSCode module
-
     foreach ($vscodeComponent in Get-ChildItem $script:VSCodeOutput) {
         if (-not $includedDlls.Contains($vscodeComponent.Name)) {
             Copy-Item -Path $vscodeComponent.FullName -Destination $psesVSCodeBinOutputPath -Force

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ git clone https://github.com/PowerShell/PowerShellEditorServices.git
 
 ```powershell
 Install-Module InvokeBuild -Scope CurrentUser
+Install-Module platyPS -Scope CurrentUser
 ```
 
 Now you're ready to build the code.  You can do so in one of two ways:

--- a/test/emacs-test.el
+++ b/test/emacs-test.el
@@ -8,7 +8,8 @@
 
 ;;; Code:
 
-(require 'ert)
+;; Avoid using old packages.
+(setq load-prefer-newer t)
 
 ;; Improved TLS Security.
 (with-eval-after-load 'gnutls
@@ -21,16 +22,17 @@
 (add-to-list 'package-archives
              '("melpa" . "https://melpa.org/packages/") t)
 (package-initialize)
+(package-refresh-contents)
+
+(require 'ert)
 
 (require 'flymake)
 
 (unless (package-installed-p 'powershell)
-  (package-refresh-contents)
   (package-install 'powershell))
 (require 'powershell)
 
 (unless (package-installed-p 'eglot)
-  (package-refresh-contents)
   (package-install 'eglot))
 (require 'eglot)
 


### PR DESCRIPTION
Since it's always used post-build to generate the documentation, we have a `#requires` for it but forgot to add it to the documentation.

Also suppress stderr for sysctl when checking if macOS is an Intel or Arm processor. On the former, it doesn't know what field we're querying.