### PR TITLE
Fix unit test broken by GitHub Action image update

### DIFF
--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompleteCommandInFile.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
             file: TestUtilities.NormalizePath("Completion/CompletionExamples.psm1"),
             text: string.Empty,
             startLineNumber: 8,
-            startColumnNumber: 7,
+            startColumnNumber: 10,
             startOffset: 0,
             endLineNumber: 0,
             endColumnNumber: 0,
@@ -22,17 +22,17 @@ namespace Microsoft.PowerShell.EditorServices.Test.Shared.Completion
         {
             Kind = CompletionItemKind.Function,
             Detail = "",
-            FilterText = "Get-Something",
-            InsertText = "Get-Something",
-            Label = "Get-Something",
-            SortText = "0001Get-Something",
+            FilterText = "Get-XYZSomething",
+            InsertText = "Get-XYZSomething",
+            Label = "Get-XYZSomething",
+            SortText = "0001Get-XYZSomething",
             TextEdit = new TextEdit
             {
-                NewText = "Get-Something",
+                NewText = "Get-XYZSomething",
                 Range = new Range
                 {
                     Start = new Position { Line = 7, Character = 0 },
-                    End = new Position { Line = 7, Character = 6 }
+                    End = new Position { Line = 7, Character = 9 }
                 }
             }
         };

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompletionExamples.psm1
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompletionExamples.psm1
@@ -1,11 +1,11 @@
-function Get-Something
+function Get-XYZSomething
 {
 	$testVar2 = "Shouldn't find this variable"
 }
 
 $testVar1 = "Should find this variable"
 
-Get-So
+Get-XYZSo
 
 $testVar
 


### PR DESCRIPTION
Which now includes an AWS module with a conflicting completion (`AWS.Tools.SocialMessaging.psd1`). Why GitHub Actions installed that, I don't know. Why our test made such a broad assumption, also unknown.