### PR TITLE
Bump PSReadLine to beta for extension preview

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -6,6 +6,7 @@
         "Version": "1.1.3"
     },
     "PSReadLine": {
-        "Version": "2.2.6"
+        "Version": "2.3.1-beta1",
+        "AllowPrerelease": true
     }
 }


### PR DESCRIPTION
We are going to test [PSReadLine v2.3.1-beta1](https://github.com/PowerShell/PSReadLine/releases/tag/v2.3.1-beta1) in the extension pre-release, and if there are no reported issues, we may roll that into the extension release.