### PR TITLE
Add `None` to `PsesLogLevel` enum

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         Normal = 2,
         Warning = 3,
         Error = 4,
+        None = 5
     }
 
     /// <summary>


### PR DESCRIPTION
So that the extension can start when logging is disabled.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4735.