### PR TITLE
Add indentation solution for powershell in vim/neovim

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -122,3 +122,26 @@ require('lspconfig')['powershell_es'].setup {
 	settings = { powershell = { scriptAnalysis = { settingsPath = custom_settings_path } } }
 }
 ```
+
+### Indentation
+
+Vim/Neovim does not contain default `:h indentexpr` for filetype `ps1`.
+So you might notice indentation on newline is not behaving as expected for powershell files.
+Luckily powershell has similar syntax like C, so we can use `:h cindent` to fix the indentation problem.
+You can use the following snippet to either callback of an autocmd or ftplugin.
+
+```lua
+--- ./nvim/lua/ftplugin/ps1.lua
+
+-- disable indent from powershell treesitter parser
+-- because the parse isn't mature currently
+-- you can ignore this step if don't use treesitter
+if pcall(require, 'nvim-treesitter') then
+  vim.schedule(function() vim.cmd([[TSBufDisable indent]]) end)
+end
+
+vim.opt_local.cindent = true
+vim.opt_local.cinoptions:append { 'J1', '(1s', '+0' } -- see :h cino-J, cino-(, cino-+
+
+vim.opt_local.iskeyword:remove { '-' } -- OPTIONALLY consider Verb-Noun as a whole word
+```


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Indentation is problem for powershell editing experience in vim/neovim since there's no dedicated indentation handler for powershell, I added a solution for this.

## PR Context

Not related to language server, but can improve life quality
