### PR TITLE
Allow daily PowerShell test to fail

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install daily
         if: ${{ github.event_name == 'schedule' || github.event_name == 'merge_group' }}
+        continue-on-error: true
         shell: pwsh
         run: ./pwsh/tools/install-powershell.ps1 -Daily
 


### PR DESCRIPTION
Really, it's the installation that's failing because literally the upstream posting of new daily PowerShell builds is broken.

If it succeeds, TestFull and the daily schedule will run it. If it doesn't, they'll ignore it because the build script will skip it.