### PR TITLE
Added null check to `GetCompletionsAsync`

### DIFF
--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 Task SetupHelpForTests {
     # TODO: Check if it must be updated in a compatible way!
     Write-Host "Updating help for tests."
-    Update-Help -Module Microsoft.PowerShell.Management,Microsoft.PowerShell.Utility -Force -Scope CurrentUser
+    Update-Help -Module Microsoft.PowerShell.Management,Microsoft.PowerShell.Utility -Force -Scope CurrentUser -UICulture en-US
 }
 
 Task Build FindDotNet, CreateBuildInfo, {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Occasionally TabExpansion2 may return null. This could be due to a custom implementation of TabExpansion2 or an underlying issue with the FileSystemProvider or LocationGlobber. 

When this happens the value of commandCompletion is not assigned and remains null. This causes a NullReferenceException to be thrown when commandCompletion.ReplacementLength is accessed in the subsequent call to LogTrace.



## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
