### PR TITLE
OneBranch now uses PowerShell 7.4 so remove workarounds

### DIFF
--- a/.pipelines/PowerShellEditorServices-Official.yml
+++ b/.pipelines/PowerShellEditorServices-Official.yml
@@ -88,12 +88,9 @@ extends:
             inputs:
               packageType: runtime
               version: 6.x
-          - pwsh: |
-              Register-PSRepository -Name CFS -SourceLocation "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v2" -InstallationPolicy Trusted
-              Install-Module -Repository CFS -Name Microsoft.PowerShell.PSResourceGet
-              ./tools/installPSResources.ps1 -PSRepository CFS
+          - pwsh: ./tools/installPSResources.ps1 -PSRepository CFS
             displayName: Install PSResources
-          - pwsh: Invoke-Build Build -Configuration $(BuildConfiguration) -PSRepository CFS
+          - pwsh: Invoke-Build TestFull -Configuration $(BuildConfiguration) -PSRepository CFS
             displayName: Build and test
           - task: PublishTestResults@2
             displayName: Publish test results

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -9,5 +9,16 @@ if ($PSRepository -eq "CFS" -and -not (Get-PSResourceRepository -Name CFS -Error
     Register-PSResourceRepository -Name CFS -Uri "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v3/index.json"
 }
 
-Install-PSResource -Repository $PSRepository -TrustRepository -Name InvokeBuild
-Install-PSResource -Repository $PSRepository -TrustRepository -Name platyPS
+# NOTE: Due to a bug in Install-PSResource with upstream feeds, we have to
+# request an exact version. Otherwise, if a newer version is available in the
+# upstream feed, it will fail to install any version at all.
+Install-PSResource -Verbose -TrustRepository -RequiredResource  @{
+    InvokeBuild = @{
+        version = "5.12.1"
+        repository = $PSRepository
+      }
+    platyPS = @{
+        version = "0.14.2"
+        repository = $PSRepository
+    }
+}


### PR DESCRIPTION
We can rely on the pre-installed PSResourceGet and we can re-enable tests!

@JustinGrote seriously we can _finally_ run tests again in the release pipeline 🤞 