### PR TITLE
Drop support for PowerShell 7.2 (net6.0) per its end-of-life

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.6" />

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -40,12 +40,11 @@ $script:BuildInfoPath = "src/PowerShellEditorServices.Hosting/BuildInfo.cs"
 
 $script:NetFramework = @{
     PS51     = 'net462'
-    PS72     = 'net6.0'
     PS74     = 'net8.0'
     Standard = 'netstandard2.0'
 }
 
-$script:HostCoreOutput = "src/PowerShellEditorServices.Hosting/bin/$Configuration/$($script:NetFramework.PS72)/publish"
+$script:HostCoreOutput = "src/PowerShellEditorServices.Hosting/bin/$Configuration/$($script:NetFramework.PS74)/publish"
 $script:HostDeskOutput = "src/PowerShellEditorServices.Hosting/bin/$Configuration/$($script:NetFramework.PS51)/publish"
 $script:PsesOutput = "src/PowerShellEditorServices/bin/$Configuration/$($script:NetFramework.Standard)/publish"
 
@@ -128,7 +127,7 @@ task RestorePsesModules -If (-not (Test-Path "module/PSReadLine") -or -not (Test
 Task Build FindDotNet, CreateBuildInfo, RestorePsesModules, {
     Write-Build DarkGreen "Building PowerShellEditorServices"
     Invoke-BuildExec { & dotnet publish $script:dotnetBuildArgs ./src/PowerShellEditorServices/PowerShellEditorServices.csproj -f $script:NetFramework.Standard }
-    Invoke-BuildExec { & dotnet publish $script:dotnetBuildArgs ./src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj -f $script:NetFramework.PS72 }
+    Invoke-BuildExec { & dotnet publish $script:dotnetBuildArgs ./src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj -f $script:NetFramework.PS74 }
 
     if (-not $script:IsNix) {
         Invoke-BuildExec { & dotnet publish $script:dotnetBuildArgs ./src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj -f $script:NetFramework.PS51 }
@@ -199,11 +198,6 @@ Task SetupHelpForTests {
 Task TestPS74 Build, SetupHelpForTests, {
     Set-Location ./test/PowerShellEditorServices.Test/
     Invoke-BuildExec { & dotnet $script:dotnetTestArgs $script:NetFramework.PS74 }
-}
-
-Task TestPS72 Build, SetupHelpForTests, {
-    Set-Location ./test/PowerShellEditorServices.Test/
-    Invoke-BuildExec { & dotnet $script:dotnetTestArgs $script:NetFramework.PS72 }
 }
 
 Task TestPS51 -If (-not $script:IsNix) Build, SetupHelpForTests, {
@@ -299,7 +293,7 @@ Task TestE2EPowerShellCLM -If (-not $script:IsNix) Build, SetupHelpForTests, {
     }
 }
 
-Task Test TestPS72, TestPS74, TestE2EPwsh, TestPS51, TestE2EPowerShell
+Task Test TestPS74, TestE2EPwsh, TestPS51, TestE2EPowerShell
 
 Task TestFull Test, TestE2EDaily, TestE2EPwshCLM, TestE2EPowerShellCLM
 

--- a/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
+++ b/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices.Hosting</AssemblyName>
   </PropertyGroup>
 

--- a/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
+++ b/test/PowerShellEditorServices.Test/PowerShellEditorServices.Test.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>Microsoft.PowerShell.EditorServices.Test</AssemblyName>
     <TargetPlatform>x64</TargetPlatform>
   </PropertyGroup>
@@ -19,11 +19,6 @@
   <!-- PowerShell 7.4.x -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.PowerShell.SDK" VersionOverride="7.4.6" />
-  </ItemGroup>
-
-  <!-- PowerShell 7.2.x -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.PowerShell.SDK" VersionOverride="7.2.24" />
   </ItemGroup>
 
   <!-- Windows PowerShell 5.1 -->


### PR DESCRIPTION
Also allows us to bump Microsoft.Extensions.Logging to 9.0.0.