### PR TITLE
Bump to new PSReadLine stable release v2.3.3

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -6,7 +6,6 @@
         "Version": "1.1.3"
     },
     "PSReadLine": {
-        "Version": "2.3.2-beta2",
-        "AllowPrerelease": true
+        "Version": "2.3.3"
     }
 }


### PR DESCRIPTION
And now we won't have to ship the beta.