### PR TITLE
Ignore not finding DSC module

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -94,7 +94,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
                 PSCommand psCommand = new PSCommand()
                     .AddCommand("Import-Module")
                     .AddArgument(@"C:\Program Files\DesiredStateConfiguration\1.0.0.0\Modules\PSDesiredStateConfiguration\PSDesiredStateConfiguration.psd1")
-                    .AddParameter("PassThru");
+                    .AddParameter("PassThru")
+                    .AddParameter("ErrorAction", ActionPreference.Ignore);
 
                 IReadOnlyList<PSModuleInfo> dscModule =
                     await psesHost.ExecutePSCommandAsync<PSModuleInfo>(


### PR DESCRIPTION
When the user has set `ErrorActionPreference` this could cause a crash, so we have to override it. Resolves #2037.