### PR TITLE
Add Breakpoint Label frame to optimize debug stepping performance

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesDebugServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesDebugServer.cs
@@ -117,6 +117,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                         response.SupportsHitConditionalBreakpoints = true;
                         response.SupportsLogPoints = true;
                         response.SupportsSetVariable = true;
+                        response.SupportsDelayedStackTraceLoading = true;
 
                         return Task.CompletedTask;
                     });

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -77,7 +77,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </summary>
         public Task StackFramesAndVariablesFetched { get; private set; }
 
-
         /// <summary>
         /// Tracks whether we are running <c>Debug-Runspace</c> in an out-of-process runspace.
         /// </summary>

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
@@ -20,14 +20,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public Task<ScopesResponse> Handle(ScopesArguments request, CancellationToken cancellationToken)
         {
-            VariableScope[] variableScopes =
-                _debugService.GetVariableScopes(
-                    (int)request.FrameId);
+            //We have an artificial breakpoint label, so just copy the stacktrace from the first stack entry for this.
+            int frameId = request.FrameId == 0 ? 0 : (int)request.FrameId - 1;
+
+            VariableScope[] variableScopes = _debugService.GetVariableScopes(frameId);
 
             return Task.FromResult(new ScopesResponse
             {
-                Scopes = new Container<Scope>(variableScopes
-                    .Select(LspDebugUtils.CreateScope))
+                Scopes = new Container<Scope>(
+                    variableScopes
+                    .Select(LspDebugUtils.CreateScope)
+                )
             });
         }
     }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ScopesHandler.cs
@@ -18,12 +18,20 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
         public ScopesHandler(DebugService debugService) => _debugService = debugService;
 
+        /// <summary>
+        /// Retrieves the variable scopes (containers) for the currently selected stack frame. Variables details are fetched via a separate request.
+        /// </summary>
         public Task<ScopesResponse> Handle(ScopesArguments request, CancellationToken cancellationToken)
         {
-            //We have an artificial breakpoint label, so just copy the stacktrace from the first stack entry for this.
-            int frameId = request.FrameId == 0 ? 0 : (int)request.FrameId - 1;
+            // HACK: The StackTraceHandler injects an artificial label frame as the first frame as a performance optimization, so when scopes are requested by the client, we need to adjust the frame index accordingly to match the underlying PowerShell frame, so when the client clicks on the label (or hit the default breakpoint), they get variables populated from the top of the PowerShell stackframe. If the client dives deeper, we need to reflect that as well (though 90% of debug users don't actually investigate this)
+            // VSCode Frame 0 (Label) -> PowerShell StackFrame 0 (for convenience)
+            // VSCode Frame 1 (First Real PS Frame) -> Also PowerShell StackFrame 0
+            // VSCode Frame 2 -> PowerShell StackFrame 1
+            // VSCode Frame 3 -> PowerShell StackFrame 2
+            // etc.
+            int powershellFrameId = request.FrameId == 0 ? 0 : (int)request.FrameId - 1;
 
-            VariableScope[] variableScopes = _debugService.GetVariableScopes(frameId);
+            VariableScope[] variableScopes = _debugService.GetVariableScopes(powershellFrameId);
 
             return Task.FromResult(new ScopesResponse
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
@@ -1,64 +1,132 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Management.Automation;
 using Microsoft.PowerShell.EditorServices.Services;
-using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
-using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
+using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
+using System.Linq;
 
-namespace Microsoft.PowerShell.EditorServices.Handlers
+namespace Microsoft.PowerShell.EditorServices.Handlers;
+
+internal class StackTraceHandler(DebugService debugService) : IStackTraceHandler
 {
-    internal class StackTraceHandler : IStackTraceHandler
+    /// <summary>
+    /// Because we don't know the size of the stacktrace beforehand, we will tell the client that there are more frames available, this is effectively a paging size, as the client should request this many frames after the first one.
+    /// </summary>
+    private const int INITIAL_PAGE_SIZE = 20;
+
+    public async Task<StackTraceResponse> Handle(StackTraceArguments request, CancellationToken cancellationToken)
     {
-        private readonly DebugService _debugService;
-
-        public StackTraceHandler(DebugService debugService) => _debugService = debugService;
-
-        public async Task<StackTraceResponse> Handle(StackTraceArguments request, CancellationToken cancellationToken)
+        if (!debugService.IsDebuggerStopped)
         {
-            StackFrameDetails[] stackFrameDetails = await _debugService.GetStackFramesAsync(cancellationToken).ConfigureAwait(false);
+            throw new NotSupportedException("Stacktrace was requested while we are not stopped at a breakpoint.");
+        }
 
-            // Handle a rare race condition where the adapter requests stack frames before they've
-            // begun building.
-            if (stackFrameDetails is null)
+        // Adapting to int to let us use LINQ, realistically if you have a stacktrace larger than this that the client is requesting, you have bigger problems...
+        int skip = Convert.ToInt32(request.StartFrame ?? 0);
+        int take = Convert.ToInt32(request.Levels ?? 0);
+
+        // We generate a label for the breakpoint and can return that immediately if the client is supporting DelayedStackTraceLoading.
+        InvocationInfo invocationInfo = debugService.CurrentDebuggerStoppedEventArgs?.OriginalEvent?.InvocationInfo
+            ?? throw new NotSupportedException("InvocationInfo was not available on CurrentDebuggerStoppedEvent args. This is a bug.");
+
+        StackFrame breakpointLabel = CreateBreakpointLabel(invocationInfo);
+
+        if (skip == 0 && take == 1) // This indicates the client is doing an initial fetch, so we want to return quickly to unblock the UI and wait on the remaining stack frames for the subsequent requests.
+        {
+            return new StackTraceResponse()
             {
-                return new StackTraceResponse
-                {
-                    StackFrames = Array.Empty<StackFrame>(),
-                    TotalFrames = 0
-                };
-            }
-
-            List<StackFrame> newStackFrames = new();
-
-            long startFrameIndex = request.StartFrame ?? 0;
-            long maxFrameCount = stackFrameDetails.Length;
-
-            // If the number of requested levels == 0 (or null), that means get all stack frames
-            // after the specified startFrame index. Otherwise get all the stack frames.
-            long requestedFrameCount = request.Levels ?? 0;
-            if (requestedFrameCount > 0)
-            {
-                maxFrameCount = Math.Min(maxFrameCount, startFrameIndex + requestedFrameCount);
-            }
-
-            for (long i = startFrameIndex; i < maxFrameCount; i++)
-            {
-                // Create the new StackFrame object with an ID that can
-                // be referenced back to the current list of stack frames
-                newStackFrames.Add(LspDebugUtils.CreateStackFrame(stackFrameDetails[i], id: i));
-            }
-
-            return new StackTraceResponse
-            {
-                StackFrames = newStackFrames,
-                TotalFrames = newStackFrames.Count
+                StackFrames = new StackFrame[] { breakpointLabel },
+                TotalFrames = INITIAL_PAGE_SIZE //Indicate to the client that there are more frames available
             };
         }
+
+        // Wait until the stack frames and variables have been fetched.
+        await debugService.StackFramesAndVariablesFetched.ConfigureAwait(false);
+
+        StackFrameDetails[] stackFrameDetails = await debugService.GetStackFramesAsync(cancellationToken)
+                                                                    .ConfigureAwait(false);
+
+        // Handle a rare race condition where the adapter requests stack frames before they've
+        // begun building.
+        if (stackFrameDetails is null)
+        {
+            return new StackTraceResponse
+            {
+                StackFrames = Array.Empty<StackFrame>(),
+                TotalFrames = 0
+            };
+        }
+
+        List<StackFrame> newStackFrames = new();
+        if (skip == 0)
+        {
+            newStackFrames.Add(breakpointLabel);
+        }
+
+        newStackFrames.AddRange(
+            stackFrameDetails
+            .Skip(skip != 0 ? skip - 1 : skip)
+            .Take(take != 0 ? take - 1 : take)
+            .Select((frame, index) => CreateStackFrame(frame, index + 1))
+        );
+
+        return new StackTraceResponse
+        {
+            StackFrames = newStackFrames,
+            TotalFrames = newStackFrames.Count
+        };
     }
+
+    public static StackFrame CreateStackFrame(StackFrameDetails stackFrame, long id)
+    {
+        SourcePresentationHint sourcePresentationHint =
+            stackFrame.IsExternalCode ? SourcePresentationHint.Deemphasize : SourcePresentationHint.Normal;
+
+        // When debugging an interactive session, the ScriptPath is <No File> which is not a valid source file.
+        // We need to make sure the user can't open the file associated with this stack frame.
+        // It will generate a VSCode error in this case.
+        Source? source = null;
+        if (!stackFrame.ScriptPath.Contains("<"))
+        {
+            source = new Source
+            {
+                Path = stackFrame.ScriptPath,
+                PresentationHint = sourcePresentationHint
+            };
+        }
+
+        return new StackFrame
+        {
+            Id = id,
+            Name = (source is not null) ? stackFrame.FunctionName : "Interactive Session",
+            Line = (source is not null) ? stackFrame.StartLineNumber : 0,
+            EndLine = stackFrame.EndLineNumber,
+            Column = (source is not null) ? stackFrame.StartColumnNumber : 0,
+            EndColumn = stackFrame.EndColumnNumber,
+            Source = source
+        };
+    }
+
+    public static StackFrame CreateBreakpointLabel(InvocationInfo invocationInfo, int id = 0) => new()
+    {
+        Name = "<Breakpoint>",
+        Id = id,
+        Source = new()
+        {
+            Path = invocationInfo.ScriptName
+        },
+        Line = invocationInfo.ScriptLineNumber,
+        Column = invocationInfo.OffsetInLine,
+        PresentationHint = StackFramePresentationHint.Label
+    };
+
 }
+

--- a/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
+++ b/src/PowerShellEditorServices/Utility/LspDebugUtils.cs
@@ -56,38 +56,6 @@ namespace Microsoft.PowerShell.EditorServices.Utility
             };
         }
 
-        public static StackFrame CreateStackFrame(
-            StackFrameDetails stackFrame,
-            long id)
-        {
-            SourcePresentationHint sourcePresentationHint =
-                stackFrame.IsExternalCode ? SourcePresentationHint.Deemphasize : SourcePresentationHint.Normal;
-
-            // When debugging an interactive session, the ScriptPath is <No File> which is not a valid source file.
-            // We need to make sure the user can't open the file associated with this stack frame.
-            // It will generate a VSCode error in this case.
-            Source source = null;
-            if (!stackFrame.ScriptPath.Contains("<"))
-            {
-                source = new Source
-                {
-                    Path = stackFrame.ScriptPath,
-                    PresentationHint = sourcePresentationHint
-                };
-            }
-
-            return new StackFrame
-            {
-                Id = id,
-                Name = (source != null) ? stackFrame.FunctionName : "Interactive Session",
-                Line = (source != null) ? stackFrame.StartLineNumber : 0,
-                EndLine = stackFrame.EndLineNumber,
-                Column = (source != null) ? stackFrame.StartColumnNumber : 0,
-                EndColumn = stackFrame.EndColumnNumber,
-                Source = source
-            };
-        }
-
         public static Scope CreateScope(VariableScope scope)
         {
             return new Scope


### PR DESCRIPTION
# PR Summary
Implements DAP `DelayedStackTraceLoading` and returns an artificial breakpoint label frame based on the invocation info ASAP once the debugger stops. The rest of the stack trace is then returned on a future request that doesn't block the client UI.

https://github.com/user-attachments/assets/b909655b-1085-4f8e-a453-99b8af21b877

## PR Context
Debug stepping takes 300ms+ due to waiting for stack trace collection via the slow `Get-PSCallStack` "hack". Further improvements will come around this later.
