### PR TITLE
Add missing MEL log levels to the `LogLevel` validation (#2235)

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -107,5 +107,13 @@ param(
     $DebugServiceOutPipeName
 )
 
+#Translate legacy PSES log levels to MEL levels
+$LogLevel = switch ($LogLevel) {
+    'Diagnostic' { 'Trace' }
+    'Verbose' { 'Debug' }
+    'Normal' { 'Information' }
+    default { $LogLevel }
+}
+
 Import-Module -Name "$PSScriptRoot/PowerShellEditorServices.psd1"
 Start-EditorServices @PSBoundParameters

--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -46,7 +46,7 @@ param(
     [ValidateNotNullOrEmpty()]
     $LogPath,
 
-    [ValidateSet("Diagnostic", "Verbose", "Normal", "Warning", "Error")]
+    [ValidateSet("Diagnostic", "Verbose", "Normal", "Warning", "Error", "Trace", "Debug", "Information", "Critical", "None")]
     $LogLevel,
 
 	[ValidateNotNullOrEmpty()]


### PR DESCRIPTION
# Summary

This PR adds `Trace`, `Debug`, `Information`, `Critical`, and `None` to the validation set on the `LogLevel` parameter when starting PSES using `Start-EditorServices.ps1` to allow for the adoption of the newer MEL log levels (#2200), closing #2235.

## Context

The `ValidationSet` defined for `LogLevel` here: [Start-EditorServices.ps1:49](https://github.com/PowerShell/PowerShellEditorServices/blob/3a429eac5544fd7613c281c0814f94ac03fad551/module/PowerShellEditorServices/Start-EditorServices.ps1#L49) was left out during the work done to enhance logging, meaning that the only MEL levels you can practically use are the ones that are the same as the legacy log levels. I chose to add the missing ones as opposed to replacing the old with the new for compatibility reasons which matched the sentiment [conveyed in the code](https://github.com/PowerShell/PowerShellEditorServices/blob/3a429eac5544fd7613c281c0814f94ac03fad551/src/PowerShellEditorServices.Hosting/Commands/StartEditorServicesCommand.cs#L268). I've included a bit more details in the issue I opened (#2235).
