### PR TITLE
Allow `WorkspacePaths` to be empty if we're not in a workspace

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -192,7 +192,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         }
 
         // NOTE: This name is now outdated since we don't have a way to distinguish one workspace
-        // from another for the extension API.
+        // from another for the extension API. TODO: Should this be an empty string if we have no
+        // workspaces?
         public string GetWorkspacePath() => _workspaceService.InitialWorkingDirectory;
 
         public string[] GetWorkspacePaths() => _workspaceService.WorkspacePaths.ToArray();

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -104,9 +104,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         #region Public Methods
 
-        public IEnumerable<string> WorkspacePaths => WorkspaceFolders.Count == 0
-                ? new List<string> { InitialWorkingDirectory }
-                : WorkspaceFolders.Select(i => i.Uri.GetFileSystemPath());
+        public IEnumerable<string> WorkspacePaths => WorkspaceFolders.Select(i => i.Uri.GetFileSystemPath());
 
         /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.


### PR DESCRIPTION
We were previously adding the initial working directory as a fallback if there was no workspace. However, this led to new VS Code windows (not in a workspace) enumerating all files in the home directory (if that's what the client had to default to, without a workspace folder). And this could even spam permission requests on more secure systems such as macOS. So we just need to let be an empty enumerable.

This may resolve https://github.com/PowerShell/vscode-powershell/issues/4814 and https://github.com/PowerShell/vscode-powershell/issues/4821. Bug was introduced in https://github.com/PowerShell/PowerShellEditorServices/pull/1995.