### PR TITLE
Add git-blame-ignore-revs file for some refactor commits to make blame better.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Enable this file in your git config: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Enabled on GitHub automatically
+
+# Close Over APIs, was mostly reformatting
+945d61634784db2e51f894c9606e785a099fd23d
+# Dotnet Format Style
+44387b36695607248cebb9467ad48061c19354cb
+# Formatting Fixup
+7233182585b63760992545c7407b17fb2965bc5c


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adds a [git-blame-ignore-revs](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) file to remove formatting commits from git blame to more accurately identify who made a change.

Enables future refactoring work to not clutter up git blame. Supported natively on Github