### PR TITLE
Fix PowerShell 7.2 E2E unit test for last change

### DIFF
--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1091,8 +1091,9 @@ enum MyEnum {
                 });
 
             Assert.Empty(completionItems);
-            LogMessageParams message = Assert.Single(Messages);
-            Assert.Contains("Exception occurred while running handling completion request", message.Message);
+            Assert.Collection(Messages,
+                (message) => Assert.Contains("Error Occurred in TabExpansion2", message.Message),
+                (message) => Assert.Contains("Exception occurred while running handling completion request", message.Message));
         }
 
         [SkippableFact(Skip = "Completion for Expand-SlowArchive is flaky.")]


### PR DESCRIPTION
PR #2115 added a new error message when no completion is returned (such as when it was interrupted) and our test covering a specific bug with PowerShell 7.2 was not updated. Investigating how CI missed this.