### PR TITLE
Enable Roslynator Analyzers via Nuget Package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,18 @@
     <PackageVersion Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.12.9">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Security.Principal" Version="4.3.0" />

--- a/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
+++ b/src/PowerShellEditorServices.Hosting/Configuration/HostLogger.cs
@@ -214,7 +214,6 @@ namespace Microsoft.PowerShell.EditorServices.Hosting
     /// <param name="ui">The PowerShell host user interface object to log output to.</param>
     internal class PSHostLogger(PSHostUserInterface ui) : IObserver<(PsesLogLevel logLevel, string message)>
     {
-
         public void OnCompleted()
         {
             // No-op since there's nothing to close or dispose,

--- a/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
+++ b/src/PowerShellEditorServices.Hosting/PowerShellEditorServices.Hosting.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
+  <Import
+    Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
@@ -14,6 +15,12 @@
     <PackageReference Include="PowerShellStandard.Library" PrivateAssets="all" />
     <PackageReference Include="System.IO.Pipes.AccessControl" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
+  </ItemGroup>
+
+  <ItemGroup Label="Roslynator">
+    <PackageReference Include="Roslynator.Analyzers" />
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
+++ b/src/PowerShellEditorServices/Logging/LanguageServerLogger.cs
@@ -137,7 +137,6 @@ internal class LanguageServerLoggerProvider(ILanguageServerFacade languageServer
     public void Dispose() { }
 }
 
-
 public static class LanguageServerLoggerExtensions
 {
     /// <summary>

--- a/src/PowerShellEditorServices/PowerShellEditorServices.csproj
+++ b/src/PowerShellEditorServices/PowerShellEditorServices.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
+  <Import
+    Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), PowerShellEditorServices.Common.props))\PowerShellEditorServices.Common.props" />
 
   <PropertyGroup>
     <AssemblyTitle>PowerShell Editor Services</AssemblyTitle>
@@ -39,6 +40,12 @@
     <PackageReference Include="System.IO.Pipes.AccessControl" />
     <PackageReference Include="System.Security.Principal" />
     <PackageReference Include="System.Security.Principal.Windows" />
+  </ItemGroup>
+
+  <ItemGroup Label="Roslynator">
+    <PackageReference Include="Roslynator.Analyzers" />
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" />
+    <PackageReference Include="Roslynator.Formatting.Analyzers" />
   </ItemGroup>
 
   <Choose>

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/LaunchAndAttachHandler.cs
@@ -301,7 +301,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                 throw new RpcErrorException(0, null, "Invalid configuration with no process ID nor custom pipe name!");
             }
 
-
             // Execute the Debug-Runspace command but don't await it because it
             // will block the debug adapter initialization process. The
             // InitializedEvent will be sent as soon as the RunspaceChanged
@@ -328,7 +327,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             if (request.RunspaceId < 1)
             {
-
                 throw new RpcErrorException(0, null, "A positive integer must be specified for the RunspaceId!");
             }
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/StackTraceHandler.cs
@@ -128,6 +128,4 @@ internal class StackTraceHandler(DebugService debugService) : IStackTraceHandler
         Column = invocationInfo.OffsetInLine,
         PresentationHint = StackFramePresentationHint.Label
     };
-
 }
-

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/VariablesHandler.cs
@@ -34,10 +34,12 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                             .ToArray()
                 };
             }
+            #pragma warning disable RCS1075
             catch (Exception)
             {
                 // TODO: This shouldn't be so broad
             }
+            #pragma warning restore RCS1075
 
             return variablesResponse;
         }

--- a/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/Handlers/ConfigurationHandler.cs
@@ -100,7 +100,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             return await Unit.Task.ConfigureAwait(false);
         }
 
-
         public event EventHandler<LanguageServerSettings> ConfigurationUpdated;
     }
 }

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -306,7 +306,6 @@ namespace PowerShellEditorServices.Test.E2E
             await PsesDebugAdapterClient.RequestConfigurationDone(new ConfigurationDoneArguments());
             await PsesDebugAdapterClient.LaunchScript(filePath, Started);
 
-
             // Get the stacktrace for the breakpoint
             await Assert.ThrowsAsync<JsonRpcException>(() => PsesDebugAdapterClient.RequestStackTrace(
                 new StackTraceArguments { }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -76,7 +76,6 @@ namespace PowerShellEditorServices.Test.Debugging
             variableScriptFile = GetDebugScript("VariableTest.ps1");
         }
 
-
         public async Task DisposeAsync()
         {
             debugService.Abort();


### PR DESCRIPTION
**This requires the following packages to be added to the Build Feed**
```
Roslynator.Analyzers
Roslynator.CodeAnalysis.Analyzers
Roslynator.Formatting.Analyzers
```

Rosylnator used to be used via vscode extension but since the switch to C# Dev Kit, Support for that has been non-functional (https://github.com/dotnet/vscode-csharp/issues/6790)

The analysis packages are now made available as Nuget packages, and this PR integrates them into the non-test repositories. This is the first step to later revise EditorConfig to enforce consistent code style among repositories.

Style-related recommendations based on current editorconfig (these are info recommendations and not enforced)
```
Analyzed solution 'D:\PowerShellEditorServices\PowerShellEditorServices.sln' (in 22.4 s)

  4 CA1510    Use ArgumentNullException throw helper
  2 CA1826    Do not use Enumerable methods on indexable collections
  2 CA1837    Use 'Environment.ProcessId'
  6 CA1859    Use concrete types when possible for improved performance
 10 CA1861    Avoid constant arrays as arguments
  1 CA2208    Instantiate argument exceptions correctly
  1 CA2249    Consider using 'string.Contains' instead of 'string.IndexOf'
  3 CS1998    Async method lacks 'await' operators and will run synchronously
  4 CS4014    Because this call is not awaited, execution of the current method continues before the call is completed
 74 IDE0028   Simplify collection initialization
 12 IDE0090   Use 'new(...)'
  2 RCS1015   Use nameof operator
  8 RCS1036   Remove unnecessary blank line
  1 RCS1075   Avoid empty catch clause that catches System.Exception
  4 RCS1097   Remove redundant 'ToString' call
  9 RCS1163   Unused parameter
  2 RCS1214   Unnecessary interpolated string
  1 RCS1218   Simplify code branching
 14 RCS1251   Remove unnecessary braces from record declaration
  2 RCS1267   Use string interpolation instead of 'string.Concat'
  1 VSTHRD104 Offer async methods
  3 xUnit1004 Test methods should not be skipped
  4 xUnit1042 The member referenced by the MemberData attribute returns untyped data rows
 26 xUnit2023 Do not use collection methods for single-item collections
```