### PR TITLE
Fix shell integration for PowerShell 5.1 with strict mode

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -663,7 +663,11 @@ function Global:Prompt() {
 }
 
 # Set IsWindows property
-Write-Host -NoNewLine ""$([char]0x1b)]633;P;IsWindows=$($IsWindows)`a""
+if ($PSVersionTable.PSVersion -lt ""6.0"") {
+	[Console]::Write(""$([char]0x1b)]633;P;IsWindows=$true`a"")
+} else {
+	[Console]::Write(""$([char]0x1b)]633;P;IsWindows=$IsWindows`a"")
+}
 
 # Set always on key handlers which map to default VS Code keybindings
 function Set-MappedKeyHandler {


### PR DESCRIPTION
Since `$IsWindows` doesn't exist in Windows PowerShell, with strict mode enabled and the `ErrorActionPreference` set to `Stop`, shell integration would cause the startup to crash. This was reported and fixed upstream too.

Resolves https://github.com/PowerShell/PowerShellEditorServices/issues/2050.