### PR TITLE
WIP: Evaluate variables on hover

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Handlers/EvaluateHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,9 +23,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public async Task<EvaluateResponseBody> Handle(EvaluateRequestArguments request, CancellationToken cancellationToken)
         {
             // This API is mostly used for F8 execution so it requires the foreground.
-            await _executionService.ExecutePSCommandAsync(
+            IReadOnlyList<PSObject> results = await _executionService.ExecutePSCommandAsync<PSObject>(
                 new PSCommand().AddScript(request.Expression),
-                CancellationToken.None,
+                cancellationToken,
                 new PowerShellExecutionOptions
                 {
                     RequiresForeground = true,
@@ -34,10 +35,9 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     ThrowOnError = false,
                 }).ConfigureAwait(false);
 
-            // TODO: Should we return a more informative result?
             return new EvaluateResponseBody
             {
-                Result = "",
+                Result = string.Join(System.Environment.NewLine, results),
                 VariablesReference = 0
             };
         }

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/HoverHandler.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Management.Automation;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell;
+using Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution;
 using Microsoft.PowerShell.EditorServices.Services.Symbols;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
@@ -18,15 +22,18 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
     internal class PsesHoverHandler : HoverHandlerBase
     {
         private readonly ILogger _logger;
+        private readonly IInternalPowerShellExecutionService _executionService;
         private readonly SymbolsService _symbolsService;
         private readonly WorkspaceService _workspaceService;
 
         public PsesHoverHandler(
             ILoggerFactory factory,
+            IInternalPowerShellExecutionService executionService,
             SymbolsService symbolsService,
             WorkspaceService workspaceService)
         {
             _logger = factory.CreateLogger<PsesHoverHandler>();
+            _executionService = executionService;
             _symbolsService = symbolsService;
             _workspaceService = workspaceService;
         }
@@ -62,6 +69,21 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             {
                 new MarkedString("PowerShell", symbolDetails.SymbolReference.Name)
             };
+
+            // If we're looking at a variable, try to get its value.
+            if (symbolDetails.SymbolReference.Type == SymbolType.Variable)
+            {
+                PSCommand command = new PSCommand().AddScript($"[System.Diagnostics.DebuggerHidden()]param() {symbolDetails.SymbolReference.Name}");
+                IReadOnlyList<PSObject> results = await _executionService.ExecutePSCommandAsync<PSObject>(
+                    command,
+                    cancellationToken,
+                    new PowerShellExecutionOptions { ThrowOnError = false }).ConfigureAwait(false);
+
+                if (results != null)
+                {
+                    symbolInfo.Add(new MarkedString("PowerShell", string.Join(Environment.NewLine, results)));
+                }
+            }
 
             if (!string.IsNullOrEmpty(symbolDetails.Documentation))
             {


### PR DESCRIPTION
If their value is available (either because its been set in the session manually, or the script has been executed or is being debugged) we can return it on the hover.

We should ask if we actually want to do this, and if so, how we want to format it.

@JustinGrote try this out!

Fixes https://github.com/PowerShell/vscode-powershell/issues/4878.