### PR TITLE
Fix disappearing output in PowerShell 5.1

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -350,7 +350,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         private static string GetPSOutputEncoding()
         {
             using SMA.PowerShell pwsh = SMA.PowerShell.Create();
-            return pwsh.AddScript("$OutputEncoding.EncodingName", useLocalScope: true).Invoke<string>()[0];
+            return pwsh.AddScript(
+                "[System.Diagnostics.DebuggerHidden()]param() $OutputEncoding.EncodingName",
+                useLocalScope: true).Invoke<string>()[0];
         }
 
         // TODO: Deduplicate this with VersionUtils.

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // Evaluate the expression to get back a PowerShell object from the expression string.
             // This may throw, in which case the exception is propagated to the caller
-            PSCommand evaluateExpressionCommand = new PSCommand().AddScript(value);
+            PSCommand evaluateExpressionCommand = new PSCommand().AddScript($"[System.Diagnostics.DebuggerHidden()]param() {value}");
             IReadOnlyList<object> expressionResults = await _executionService.ExecutePSCommandAsync<object>(evaluateExpressionCommand, CancellationToken.None).ConfigureAwait(false);
             if (expressionResults.Count == 0)
             {
@@ -500,7 +500,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             bool writeResultAsOutput,
             CancellationToken cancellationToken)
         {
-            PSCommand command = new PSCommand().AddScript(expressionString);
+            PSCommand command = new PSCommand().AddScript($"[System.Diagnostics.DebuggerHidden()]param() {expressionString}");
             IReadOnlyList<PSObject> results;
             try
             {
@@ -799,7 +799,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             // PSObject is used here instead of the specific type because we get deserialized
             // objects from remote sessions and want a common interface.
-            PSCommand psCommand = new PSCommand().AddScript($"[Collections.ArrayList]{callStackVarName} = @(); {getPSCallStack}; {returnSerializedIfInRemoteRunspace}");
+            PSCommand psCommand = new PSCommand().AddScript($"[System.Diagnostics.DebuggerHidden()]param() [Collections.ArrayList]{callStackVarName} = @(); {getPSCallStack}; {returnSerializedIfInRemoteRunspace}");
             IReadOnlyList<PSObject> results = await _executionService.ExecutePSCommandAsync<PSObject>(psCommand, CancellationToken.None).ConfigureAwait(false);
 
             IEnumerable callStack = isRemoteRunspace

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             if (isFromRepl)
             {
                 await _executionService.ExecutePSCommandAsync(
-                    new PSCommand().AddScript(request.Expression),
+                    new PSCommand().AddScript($"[System.Diagnostics.DebuggerHidden()]param() {request.Expression}"),
                     cancellationToken,
                     new PowerShellExecutionOptions { WriteOutputToHost = true, ThrowOnError = false, AddToHistory = true }).HandleErrorsAsync(_logger).ConfigureAwait(false);
             }

--- a/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellVersionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Context/PowerShellVersionDetails.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Context
             try
             {
                 Hashtable psVersionTable = pwsh
-                    .AddScript("$PSVersionTable", useLocalScope: true)
+                    .AddScript("[System.Diagnostics.DebuggerHidden()]param() $PSVersionTable", useLocalScope: true)
                     .InvokeAndClear<Hashtable>()
                     .FirstOrDefault();
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/ExpandAliasHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/ExpandAliasHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         {
             const string script = @"
 function __Expand-Alias {
-
+    [System.Diagnostics.DebuggerHidden()]
     param($targetScript)
 
     [ref]$errors=$null

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/ShowHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/ShowHelpHandler.cs
@@ -27,7 +27,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public async Task<Unit> Handle(ShowHelpParams request, CancellationToken cancellationToken)
         {
+            // TODO: Refactor to not rerun the function definition every time.
             const string CheckHelpScript = @"
+                [System.Diagnostics.DebuggerHidden()]
                 [CmdletBinding()]
                 param (
                     [String]$CommandName

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/EditorServicesConsolePSHostUserInterface.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Host;
+using System.Reflection;
 using System.Security;
 using Microsoft.Extensions.Logging;
+using Microsoft.PowerShell.EditorServices.Utility;
 
 namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 {
@@ -16,11 +18,27 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
     {
         private readonly PSHostUserInterface _underlyingHostUI;
 
+        private static readonly Action<PSHostUserInterface, bool> s_setTranscribeOnlyDelegate;
+
         /// <summary>
         /// We use a ConcurrentDictionary because ConcurrentHashSet does not exist, hence the value
         /// is never actually used, and `WriteProgress` must be thread-safe.
         /// </summary>
         private readonly ConcurrentDictionary<(long, int), object> _currentProgressRecords = new();
+
+        static EditorServicesConsolePSHostUserInterface()
+        {
+            if (VersionUtils.IsPS5)
+            {
+                PropertyInfo transcribeOnlyProperty = typeof(PSHostUserInterface)
+                    .GetProperty("TranscribeOnly", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                MethodInfo transcribeOnlySetMethod = transcribeOnlyProperty.GetSetMethod(nonPublic: true);
+
+                s_setTranscribeOnlyDelegate = (Action<PSHostUserInterface, bool>)Delegate.CreateDelegate(
+                    typeof(Action<PSHostUserInterface, bool>), transcribeOnlySetMethod);
+            }
+        }
 
         public EditorServicesConsolePSHostUserInterface(
             ILoggerFactory loggerFactory,
@@ -70,7 +88,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             _underlyingHostUI.WriteProgress(sourceId, record);
         }
 
-        public void ResetProgress()
+        internal void ResetProgress()
         {
             // Mark all processed progress records as completed.
             foreach ((long sourceId, int activityId) in _currentProgressRecords.Keys)
@@ -85,6 +103,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
                 _currentProgressRecords.Clear();
             }
             // TODO: Maybe send the OSC sequence to turn off progress indicator.
+        }
+
+        // This works around a bug in PowerShell 5.1 (that was later fixed) where a running
+        // transcription could cause output to disappear since the `TranscribeOnly` property was
+        // accidentally not reset to false.
+        internal void DisableTranscribeOnly()
+        {
+            if (VersionUtils.IsPS5)
+            {
+                s_setTranscribeOnlyDelegate(_underlyingHostUI, false);
+            }
         }
 
         public override void WriteVerboseLine(string message) => _underlyingHostUI.WriteVerboseLine(message);

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -1261,7 +1261,12 @@ Set-MappedKeyHandlers
 
                     // If we're executing a PowerShell task, we don't need to run an extra pipeline
                     // later for events.
-                    runPipelineForEventProcessing = task is not ISynchronousPowerShellTask;
+                    if (task is ISynchronousPowerShellTask)
+                    {
+                        // We don't ever want to set this to true here, just skip if it had
+                        // previously been set true.
+                        runPipelineForEventProcessing = false;
+                    }
                     ExecuteTaskSynchronously(task, cancellationScope.CancellationToken);
                 }
             }

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -35,6 +35,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
     {
         internal const string DefaultPrompt = "> ";
 
+        private static readonly PSCommand s_promptCommand = new PSCommand().AddCommand("prompt");
+
         private static readonly PropertyInfo s_scriptDebuggerTriggerObjectProperty;
 
         private readonly ILoggerFactory _loggerFactory;
@@ -1026,10 +1028,8 @@ Set-MappedKeyHandlers
             string prompt = DefaultPrompt;
             try
             {
-                // TODO: Should we cache PSCommands like this as static members?
-                PSCommand command = new PSCommand().AddCommand("prompt");
                 IReadOnlyList<string> results = InvokePSCommand<string>(
-                    command,
+                    s_promptCommand,
                     executionOptions: new PowerShellExecutionOptions { ThrowOnError = false },
                     cancellationToken);
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Runspace/SessionDetails.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Runspace/SessionDetails.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace
         {
             Hashtable detailsObject = pwsh
                 .AddScript(
-                    $"@{{ '{Property_ComputerName}' = if ([Environment]::MachineName) {{[Environment]::MachineName}}  else {{'localhost'}}; '{Property_ProcessId}' = $PID; '{Property_InstanceId}' = $host.InstanceId }}",
+                    $"[System.Diagnostics.DebuggerHidden()]param() @{{ '{Property_ComputerName}' = if ([Environment]::MachineName) {{[Environment]::MachineName}} else {{'localhost'}}; '{Property_ProcessId}' = $PID; '{Property_InstanceId}' = $host.InstanceId }}",
                     useLocalScope: true)
                 .InvokeAndClear<Hashtable>()
                 .FirstOrDefault();


### PR DESCRIPTION
What a bug! In PowerShell 5.1 our artificial pipeline for event handling (among other possible PowerShell tasks) could cause the output to just disappear. Turns out a [bug in 5.1](https://github.com/PowerShell/PowerShell/pull/3436) with the transcript was being triggered. Scripts without `Out-Default` would get it appended with `-TranscribeOnly True` in order for the transcription to happen...but the `TranscribeOnly` field could erroneously not be set back to `false`! This would cause all output to just "disappear." It was fixed in PowerShell 7, but we still have to work around it for PowerShell 5.1 by resetting it.

Resolves https://github.com/PowerShell/vscode-powershell/issues/3991, and fixes a few other things too.

Unfortunately due to the implementation of PowerShell 5.1's transcript, we still get a flood of `[System.Diagnostics.DebuggerHidden()]param() 0` in the transcript sometimes. It's annoying, and can lead to massive transcript files, but I don't believe it's the root cause. We're still looking for a way to fix that.