### PR TITLE
Fix the `TranscribeOnly` bug (take three)

### DIFF
--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
     public sealed class EditorServicesLoader : IDisposable
     {
 #if !CoreCLR
+        // TODO: Well, we're saying we need 4.8 here but we're building for 4.6.2...
         // See https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
         private const int Net48Version = 528040;
 
@@ -342,7 +343,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _logger.Log(PsesLogLevel.Verbose, $@"
 == Environment Details ==
  - OS description:  {RuntimeInformation.OSDescription}
- - OS architecture: {GetOSArchitecture()}
+ - OS architecture: {RuntimeInformation.OSArchitecture}
  - Process bitness: {(Environment.Is64BitProcess ? "64" : "32")}
 ");
         }
@@ -353,27 +354,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             return pwsh.AddScript(
                 "[System.Diagnostics.DebuggerHidden()]param() $OutputEncoding.EncodingName",
                 useLocalScope: true).Invoke<string>()[0];
-        }
-
-        // TODO: Deduplicate this with VersionUtils.
-        private static string GetOSArchitecture()
-        {
-#if CoreCLR
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-            {
-                return RuntimeInformation.OSArchitecture.ToString();
-            }
-#endif
-
-            // If on win7 (version 6.1.x), avoid System.Runtime.InteropServices.RuntimeInformation
-            if (Environment.OSVersion.Version < new Version(6, 2))
-            {
-                return Environment.Is64BitProcess
-                    ? "X64"
-                    : "X86";
-            }
-
-            return RuntimeInformation.OSArchitecture.ToString();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Checking user-defined configuration")]

--- a/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
+++ b/src/PowerShellEditorServices.VSCode/PowerShellEditorServices.VSCode.csproj
@@ -9,10 +9,6 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
-  </PropertyGroup>
-
   <!-- Fail the release build if there are missing public API documentation comments -->
   <PropertyGroup>
     <WarningsAsErrors>1591,1573,1572</WarningsAsErrors>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -9,9 +9,12 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
-  </PropertyGroup>
+  <!--
+    Be careful about using CoreCLR as a definition, it doesn't work for most of
+    our code because the shared libraries target netstandard2.0 and so can't use
+    a property group condition to define it. It's only available to code under
+    src/PowerShellEditorServices.Hosting and the tests.
+  -->
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousPowerShellTask.cs
@@ -106,7 +106,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
             {
                 _psCommand.AddOutputCommand();
 
-                // Fix the transcription bug!
+                // Fix the transcription bug! Here we're fixing immediately before the invocation of
+                // our command, that has had `Out-Default` added to it.
                 if (!_pwsh.Runspace.RunspaceIsRemote)
                 {
                     _psesHost.DisableTranscribeOnly();
@@ -281,6 +282,14 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
                 if (_pwsh.HadErrors)
                 {
                     _pwsh.Streams.Error.Clear();
+                }
+
+                // Fix the transcription bug! Since we don't depend on `Out-Default` for
+                // `ExecuteDebugger`, we fix the bug here so the original invocation (before the
+                // script is executed) is good to go.
+                if (!_pwsh.Runspace.RunspaceIsRemote)
+                {
+                    _psesHost.DisableTranscribeOnly();
                 }
             }
 

--- a/src/PowerShellEditorServices/Utility/VersionUtils.cs
+++ b/src/PowerShellEditorServices/Utility/VersionUtils.cs
@@ -43,11 +43,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static bool IsPS5 { get; } = PSVersion.Major == 5;
 
         /// <summary>
-        /// True if we are running in PowerShell Core 6, false otherwise.
-        /// </summary>
-        public static bool IsPS6 { get; } = PSVersion.Major == 6;
-
-        /// <summary>
         /// True if we are running in PowerShell 7, false otherwise.
         /// </summary>
         public static bool IsPS7OrGreater { get; } = PSVersion.Major >= 7;
@@ -70,7 +65,7 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         /// <summary>
         /// The .NET Architecture as a string.
         /// </summary>
-        public static string Architecture { get; } = PowerShellReflectionUtils.GetOSArchitecture();
+        public static string Architecture { get; } = RuntimeInformation.OSArchitecture.ToString();
     }
 
     internal static class PowerShellReflectionUtils
@@ -117,24 +112,5 @@ namespace Microsoft.PowerShell.EditorServices.Utility
         public static string PSVersionString { get; } = s_psCurrentVersionProperty != null
             ? s_psCurrentVersionProperty.GetValue(null).ToString()
             : PSVersion.ToString(3);
-
-        public static string GetOSArchitecture()
-        {
-#if CoreCLR
-            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-            {
-                return RuntimeInformation.OSArchitecture.ToString();
-            }
-#endif
-            // If on win7 (version 6.1.x), avoid System.Runtime.InteropServices.RuntimeInformation
-            if (Environment.OSVersion.Version < new Version(6, 2))
-            {
-                return Environment.Is64BitProcess
-                    ? "X64"
-                    : "X86";
-            }
-
-            return RuntimeInformation.OSArchitecture.ToString();
-        }
     }
 }

--- a/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
+++ b/test/PowerShellEditorServices.Test.E2E/PowerShellEditorServices.Test.E2E.csproj
@@ -6,10 +6,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <DefineConstants>$(DefineConstants);CoreCLR</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />


### PR DESCRIPTION
Yet again fixing compiler constants, just go this plain wrong last time. Also caught in testing that we need to disable `TranscribeOnly` in the `finally` of `ExecuteDebugger` too, so that the original `Out-Default` (from the invocation of the debugged script) isn't broken.