### PR TITLE
Fix repeated failure to load DSC module

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _debugStateService = debugStateService;
         }
 
-        public async Task<List<Breakpoint>> GetBreakpointsAsync()
+        public async Task<IReadOnlyList<Breakpoint>> GetBreakpointsAsync()
         {
             if (BreakpointApiUtils.SupportsBreakpointApis(_editorServicesHost.CurrentRunspace))
             {
@@ -52,14 +52,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Legacy behavior
             PSCommand psCommand = new PSCommand().AddCommand(@"Microsoft.PowerShell.Utility\Get-PSBreakpoint");
-            IEnumerable<Breakpoint> breakpoints = await _executionService
+            return await _executionService
                 .ExecutePSCommandAsync<Breakpoint>(psCommand, CancellationToken.None)
                 .ConfigureAwait(false);
-
-            return breakpoints.ToList();
         }
 
-        public async Task<IEnumerable<BreakpointDetails>> SetBreakpointsAsync(string escapedScriptPath, IEnumerable<BreakpointDetails> breakpoints)
+        public async Task<IReadOnlyList<BreakpointDetails>> SetBreakpointsAsync(string escapedScriptPath, IReadOnlyList<BreakpointDetails> breakpoints)
         {
             if (BreakpointApiUtils.SupportsBreakpointApis(_editorServicesHost.CurrentRunspace))
             {
@@ -147,7 +145,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             return configuredBreakpoints;
         }
 
-        public async Task<IEnumerable<CommandBreakpointDetails>> SetCommandBreakpointsAsync(IEnumerable<CommandBreakpointDetails> breakpoints)
+        public async Task<IReadOnlyList<CommandBreakpointDetails>> SetCommandBreakpointsAsync(IReadOnlyList<CommandBreakpointDetails> breakpoints)
         {
             if (BreakpointApiUtils.SupportsBreakpointApis(_editorServicesHost.CurrentRunspace))
             {
@@ -216,7 +214,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // If no PSCommand was created then there are no breakpoints to set.
             if (psCommand is not null)
             {
-                IEnumerable<Breakpoint> setBreakpoints = await _executionService
+                IReadOnlyList<Breakpoint> setBreakpoints = await _executionService
                     .ExecutePSCommandAsync<Breakpoint>(psCommand, CancellationToken.None)
                     .ConfigureAwait(false);
                 configuredBreakpoints.AddRange(setBreakpoints.Select(CommandBreakpointDetails.Create));

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -130,9 +130,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// <param name="breakpoints">BreakpointDetails for each breakpoint that will be set.</param>
         /// <param name="clearExisting">If true, causes all existing breakpoints to be cleared before setting new ones.</param>
         /// <returns>An awaitable Task that will provide details about the breakpoints that were set.</returns>
-        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
+        public async Task<IEnumerable<BreakpointDetails>> SetLineBreakpointsAsync(
             ScriptFile scriptFile,
-            BreakpointDetails[] breakpoints,
+            IEnumerable<BreakpointDetails> breakpoints,
             bool clearExisting = true)
         {
             DscBreakpointCapability dscBreakpoints = await _debugContext.GetDscBreakpointCapabilityAsync(CancellationToken.None).ConfigureAwait(false);
@@ -146,7 +146,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 if (!_remoteFileManager.IsUnderRemoteTempPath(scriptPath))
                 {
                     _logger.LogTrace($"Could not set breakpoints for local path '{scriptPath}' in a remote session.");
-                    return Array.Empty<BreakpointDetails>();
+                    return Enumerable.Empty<BreakpointDetails>();
                 }
 
                 scriptPath = _remoteFileManager.GetMappedPath(scriptPath, _psesHost.CurrentRunspace);
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             else if (temporaryScriptListingPath?.Equals(scriptPath, StringComparison.CurrentCultureIgnoreCase) == true)
             {
                 _logger.LogTrace($"Could not set breakpoint on temporary script listing path '{scriptPath}'.");
-                return Array.Empty<BreakpointDetails>();
+                return Enumerable.Empty<BreakpointDetails>();
             }
 
             // Fix for issue #123 - file paths that contain wildcard chars [ and ] need to
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
                 }
 
-                return (await _breakpointService.SetBreakpointsAsync(escapedScriptPath, breakpoints).ConfigureAwait(false)).ToArray();
+                return await _breakpointService.SetBreakpointsAsync(escapedScriptPath, breakpoints).ConfigureAwait(false);
             }
 
             return await dscBreakpoints

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             IEnumerable<BreakpointDetails> breakpoints,
             bool clearExisting = true)
         {
-            DscBreakpointCapability dscBreakpoints = await _debugContext.GetDscBreakpointCapabilityAsync(CancellationToken.None).ConfigureAwait(false);
+            DscBreakpointCapability dscBreakpoints = await _debugContext.GetDscBreakpointCapabilityAsync().ConfigureAwait(false);
 
             string scriptPath = scriptFile.FilePath;
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             if (!_workspaceService.TryGetFile(request.Source.Path, out ScriptFile scriptFile))
             {
                 string message = _debugStateService.NoDebug ? string.Empty : "Source file could not be accessed, breakpoint not set.";
-                System.Collections.Generic.IEnumerable<Breakpoint> srcBreakpoints = request.Breakpoints
+                IEnumerable<Breakpoint> srcBreakpoints = request.Breakpoints
                     .Select(srcBkpt => LspDebugUtils.CreateBreakpoint(
                         srcBkpt, request.Source.Path, message, verified: _debugStateService.NoDebug));
 
@@ -71,7 +71,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
                 string message = _debugStateService.NoDebug ? string.Empty : "Source is not a PowerShell script, breakpoint not set.";
 
-                System.Collections.Generic.IEnumerable<Breakpoint> srcBreakpoints = request.Breakpoints
+                IEnumerable<Breakpoint> srcBreakpoints = request.Breakpoints
                     .Select(srcBkpt => LspDebugUtils.CreateBreakpoint(
                         srcBkpt, request.Source.Path, message, verified: _debugStateService.NoDebug));
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -82,18 +83,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             }
 
             // At this point, the source file has been verified as a PowerShell script.
-            BreakpointDetails[] breakpointDetails = request.Breakpoints
+            IEnumerable<BreakpointDetails> breakpointDetails = request.Breakpoints
                 .Select((srcBreakpoint) => BreakpointDetails.Create(
                     scriptFile.FilePath,
                     srcBreakpoint.Line,
                     srcBreakpoint.Column,
                     srcBreakpoint.Condition,
                     srcBreakpoint.HitCondition,
-                    srcBreakpoint.LogMessage))
-                .ToArray();
+                    srcBreakpoint.LogMessage));
 
             // If this is a "run without debugging (Ctrl+F5)" session ignore requests to set breakpoints.
-            BreakpointDetails[] updatedBreakpointDetails = breakpointDetails;
+            IEnumerable<BreakpointDetails> updatedBreakpointDetails = breakpointDetails;
             if (!_debugStateService.NoDebug)
             {
                 await _debugStateService.WaitForSetBreakpointHandleAsync().ConfigureAwait(false);

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -22,24 +22,19 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
     {
         private string[] dscResourceRootPaths = Array.Empty<string>();
 
-        private readonly Dictionary<string, int[]> breakpointsPerFile =
-            new();
+        private readonly Dictionary<string, int[]> breakpointsPerFile = new();
 
-        public async Task<BreakpointDetails[]> SetLineBreakpointsAsync(
+        public async Task<IEnumerable<BreakpointDetails>> SetLineBreakpointsAsync(
             IInternalPowerShellExecutionService executionService,
             string scriptPath,
-            BreakpointDetails[] breakpoints)
+            IEnumerable<BreakpointDetails> breakpoints)
         {
-            List<BreakpointDetails> resultBreakpointDetails =
-                new();
-
             // We always get the latest array of breakpoint line numbers
             // so store that for future use
-            if (breakpoints.Length > 0)
+            if (breakpoints.Any())
             {
                 // Set the breakpoints for this scriptPath
-                breakpointsPerFile[scriptPath] =
-                    breakpoints.Select(b => b.LineNumber).ToArray();
+                breakpointsPerFile[scriptPath] = breakpoints.Select(b => b.LineNumber).ToArray();
             }
             else
             {
@@ -72,7 +67,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
                 breakpoint.Verified = true;
             }
 
-            return breakpoints.ToArray();
+            return breakpoints;
         }
 
         public bool IsDscResourcePath(string scriptPath)

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -21,17 +21,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
         private string[] dscResourceRootPaths = Array.Empty<string>();
         private readonly Dictionary<string, int[]> breakpointsPerFile = new();
 
-        public async Task<IEnumerable<BreakpointDetails>> SetLineBreakpointsAsync(
+        public async Task<IReadOnlyList<BreakpointDetails>> SetLineBreakpointsAsync(
             IInternalPowerShellExecutionService executionService,
             string scriptPath,
-            IEnumerable<BreakpointDetails> breakpoints)
+            IReadOnlyList<BreakpointDetails> breakpoints)
         {
             // We always get the latest array of breakpoint line numbers
             // so store that for future use
-            if (breakpoints.Any())
+            int[] lineNumbers = breakpoints.Select(b => b.LineNumber).ToArray();
+            if (lineNumbers.Length > 0)
             {
                 // Set the breakpoints for this scriptPath
-                breakpointsPerFile[scriptPath] = breakpoints.Select(b => b.LineNumber).ToArray();
+                breakpointsPerFile[scriptPath] = lineNumbers;
             }
             else
             {

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -1,27 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.PowerShell.EditorServices.Logging;
-using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Linq;
 using System.Management.Automation;
 using System.Threading;
-using SMA = System.Management.Automation;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
 {
     internal class DscBreakpointCapability
     {
+        private static bool? isDscInstalled;
         private string[] dscResourceRootPaths = Array.Empty<string>();
-
         private readonly Dictionary<string, int[]> breakpointsPerFile = new();
 
         public async Task<IEnumerable<BreakpointDetails>> SetLineBreakpointsAsync(
@@ -79,88 +76,57 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
                         StringComparison.CurrentCultureIgnoreCase));
         }
 
-        public static Task<DscBreakpointCapability> GetDscCapabilityAsync(
+        public static async Task<DscBreakpointCapability> GetDscCapabilityAsync(
             ILogger logger,
             IRunspaceInfo currentRunspace,
-            PsesInternalHost psesHost,
-            CancellationToken cancellationToken)
+            PsesInternalHost psesHost)
         {
             // DSC support is enabled only for Windows PowerShell.
             if ((currentRunspace.PowerShellVersionDetails.Version.Major >= 6) &&
                 (currentRunspace.RunspaceOrigin != RunspaceOrigin.DebuggedRunspace))
             {
-                return Task.FromResult<DscBreakpointCapability>(null);
+                return null;
             }
 
-            DscBreakpointCapability getDscBreakpointCapabilityFunc(SMA.PowerShell pwsh, CancellationToken _)
+            if (!isDscInstalled.HasValue)
             {
-                PSInvocationSettings invocationSettings = new()
-                {
-                    AddToHistory = false,
-                    ErrorActionPreference = ActionPreference.Stop
-                };
+                PSCommand psCommand = new PSCommand()
+                    .AddCommand("Import-Module")
+                    .AddArgument(@"C:\Program Files\DesiredStateConfiguration\1.0.0.0\Modules\PSDesiredStateConfiguration\PSDesiredStateConfiguration.psd1")
+                    .AddParameter("PassThru");
 
-                PSModuleInfo dscModule = null;
-                try
-                {
-                    dscModule = pwsh.AddCommand("Import-Module")
-                        .AddArgument(@"C:\Program Files\DesiredStateConfiguration\1.0.0.0\Modules\PSDesiredStateConfiguration\PSDesiredStateConfiguration.psd1")
-                        .AddParameter("PassThru")
-                        .InvokeAndClear<PSModuleInfo>(invocationSettings)
-                        .FirstOrDefault();
-                }
-                catch (RuntimeException e)
-                {
-                    logger.LogException("Could not load the DSC module!", e);
-                }
+                IReadOnlyList<PSModuleInfo> dscModule =
+                    await psesHost.ExecutePSCommandAsync<PSModuleInfo>(
+                        psCommand,
+                        CancellationToken.None,
+                        new PowerShellExecutionOptions { ThrowOnError = false }).ConfigureAwait(false);
 
-                if (dscModule == null)
-                {
-                    logger.LogTrace("Side-by-side DSC module was not found.");
-                    return null;
-                }
+                isDscInstalled = dscModule.Count > 0;
+                logger.LogTrace("Side-by-side DSC module found: " + isDscInstalled.Value);
+            }
 
-                logger.LogTrace("Side-by-side DSC module found, gathering DSC resource paths...");
+            if (isDscInstalled.Value)
+            {
+                PSCommand psCommand = new PSCommand()
+                    .AddCommand("Get-DscResource")
+                    .AddCommand("Select-Object")
+                    .AddParameter("ExpandProperty", "ParentPath");
 
-                // The module was loaded, add the breakpoint capability
-                DscBreakpointCapability capability = new();
-
-                pwsh.AddCommand("Microsoft.PowerShell.Utility\\Write-Host")
-                    .AddArgument("Gathering DSC resource paths, this may take a while...")
-                    .InvokeAndClear(invocationSettings);
-
-                Collection<string> resourcePaths = null;
-                try
-                {
-                    // Get the list of DSC resource paths
-                    resourcePaths = pwsh.AddCommand("Get-DscResource")
-                        .AddCommand("Select-Object")
-                        .AddParameter("ExpandProperty", "ParentPath")
-                        .InvokeAndClear<string>(invocationSettings);
-                }
-                catch (CmdletInvocationException e)
-                {
-                    logger.LogException("Get-DscResource failed!", e);
-                }
-
-                if (resourcePaths == null)
-                {
-                    logger.LogTrace("No DSC resources found.");
-                    return null;
-                }
-
-                capability.dscResourceRootPaths = resourcePaths.ToArray();
+                IReadOnlyList<string> resourcePaths =
+                    await psesHost.ExecutePSCommandAsync<string>(
+                        psCommand,
+                        CancellationToken.None,
+                        new PowerShellExecutionOptions { ThrowOnError = false }
+                    ).ConfigureAwait(false);
 
                 logger.LogTrace($"DSC resources found: {resourcePaths.Count}");
-
-                return capability;
+                return new DscBreakpointCapability
+                {
+                    dscResourceRootPaths = resourcePaths.ToArray()
+                };
             }
 
-            return psesHost.ExecuteDelegateAsync(
-                nameof(getDscBreakpointCapabilityFunc),
-                executionOptions: null,
-                getDscBreakpointCapabilityFunc,
-                cancellationToken);
+            return null;
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/IPowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/IPowerShellDebugContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Management.Automation;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
@@ -34,6 +33,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
 
         void Abort();
 
-        Task<DscBreakpointCapability> GetDscBreakpointCapabilityAsync(CancellationToken cancellationToken);
+        Task<DscBreakpointCapability> GetDscBreakpointCapabilityAsync();
     }
 }

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Management.Automation;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Context;
@@ -81,10 +80,10 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
         public event Action<object, DebuggerResumingEventArgs> DebuggerResuming;
         public event Action<object, BreakpointUpdatedEventArgs> BreakpointUpdated;
 
-        public Task<DscBreakpointCapability> GetDscBreakpointCapabilityAsync(CancellationToken cancellationToken)
+        public Task<DscBreakpointCapability> GetDscBreakpointCapabilityAsync()
         {
             _psesHost.Runspace.ThrowCancelledIfUnusable();
-            return _psesHost.CurrentRunspace.GetDscBreakpointCapabilityAsync(_logger, _psesHost, cancellationToken);
+            return _psesHost.CurrentRunspace.GetDscBreakpointCapabilityAsync(_logger, _psesHost);
         }
 
         // This is required by the PowerShell API so that remote debugging works. Without it, a

--- a/src/PowerShellEditorServices/Services/PowerShell/Runspace/RunspaceInfo.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Runspace/RunspaceInfo.cs
@@ -5,7 +5,6 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShell.Context;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
-using System.Threading;
 using System;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 
@@ -86,14 +85,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace
 
         public async Task<DscBreakpointCapability> GetDscBreakpointCapabilityAsync(
             ILogger logger,
-            PsesInternalHost psesHost,
-            CancellationToken cancellationToken)
+            PsesInternalHost psesHost)
         {
             return _dscBreakpointCapability ??= await DscBreakpointCapability.GetDscCapabilityAsync(
                     logger,
                     this,
-                    psesHost,
-                    cancellationToken)
+                    psesHost)
                     .ConfigureAwait(false);
         }
     }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -203,7 +203,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [MemberData(nameof(DebuggerAcceptsScriptArgsTestData))]
         public async Task DebuggerAcceptsScriptArgs(string[] args)
         {
-            BreakpointDetails[] breakpoints = await debugService.SetLineBreakpointsAsync(
+            IEnumerable<BreakpointDetails> breakpoints = await debugService.SetLineBreakpointsAsync(
                 oddPathScriptFile,
                 new[] { BreakpointDetails.Create(oddPathScriptFile.FilePath, 3) }).ConfigureAwait(true);
 
@@ -264,8 +264,8 @@ namespace PowerShellEditorServices.Test.Debugging
                 }).ConfigureAwait(true);
 
             Assert.Equal(2, breakpoints.Length);
-            Assert.Equal("Write-Host", breakpoints[0].Name);
-            Assert.Equal("Get-Date", breakpoints[1].Name);
+            Assert.Equal("Write-Host", breakpoints.ElementAt(0).Name);
+            Assert.Equal("Get-Date", breakpoints.ElementAt(1).Name);
 
             breakpoints = await debugService.SetCommandBreakpointsAsync(
                 new[] { CommandBreakpointDetails.Create("Get-Host") }).ConfigureAwait(true);
@@ -311,7 +311,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsAndClearsLineBreakpoints()
         {
-            BreakpointDetails[] breakpoints =
+            IEnumerable<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -322,8 +322,8 @@ namespace PowerShellEditorServices.Test.Debugging
             IReadOnlyList<LineBreakpoint> confirmedBreakpoints = await GetConfirmedBreakpoints(debugScriptFile).ConfigureAwait(true);
 
             Assert.Equal(2, confirmedBreakpoints.Count);
-            Assert.Equal(5, breakpoints[0].LineNumber);
-            Assert.Equal(10, breakpoints[1].LineNumber);
+            Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
+            Assert.Equal(10, breakpoints.ElementAt(1).LineNumber);
 
             breakpoints = await debugService.SetLineBreakpointsAsync(
                 debugScriptFile,
@@ -331,7 +331,7 @@ namespace PowerShellEditorServices.Test.Debugging
             confirmedBreakpoints = await GetConfirmedBreakpoints(debugScriptFile).ConfigureAwait(true);
 
             Assert.Single(confirmedBreakpoints);
-            Assert.Equal(2, breakpoints[0].LineNumber);
+            Assert.Equal(2, breakpoints.ElementAt(0).LineNumber);
 
             await debugService.SetLineBreakpointsAsync(
                 debugScriptFile,
@@ -442,7 +442,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerProvidesMessageForInvalidConditionalBreakpoint()
         {
-            BreakpointDetails[] breakpoints =
+            IEnumerable<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -457,20 +457,20 @@ namespace PowerShellEditorServices.Test.Debugging
                     }).ConfigureAwait(true);
 
             Assert.Single(breakpoints);
-            // Assert.Equal(5, breakpoints[0].LineNumber);
-            // Assert.True(breakpoints[0].Verified);
-            // Assert.Null(breakpoints[0].Message);
+            // Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
+            // Assert.True(breakpoints.ElementAt(0).Verified);
+            // Assert.Null(breakpoints.ElementAt(0).Message);
 
-            Assert.Equal(10, breakpoints[0].LineNumber);
-            Assert.False(breakpoints[0].Verified);
-            Assert.NotNull(breakpoints[0].Message);
-            Assert.Contains("Unexpected token '-ez'", breakpoints[0].Message);
+            Assert.Equal(10, breakpoints.ElementAt(0).LineNumber);
+            Assert.False(breakpoints.ElementAt(0).Verified);
+            Assert.NotNull(breakpoints.ElementAt(0).Message);
+            Assert.Contains("Unexpected token '-ez'", breakpoints.ElementAt(0).Message);
         }
 
         [Fact]
         public async Task DebuggerFindsParsableButInvalidSimpleBreakpointConditions()
         {
-            BreakpointDetails[] breakpoints =
+            IEnumerable<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -478,15 +478,15 @@ namespace PowerShellEditorServices.Test.Debugging
                         BreakpointDetails.Create(debugScriptFile.FilePath, 7, column: null, condition: "$i > 100")
                     }).ConfigureAwait(true);
 
-            Assert.Equal(2, breakpoints.Length);
-            Assert.Equal(5, breakpoints[0].LineNumber);
-            Assert.False(breakpoints[0].Verified);
-            Assert.Contains("Use '-eq' instead of '=='", breakpoints[0].Message);
+            Assert.Equal(2, breakpoints.Count());
+            Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
+            Assert.False(breakpoints.ElementAt(0).Verified);
+            Assert.Contains("Use '-eq' instead of '=='", breakpoints.ElementAt(0).Message);
 
-            Assert.Equal(7, breakpoints[1].LineNumber);
-            Assert.False(breakpoints[1].Verified);
-            Assert.NotNull(breakpoints[1].Message);
-            Assert.Contains("Use '-gt' instead of '>'", breakpoints[1].Message);
+            Assert.Equal(7, breakpoints.ElementAt(1).LineNumber);
+            Assert.False(breakpoints.ElementAt(1).Verified);
+            Assert.NotNull(breakpoints.ElementAt(1).Message);
+            Assert.Contains("Use '-gt' instead of '>'", breakpoints.ElementAt(1).Message);
         }
 
         [Fact]

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -203,7 +203,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [MemberData(nameof(DebuggerAcceptsScriptArgsTestData))]
         public async Task DebuggerAcceptsScriptArgs(string[] args)
         {
-            IEnumerable<BreakpointDetails> breakpoints = await debugService.SetLineBreakpointsAsync(
+            IReadOnlyList<BreakpointDetails> breakpoints = await debugService.SetLineBreakpointsAsync(
                 oddPathScriptFile,
                 new[] { BreakpointDetails.Create(oddPathScriptFile.FilePath, 3) }).ConfigureAwait(true);
 
@@ -257,15 +257,15 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsAndClearsFunctionBreakpoints()
         {
-            CommandBreakpointDetails[] breakpoints = await debugService.SetCommandBreakpointsAsync(
+            IReadOnlyList<CommandBreakpointDetails> breakpoints = await debugService.SetCommandBreakpointsAsync(
                 new[] {
                     CommandBreakpointDetails.Create("Write-Host"),
                     CommandBreakpointDetails.Create("Get-Date")
                 }).ConfigureAwait(true);
 
-            Assert.Equal(2, breakpoints.Length);
-            Assert.Equal("Write-Host", breakpoints.ElementAt(0).Name);
-            Assert.Equal("Get-Date", breakpoints.ElementAt(1).Name);
+            Assert.Equal(2, breakpoints.Count);
+            Assert.Equal("Write-Host", breakpoints[0].Name);
+            Assert.Equal("Get-Date", breakpoints[1].Name);
 
             breakpoints = await debugService.SetCommandBreakpointsAsync(
                 new[] { CommandBreakpointDetails.Create("Get-Host") }).ConfigureAwait(true);
@@ -281,7 +281,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerStopsOnFunctionBreakpoints()
         {
-            CommandBreakpointDetails[] breakpoints = await debugService.SetCommandBreakpointsAsync(
+            IReadOnlyList<CommandBreakpointDetails> breakpoints = await debugService.SetCommandBreakpointsAsync(
                 new[] { CommandBreakpointDetails.Create("Write-Host") }).ConfigureAwait(true);
 
             Task _ = ExecuteDebugFileAsync();
@@ -311,7 +311,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerSetsAndClearsLineBreakpoints()
         {
-            IEnumerable<BreakpointDetails> breakpoints =
+            IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -322,8 +322,8 @@ namespace PowerShellEditorServices.Test.Debugging
             IReadOnlyList<LineBreakpoint> confirmedBreakpoints = await GetConfirmedBreakpoints(debugScriptFile).ConfigureAwait(true);
 
             Assert.Equal(2, confirmedBreakpoints.Count);
-            Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
-            Assert.Equal(10, breakpoints.ElementAt(1).LineNumber);
+            Assert.Equal(5, breakpoints[0].LineNumber);
+            Assert.Equal(10, breakpoints[1].LineNumber);
 
             breakpoints = await debugService.SetLineBreakpointsAsync(
                 debugScriptFile,
@@ -331,7 +331,7 @@ namespace PowerShellEditorServices.Test.Debugging
             confirmedBreakpoints = await GetConfirmedBreakpoints(debugScriptFile).ConfigureAwait(true);
 
             Assert.Single(confirmedBreakpoints);
-            Assert.Equal(2, breakpoints.ElementAt(0).LineNumber);
+            Assert.Equal(2, breakpoints[0].LineNumber);
 
             await debugService.SetLineBreakpointsAsync(
                 debugScriptFile,
@@ -442,7 +442,7 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task DebuggerProvidesMessageForInvalidConditionalBreakpoint()
         {
-            IEnumerable<BreakpointDetails> breakpoints =
+            IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -457,20 +457,20 @@ namespace PowerShellEditorServices.Test.Debugging
                     }).ConfigureAwait(true);
 
             Assert.Single(breakpoints);
-            // Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
-            // Assert.True(breakpoints.ElementAt(0).Verified);
-            // Assert.Null(breakpoints.ElementAt(0).Message);
+            // Assert.Equal(5, breakpoints[0].LineNumber);
+            // Assert.True(breakpoints[0].Verified);
+            // Assert.Null(breakpoints[0].Message);
 
-            Assert.Equal(10, breakpoints.ElementAt(0).LineNumber);
-            Assert.False(breakpoints.ElementAt(0).Verified);
-            Assert.NotNull(breakpoints.ElementAt(0).Message);
-            Assert.Contains("Unexpected token '-ez'", breakpoints.ElementAt(0).Message);
+            Assert.Equal(10, breakpoints[0].LineNumber);
+            Assert.False(breakpoints[0].Verified);
+            Assert.NotNull(breakpoints[0].Message);
+            Assert.Contains("Unexpected token '-ez'", breakpoints[0].Message);
         }
 
         [Fact]
         public async Task DebuggerFindsParsableButInvalidSimpleBreakpointConditions()
         {
-            IEnumerable<BreakpointDetails> breakpoints =
+            IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
                     debugScriptFile,
                     new[] {
@@ -478,15 +478,15 @@ namespace PowerShellEditorServices.Test.Debugging
                         BreakpointDetails.Create(debugScriptFile.FilePath, 7, column: null, condition: "$i > 100")
                     }).ConfigureAwait(true);
 
-            Assert.Equal(2, breakpoints.Count());
-            Assert.Equal(5, breakpoints.ElementAt(0).LineNumber);
-            Assert.False(breakpoints.ElementAt(0).Verified);
-            Assert.Contains("Use '-eq' instead of '=='", breakpoints.ElementAt(0).Message);
+            Assert.Equal(2, breakpoints.Count);
+            Assert.Equal(5, breakpoints[0].LineNumber);
+            Assert.False(breakpoints[0].Verified);
+            Assert.Contains("Use '-eq' instead of '=='", breakpoints[0].Message);
 
-            Assert.Equal(7, breakpoints.ElementAt(1).LineNumber);
-            Assert.False(breakpoints.ElementAt(1).Verified);
-            Assert.NotNull(breakpoints.ElementAt(1).Message);
-            Assert.Contains("Use '-gt' instead of '>'", breakpoints.ElementAt(1).Message);
+            Assert.Equal(7, breakpoints[1].LineNumber);
+            Assert.False(breakpoints[1].Verified);
+            Assert.NotNull(breakpoints[1].Message);
+            Assert.Contains("Use '-gt' instead of '>'", breakpoints[1].Message);
         }
 
         [Fact]

--- a/test/emacs-test.el
+++ b/test/emacs-test.el
@@ -59,9 +59,8 @@
       (should (apply #'eglot--connect (eglot--guess-contact)))
       (should (eglot-current-server))
       (let ((lsp (eglot-current-server)))
-        (should (string= (oref lsp project-nickname) "PowerShellEditorServices"))
-        (should (member 'powershell-mode (oref lsp major-modes)))
-        (should (string= (oref lsp language-id) "powershell")))
+        (should (string= (eglot--project-nickname lsp) "PowerShellEditorServices"))
+        (should (member (cons 'powershell-mode "powershell") (eglot--languages lsp))))
       (sleep-for 5) ; TODO: Wait for "textDocument/publishDiagnostics" instead
       (flymake-start)
       (goto-char (point-min))


### PR DESCRIPTION
While debugging the `Write-Output` bug (hence the branch name) I came across another bug where the server was attempting to load the DSC module repeatedly. The `SetLineBreakpoint` logic queries for DSC breakpoint capability, which was importing the module, catching the failure to import as an error, and then trying again every single time. Instead we should import (or fail to import) only the first time we try. Also, we don't need to transform the `BreakpointDetails` list into an array and back, just leave it as `IEnumerable`.