### PR TITLE
Enhanced Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $command = @(
         "-HostName 'My Client'",
         "-HostProfileId 'myclient'",
         "-HostVersion 1.0.0",
-        "-LogLevel Diagnostic"
+        "-LogLevel Trace"
 ) -join " "
 
 $pwsh_arguments = "-NoLogo -NoProfile -Command $command"

--- a/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
+++ b/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         /// The minimum log level that should be emitted.
         /// </summary>
         [Parameter]
-        public PsesLogLevel LogLevel { get; set; } = PsesLogLevel.Normal;
+        public PsesLogLevel LogLevel { get; set; } = PsesLogLevel.Warning;
 
         /// <summary>
         /// Paths to additional PowerShell modules to be imported at startup.
@@ -218,7 +218,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD002:Avoid problematic synchronous waits", Justification = "We have to wait here, it's the whole program.")]
         protected override void EndProcessing()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Beginning EndProcessing block");
+            _logger.Log(PsesLogLevel.Trace, "Beginning EndProcessing block");
             try
             {
                 // First try to remove PSReadLine to decomplicate startup
@@ -229,7 +229,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                 EditorServicesConfig editorServicesConfig = CreateConfigObject();
 
                 using EditorServicesLoader psesLoader = EditorServicesLoader.Create(_logger, editorServicesConfig, SessionDetailsPath, _loggerUnsubscribers);
-                _logger.Log(PsesLogLevel.Verbose, "Loading EditorServices");
+                _logger.Log(PsesLogLevel.Debug, "Loading EditorServices");
                 // Synchronously start editor services and wait here until it shuts down.
                 psesLoader.LoadAndRunEditorServicesAsync().GetAwaiter().GetResult();
             }
@@ -281,7 +281,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
             IDisposable fileLoggerUnsubscriber = _logger.Subscribe(fileLogger);
             fileLogger.AddUnsubscriber(fileLoggerUnsubscriber);
             _loggerUnsubscribers.Add(fileLoggerUnsubscriber);
-            _logger.Log(PsesLogLevel.Diagnostic, "Logging started");
+            _logger.Log(PsesLogLevel.Trace, "Logging started");
         }
 
         // Sanitizes user input and ensures the directory is created.
@@ -299,7 +299,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
         private void RemovePSReadLineForStartup()
         {
-            _logger.Log(PsesLogLevel.Verbose, "Removing PSReadLine");
+            _logger.Log(PsesLogLevel.Debug, "Removing PSReadLine");
             using SMA.PowerShell pwsh = SMA.PowerShell.Create(RunspaceMode.CurrentRunspace);
             bool hasPSReadLine = pwsh.AddCommand(new CmdletInfo(@"Microsoft.PowerShell.Core\Get-Module", typeof(GetModuleCommand)))
                 .AddParameter("Name", "PSReadLine")
@@ -314,13 +314,13 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                     .AddParameter("Name", "PSReadLine")
                     .AddParameter("ErrorAction", "SilentlyContinue");
 
-                _logger.Log(PsesLogLevel.Verbose, "Removed PSReadLine");
+                _logger.Log(PsesLogLevel.Debug, "Removed PSReadLine");
             }
         }
 
         private EditorServicesConfig CreateConfigObject()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Creating host configuration");
+            _logger.Log(PsesLogLevel.Trace, "Creating host configuration");
 
             string bundledModulesPath = BundledModulesPath;
             if (!Path.IsPathRooted(bundledModulesPath))
@@ -399,31 +399,31 @@ namespace Microsoft.PowerShell.EditorServices.Commands
         // * On Linux or macOS on any version greater than or equal to 7
         private ConsoleReplKind GetReplKind()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Determining REPL kind");
+            _logger.Log(PsesLogLevel.Trace, "Determining REPL kind");
 
             if (Stdio || !EnableConsoleRepl)
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "REPL configured as None");
+                _logger.Log(PsesLogLevel.Trace, "REPL configured as None");
                 return ConsoleReplKind.None;
             }
 
             if (UseLegacyReadLine)
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "REPL configured as Legacy");
+                _logger.Log(PsesLogLevel.Trace, "REPL configured as Legacy");
                 return ConsoleReplKind.LegacyReadLine;
             }
 
-            _logger.Log(PsesLogLevel.Diagnostic, "REPL configured as PSReadLine");
+            _logger.Log(PsesLogLevel.Trace, "REPL configured as PSReadLine");
             return ConsoleReplKind.PSReadLine;
         }
 
         private ITransportConfig GetLanguageServiceTransport()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Configuring LSP transport");
+            _logger.Log(PsesLogLevel.Trace, "Configuring LSP transport");
 
             if (DebugServiceOnly)
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "No LSP transport: PSES is debug only");
+                _logger.Log(PsesLogLevel.Trace, "No LSP transport: PSES is debug only");
                 return null;
             }
 
@@ -447,11 +447,11 @@ namespace Microsoft.PowerShell.EditorServices.Commands
 
         private ITransportConfig GetDebugServiceTransport()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Configuring debug transport");
+            _logger.Log(PsesLogLevel.Trace, "Configuring debug transport");
 
             if (LanguageServiceOnly)
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "No Debug transport: PSES is language service only");
+                _logger.Log(PsesLogLevel.Trace, "No Debug transport: PSES is language service only");
                 return null;
             }
 
@@ -462,7 +462,7 @@ namespace Microsoft.PowerShell.EditorServices.Commands
                     return new StdioTransportConfig(_logger);
                 }
 
-                _logger.Log(PsesLogLevel.Diagnostic, "No debug transport: Transport is Stdio with debug disabled");
+                _logger.Log(PsesLogLevel.Trace, "No debug transport: Transport is Stdio with debug disabled");
                 return null;
             }
 

--- a/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/EditorServicesConfig.cs
@@ -90,14 +90,14 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         public ConsoleReplKind ConsoleRepl { get; set; } = ConsoleReplKind.None;
 
         /// <summary>
-        /// Will suppress messages to PSHost (to prevent Stdio clobbering)        
+        /// Will suppress messages to PSHost (to prevent Stdio clobbering)
         /// </summary>
         public bool UseNullPSHostUI { get; set; }
 
         /// <summary>
-        /// The minimum log level to log events with.
+        /// The minimum log level to log events with. Defaults to warning but is usually overriden by the startup process.
         /// </summary>
-        public PsesLogLevel LogLevel { get; set; } = PsesLogLevel.Normal;
+        public PsesLogLevel LogLevel { get; set; } = PsesLogLevel.Warning;
 
         /// <summary>
         /// Configuration for the language server protocol transport to use.

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -229,25 +229,23 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             switch (logLevel)
             {
                 case PsesLogLevel.Trace:
+                    ui.WriteDebugLine("[Trace] " + message);
+                    break;
                 case PsesLogLevel.Debug:
                     ui.WriteDebugLine(message);
                     break;
-
                 case PsesLogLevel.Information:
                     ui.WriteVerboseLine(message);
                     break;
-
                 case PsesLogLevel.Warning:
                     ui.WriteWarningLine(message);
                     break;
-
                 case PsesLogLevel.Error:
                 case PsesLogLevel.Critical:
                     ui.WriteErrorLine(message);
                     break;
-
                 default:
-                    ui.WriteLine(message);
+                    ui.WriteDebugLine("UNKNOWN:" + message);
                     break;
             }
         }

--- a/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/SessionFileWriter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="reason">The reason for the startup failure.</param>
         public void WriteSessionFailure(string reason)
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Writing session failure");
+            _logger.Log(PsesLogLevel.Trace, "Writing session failure");
 
             Dictionary<string, object> sessionObject = new()
             {
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         /// <param name="debugAdapterTransport">The debug adapter transport configuration.</param>
         public void WriteSessionStarted(ITransportConfig languageServiceTransport, ITransportConfig debugAdapterTransport)
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Writing session started");
+            _logger.Log(PsesLogLevel.Trace, "Writing session started");
 
             Dictionary<string, object> sessionObject = new()
             {
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 File.WriteAllText(_sessionFilePath, content, s_sessionFileEncoding);
             }
 
-            _logger.Log(PsesLogLevel.Verbose, $"Session file written to {_sessionFilePath} with content:\n{content}");
+            _logger.Log(PsesLogLevel.Debug, $"Session file written to {_sessionFilePath} with content:\n{content}");
         }
     }
 }

--- a/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/TransportConfig.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public Task<(Stream inStream, Stream outStream)> ConnectStreamsAsync()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Connecting stdio streams");
+            _logger.Log(PsesLogLevel.Trace, "Connecting stdio streams");
             return Task.FromResult((Console.OpenStandardInput(), Console.OpenStandardOutput()));
         }
     }
@@ -102,11 +102,11 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public async Task<(Stream inStream, Stream outStream)> ConnectStreamsAsync()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Creating named pipe");
+            _logger.Log(PsesLogLevel.Trace, "Creating named pipe");
             NamedPipeServerStream namedPipe = NamedPipeUtils.CreateNamedPipe(_pipeName, PipeDirection.InOut);
-            _logger.Log(PsesLogLevel.Diagnostic, "Waiting for named pipe connection");
+            _logger.Log(PsesLogLevel.Trace, "Waiting for named pipe connection");
             await namedPipe.WaitForConnectionAsync().ConfigureAwait(false);
-            _logger.Log(PsesLogLevel.Diagnostic, "Named pipe connected");
+            _logger.Log(PsesLogLevel.Trace, "Named pipe connected");
             return (namedPipe, namedPipe);
         }
     }
@@ -173,18 +173,18 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public async Task<(Stream inStream, Stream outStream)> ConnectStreamsAsync()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Starting in pipe connection");
+            _logger.Log(PsesLogLevel.Trace, "Starting in pipe connection");
             NamedPipeServerStream inPipe = NamedPipeUtils.CreateNamedPipe(_inPipeName, PipeDirection.InOut);
             Task inPipeConnected = inPipe.WaitForConnectionAsync();
 
-            _logger.Log(PsesLogLevel.Diagnostic, "Starting out pipe connection");
+            _logger.Log(PsesLogLevel.Trace, "Starting out pipe connection");
             NamedPipeServerStream outPipe = NamedPipeUtils.CreateNamedPipe(_outPipeName, PipeDirection.Out);
             Task outPipeConnected = outPipe.WaitForConnectionAsync();
 
-            _logger.Log(PsesLogLevel.Diagnostic, "Wating for pipe connections");
+            _logger.Log(PsesLogLevel.Trace, "Wating for pipe connections");
             await Task.WhenAll(inPipeConnected, outPipeConnected).ConfigureAwait(false);
 
-            _logger.Log(PsesLogLevel.Diagnostic, "Simplex named pipe transport connected");
+            _logger.Log(PsesLogLevel.Trace, "Simplex named pipe transport connected");
             return (inPipe, outPipe);
         }
     }

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -212,10 +212,10 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ValidateConfiguration();
 
             // Method with no implementation that forces the PSES assembly to load, triggering an AssemblyResolve event
-            _logger.Log(PsesLogLevel.Information, "Loading PowerShell Editor Services");
+            _logger.Log(PsesLogLevel.Information, "Loading PowerShell Editor Services Assemblies");
             LoadEditorServices();
 
-            _logger.Log(PsesLogLevel.Information, "Starting EditorServices");
+            _logger.Log(PsesLogLevel.Information, "Starting PowerShell Editor Services");
 
             _editorServicesRunner = new EditorServicesRunner(_logger, _hostConfig, _sessionFileWriter, _loggersToUnsubscribe);
 
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             PSLanguageMode languageMode = Runspace.DefaultRunspace.SessionStateProxy.LanguageMode;
 
-            _logger.Log(PsesLogLevel.Debug, $@"
+            _logger.Log(PsesLogLevel.Trace, $@"
 == PowerShell Details ==
 - PowerShell version: {_powerShellVersion}
 - Language mode:      {languageMode}
@@ -295,12 +295,12 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             }
             psModulePath = $"{psModulePath}{Path.PathSeparator}{_hostConfig.BundledModulePath}";
             Environment.SetEnvironmentVariable("PSModulePath", psModulePath);
-            _logger.Log(PsesLogLevel.Debug, $"Updated PSModulePath to: '{psModulePath}'");
+            _logger.Log(PsesLogLevel.Trace, $"Updated PSModulePath to: '{psModulePath}'");
         }
 
         private void LogHostInformation()
         {
-            _logger.Log(PsesLogLevel.Debug, $"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
+            _logger.Log(PsesLogLevel.Trace, $"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
 
             _logger.Log(PsesLogLevel.Debug, $@"
 == Build Details ==
@@ -359,7 +359,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Checking user-defined configuration")]
         private void ValidateConfiguration()
         {
-            _logger.Log(PsesLogLevel.Trace, "Validating configuration");
+            _logger.Log(PsesLogLevel.Debug, "Validating configuration");
 
             bool lspUsesStdio = _hostConfig.LanguageServiceTransport is StdioTransportConfig;
             bool debugUsesStdio = _hostConfig.DebugServiceTransport is StdioTransportConfig;

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -70,20 +70,20 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
             Version powerShellVersion = GetPSVersion();
             SessionFileWriter sessionFileWriter = new(logger, sessionDetailsPath, powerShellVersion);
-            logger.Log(PsesLogLevel.Diagnostic, "Session file writer created");
+            logger.Log(PsesLogLevel.Trace, "Session file writer created");
 
 #if CoreCLR
             // In .NET Core, we add an event here to redirect dependency loading to the new AssemblyLoadContext we load PSES' dependencies into
-            logger.Log(PsesLogLevel.Verbose, "Adding AssemblyResolve event handler for new AssemblyLoadContext dependency loading");
+            logger.Log(PsesLogLevel.Debug, "Adding AssemblyResolve event handler for new AssemblyLoadContext dependency loading");
 
             PsesLoadContext psesLoadContext = new(s_psesDependencyDirPath);
 
-            if (hostConfig.LogLevel == PsesLogLevel.Diagnostic)
+            if (hostConfig.LogLevel == PsesLogLevel.Trace)
             {
                 AppDomain.CurrentDomain.AssemblyLoad += (object sender, AssemblyLoadEventArgs args) =>
                 {
                     logger.Log(
-                        PsesLogLevel.Diagnostic,
+                        PsesLogLevel.Trace,
                         $"Loaded into load context {AssemblyLoadContext.GetLoadContext(args.LoadedAssembly)}: {args.LoadedAssembly}");
                 };
             }
@@ -91,9 +91,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext _, AssemblyName asmName) =>
             {
 #if ASSEMBLY_LOAD_STACKTRACE
-                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}. Stacktrace:\n{new StackTrace()}");
+                logger.Log(PsesLogLevel.Trace, $"Assembly resolve event fired for {asmName}. Stacktrace:\n{new StackTrace()}");
 #else
-                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {asmName}");
+                logger.Log(PsesLogLevel.Trace, $"Assembly resolve event fired for {asmName}");
 #endif
 
                 // We only want the Editor Services DLL; the new ALC will lazily load its dependencies automatically
@@ -104,15 +104,15 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
                 string asmPath = Path.Combine(s_psesDependencyDirPath, $"{asmName.Name}.dll");
 
-                logger.Log(PsesLogLevel.Verbose, "Loading PSES DLL using new assembly load context");
+                logger.Log(PsesLogLevel.Debug, "Loading PSES DLL using new assembly load context");
 
                 return psesLoadContext.LoadFromAssemblyPath(asmPath);
             };
 #else
             // In .NET Framework we add an event here to redirect dependency loading in the current AppDomain for PSES' dependencies
-            logger.Log(PsesLogLevel.Verbose, "Adding AssemblyResolve event handler for dependency loading");
+            logger.Log(PsesLogLevel.Debug, "Adding AssemblyResolve event handler for dependency loading");
 
-            if (hostConfig.LogLevel == PsesLogLevel.Diagnostic)
+            if (hostConfig.LogLevel == PsesLogLevel.Trace)
             {
                 AppDomain.CurrentDomain.AssemblyLoad += (object sender, AssemblyLoadEventArgs args) =>
                 {
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                     }
 
                     logger.Log(
-                        PsesLogLevel.Diagnostic,
+                        PsesLogLevel.Trace,
                         $"Loaded '{args.LoadedAssembly.GetName()}' from '{args.LoadedAssembly.Location}'");
                 };
             }
@@ -131,9 +131,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) =>
             {
 #if ASSEMBLY_LOAD_STACKTRACE
-                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}. Stacktrace:\n{new StackTrace()}");
+                logger.Log(PsesLogLevel.Trace, $"Assembly resolve event fired for {args.Name}. Stacktrace:\n{new StackTrace()}");
 #else
-                logger.Log(PsesLogLevel.Diagnostic, $"Assembly resolve event fired for {args.Name}");
+                logger.Log(PsesLogLevel.Trace, $"Assembly resolve event fired for {args.Name}");
 #endif
 
                 AssemblyName asmName = new(args.Name);
@@ -143,7 +143,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 string baseDirAsmPath = Path.Combine(s_psesBaseDirPath, dllName);
                 if (File.Exists(baseDirAsmPath))
                 {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES base dir into LoadFile context");
+                    logger.Log(PsesLogLevel.Trace, $"Loading {args.Name} from PSES base dir into LoadFile context");
                     return Assembly.LoadFile(baseDirAsmPath);
                 }
 
@@ -151,7 +151,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 string asmPath = Path.Combine(s_psesDependencyDirPath, dllName);
                 if (File.Exists(asmPath))
                 {
-                    logger.Log(PsesLogLevel.Diagnostic, $"Loading {args.Name} from PSES dependency dir into LoadFile context");
+                    logger.Log(PsesLogLevel.Trace, $"Loading {args.Name} from PSES dependency dir into LoadFile context");
                     return Assembly.LoadFile(asmPath);
                 }
 
@@ -212,10 +212,10 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ValidateConfiguration();
 
             // Method with no implementation that forces the PSES assembly to load, triggering an AssemblyResolve event
-            _logger.Log(PsesLogLevel.Verbose, "Loading PowerShell Editor Services");
+            _logger.Log(PsesLogLevel.Debug, "Loading PowerShell Editor Services");
             LoadEditorServices();
 
-            _logger.Log(PsesLogLevel.Verbose, "Starting EditorServices");
+            _logger.Log(PsesLogLevel.Debug, "Starting EditorServices");
 
             _editorServicesRunner = new EditorServicesRunner(_logger, _hostConfig, _sessionFileWriter, _loggersToUnsubscribe);
 
@@ -225,7 +225,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         public void Dispose()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Loader disposed");
+            _logger.Log(PsesLogLevel.Trace, "Loader disposed");
             _editorServicesRunner?.Dispose();
 
             // TODO:
@@ -242,7 +242,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             PSLanguageMode languageMode = Runspace.DefaultRunspace.SessionStateProxy.LanguageMode;
 
-            _logger.Log(PsesLogLevel.Verbose, $@"
+            _logger.Log(PsesLogLevel.Debug, $@"
 == PowerShell Details ==
 - PowerShell version: {_powerShellVersion}
 - Language mode:      {languageMode}
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 #if !CoreCLR
         private void CheckDotNetVersion()
         {
-            _logger.Log(PsesLogLevel.Verbose, "Checking that .NET Framework version is at least 4.8");
+            _logger.Log(PsesLogLevel.Debug, "Checking that .NET Framework version is at least 4.8");
             using RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full");
             object netFxValue = key?.GetValue("Release");
             if (netFxValue == null || netFxValue is not int netFxVersion)
@@ -269,7 +269,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 return;
             }
 
-            _logger.Log(PsesLogLevel.Verbose, $".NET registry version: {netFxVersion}");
+            _logger.Log(PsesLogLevel.Debug, $".NET registry version: {netFxVersion}");
 
             if (netFxVersion < Net48Version)
             {
@@ -283,26 +283,26 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             if (string.IsNullOrEmpty(_hostConfig.BundledModulePath))
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "BundledModulePath not set, skipping");
+                _logger.Log(PsesLogLevel.Trace, "BundledModulePath not set, skipping");
                 return;
             }
 
             string psModulePath = Environment.GetEnvironmentVariable("PSModulePath").TrimEnd(Path.PathSeparator);
             if ($"{psModulePath}{Path.PathSeparator}".Contains($"{_hostConfig.BundledModulePath}{Path.PathSeparator}"))
             {
-                _logger.Log(PsesLogLevel.Diagnostic, "BundledModulePath already set, skipping");
+                _logger.Log(PsesLogLevel.Trace, "BundledModulePath already set, skipping");
                 return;
             }
             psModulePath = $"{psModulePath}{Path.PathSeparator}{_hostConfig.BundledModulePath}";
             Environment.SetEnvironmentVariable("PSModulePath", psModulePath);
-            _logger.Log(PsesLogLevel.Verbose, $"Updated PSModulePath to: '{psModulePath}'");
+            _logger.Log(PsesLogLevel.Debug, $"Updated PSModulePath to: '{psModulePath}'");
         }
 
         private void LogHostInformation()
         {
-            _logger.Log(PsesLogLevel.Verbose, $"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
+            _logger.Log(PsesLogLevel.Debug, $"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
 
-            _logger.Log(PsesLogLevel.Verbose, $@"
+            _logger.Log(PsesLogLevel.Debug, $@"
 == Build Details ==
 - Editor Services version: {BuildInfo.BuildVersion}
 - Build origin:            {BuildInfo.BuildOrigin}
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 - Build time:              {BuildInfo.BuildTime}
 ");
 
-            _logger.Log(PsesLogLevel.Verbose, $@"
+            _logger.Log(PsesLogLevel.Debug, $@"
 == Host Startup Configuration Details ==
  - Host name:                 {_hostConfig.HostInfo.Name}
  - Host version:              {_hostConfig.HostInfo.Version}
@@ -333,14 +333,14 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
    + CurrentUserCurrentHost: {_hostConfig.ProfilePaths.CurrentUserCurrentHost ?? "<null>"}
 ");
 
-            _logger.Log(PsesLogLevel.Verbose, $@"
+            _logger.Log(PsesLogLevel.Debug, $@"
 == Console Details ==
  - Console input encoding: {Console.InputEncoding.EncodingName}
  - Console output encoding: {Console.OutputEncoding.EncodingName}
  - PowerShell output encoding: {GetPSOutputEncoding()}
 ");
 
-            _logger.Log(PsesLogLevel.Verbose, $@"
+            _logger.Log(PsesLogLevel.Debug, $@"
 == Environment Details ==
  - OS description:  {RuntimeInformation.OSDescription}
  - OS architecture: {RuntimeInformation.OSArchitecture}
@@ -359,7 +359,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "Checking user-defined configuration")]
         private void ValidateConfiguration()
         {
-            _logger.Log(PsesLogLevel.Diagnostic, "Validating configuration");
+            _logger.Log(PsesLogLevel.Trace, "Validating configuration");
 
             bool lspUsesStdio = _hostConfig.LanguageServiceTransport is StdioTransportConfig;
             bool debugUsesStdio = _hostConfig.DebugServiceTransport is StdioTransportConfig;

--- a/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
+++ b/src/PowerShellEditorServices.Hosting/EditorServicesLoader.cs
@@ -212,10 +212,10 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             ValidateConfiguration();
 
             // Method with no implementation that forces the PSES assembly to load, triggering an AssemblyResolve event
-            _logger.Log(PsesLogLevel.Debug, "Loading PowerShell Editor Services");
+            _logger.Log(PsesLogLevel.Information, "Loading PowerShell Editor Services");
             LoadEditorServices();
 
-            _logger.Log(PsesLogLevel.Debug, "Starting EditorServices");
+            _logger.Log(PsesLogLevel.Information, "Starting EditorServices");
 
             _editorServicesRunner = new EditorServicesRunner(_logger, _hostConfig, _sessionFileWriter, _loggersToUnsubscribe);
 

--- a/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
+++ b/src/PowerShellEditorServices.Hosting/Internal/EditorServicesRunner.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
             _sessionFileWriter.WriteSessionStarted(_config.LanguageServiceTransport, _config.DebugServiceTransport);
 
             // Finally, wait for Editor Services to shut down
-            _logger.Log(PsesLogLevel.Trace, "Waiting on PSES run/shutdown");
+            _logger.Log(PsesLogLevel.Debug, "Waiting on PSES run/shutdown");
             return runAndAwaitShutdown;
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
         {
             try
             {
-                _logger.Log(PsesLogLevel.Trace, "Creating/running editor services");
+                _logger.Log(PsesLogLevel.Debug, "Creating/running editor services");
 
                 bool creatingLanguageServer = _config.LanguageServiceTransport != null;
                 bool creatingDebugServer = _config.DebugServiceTransport != null;
@@ -140,6 +140,9 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                     return;
                 }
 
+                _logger.Log(PsesLogLevel.Information, "PSES Startup Completed. Starting Language Server.");
+                _logger.Log(PsesLogLevel.Information, "Please check the LSP log file in your client for further messages. In VSCode, this is the 'PowerShell' output pane");
+
                 // We want LSP and maybe debugging
                 // To do that we:
                 //  - Create the LSP server
@@ -149,7 +152,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
                 //  - Wait for the LSP server to finish
 
                 // Unsubscribe the host logger here so that the Extension Terminal is not polluted with input after the first prompt
-                _logger.Log(PsesLogLevel.Debug, "Starting server, deregistering host logger and registering shutdown listener");
                 if (_loggersToUnsubscribe != null)
                 {
                     foreach (IDisposable loggerToUnsubscribe in _loggersToUnsubscribe)
@@ -193,7 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private async Task RunTempDebugSessionAsync(HostStartupInfo hostDetails)
         {
-            _logger.Log(PsesLogLevel.Trace, "Running temp debug session");
+            _logger.Log(PsesLogLevel.Information, "Starting temporary debug session");
             PsesDebugServer debugServer = await CreateDebugServerForTempSessionAsync(hostDetails).ConfigureAwait(false);
             _logger.Log(PsesLogLevel.Debug, "Debug server created");
             await debugServer.StartAsync().ConfigureAwait(false);
@@ -222,35 +224,35 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private Task RestartDebugServerAsync(PsesDebugServer debugServer)
         {
-            _logger.Log(PsesLogLevel.Trace, "Restarting debug server");
+            _logger.Log(PsesLogLevel.Debug, "Restarting debug server");
             Task<PsesDebugServer> debugServerCreation = RecreateDebugServerAsync(debugServer);
             return StartDebugServer(debugServerCreation);
         }
 
         private async Task<PsesLanguageServer> CreateLanguageServerAsync(HostStartupInfo hostDetails)
         {
-            _logger.Log(PsesLogLevel.Debug, $"Creating LSP transport with endpoint {_config.LanguageServiceTransport.EndpointDetails}");
+            _logger.Log(PsesLogLevel.Trace, $"Creating LSP transport with endpoint {_config.LanguageServiceTransport.EndpointDetails}");
             (Stream inStream, Stream outStream) = await _config.LanguageServiceTransport.ConnectStreamsAsync().ConfigureAwait(false);
 
-            _logger.Log(PsesLogLevel.Trace, "Creating language server");
+            _logger.Log(PsesLogLevel.Debug, "Creating language server");
             return _serverFactory.CreateLanguageServer(inStream, outStream, hostDetails);
         }
 
         private async Task<PsesDebugServer> CreateDebugServerWithLanguageServerAsync(PsesLanguageServer languageServer)
         {
-            _logger.Log(PsesLogLevel.Debug, $"Creating debug adapter transport with endpoint {_config.DebugServiceTransport.EndpointDetails}");
+            _logger.Log(PsesLogLevel.Trace, $"Creating debug adapter transport with endpoint {_config.DebugServiceTransport.EndpointDetails}");
             (Stream inStream, Stream outStream) = await _config.DebugServiceTransport.ConnectStreamsAsync().ConfigureAwait(false);
 
-            _logger.Log(PsesLogLevel.Trace, "Creating debug adapter");
+            _logger.Log(PsesLogLevel.Debug, "Creating debug adapter");
             return _serverFactory.CreateDebugServerWithLanguageServer(inStream, outStream, languageServer);
         }
 
         private async Task<PsesDebugServer> RecreateDebugServerAsync(PsesDebugServer debugServer)
         {
-            _logger.Log(PsesLogLevel.Trace, "Recreating debug adapter transport");
+            _logger.Log(PsesLogLevel.Debug, "Recreating debug adapter transport");
             (Stream inStream, Stream outStream) = await _config.DebugServiceTransport.ConnectStreamsAsync().ConfigureAwait(false);
 
-            _logger.Log(PsesLogLevel.Trace, "Recreating debug adapter");
+            _logger.Log(PsesLogLevel.Debug, "Recreating debug adapter");
             return _serverFactory.RecreateDebugServer(inStream, outStream, debugServer);
         }
 
@@ -263,7 +265,7 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
 
         private HostStartupInfo CreateHostStartupInfo()
         {
-            _logger.Log(PsesLogLevel.Trace, "Creating startup info object");
+            _logger.Log(PsesLogLevel.Debug, "Creating startup info object");
 
             ProfilePathInfo profilePaths = null;
             if (_config.ProfilePaths.AllUsersAllHosts != null

--- a/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
+++ b/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
@@ -13,6 +13,9 @@ namespace Microsoft.PowerShell.EditorServices.Logging
     {
         public void OnError(Exception error) => logger.LogError(error, "Error in host logger");
 
+        /// <summary>
+        /// Log the message received from the host into MEL.
+        /// </summary>
         public void OnNext((int logLevel, string message) value) => logger.Log((LogLevel)value.logLevel, value.message);
 
         public void OnCompleted()

--- a/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
+++ b/src/PowerShellEditorServices/Logging/HostLoggerAdapter.cs
@@ -22,6 +22,5 @@ namespace Microsoft.PowerShell.EditorServices.Logging
         {
             // Nothing to do; we simply don't send more log messages
         }
-
     }
 }

--- a/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
+++ b/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
@@ -1,11 +1,138 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
 
 namespace Microsoft.PowerShell.EditorServices.Logging;
+
+internal class LanguageServerLogger(ILanguageServerFacade responseRouter, string categoryName) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => Disposable.Empty;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter
+    )
+    {
+        // Any Omnisharp or trace logs are directly LSP protocol related and we send them to the trace channel
+        // TODO: Dynamically adjust if SetTrace is reported
+        if (categoryName.StartsWith("OmniSharp") || logLevel == LogLevel.Trace)
+        {
+            // Everything with omnisharp goes directly to trace
+            string eventMessage = string.Empty;
+            string exceptionName = exception?.GetType().Name ?? string.Empty;
+            if (eventId.Name is not null)
+            {
+                eventMessage = eventId.Id == 0 ? eventId.Name : $"{eventId.Name} [{eventId.Id}] ";
+            }
+
+            LogTraceParams trace = new()
+            {
+                Message = categoryName + ": " + eventMessage + exceptionName,
+                Verbose = formatter(state, exception)
+            };
+            responseRouter.Client.LogTrace(trace);
+        }
+        else if (TryGetMessageType(logLevel, out MessageType messageType))
+        {
+            LogMessageParams logMessage = new()
+            {
+                Type = messageType,
+                // TODO: Add Critical and Debug delineations
+                Message = categoryName + ": " + formatter(state, exception) +
+                                (exception != null ? " - " + exception : "") + " | " +
+                                //Hopefully this isn't too expensive in the long run
+                                FormatState(state, exception)
+            };
+            responseRouter.Window.Log(logMessage);
+        }
+    }
+
+
+    private static string FormatState<TState>(TState state, Exception? exception)
+    {
+        return state switch
+        {
+            IEnumerable<KeyValuePair<string, object>> dict => string.Join(" ", dict.Where(z => z.Key != "{OriginalFormat}").Select(z => $"{z.Key}='{z.Value}'")),
+            _ => JsonConvert.SerializeObject(state).Replace("\"", "'")
+        };
+    }
+
+    private static bool TryGetMessageType(LogLevel logLevel, out MessageType messageType)
+    {
+        switch (logLevel)
+        {
+            case LogLevel.Critical:
+            case LogLevel.Error:
+                messageType = MessageType.Error;
+                return true;
+            case LogLevel.Warning:
+                messageType = MessageType.Warning;
+                return true;
+            case LogLevel.Information:
+                messageType = MessageType.Info;
+                return true;
+            case LogLevel.Debug:
+            case LogLevel.Trace:
+                messageType = MessageType.Log;
+                return true;
+        }
+
+        messageType = MessageType.Log;
+        return false;
+    }
+}
+
+internal class LanguageServerLoggerProvider(ILanguageServerFacade languageServer) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new LanguageServerLogger(languageServer, categoryName);
+
+    public void Dispose() { }
+}
+
+
+public static class LanguageServerLoggerExtensions
+{
+    /// <summary>
+    /// Adds a custom logger provider for PSES LSP, that provides more granular categorization than the default Omnisharp logger, such as separating Omnisharp and PSES messages to different channels.
+    /// </summary>
+    public static ILoggingBuilder AddPsesLanguageServerLogging(this ILoggingBuilder builder)
+    {
+        builder.Services.AddSingleton<ILoggerProvider, LanguageServerLoggerProvider>();
+        return builder;
+    }
+
+    public static ILoggingBuilder AddLspClientConfigurableMinimumLevel(
+        this ILoggingBuilder builder,
+        LogLevel initialLevel = LogLevel.Trace
+    )
+    {
+        builder.Services.AddOptions<LoggerFilterOptions>();
+        builder.Services.AddSingleton<DynamicLogLevelOptions>(sp =>
+        {
+            IOptionsMonitor<LoggerFilterOptions> optionsMonitor = sp.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>();
+            return new(initialLevel, optionsMonitor);
+        });
+        builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
+            sp.GetRequiredService<DynamicLogLevelOptions>());
+
+        return builder;
+    }
+}
+
 internal class DynamicLogLevelOptions(
     LogLevel initialLevel,
     IOptionsMonitor<LoggerFilterOptions> optionsMonitor) : IConfigureOptions<LoggerFilterOptions>
@@ -22,23 +149,3 @@ internal class DynamicLogLevelOptions(
         _optionsMonitor.CurrentValue.MinLevel = level;
     }
 }
-
-public static class LoggingBuilderExtensions
-{
-    public static ILoggingBuilder AddLspClientConfigurableMinimumLevel(
-        this ILoggingBuilder builder,
-        LogLevel initialLevel = LogLevel.Trace
-    )
-    {
-        builder.Services.AddOptions<LoggerFilterOptions>();
-        builder.Services.AddSingleton<DynamicLogLevelOptions>(sp =>
-        {
-            IOptionsMonitor<LoggerFilterOptions> optionsMonitor = sp.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>();
-            return new(initialLevel, optionsMonitor);
-        });
-        builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
-            sp.GetRequiredService<DynamicLogLevelOptions>());
-        return builder;
-    }
-}
-

--- a/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
+++ b/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
@@ -68,7 +68,7 @@ internal class LanguageServerLogger(ILanguageServerFacade responseRouter, string
         {
             messagePrepend = logLevel switch
             {
-                LogLevel.Critical => "<Error> CRITICAL: ",
+                LogLevel.Critical => "<Error>CRITICAL: ",
                 LogLevel.Error => "<Error>",
                 LogLevel.Warning => "<Warning>",
                 LogLevel.Information => "<Info>",
@@ -76,6 +76,12 @@ internal class LanguageServerLogger(ILanguageServerFacade responseRouter, string
                 LogLevel.Trace => "<Trace>",
                 _ => string.Empty
             };
+
+            // The vscode formatter prepends some extra stuff to Info specifically, so we drop Info to Log, but it will get logged correctly on the other side thanks to our inline indicator that our custom parser on the other side will pick up and process.
+            if (messageType == MessageType.Info)
+            {
+                messageType = MessageType.Log;
+            }
         }
 
         LogMessageParams logMessage = new()

--- a/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
+++ b/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.PowerShell.EditorServices.Logging;
+internal class DynamicLogLevelOptions(
+    LogLevel initialLevel,
+    IOptionsMonitor<LoggerFilterOptions> optionsMonitor) : IConfigureOptions<LoggerFilterOptions>
+{
+    private LogLevel _currentLevel = initialLevel;
+    private readonly IOptionsMonitor<LoggerFilterOptions> _optionsMonitor = optionsMonitor;
+
+    public void Configure(LoggerFilterOptions options) => options.MinLevel = _currentLevel;
+
+    public void SetLogLevel(LogLevel level)
+    {
+        _currentLevel = level;
+        // Trigger reload of options to apply new log level
+        _optionsMonitor.CurrentValue.MinLevel = level;
+    }
+}
+
+public static class LoggingBuilderExtensions
+{
+    public static ILoggingBuilder AddLspClientConfigurableMinimumLevel(
+        this ILoggingBuilder builder,
+        LogLevel initialLevel = LogLevel.Trace
+    )
+    {
+        builder.Services.AddOptions<LoggerFilterOptions>();
+        builder.Services.AddSingleton<DynamicLogLevelOptions>(sp =>
+        {
+            IOptionsMonitor<LoggerFilterOptions> optionsMonitor = sp.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>();
+            return new(initialLevel, optionsMonitor);
+        });
+        builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(sp =>
+            sp.GetRequiredService<DynamicLogLevelOptions>());
+        return builder;
+    }
+}
+

--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
                     })
                     .ConfigureLogging(builder => builder
                         .ClearProviders()
-                        .AddLanguageProtocolLogging()
+                        .AddPsesLanguageServerLogging()
                         .SetMinimumLevel(_minimumLogLevel))
                     .WithHandler<PsesWorkspaceSymbolsHandler>()
                     .WithHandler<PsesTextDocumentHandler>()


### PR DESCRIPTION
- Align PsesLogLevel to MEL log levels
- Adjust some logging verbosity levels for the PSES startup logging flow to move better.
- Create a new LSP Log Debug Provider to get around limitations with the CSharp Omnisharp one.
- Drop all Omnisharp logs to trace since they are just LSP related
- Address LSP bugs by wiring up log levels in-band.

Should be merged with https://github.com/PowerShell/vscode-powershell/pull/5065