### PR TITLE
Update semantic tokens

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/PsesSemanticTokensHandler.cs
@@ -108,6 +108,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 return SemanticTokenType.Operator;
             }
 
+            if ((token.TokenFlags & TokenFlags.AttributeName) != 0)
+            {
+                return SemanticTokenType.Decorator;
+            }
+
             if ((token.TokenFlags & TokenFlags.TypeName) != 0)
             {
                 return SemanticTokenType.Type;
@@ -142,8 +147,8 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 case TokenKind.Number:
                     return SemanticTokenType.Number;
 
-                case TokenKind.Generic:
-                    return SemanticTokenType.Function;
+                case TokenKind.Label:
+                    return SemanticTokenType.Label;
             }
 
             return null;

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -20,7 +20,8 @@ namespace PowerShellEditorServices.Test.Language
         {
             const string text = @"
 function Get-Sum {
-    param( [int]$a, [int]$b )
+    param( [parameter()] [int]$a, [int]$b )
+    :loopLabel while (0) {break loopLabel}
     return $a + $b
 }
 ";
@@ -38,10 +39,21 @@ function Get-Sum {
                     case "function":
                     case "param":
                     case "return":
+                    case "while":
+                    case "break":
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Keyword == sToken.Type);
                         break;
-                    case "Get-Sum":
-                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Function == sToken.Type);
+                    case "parameter":
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Decorator == sToken.Type);
+                        break;
+                    case "0":
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Number == sToken.Type);
+                        break;
+                    case ":loopLabel":
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Label == sToken.Type);
+                        break;
+                    case "loopLabel":
+                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Property == sToken.Type);
                         break;
                     case "$a":
                     case "$b":
@@ -74,7 +86,6 @@ function Get-Sum {
             Token stringExpandableToken = scriptFile.ScriptTokens[1];
             mappedTokens = new List<SemanticToken>(PsesSemanticTokensHandler.ConvertToSemanticTokens(stringExpandableToken));
             Assert.Collection(mappedTokens,
-                sToken => Assert.Equal(SemanticTokenType.Function, sToken.Type),
                 sToken => Assert.Equal(SemanticTokenType.Function, sToken.Type),
                 sToken => Assert.Equal(SemanticTokenType.Function, sToken.Type)
             );

--- a/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
+++ b/test/PowerShellEditorServices.Test/Language/SemanticTokenTest.cs
@@ -114,7 +114,11 @@ Get-A*A
                         Assert.Single(mappedTokens, sToken => SemanticTokenType.Keyword == sToken.Type);
                         break;
                     case "Get-A*A":
-                        Assert.Single(mappedTokens, sToken => SemanticTokenType.Function == sToken.Type);
+                        if (t.TokenFlags.HasFlag(TokenFlags.CommandName))
+                        {
+                            Assert.Single(mappedTokens, sToken => SemanticTokenType.Function == sToken.Type);
+                        }
+
                         break;
                 }
             }


### PR DESCRIPTION
# PR Summary
Updates the semantic token mapping so attributes now get the "Decorator" token type and loop labels get the "Label" type. They seem to best match the mappings listed here: https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
  
I also removed the Generic -> Function mapping as I feel it does more harm than good to provide an inaccurate mapping. Unfortunately there's no fitting token for them, but feel free to give a thumbs up here: https://github.com/microsoft/vscode/issues/97063#issuecomment-2240581375 so it may get added in the future.

I didn't change this, but I see there's this mapping:
```
case TokenKind.Parameter:
case TokenKind.Generic when token is StringLiteralToken slt && slt.Text.StartsWith("--"):
    return SemanticTokenType.Parameter;
```

This seems wrong. The point of the syntax highlighting is to show what the parser sees, and if `SomeApp --Parameter` is not seen as a parameter by the parser then it shouldn't be highlighted as such. Can this be changed?

Also is the token kind check really necessary here?
```
if (token.Kind != TokenKind.Generic && (token.TokenFlags &
    (TokenFlags.BinaryOperator | TokenFlags.UnaryOperator | TokenFlags.AssignmentOperator)) != 0)
```
All the various operators have their own token kind and I can't think of a scenario where a generic token would have those those flags.

## PR Context
I've been stubbornly holding on to ISE partially because of its superior syntax highlighting and while this doesn't fix it completely, it's a step in the right direction.
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
