### PR TITLE
Wrap import of DSC module with `ProgressPreference = SilentlyContinue`

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
     {
         #region Fields
 
-        private const string PsesGlobalVariableNamePrefix = "__psEditorServices_";
+        internal const string PsesGlobalVariableNamePrefix = "__psEditorServices_";
         private const string TemporaryScriptFileName = "Script Listing.ps1";
 
         private readonly ILogger _logger;

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
     {
         #region Private Static Fields
 
-        private const string s_psesGlobalVariableNamePrefix = "__psEditorServices_";
-
         private static readonly Lazy<Func<Debugger, string, int, int, ScriptBlock, int?, LineBreakpoint>> s_setLineBreakpointLazy;
 
         private static readonly Lazy<Func<Debugger, string, ScriptBlock, string, int?, CommandBreakpoint>> s_setCommandBreakpointLazy;
@@ -199,7 +197,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                     int incrementResult = Interlocked.Increment(ref breakpointHitCounter);
 
                     string globalHitCountVarName =
-                        $"$global:{s_psesGlobalVariableNamePrefix}BreakHitCounter_{incrementResult}";
+                        $"$global:{DebugService.PsesGlobalVariableNamePrefix}BreakHitCounter_{incrementResult}";
 
                     builder.Insert(0, $"if (++{globalHitCountVarName} -eq {parsedHitCount}) {{ ")
                         .Append(" }");

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -92,10 +92,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
             if (!isDscInstalled.HasValue)
             {
                 PSCommand psCommand = new PSCommand()
+                    .AddScript($"$global:{DebugService.PsesGlobalVariableNamePrefix}prevProgressPreference = $ProgressPreference")
+                    .AddScript("$ProgressPreference = 'SilentlyContinue'")
                     .AddCommand(@"Microsoft.PowerShell.Core\Import-Module")
-                    .AddParameter("-Name", "PSDesiredStateConfiguration")
+                    .AddParameter("Name", "PSDesiredStateConfiguration")
                     .AddParameter("PassThru")
-                    .AddParameter("ErrorAction", ActionPreference.Ignore);
+                    .AddParameter("ErrorAction", ActionPreference.Ignore)
+                    .AddScript($"$ProgressPreference = $global:{DebugService.PsesGlobalVariableNamePrefix}prevProgressPreference");
 
                 IReadOnlyList<PSModuleInfo> dscModule =
                     await psesHost.ExecutePSCommandAsync<PSModuleInfo>(

--- a/src/PowerShellEditorServices/Services/PowerShell/Utility/PowerShellExtensions.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Utility/PowerShellExtensions.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
             // Calling the cmdlet is the simplest way to do that
             IReadOnlyList<PSObject> policies = pwsh
                 .AddCommand(@"Microsoft.PowerShell.Security\Get-ExecutionPolicy")
-                    .AddParameter("-List")
+                .AddParameter("List")
                 .InvokeAndClear<PSObject>();
 
             // The policies come out in the following order:
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Utility
         public static void ImportModule(this PowerShell pwsh, string moduleNameOrPath)
         {
             pwsh.AddCommand(@"Microsoft.PowerShell.Core\Import-Module")
-                .AddParameter("-Name", moduleNameOrPath)
+                .AddParameter("Name", moduleNameOrPath)
                 .InvokeAndClear();
         }
 


### PR DESCRIPTION
And set it back afterwards. Since it has `ErrorAction = Ignore` it should always get set back correctly. This prevents the progress pane from getting stuck in certain circumstances.