### PR TITLE
Add sane defaults to `Start-EditorServices`

### DIFF
--- a/.github/workflows/emacs-test.yml
+++ b/.github/workflows/emacs-test.yml
@@ -41,7 +41,12 @@ jobs:
         with:
           version: '28.2'
 
-      - name: Run ERT
+      - name: Run ERT with full CLI
         run: |
           emacs -Q --batch -f package-refresh-contents --eval "(package-install 'eglot)"
           emacs -Q --batch -l test/emacs-test.el -f ert-run-tests-batch-and-exit
+
+      - name: Run ERT with simple CLI
+        run: |
+          emacs -Q --batch -f package-refresh-contents --eval "(package-install 'eglot)"
+          emacs -Q --batch -l test/emacs-simple-test.el -f ert-run-tests-batch-and-exit

--- a/.github/workflows/vim-test.yml
+++ b/.github/workflows/vim-test.yml
@@ -61,7 +61,12 @@ jobs:
           repository: thinca/vim-themis
           path: vim-themis
 
-      - name: Run Themis
+      - name: Run Themis with full CLI
         env:
           THEMIS_VIM: ${{ steps.vim.outputs.executable }}
         run: ./vim-themis/bin/themis ./test/vim-test.vim
+
+      - name: Run Themis with simple CLI
+        env:
+          THEMIS_VIM: ${{ steps.vim.outputs.executable }}
+        run: ./vim-themis/bin/themis ./test/vim-simple-test.vim

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -27,17 +27,14 @@
 #>
 [CmdletBinding(DefaultParameterSetName="NamedPipe")]
 param(
-    [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
     $HostName,
 
-    [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
     $HostProfileId,
 
-    [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
     $HostVersion,
@@ -52,7 +49,6 @@ param(
     [ValidateSet("Diagnostic", "Verbose", "Normal", "Warning", "Error")]
     $LogLevel,
 
-	[Parameter(Mandatory=$true)]
 	[ValidateNotNullOrEmpty()]
 	[string]
 	$SessionDetailsPath,
@@ -78,20 +74,17 @@ param(
     [switch]
     $WaitForDebugger,
 
-    [switch]
-    $ConfirmInstall,
-
-    [Parameter(ParameterSetName="Stdio", Mandatory=$true)]
+    [Parameter(ParameterSetName="Stdio", Mandatory)]
     [switch]
     $Stdio,
 
     [Parameter(ParameterSetName="NamedPipe")]
     [string]
-    $LanguageServicePipeName = $null,
+    $LanguageServicePipeName,
 
     [Parameter(ParameterSetName="NamedPipe")]
     [string]
-    $DebugServicePipeName = $null,
+    $DebugServicePipeName,
 
     [Parameter(ParameterSetName="NamedPipeSimplex")]
     [switch]
@@ -107,11 +100,11 @@ param(
 
     [Parameter(ParameterSetName="NamedPipeSimplex")]
     [string]
-    $DebugServiceInPipeName = $null,
+    $DebugServiceInPipeName,
 
     [Parameter(ParameterSetName="NamedPipeSimplex")]
     [string]
-    $DebugServiceOutPipeName = $null
+    $DebugServiceOutPipeName
 )
 
 Import-Module -Name "$PSScriptRoot/PowerShellEditorServices.psd1"

--- a/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
+++ b/src/PowerShellEditorServices/Hosting/EditorServicesServerFactory.cs
@@ -43,11 +43,15 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// constructor? In the end it returns an instance (albeit a "singleton").
         /// </para>
         /// </remarks>
-        /// <param name="logPath">The path of the log file to use.</param>
+        /// <param name="logDirectoryPath">The path of the log file to use.</param>
         /// <param name="minimumLogLevel">The minimum log level to use.</param>
         /// <param name="hostLogger">The host logger?</param>
-        public static EditorServicesServerFactory Create(string logPath, int minimumLogLevel, IObservable<(int logLevel, string message)> hostLogger)
+        public static EditorServicesServerFactory Create(string logDirectoryPath, int minimumLogLevel, IObservable<(int logLevel, string message)> hostLogger)
         {
+            // NOTE: Ignore the suggestion to use Environment.ProcessId as it doesn't work for
+            // .NET 4.6.2 (for Windows PowerShell), and this won't be caught in CI.
+            int currentPID = Process.GetCurrentProcess().Id;
+            string logPath = Path.Combine(logDirectoryPath, $"PowerShellEditorServices-{currentPID}.log");
             Log.Logger = new LoggerConfiguration()
                 .Enrich.FromLogContext()
                 .WriteTo.Async(config => config.File(logPath))

--- a/test/emacs-simple-test.el
+++ b/test/emacs-simple-test.el
@@ -1,0 +1,63 @@
+;;; emacs-test.el --- Integration testing script          -*- lexical-binding: t; -*-
+
+;; Copyright (c) Microsoft Corporation.
+;; Licensed under the MIT License.
+
+;; Author: Andy Jordan <andy.jordan@microsoft.com>
+;; Keywords: PowerShell, LSP
+
+;;; Code:
+
+;; Avoid using old packages.
+(setq load-prefer-newer t)
+
+;; Improved TLS Security.
+(with-eval-after-load 'gnutls
+  (custom-set-variables
+   '(gnutls-verify-error t)
+   '(gnutls-min-prime-bits 3072)))
+
+;; Package setup.
+(require 'package)
+(add-to-list 'package-archives
+             '("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+(package-refresh-contents)
+
+(require 'ert)
+
+(require 'flymake)
+
+(unless (package-installed-p 'powershell)
+  (package-install 'powershell))
+(require 'powershell)
+
+(unless (package-installed-p 'eglot)
+  (package-install 'eglot))
+(require 'eglot)
+
+(ert-deftest powershell-editor-services ()
+  "Eglot should connect to PowerShell Editor Services."
+  (let* ((repo (project-root (project-current)))
+         (start-script (expand-file-name "module/PowerShellEditorServices/Start-EditorServices.ps1" repo))
+         (test-script (expand-file-name "test/PowerShellEditorServices.Test.Shared/Debugging/VariableTest.ps1" repo))
+         (eglot-sync-connect t))
+    (add-to-list
+     'eglot-server-programs
+     `(powershell-mode
+       . ("pwsh" "-NoLogo" "-NoProfile" "-Command" ,start-script "-Stdio")))
+    (with-current-buffer (find-file-noselect test-script)
+      (should (eq major-mode 'powershell-mode))
+      (should (apply #'eglot--connect (eglot--guess-contact)))
+      (should (eglot-current-server))
+      (let ((lsp (eglot-current-server)))
+        (should (string= (eglot--project-nickname lsp) "PowerShellEditorServices"))
+        (should (member (cons 'powershell-mode "powershell") (eglot--languages lsp))))
+      (sleep-for 5) ; TODO: Wait for "textDocument/publishDiagnostics" instead
+      (flymake-start)
+      (goto-char (point-min))
+      (flymake-goto-next-error)
+      (should (eq 'flymake-warning (face-at-point))))))
+
+(provide 'emacs-test)
+;;; emacs-test.el ends here

--- a/test/vim-simple-test.vim
+++ b/test/vim-simple-test.vim
@@ -5,11 +5,7 @@ function s:suite.before()
   let l:pses_path = g:repo_root . '/module'
   let g:LanguageClient_serverCommands = {
     \ 'ps1': [ 'pwsh', '-NoLogo', '-NoProfile', '-Command',
-    \   l:pses_path . '/PowerShellEditorServices/Start-EditorServices.ps1',
-    \   '-HostName', 'vim', '-HostProfileId', 'vim', '-HostVersion', '1.0.0',
-    \   '-BundledModulesPath', l:pses_path, '-Stdio',
-    \   '-LogPath', g:repo_root . '/pses.log', '-LogLevel', 'Diagnostic',
-    \   '-SessionDetailsPath', g:repo_root . '/pses_session.json' ]
+    \   l:pses_path . '/PowerShellEditorServices/Start-EditorServices.ps1', '-Stdio' ]
     \ }
   let g:LanguageClient_serverStderr = 'DEBUG'
   let g:LanguageClient_loggingFile = g:repo_root . '/LanguageClient.log'


### PR DESCRIPTION
We do not need to require so many CLI flags.

This continues to run the existing Emacs and Vim tests utilizing those flags as a regression scenario, and adds an additional pair of tests that launch PSES with a minimal set of flags.

Resolves #1855.

Slight breaking change for CLI users of the `-LogPath` parameter. It now takes a directory name instead of a log name, which makes a lot more sense because multiple log files get written to that location.