### PR TITLE
Fix up extension API

### DIFF
--- a/src/PowerShellEditorServices/Extensions/EditorRequests.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorRequests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
     internal class GetEditorContextRequest
     { }
 
-    internal enum EditorCommandResponse
+    internal enum EditorOperationResponse
     {
-        Unsupported,
-        OK
+        Completed,
+        Failed
     }
 
     internal class InsertTextRequest

--- a/src/PowerShellEditorServices/Extensions/EditorWindow.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWindow.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         #endregion
 
         #region Public Methods
-        #pragma warning disable VSTHRD002 // These are public APIs that use async internal methods.
-
         /// <summary>
         /// Shows an informational message to the user.
         /// </summary>
@@ -72,7 +70,6 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="timeout">A timeout in milliseconds for how long the message should remain visible.</param>
         public void SetStatusBarMessage(string message, int timeout) => editorOperations.SetStatusBarMessageAsync(message, timeout).Wait();
 
-        #pragma warning restore VSTHRD002
         #endregion
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -18,7 +18,8 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         #region Properties
 
         /// <summary>
-        /// Gets the current workspace path if there is one for the open editor or null otherwise.
+        /// Gets the server's initial working directory, since the extension API doesn't have a
+        /// multi-root workspace concept.
         /// </summary>
         public string Path => editorOperations.GetWorkspacePath();
 
@@ -31,22 +32,23 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         #endregion
 
         #region Public Methods
-        #pragma warning disable VSTHRD002 // These are public APIs that use async internal methods.
+        // TODO: Consider returning bool instead of void to indicate success?
 
         /// <summary>
-        /// Creates a new file in the editor
+        /// Creates a new file in the editor.
         /// </summary>
-        public void NewFile() => editorOperations.NewFileAsync().Wait();
+        /// <param name="content">The content to place in the new file.</param>
+        public void NewFile(string content = "") => editorOperations.NewFileAsync(content).Wait();
 
         /// <summary>
-        /// Opens a file in the workspace.  If the file is already open
+        /// Opens a file in the workspace. If the file is already open
         /// its buffer will be made active.
         /// </summary>
         /// <param name="filePath">The path to the file to be opened.</param>
         public void OpenFile(string filePath) => editorOperations.OpenFileAsync(filePath).Wait();
 
         /// <summary>
-        /// Opens a file in the workspace.  If the file is already open
+        /// Opens a file in the workspace. If the file is already open
         /// its buffer will be made active.
         /// You can specify whether the file opens as a preview or as a durable editor.
         /// </summary>
@@ -54,7 +56,25 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="preview">Determines wether the file is opened as a preview or as a durable editor.</param>
         public void OpenFile(string filePath, bool preview) => editorOperations.OpenFileAsync(filePath, preview).Wait();
 
-        #pragma warning restore VSTHRD002
+        /// <summary>
+        /// Closes a file in the workspace.
+        /// </summary>
+        /// <param name="filePath">The path to the file to be closed.</param>
+        public void CloseFile(string filePath) => editorOperations.CloseFileAsync(filePath).Wait();
+
+        /// <summary>
+        /// Saves an open file in the workspace.
+        /// </summary>
+        /// <param name="filePath">The path to the file to be saved.</param>
+        public void SaveFile(string filePath) => editorOperations.SaveFileAsync(filePath).Wait();
+
+        /// <summary>
+        /// Saves a file with a new name AKA a copy.
+        /// </summary>
+        /// <param name="oldFilePath">The file to copy.</param>
+        /// <param name="newFilePath">The file to create.</param>
+        public void SaveFile(string oldFilePath, string newFilePath) => editorOperations.SaveFileAsync(oldFilePath, newFilePath).Wait();
+
         #endregion
     }
 }

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -42,8 +42,13 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Creates a new file in the editor.
         /// </summary>
+        public void NewFile() => editorOperations.NewFileAsync(string.Empty).Wait();
+
+        /// <summary>
+        /// Creates a new file in the editor.
+        /// </summary>
         /// <param name="content">The content to place in the new file.</param>
-        public void NewFile(string content = "") => editorOperations.NewFileAsync(content).Wait();
+        public void NewFile(string content) => editorOperations.NewFileAsync(content).Wait();
 
         /// <summary>
         /// Opens a file in the workspace. If the file is already open

--- a/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
+++ b/src/PowerShellEditorServices/Extensions/EditorWorkspace.cs
@@ -23,6 +23,11 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         public string Path => editorOperations.GetWorkspacePath();
 
+        /// <summary>
+        /// Get all the workspace folders' paths.
+        /// </summary>
+        public string[] Paths => editorOperations.GetWorkspacePaths();
+
         #endregion
 
         #region Constructors

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -58,8 +58,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Gets the workspace-relative path of the file.
         /// </summary>
-        public string WorkspacePath => editorOperations.GetWorkspaceRelativePath(
-                        scriptFile.FilePath);
+        public string WorkspacePath => editorOperations.GetWorkspaceRelativePath(scriptFile);
 
         #endregion
 

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -41,9 +41,15 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Causes a new untitled file to be created in the editor.
         /// </summary>
+        /// <returns>A task that can be awaited for completion.</returns>
+        Task NewFileAsync();
+
+        /// <summary>
+        /// Causes a new untitled file to be created in the editor.
+        /// </summary>
         /// <param name="content">The content to insert into the new file.</param>
         /// <returns>A task that can be awaited for completion.</returns>
-        Task NewFileAsync(string content = "");
+        Task NewFileAsync(string content);
 
         /// <summary>
         /// Causes a file to be opened in the editor.  If the file is

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -27,6 +27,12 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         string GetWorkspacePath();
 
         /// <summary>
+        /// Get all the workspace folders' paths.
+        /// </summary>
+        /// <returns></returns>
+        string[] GetWorkspacePaths();
+
+        /// <summary>
         /// Resolves the given file path relative to the current workspace path.
         /// </summary>
         /// <returns>The resolved file path.</returns>

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -29,9 +29,8 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Resolves the given file path relative to the current workspace path.
         /// </summary>
-        /// <param name="filePath">The file path to be resolved.</param>
         /// <returns>The resolved file path.</returns>
-        string GetWorkspaceRelativePath(string filePath);
+        string GetWorkspaceRelativePath(ScriptFile scriptFile);
 
         /// <summary>
         /// Causes a new untitled file to be created in the editor.

--- a/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
+++ b/src/PowerShellEditorServices/Extensions/IEditorOperations.cs
@@ -20,9 +20,10 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         Task<EditorContext> GetEditorContextAsync();
 
         /// <summary>
-        /// Gets the path to the editor's active workspace.
+        /// Gets the server's initial working directory, since the extension API doesn't have a
+        /// multi-root workspace concept.
         /// </summary>
-        /// <returns>The workspace path or null if there isn't one.</returns>
+        /// <returns>The server's initial working directory.</returns>
         string GetWorkspacePath();
 
         /// <summary>
@@ -35,8 +36,9 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <summary>
         /// Causes a new untitled file to be created in the editor.
         /// </summary>
+        /// <param name="content">The content to insert into the new file.</param>
         /// <returns>A task that can be awaited for completion.</returns>
-        Task NewFileAsync();
+        Task NewFileAsync(string content = "");
 
         /// <summary>
         /// Causes a file to be opened in the editor.  If the file is

--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -191,6 +192,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         // NOTE: This name is now outdated since we don't have a way to distinguish one workspace
         // from another for the extension API.
         public string GetWorkspacePath() => _workspaceService.InitialWorkingDirectory;
+
+        public string[] GetWorkspacePaths() => _workspaceService.WorkspacePaths.ToArray();
 
         public string GetWorkspaceRelativePath(ScriptFile scriptFile) => _workspaceService.GetRelativePath(scriptFile);
 

--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -121,7 +121,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                     clientContext.CurrentFileLanguage);
         }
 
-        public async Task NewFileAsync(string content = "")
+        public async Task NewFileAsync() => await NewFileAsync(string.Empty).ConfigureAwait(false);
+
+        public async Task NewFileAsync(string content)
         {
             if (!TestHasLanguageServer())
             {

--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -13,11 +13,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
 {
     internal class EditorOperationsService : IEditorOperations
     {
-        private const bool DefaultPreviewSetting = true;
-
         private readonly PsesInternalHost _psesHost;
         private readonly WorkspaceService _workspaceService;
-
         private readonly ILanguageServerFacade _languageServer;
 
         public EditorOperationsService(
@@ -72,7 +69,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                             Character = insertRange.End.Column - 1
                         }
                     }
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task SetSelectionAsync(BufferRange selectionRange)
@@ -98,7 +95,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                             Character = selectionRange.End.Column - 1
                         }
                     }
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
         public EditorContext ConvertClientEditorContext(
@@ -123,15 +120,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
                     clientContext.CurrentFileLanguage);
         }
 
-        public async Task NewFileAsync()
+        public async Task NewFileAsync(string content = "")
         {
             if (!TestHasLanguageServer())
             {
                 return;
             }
 
-            await _languageServer.SendRequest<string>("editor/newFile", null)
-                .ReturningVoid(CancellationToken.None)
+            await _languageServer.SendRequest("editor/newFile", content)
+                .Returning<EditorOperationResponse>(CancellationToken.None)
                 .ConfigureAwait(false);
         }
 
@@ -145,8 +142,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             await _languageServer.SendRequest("editor/openFile", new OpenFileDetails
             {
                 FilePath = filePath,
-                Preview = DefaultPreviewSetting
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+                Preview = true
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task OpenFileAsync(string filePath, bool preview)
@@ -160,7 +157,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             {
                 FilePath = filePath,
                 Preview = preview
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task CloseFileAsync(string filePath)
@@ -171,7 +168,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             }
 
             await _languageServer.SendRequest("editor/closeFile", filePath)
-                .ReturningVoid(CancellationToken.None)
+                .Returning<EditorOperationResponse>(CancellationToken.None)
                 .ConfigureAwait(false);
         }
 
@@ -188,11 +185,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             {
                 FilePath = currentPath,
                 NewPath = newSavePath
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
-        // TODO: This should get the current editor's context and use it to determine which
-        // workspace it's in.
+        // NOTE: This name is now outdated since we don't have a way to distinguish one workspace
+        // from another for the extension API.
         public string GetWorkspacePath() => _workspaceService.InitialWorkingDirectory;
 
         public string GetWorkspaceRelativePath(string filePath) => _workspaceService.GetRelativePath(filePath);
@@ -205,7 +202,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             }
 
             await _languageServer.SendRequest("editor/showInformationMessage", message)
-                .ReturningVoid(CancellationToken.None)
+                .Returning<EditorOperationResponse>(CancellationToken.None)
                 .ConfigureAwait(false);
         }
 
@@ -217,7 +214,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             }
 
             await _languageServer.SendRequest("editor/showErrorMessage", message)
-                .ReturningVoid(CancellationToken.None)
+                .Returning<EditorOperationResponse>(CancellationToken.None)
                 .ConfigureAwait(false);
         }
 
@@ -229,7 +226,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             }
 
             await _languageServer.SendRequest("editor/showWarningMessage", message)
-                .ReturningVoid(CancellationToken.None)
+                .Returning<EditorOperationResponse>(CancellationToken.None)
                 .ConfigureAwait(false);
         }
 
@@ -244,7 +241,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             {
                 Message = message,
                 Timeout = timeout
-            }).ReturningVoid(CancellationToken.None).ConfigureAwait(false);
+            }).Returning<EditorOperationResponse>(CancellationToken.None).ConfigureAwait(false);
         }
 
         public void ClearTerminal()
@@ -267,7 +264,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
             if (warnUser)
             {
                 _psesHost.UI.WriteWarningLine(
-                    "Editor operations are not supported in temporary consoles. Re-run the command in the main PowerShell Intergrated Console.");
+                    "Editor operations are not supported in temporary consoles. Re-run the command in the main Extension Terminal.");
             }
 
             return false;

--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         // from another for the extension API.
         public string GetWorkspacePath() => _workspaceService.InitialWorkingDirectory;
 
-        public string GetWorkspaceRelativePath(string filePath) => _workspaceService.GetRelativePath(filePath);
+        public string GetWorkspaceRelativePath(ScriptFile scriptFile) => _workspaceService.GetRelativePath(scriptFile);
 
         public async Task ShowInformationMessageAsync(string message)
         {

--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/GetCommentHelpHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/GetCommentHelpHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 // check if the previous character is `<` because it invalidates
                 // the param block the follows it.
-                IList<string> lines = ScriptFile.GetLinesInternal(funcText);
+                IList<string> lines = ScriptFile.GetLines(funcText);
                 int relativeTriggerLine0b = triggerLine - funcExtent.StartLineNumber;
                 if (relativeTriggerLine0b > 0 && lines[relativeTriggerLine0b].IndexOf("<", StringComparison.OrdinalIgnoreCase) > -1)
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return result;
             }
 
-            List<string> helpLines = ScriptFile.GetLinesInternal(helpText);
+            List<string> helpLines = ScriptFile.GetLines(helpText);
 
             if (helpLocation?.Equals("before", StringComparison.OrdinalIgnoreCase) == false)
             {

--- a/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/ScriptFile.cs
@@ -32,13 +32,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         #region Properties
 
         /// <summary>
-        /// Gets a unique string that identifies this file.  At this time,
-        /// this property returns a normalized version of the value stored
-        /// in the FilePath property.
-        /// </summary>
-        public string Id => FilePath.ToLower();
-
-        /// <summary>
         /// Gets the path at which this file resides.
         /// </summary>
         public string FilePath { get; }
@@ -173,14 +166,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         /// </summary>
         /// <param name="text">Input string to be split up into lines.</param>
         /// <returns>The lines in the string.</returns>
-        internal static IList<string> GetLines(string text) => GetLinesInternal(text);
-
-        /// <summary>
-        /// Get the lines in a string.
-        /// </summary>
-        /// <param name="text">Input string to be split up into lines.</param>
-        /// <returns>The lines in the string.</returns>
-        internal static List<string> GetLinesInternal(string text)
+        internal static List<string> GetLines(string text)
         {
             if (text == null)
             {
@@ -520,7 +506,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.TextDocument
         {
             // Split the file contents into lines and trim
             // any carriage returns from the strings.
-            FileLines = GetLinesInternal(fileContents);
+            FileLines = GetLines(fileContents);
 
             // Parse the contents to get syntax tree and errors
             ParseFileContents();

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -104,6 +104,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         #region Public Methods
 
+        public IEnumerable<string> WorkspacePaths => WorkspaceFolders.Count == 0
+                ? new List<string> { InitialWorkingDirectory }
+                : WorkspaceFolders.Select(i => i.Uri.GetFileSystemPath());
+
         /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.
         /// <para>IMPORTANT: Not all documents have a backing file e.g. untitled: scheme documents.  Consider using
@@ -358,15 +362,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
             int maxDepth,
             bool ignoreReparsePoints)
         {
-            IEnumerable<string> rootPaths = WorkspaceFolders.Count == 0
-                ? new List<string> { InitialWorkingDirectory }
-                : WorkspaceFolders.Select(i => i.Uri.GetFileSystemPath());
-
             Matcher matcher = new();
             foreach (string pattern in includeGlobs) { matcher.AddInclude(pattern); }
             foreach (string pattern in excludeGlobs) { matcher.AddExclude(pattern); }
 
-            foreach (string rootPath in rootPaths)
+            foreach (string rootPath in WorkspacePaths)
             {
                 if (!Directory.Exists(rootPath))
                 {

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -80,6 +80,14 @@ namespace PowerShellEditorServices.Test.Session
             };
         }
 
+        [Fact]
+        public void HasDefaultForWorkspacePaths()
+        {
+            WorkspaceService workspace = FixturesWorkspace();
+            string actual = Assert.Single(workspace.WorkspacePaths);
+            Assert.Equal(workspace.InitialWorkingDirectory, actual);
+        }
+
         // These are the default values for the EnumeratePSFiles() method
         // in Microsoft.PowerShell.EditorServices.Workspace class
         private static readonly string[] s_defaultExcludeGlobs = Array.Empty<string>();


### PR DESCRIPTION
Receive a `EditorOperationResponse` (not yet otherwise used). Delete dead code. Add optional `content` parameter to `NewFile`. Expose `CloseFile` and `SaveFile`. Fix an outdated warning message.

Part of https://github.com/PowerShell/vscode-powershell/pull/4703 so I could test it.