### PR TITLE
Disable Azure Pipelines CI for release branch

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -52,12 +52,12 @@ jobs:
 
       - name: Build and test
         shell: pwsh
-        run: Invoke-Build ${{ github.event_name == 'merge_group' && 'TestFull' || 'Test' }}
+        run: Invoke-Build -Configuration Release ${{ github.event_name == 'merge_group' && 'TestFull' || 'Test' }}
 
       - name: Test with daily
         if: ${{ github.event_name == 'schedule' }}
         shell: pwsh
-        run: ./pwsh/tools/install-powershell.ps1 -Daily && Invoke-Build TestE2EDaily
+        run: ./pwsh/tools/install-powershell.ps1 -Daily && Invoke-Build -Configuration Release TestE2EDaily
 
       - name: Upload build artifacts
         if: always()

--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -1,11 +1,8 @@
 name: CI-$(Build.SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rr)
 
+# NOTE: This was superceded by the GitHub Actions workflow.
 pr: none
-
-trigger:
-  branches:
-    include:
-      - release
+trigger: none
 
 variables:
   # Don't download unneeded packages


### PR DESCRIPTION
It is completely superfluous because the release pipeline runs the exact same CI template, and it's still really flaky.

Also run the GitHub Actions CI with the Release configuration.