### PR TITLE
When the built-in `$null` was watched its value was incorrect

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -527,11 +527,15 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return null;
             }
 
-            // If we didn't write output,
-            // return a VariableDetails instance.
+            // If we didn't write output, return a VariableDetails instance.
             return new VariableDetails(
-                    expressionString,
-                    string.Join(Environment.NewLine, results));
+                expressionString,
+                // If there's only one result, we want its raw value (especially if it's null). For
+                // a collection, since we're displaying these, we want to concatenante them.
+                // However, doing that for one result caused null to be turned into an empty string.
+                results.Count == 1
+                    ? results[0]
+                    : string.Join(Environment.NewLine, results));
         }
 
         /// <summary>

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DebugEvaluateHandler.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly IInternalPowerShellExecutionService _executionService;
         private readonly DebugService _debugService;
 
+        // AKA Watch Variables
         public DebugEvaluateHandler(
             ILoggerFactory factory,
             IPowerShellDebugContext debugContext,

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -529,7 +529,7 @@ namespace PowerShellEditorServices.Test.Debugging
             AssertDebuggerStopped(testScript.FilePath, 11);
 
             VariableDetails prompt = await debugService.EvaluateExpressionAsync("prompt", false, CancellationToken.None);
-            Assert.Equal("\"True > \"", prompt.ValueString);
+            Assert.Equal("True > ", prompt.ValueString);
         }
 
         [SkippableFact]


### PR DESCRIPTION
No idea _why_ its value was `""`, but it was, so we special case it and return `$null` just like you get from watched variables that were assigned the built-in `$null`.

Resolves https://github.com/PowerShell/vscode-powershell/issues/4816.