### PR TITLE
Fix Dependabot pull requests limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-      interval: daily
+    interval: weekly


### PR DESCRIPTION
There seems to be a bug in the backend that thinks we're hitting the default limit of 5 even when no PRs are open.

Also switch to weekly like the client.