### PR TITLE
Add the ability to use either `.` or `&` when launching script

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
@@ -34,6 +34,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         internal bool IsUsingTempIntegratedConsole { get; set; }
 
+        internal string ExecuteMode { get; set; }
+
         // This gets set at the end of the Launch/Attach handler which set debug state.
         internal TaskCompletionSource<bool> ServerStarted { get; set; }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -110,9 +110,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             PSCommand command;
             if (System.IO.File.Exists(scriptToLaunch))
             {
-                // For a saved file we just execute its path (after escaping it).
+                // For a saved file we just execute its path (after escaping it), with the configured operator
+                // (which can't be called that because it's a reserved keyword in C#).
+                string executeMode = _debugStateService?.ExecuteMode == "Call" ? "&" : ".";
                 command = PSCommandHelpers.BuildDotSourceCommandWithArguments(
-                    PSCommandHelpers.EscapeScriptFilePath(scriptToLaunch), _debugStateService?.Arguments);
+                    PSCommandHelpers.EscapeScriptFilePath(scriptToLaunch), _debugStateService?.Arguments, executeMode);
             }
             else // It's a URI to an untitled script, or a raw script.
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -66,6 +66,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         public string[] RuntimeArgs { get; set; }
 
         /// <summary>
+        /// Gets or sets the script execution mode, either "DotSource" or "Call".
+        /// </summary>
+        public string ExecuteMode { get; set; }
+
+        /// <summary>
         /// Gets or sets optional environment variables to pass to the debuggee. The string valued
         /// properties of the 'environmentVariables' are used as key/value pairs.
         /// </summary>
@@ -186,6 +191,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             _debugStateService.ScriptToLaunch = request.Script;
             _debugStateService.Arguments = request.Args;
             _debugStateService.IsUsingTempIntegratedConsole = request.CreateTemporaryIntegratedConsole;
+            _debugStateService.ExecuteMode = request.ExecuteMode;
 
             if (request.CreateTemporaryIntegratedConsole
                 && !string.IsNullOrEmpty(request.Script)

--- a/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
+++ b/src/PowerShellEditorServices/Utility/PSCommandExtensions.cs
@@ -94,10 +94,12 @@ namespace Microsoft.PowerShell.EditorServices.Utility
 
         public static string EscapeScriptFilePath(string f) => string.Concat("'", f.Replace("'", "''"), "'");
 
-        public static PSCommand BuildDotSourceCommandWithArguments(string command, IEnumerable<string> arguments)
+        // Operator defaults to dot-source but could also be call (ampersand).
+        // It can't be called that because it's a reserved keyword in C#.
+        public static PSCommand BuildDotSourceCommandWithArguments(string command, IEnumerable<string> arguments, string executeMode = ".")
         {
             string args = string.Join(" ", arguments ?? Array.Empty<string>());
-            string script = string.Concat(". ", command, string.IsNullOrEmpty(args) ? "" : " ", args);
+            string script = string.Concat(executeMode, " ", command, string.IsNullOrEmpty(args) ? "" : " ", args);
             // HACK: We use AddScript instead of AddArgument/AddParameter to reuse Powershell parameter binding logic.
             return new PSCommand().AddScript(script);
         }

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterClientExtensions.cs
@@ -11,21 +11,17 @@ namespace PowerShellEditorServices.Test.E2E
 {
     public static class DebugAdapterClientExtensions
     {
-        public static async Task LaunchScript(this DebugAdapterClient debugAdapterClient, string script, TaskCompletionSource<object> started)
+        public static async Task LaunchScript(this DebugAdapterClient debugAdapterClient, string script, TaskCompletionSource<object> started, string executeMode = "DotSource")
         {
-            LaunchResponse launchResponse = await debugAdapterClient.Launch(
+            _ = await debugAdapterClient.Launch(
                 new PsesLaunchRequestArguments
                 {
                     NoDebug = false,
                     Script = script,
                     Cwd = "",
-                    CreateTemporaryIntegratedConsole = false
-                });
-
-            if (launchResponse is null)
-            {
-                throw new Exception("Launch response was null.");
-            }
+                    CreateTemporaryIntegratedConsole = false,
+                    ExecuteMode = executeMode,
+                }) ?? throw new Exception("Launch response was null.");
 
             // This will check to see if we received the Initialized event from the server.
             await started.Task;

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -190,6 +190,17 @@ namespace PowerShellEditorServices.Test.E2E
         }
 
         [Fact]
+        public async Task UsesCallOperatorWithSettingAsync()
+        {
+            string filePath = NewTestFile(GenerateScriptFromLoggingStatements("$($MyInvocation.Line)"));
+            await PsesDebugAdapterClient.LaunchScript(filePath, Started, executeMode: "Call");
+            ConfigurationDoneResponse configDoneResponse = await PsesDebugAdapterClient.RequestConfigurationDone(new ConfigurationDoneArguments());
+            Assert.NotNull(configDoneResponse);
+            Assert.Collection(await GetLog(),
+                (i) => Assert.StartsWith("& '", i));
+        }
+
+        [Fact]
         public async Task CanLaunchScriptWithNoBreakpointsAsync()
         {
             string filePath = NewTestFile(GenerateScriptFromLoggingStatements("works"));


### PR DESCRIPTION
Add support to change how the scripts are launched (DotSource vs Call operator).

# PR Summary

Adds the ExecuteMode property and the corresponding method to either use the DotSource operator or the Call operator when launching scripts.

Related to this PR: ~~https://github.com/PowerShell/vscode-powershell/pull/5036~~ https://github.com/PowerShell/vscode-powershell/pull/5059


## PR Context
See https://github.com/PowerShell/vscode-powershell/issues/4327

It's not always desirable to alter the current scope, this PR allows the use of the Call operator when launching scripts.