### PR TITLE
Surface Additional Parameter Documentation/Tooltips

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -482,6 +482,15 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         {
                             documentation = documentation.Substring((label + " - ").Length).Trim();
                         }
+                        // If the documentation starts with the same name as the variable, truncate this as well.
+                        else if (documentation.StartsWith("$" + label, StringComparison.OrdinalIgnoreCase))
+                        {
+                            documentation = documentation.Substring(("$" + label).Length).Trim();
+                        }
+                    }
+                    if (string.IsNullOrWhiteSpace(documentation))
+                    {
+                        documentation = null;
                     }
                 }
 

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -334,7 +334,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                     // deduce it is an operator.
                     : item with { Kind = CompletionItemKind.Operator },
                 CompletionResultType.ParameterValue => item with { Kind = CompletionItemKind.Value },
-                CompletionResultType.Variable => TryExtractType(detail, item.Label, out string type, out string documentation)
+                CompletionResultType.Variable => TryExtractType(detail, "$" + item.Label, out string type, out string documentation)
                     ? item with { Kind = CompletionItemKind.Variable, Detail = type, Documentation = documentation }
                     : item with { Kind = CompletionItemKind.Variable },
                 CompletionResultType.Namespace => item with { Kind = CompletionItemKind.Module },
@@ -481,11 +481,6 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
                         else if (documentation.StartsWith(label + " - ", StringComparison.OrdinalIgnoreCase))
                         {
                             documentation = documentation.Substring((label + " - ").Length).Trim();
-                        }
-                        // If the documentation starts with the same name as the variable, truncate this as well.
-                        else if (documentation.StartsWith("$" + label, StringComparison.OrdinalIgnoreCase))
-                        {
-                            documentation = documentation.Substring(("$" + label).Length).Trim();
                         }
                     }
                     if (string.IsNullOrWhiteSpace(documentation))

--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/CompletionHandler.cs
@@ -455,7 +455,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         /// <param name="documentation">The remaining text after the type, if any</param>
         /// <param name="label">The label to check for in the documentation prefix</param>
         /// <returns>Whether or not the type was found.</returns>
-        private static bool TryExtractType(string toolTipText, string label, out string type, out string documentation)
+        internal static bool TryExtractType(string toolTipText, string label, out string type, out string documentation)
         {
             MatchCollection matches = s_typeRegex.Matches(toolTipText);
             type = string.Empty;

--- a/test/PowerShellEditorServices.Test.Shared/Completion/CompletionExamples.psm1
+++ b/test/PowerShellEditorServices.Test.Shared/Completion/CompletionExamples.psm1
@@ -13,7 +13,7 @@ Import-Module PowerShellGet
 Get-Rand
 
 function Test-Completion {
-    param([Parameter(Mandatory, Value)])
+    param([Parameter(Mandatory, Value)]$test)
 }
 
 Get-ChildItem /

--- a/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
@@ -126,5 +126,28 @@ namespace PowerShellEditorServices.Test.Language
             Assert.Equal(actual.TextEdit.TextEdit with { NewText = "" }, CompleteFilePath.ExpectedEdit);
             Assert.All(results, r => Assert.True(r.Kind is CompletionItemKind.File or CompletionItemKind.Folder));
         }
+
+        // TODO: These should be an integration tests at a higher level if/when https://github.com/PowerShell/PowerShell/pull/25108 is merged. As of today, we can't actually test this in the PS engine currently.
+        [Fact]
+        public void CanExtractTypeAndDescriptionFromTooltip()
+        {
+            string expectedType = "[string]";
+            string expectedDescription = "Test String";
+            string paramName = "TestParam";
+            string testHelp = $"{expectedType} {paramName} - {expectedDescription}";
+            Assert.True(PsesCompletionHandler.TryExtractType(testHelp, paramName, out string type, out string description));
+            Assert.Equal(expectedType, type);
+            Assert.Equal(expectedDescription, description);
+        }
+
+        [Fact]
+        public void CanExtractTypeFromTooltip()
+        {
+            string expectedType = "[string]";
+            string testHelp = $"{expectedType}";
+            Assert.True(PsesCompletionHandler.TryExtractType(testHelp, string.Empty, out string type, out string description));
+            Assert.Null(description);
+            Assert.Equal(expectedType, type);
+        }
     }
 }

--- a/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/CompletionHandlerTests.cs
@@ -105,7 +105,6 @@ namespace PowerShellEditorServices.Test.Language
         [SkippableFact]
         public async Task CompletesAttributeValue()
         {
-            Skip.If(VersionUtils.IsPS74, "PowerShell 7.4 isn't returning these!");
             (_, IEnumerable<CompletionItem> results) = await GetCompletionResultsAsync(CompleteAttributeValue.SourceDetails);
             // NOTE: Since the completions come through un-ordered from PowerShell, their SortText
             // (which has an index prepended from the original order) will mis-match our assumed

--- a/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Language/SymbolsServiceTests.cs
@@ -796,37 +796,37 @@ namespace PowerShellEditorServices.Test.Language
             Assert.False(symbol.IsDeclaration);
             AssertIsRegion(symbol.NameRegion, 16, 29, 16, 39);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Workflow));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Workflow);
             Assert.Equal("fn AWorkflow", symbol.Id);
             Assert.Equal("workflow AWorkflow ()", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Class));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Class);
             Assert.Equal("type AClass", symbol.Id);
             Assert.Equal("class AClass { }", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Property));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Property);
             Assert.Equal("prop AProperty", symbol.Id);
             Assert.Equal("[string] $AProperty", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Constructor));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Constructor);
             Assert.Equal("mtd AClass", symbol.Id);
             Assert.Equal("AClass([string]$AParameter)", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Method));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Method);
             Assert.Equal("mtd AMethod", symbol.Id);
             Assert.Equal("void AMethod([string]$param1, [int]$param2, $param3)", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Enum));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Enum);
             Assert.Equal("type AEnum", symbol.Id);
             Assert.Equal("enum AEnum { }", symbol.Name);
             Assert.True(symbol.IsDeclaration);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.EnumMember));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.EnumMember);
             Assert.Equal("prop AValue", symbol.Id);
             Assert.Equal("AValue", symbol.Name);
             Assert.True(symbol.IsDeclaration);
@@ -866,38 +866,38 @@ namespace PowerShellEditorServices.Test.Language
         {
             IEnumerable<SymbolReference> symbols = FindSymbolsInFile(FindSymbolsInNewLineSymbolFile.SourceDetails);
 
-            SymbolReference symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Function));
+            SymbolReference symbol = Assert.Single(symbols, i => i.Type == SymbolType.Function);
             Assert.Equal("fn returnTrue", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 2, 1, 2, 11);
             AssertIsRegion(symbol.ScriptRegion, 1, 1, 4, 2);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Class));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Class);
             Assert.Equal("type NewLineClass", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 7, 1, 7, 13);
             AssertIsRegion(symbol.ScriptRegion, 6, 1, 23, 2);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Constructor));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Constructor);
             Assert.Equal("mtd NewLineClass", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 8, 5, 8, 17);
             AssertIsRegion(symbol.ScriptRegion, 8, 5, 10, 6);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Property));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Property);
             Assert.Equal("prop SomePropWithDefault", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 15, 5, 15, 25);
             AssertIsRegion(symbol.ScriptRegion, 12, 5, 15, 40);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Method));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Method);
             Assert.Equal("mtd MyClassMethod", symbol.Id);
             Assert.Equal("string MyClassMethod([MyNewLineEnum]$param1)", symbol.Name);
             AssertIsRegion(symbol.NameRegion, 20, 5, 20, 18);
             AssertIsRegion(symbol.ScriptRegion, 17, 5, 22, 6);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.Enum));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.Enum);
             Assert.Equal("type MyNewLineEnum", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 26, 1, 26, 14);
             AssertIsRegion(symbol.ScriptRegion, 25, 1, 28, 2);
 
-            symbol = Assert.Single(symbols.Where(i => i.Type == SymbolType.EnumMember));
+            symbol = Assert.Single(symbols, i => i.Type == SymbolType.EnumMember);
             Assert.Equal("prop First", symbol.Id);
             AssertIsRegion(symbol.NameRegion, 27, 5, 27, 10);
             AssertIsRegion(symbol.ScriptRegion, 27, 5, 27, 10);


### PR DESCRIPTION
Fixes an issue in type parsing where, if a type is discovered, additional documentation gets trimmed off. This restores that to the `Documentation` field.

I did a little experimenting with the new LabelDetail fields in LSP 3.17, but at least in vscode there was little to no visual advantage, something to maybe explore more later.

Would be nice to not have to text parse a string like this but it's where we are at currently with PS API

Related: https://github.com/PowerShell/PowerShell/pull/25108
![image](https://github.com/user-attachments/assets/60d11351-27b8-42f6-b393-7ced156ca718)

Related: https://github.com/PowerShell/PowerShell/pull/25112
![image](https://github.com/user-attachments/assets/d58d44da-f5d3-459a-9a84-2a6ab70d4f9c)


- [x] Needs Tests