### PR TITLE
Ignore `didOpen` notifications for `git` schemed documents from VS Code

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/TextDocumentHandler.cs
@@ -74,6 +74,14 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public override Task<Unit> Handle(DidOpenTextDocumentParams notification, CancellationToken token)
         {
+            // We're receiving notifications for special "git" scheme files from VS Code, and we
+            // need to ignore those! Otherwise they're added to our workspace service's opened files
+            // and cause duplicate references.
+            if (notification.TextDocument.Uri.Scheme == "git")
+            {
+                return Unit.Task;
+            }
+
             // We use a fake Uri because we only want to test the LanguageId here and not if the
             // file ends in ps*1.
             TextDocumentAttributes attributes = new(s_fakeUri, notification.TextDocument.LanguageId);


### PR DESCRIPTION
For some reason VS Code, in some repositories and configurations, will send us `DidOpenTextDocument` notifications for special documents with the `git` scheme (not `file` or `untitled`). It's probably some internal representation that VS Code is using to supply VCS information. Because we were specifically ignoring the URI in this handler these files were getting erroneously added to our workspace service's list of open files, which then caused duplicate references.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4784.