### PR TITLE
Update deprecated API method in docs

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -61,7 +61,7 @@ Once the basic language configurations have been installed, add this to your
 ```lua
 local on_attach = function(client, bufnr)
 	-- Enable completion triggered by <c-x><c-o>
-	vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+	vim.api.nvim_set_option_value("omnifunc", "v:lua.vim.lsp.omnifunc", { buf = bufnr })
 
 	local bufopts = { noremap = true, silent = true, buffer = bufnr }
 	vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, bufopts)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Not super familiar with Neovim but this is deprecated
```lua
vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
```
and I believe this is the fix
```lua
vim.api.nvim_set_option_value("omnifunc", "v:lua.vim.lsp.omnifunc", { buf = bufnr })
```

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
