### PR TITLE
Switch VIM E2E tests to use nightly

### DIFF
--- a/.github/workflows/vim-test.yml
+++ b/.github/workflows/vim-test.yml
@@ -35,7 +35,10 @@ jobs:
         run: Invoke-Build Build
 
       - name: Install Vim
+        id: vim
         uses: rhysd/action-setup-vim@v1
+        with:
+          version: nightly
 
       - name: Checkout vim-ps1
         uses: actions/checkout@v4
@@ -58,6 +61,9 @@ jobs:
         with:
           repository: thinca/vim-themis
           path: vim-themis
+
+      # - name: Debug if run with debugging enabled
+      #   uses: lhotari/action-upterm@v1
 
       - name: Run Themis with full CLI
         env:


### PR DESCRIPTION
The current ubuntu2.19 package breaks E2E tests. Latest VIM works fine, so switching to nightly for testing.

Band-Aid for https://github.com/PowerShell/PowerShellEditorServices/issues/2182 but will not close it as we should probably find out what in that 2.19 ubuntu security update broke it, as it is currently being distributed widely and we should make sure it hasn't broken ubuntu VIM users.