### PR TITLE
Support breakpoints in untitled files in WinPS

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -52,6 +52,10 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 # If using Set-PSBreakpoint we need to escape any wildcard patterns.
                 $PSBoundParameters['Script'] = [WildcardPattern]::Escape($Script)
             }
+            else {
+                # WinPS must use null for the Script if unset.
+                $Script = [NullString]::Value
+            }
 
             if ($PSCmdlet.ParameterSetName -eq 'Command') {
                 $cmdCtor = [System.Management.Automation.CommandBreakpoint].GetConstructor(

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -48,6 +48,11 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 $Command
             )
 
+            if ($Script) {
+                # If using Set-PSBreakpoint we need to escape any wildcard patterns.
+                $PSBoundParameters['Script'] = [WildcardPattern]::Escape($Script)
+            }
+
             if ($PSCmdlet.ParameterSetName -eq 'Command') {
                 $cmdCtor = [System.Management.Automation.CommandBreakpoint].GetConstructor(
                     [System.Reflection.BindingFlags]'NonPublic, Public, Instance',
@@ -125,7 +130,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 .ConfigureAwait(false);
         }
 
-        public async Task<IReadOnlyList<BreakpointDetails>> SetBreakpointsAsync(string escapedScriptPath, IReadOnlyList<BreakpointDetails> breakpoints)
+        public async Task<IReadOnlyList<BreakpointDetails>> SetBreakpointsAsync(IReadOnlyList<BreakpointDetails> breakpoints)
         {
             if (BreakpointApiUtils.SupportsBreakpointApis(_editorServicesHost.CurrentRunspace))
             {
@@ -186,7 +191,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // path which may or may not exist.
                 psCommand
                     .AddScript(_setPSBreakpointLegacy, useLocalScope: true)
-                    .AddParameter("Script", escapedScriptPath)
+                    .AddParameter("Script", breakpoint.Source)
                     .AddParameter("Line", breakpoint.LineNumber);
 
                 // Check if the user has specified the column number for the breakpoint.

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     await _breakpointService.RemoveAllBreakpointsAsync(scriptFile.FilePath).ConfigureAwait(false);
                 }
 
-                return await _breakpointService.SetBreakpointsAsync(escapedScriptPath, breakpoints).ConfigureAwait(false);
+                return await _breakpointService.SetBreakpointsAsync(breakpoints).ConfigureAwait(false);
             }
 
             return await dscBreakpoints

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/BreakpointHandlers.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
 using Microsoft.PowerShell.EditorServices.Services.DebugAdapter;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Runspace;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
 using Microsoft.PowerShell.EditorServices.Utility;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Models;
@@ -31,20 +30,17 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
         private readonly DebugService _debugService;
         private readonly DebugStateService _debugStateService;
         private readonly WorkspaceService _workspaceService;
-        private readonly IRunspaceContext _runspaceContext;
 
         public BreakpointHandlers(
             ILoggerFactory loggerFactory,
             DebugService debugService,
             DebugStateService debugStateService,
-            WorkspaceService workspaceService,
-            IRunspaceContext runspaceContext)
+            WorkspaceService workspaceService)
         {
             _logger = loggerFactory.CreateLogger<BreakpointHandlers>();
             _debugService = debugService;
             _debugStateService = debugStateService;
             _workspaceService = workspaceService;
-            _runspaceContext = runspaceContext;
         }
 
         public async Task<SetBreakpointsResponse> Handle(SetBreakpointsArguments request, CancellationToken cancellationToken)
@@ -182,12 +178,11 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
 
             Task.FromResult(new SetExceptionBreakpointsResponse());
 
-        private bool IsFileSupportedForBreakpoints(string requestedPath, ScriptFile resolvedScriptFile)
+        private static bool IsFileSupportedForBreakpoints(string requestedPath, ScriptFile resolvedScriptFile)
         {
-            // PowerShell 7 and above support breakpoints in untitled files
             if (ScriptFile.IsUntitledPath(requestedPath))
             {
-                return BreakpointApiUtils.SupportsBreakpointApis(_runspaceContext.CurrentRunspace);
+                return true;
             }
 
             if (string.IsNullOrEmpty(resolvedScriptFile?.FilePath))


### PR DESCRIPTION
# PR Summary
Adds support for setting breakpoints in untitled/unsaved files for Windows PowerShell 5.1. This aligns the breakpoint validation behaviour with the PowerShell 7.x API so that a breakpoint can be set for any ScriptBlock with a filename if it aligns with the client's filename.

## PR Context
Fixes: https://github.com/PowerShell/PowerShellEditorServices/issues/2243

This also means that breakpoints in untitled files will work in Windows PowerShell 5.1 and not just PowerShell 7+.
