### PR TITLE
Allow new log levels in Start-EditorServices.ps1

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -46,7 +46,7 @@ param(
     [ValidateNotNullOrEmpty()]
     $LogPath,
 
-    [ValidateSet("Diagnostic", "Verbose", "Normal", "Warning", "Error")]
+    [ValidateSet(("Diagnostic", "Verbose", "Normal") + ("Trace", "Debug", "Information", "Warning", "Error", "Critical", "None"))]
     $LogLevel,
 
 	[ValidateNotNullOrEmpty()]


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Server yells against to be deprecated log levels, while new log levels are not allow for `$LogLevel` parameter in Start-EditorServices.ps1

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

https://github.com/PowerShell/PowerShellEditorServices/commit/d9de5bd8b1ed624a687d701fa2616e5991db2e2c
