### PR TITLE
Add `UseNullPSHostUI` config so apps hosting PSES can disable it

### DIFF
--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -351,6 +351,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 FeatureFlags = FeatureFlags,
                 LogLevel = LogLevel,
                 ConsoleRepl = GetReplKind(),
+                UseNullPSHostUI = Stdio, // If Stdio is used we can't write anything else out
                 AdditionalModules = AdditionalModules,
                 LanguageServiceTransport = GetLanguageServiceTransport(),
                 DebugServiceTransport = GetDebugServiceTransport(),

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -90,6 +90,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public ConsoleReplKind ConsoleRepl { get; set; } = ConsoleReplKind.None;
 
         /// <summary>
+        /// Will suppress messages to PSHost (to prevent Stdio clobbering)        
+        /// </summary>
+        public bool UseNullPSHostUI { get; set; }
+
+        /// <summary>
         /// The minimum log level to log events with.
         /// </summary>
         public PsesLogLevel LogLevel { get; set; } = PsesLogLevel.Normal;

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -289,6 +289,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 _config.LogPath,
                 (int)_config.LogLevel,
                 consoleReplEnabled: _config.ConsoleRepl != ConsoleReplKind.None,
+                useNullPSHostUI: _config.UseNullPSHostUI,
                 usesLegacyReadLine: _config.ConsoleRepl == ConsoleReplKind.LegacyReadLine,
                 bundledModulePath: _config.BundledModulePath);
         }

--- a/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
+++ b/src/PowerShellEditorServices/Hosting/HostStartupInfo.cs
@@ -77,6 +77,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public bool ConsoleReplEnabled { get; }
 
         /// <summary>
+        /// True if we want to suppress messages to PSHost (to prevent Stdio clobbering)
+        /// </summary>
+        public bool UseNullPSHostUI { get; }
+
+        /// <summary>
         /// If true, the legacy PSES readline implementation will be used. Otherwise PSReadLine will be used.
         /// If the console REPL is not enabled, this setting will be ignored.
         /// </summary>
@@ -139,6 +144,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="logPath">The path to log to.</param>
         /// <param name="logLevel">The minimum log event level.</param>
         /// <param name="consoleReplEnabled">Enable console if true.</param>
+        /// <param name="useNullPSHostUI">Whether or not to use the Null UI.</param>
         /// <param name="usesLegacyReadLine">Use PSReadLine if false, otherwise use the legacy readline implementation.</param>
         /// <param name="bundledModulePath">A custom path to the expected bundled modules.</param>
         public HostStartupInfo(
@@ -153,6 +159,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             string logPath,
             int logLevel,
             bool consoleReplEnabled,
+            bool useNullPSHostUI,
             bool usesLegacyReadLine,
             string bundledModulePath)
         {
@@ -167,6 +174,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             LogPath = logPath;
             LogLevel = logLevel;
             ConsoleReplEnabled = consoleReplEnabled;
+            UseNullPSHostUI = useNullPSHostUI;
             UsesLegacyReadLine = usesLegacyReadLine;
 
             // Respect a user provided bundled module path.

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -292,10 +292,17 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             catch (CmdletInvocationException ex)
             {
                 // We do not want to crash EditorServices for exceptions caused by cmdlet invocation.
-                // Two main reasons that cause the exception are:
+                // The main reasons that cause the exception are:
                 // * PSCmdlet.WriteOutput being called from another thread than Begin/Process
                 // * CompositionContainer.ComposeParts complaining that "...Only one batch can be composed at a time"
-                _logger.LogError(ex.Message);
+                // * PSScriptAnalyzer not being able to find its PSScriptAnalyzer.psd1 because we are hosted by an Assembly other than pwsh.exe
+                string message = ex.Message;
+                if (!string.IsNullOrEmpty(ex.ErrorRecord.FullyQualifiedErrorId))
+                {
+                    // Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Exception of type 'System.Exception' was thrown. |
+                    message += $" | {ex.ErrorRecord.FullyQualifiedErrorId}";
+                }
+                _logger.LogError(message);
             }
 
             return result;

--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -193,9 +193,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
             Version = hostInfo.Version;
 
             DebugContext = new PowerShellDebugContext(loggerFactory, this);
-            UI = hostInfo.ConsoleReplEnabled
-                ? new EditorServicesConsolePSHostUserInterface(loggerFactory, hostInfo.PSHost.UI)
-                : new NullPSHostUI();
+            UI = hostInfo.UseNullPSHostUI
+                ? new NullPSHostUI()
+                : new EditorServicesConsolePSHostUserInterface(loggerFactory, hostInfo.PSHost.UI);
         }
 
         public override CultureInfo CurrentCulture => _hostInfo.PSHost.CurrentCulture;

--- a/test/PowerShellEditorServices.Test/PsesHostFactory.cs
+++ b/test/PowerShellEditorServices.Test/PsesHostFactory.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerShell.EditorServices.Test
                 logLevel: (int)LogLevel.None,
                 consoleReplEnabled: false,
                 usesLegacyReadLine: false,
+                useNullPSHostUI: true,
                 bundledModulePath: BundledModulePath);
 
             PsesInternalHost psesHost = new(loggerFactory, null, testHostDetails);

--- a/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
@@ -36,6 +36,7 @@ namespace PowerShellEditorServices.Test.Services.Symbols
                 logPath: null,
                 logLevel: 0,
                 consoleReplEnabled: false,
+                useNullPSHostUI: true,
                 usesLegacyReadLine: false,
                 bundledModulePath: PsesHostFactory.BundledModulePath));
 


### PR DESCRIPTION
# PR Summary

Meaningful output from PSES's internal PowerShell is suppressed if you don't specify -EnableConsoleRepl.

## PR Context

I'd like to be able to see the output from PSScriptAnalyzer but my application has a read-only terminal. 
This SwitchParameter prevents the UI from being set to NullPSHostUI without enabling Repl functionality.

Perhaps a better way to implement this would be to condition off the use of named pipes as I believe the intention of the following code is to prevent clobbering stdio since ConsoleRepl can only be used when connecting via named pipes.

```csharp
     UI = hostInfo.ConsoleReplEnabled || hostInfo.UseCurrentPSHostUI
                ? new EditorServicesConsolePSHostUserInterface(loggerFactory, hostInfo.PSHost.UI)
                : new NullPSHostUI();
```


