### PR TITLE
Test end-to-end with PowerShell Daily

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore: [ '**/*.md' ]
   merge_group:
     types: [ checks_requested ]
+  schedule:
+    # 6am UTC which should be after a new daily build posts
+    - cron: "0 6 * * *"
 
 jobs:
   ci:
@@ -37,11 +40,24 @@ jobs:
 
       - name: Install PSResources
         shell: pwsh
-        run: tools/installPSResources.ps1
+        run: ./tools/installPSResources.ps1
+
+      - name: Download daily install script
+        uses: actions/checkout@v4
+        with:
+          repository: PowerShell/PowerShell
+          path: pwsh
+          sparse-checkout: tools/install-powershell.ps1
+          sparse-checkout-cone-mode: false
 
       - name: Build and test
         shell: pwsh
         run: Invoke-Build ${{ github.event_name == 'merge_group' && 'TestFull' || 'Test' }}
+
+      - name: Test with daily
+        if: ${{ github.event_name == 'schedule' }}
+        shell: pwsh
+        run: ./pwsh/tools/install-powershell.ps1 -Daily && Invoke-Build TestE2EDaily
 
       - name: Upload build artifacts
         if: always()

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -221,6 +221,19 @@ Task TestE2EPwsh Build, SetupHelpForTests, {
     Invoke-BuildExec { & dotnet $script:dotnetTestArgs $script:NetFramework.PS74 }
 }
 
+$PwshDaily = if ($script:IsNix) {
+    "$HOME/.powershell-daily/pwsh"
+} else {
+    "$env:LOCALAPPDATA\Microsoft\powershell-daily\pwsh.exe"
+}
+
+Task TestE2EDaily -If (Test-Path $PwshDaily) Build, SetupHelpForTests, {
+    Set-Location .\test\PowerShellEditorServices.Test.E2E\
+    $env:PWSH_EXE_NAME = $PwshDaily
+    Write-Host "Running end-to-end tests with: $(& $PwshDaily --version)"
+    Invoke-BuildExec { & dotnet $script:dotnetTestArgs $script:NetFramework.PS74 }
+}
+
 Task TestE2EPowerShell -If (-not $script:IsNix) Build, SetupHelpForTests, {
     Set-Location .\test\PowerShellEditorServices.Test.E2E\
     $env:PWSH_EXE_NAME = "powershell"

--- a/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
+++ b/test/PowerShellEditorServices.Test.E2E/Processes/PsesStdioProcess.cs
@@ -42,7 +42,7 @@ namespace PowerShellEditorServices.Test.E2E
 
         // NOTE: Just hard-code this to "powershell" when testing with the code lens.
         public static string PwshExe { get; } = Environment.GetEnvironmentVariable("PWSH_EXE_NAME") ?? "pwsh";
-        public static bool IsWindowsPowerShell { get; } = PwshExe.Contains("powershell");
+        public static bool IsWindowsPowerShell { get; } = PwshExe.EndsWith("powershell");
         public static bool RunningInConstrainedLanguageMode { get; } =
             Environment.GetEnvironmentVariable("__PSLockdownPolicy", EnvironmentVariableTarget.Machine) != null;
 


### PR DESCRIPTION
This downloads the PowerShell Daily build on CI and executes the end-to-end tests with it. It's set to run on a schedule and fail to alert us to issues (but won't block PRs because it won't run on them at all).