### PR TITLE
Delay launch/attach until after config done

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugEventHandlerService.cs
@@ -94,17 +94,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
         {
             switch (e.ChangeAction)
             {
-                case RunspaceChangeAction.Enter:
-                    if (_debugStateService.WaitingForAttach
-                        && e.NewRunspace.RunspaceOrigin == RunspaceOrigin.DebuggedRunspace)
-                    {
-                        // Sends the InitializedEvent so that the debugger will continue
-                        // sending configuration requests
-                        _debugStateService.WaitingForAttach = false;
-                        _debugStateService.ServerStarted.TrySetResult(true);
-                    }
-                    return;
-
                 case RunspaceChangeAction.Exit:
                     if (_debugContext.IsStopped)
                     {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugStateService.cs
@@ -4,26 +4,23 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerShell.EditorServices.Utility;
+using OmniSharp.Extensions.JsonRpc;
 
 namespace Microsoft.PowerShell.EditorServices.Services
 {
     internal class DebugStateService
     {
         private readonly SemaphoreSlim _setBreakpointInProgressHandle = AsyncUtils.CreateSimpleLockingSemaphore();
+        private readonly SemaphoreSlim _inLaunchOrAttachHandle = AsyncUtils.CreateSimpleLockingSemaphore();
+        private TaskCompletionSource<bool> _waitForConfigDone;
 
         internal bool NoDebug { get; set; }
-
-        internal string[] Arguments { get; set; }
 
         internal bool IsRemoteAttach { get; set; }
 
         internal int? RunspaceId { get; set; }
 
         internal bool IsAttachSession { get; set; }
-
-        internal bool WaitingForAttach { get; set; }
-
-        internal string ScriptToLaunch { get; set; }
 
         internal bool ExecutionCompleted { get; set; }
 
@@ -34,13 +31,79 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         internal bool IsUsingTempIntegratedConsole { get; set; }
 
-        internal string ExecuteMode { get; set; }
-
         // This gets set at the end of the Launch/Attach handler which set debug state.
         internal TaskCompletionSource<bool> ServerStarted { get; set; }
 
         internal int ReleaseSetBreakpointHandle() => _setBreakpointInProgressHandle.Release();
 
         internal Task WaitForSetBreakpointHandleAsync() => _setBreakpointInProgressHandle.WaitAsync();
+
+        /// <summary>
+        /// Sends the InitializedEvent and waits for the configuration done
+        /// event to be sent by the client.
+        /// </summary>
+        /// <param name="action">The action being performed, either "attach" or "launch".</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <exception cref="RpcErrorException">A launch or attach request is already in progress</exception>
+        internal async Task WaitForConfigurationDoneAsync(
+            string action,
+            CancellationToken cancellationToken)
+        {
+            Task<bool> waitForConfigDone;
+
+            // First check we are not already running a launch or attach request.
+            await _inLaunchOrAttachHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_waitForConfigDone is not null)
+                {
+                    // If we are already waiting for a configuration done, then we cannot start another
+                    // launch or attach request.
+                    throw new RpcErrorException(0, null, $"Cannot start a new {action} request when one is already in progress.");
+                }
+
+                _waitForConfigDone = new TaskCompletionSource<bool>();
+                waitForConfigDone = _waitForConfigDone.Task;
+            }
+            finally
+            {
+                _inLaunchOrAttachHandle.Release();
+            }
+
+            using CancellationTokenRegistration _ = cancellationToken.Register(_waitForConfigDone.SetCanceled);
+
+            // Sends the InitializedEvent so that the debugger will continue
+            // sending configuration requests before the final configuration
+            // done.
+            ServerStarted.TrySetResult(true);
+            await waitForConfigDone.ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sets the configuration done task to complete, indicating that the
+        /// client has sent all the initial configuration information and the
+        /// debugger is ready to start.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        internal async Task SetConfigurationDoneAsync(
+            CancellationToken cancellationToken)
+        {
+            await _inLaunchOrAttachHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_waitForConfigDone is null)
+                {
+                    // If we are not waiting for a configuration done, then we cannot set it.
+                    throw new RpcErrorException(0, null, "Unexpected configuration done request when server is not expecting it.");
+                }
+
+                _waitForConfigDone.TrySetResult(true);
+                _waitForConfigDone = null;
+            }
+            finally
+            {
+                _inLaunchOrAttachHandle.Release();
+            }
+        }
     }
 }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/ConfigurationDoneHandler.cs
@@ -1,161 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Management.Automation;
-using System.Management.Automation.Language;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Microsoft.PowerShell.EditorServices.Services;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging;
-using Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution;
-using Microsoft.PowerShell.EditorServices.Services.TextDocument;
-using Microsoft.PowerShell.EditorServices.Utility;
-using OmniSharp.Extensions.DebugAdapter.Protocol.Events;
 using OmniSharp.Extensions.DebugAdapter.Protocol.Requests;
-using OmniSharp.Extensions.DebugAdapter.Protocol.Server;
 
 namespace Microsoft.PowerShell.EditorServices.Handlers
 {
     internal class ConfigurationDoneHandler : IConfigurationDoneHandler
     {
-        // TODO: We currently set `WriteInputToHost` as true, which writes our debugged commands'
-        // `GetInvocationText` and that reveals some obscure implementation details we should
-        // instead hide from the user with pretty strings (or perhaps not write out at all).
-        //
-        // This API is mostly used for F5 execution so it requires the foreground.
-        private static readonly PowerShellExecutionOptions s_debuggerExecutionOptions = new()
-        {
-            RequiresForeground = true,
-            WriteInputToHost = true,
-            WriteOutputToHost = true,
-            ThrowOnError = false,
-            AddToHistory = true,
-        };
-
-        private readonly ILogger _logger;
-        private readonly IDebugAdapterServerFacade _debugAdapterServer;
         private readonly DebugService _debugService;
         private readonly DebugStateService _debugStateService;
-        private readonly DebugEventHandlerService _debugEventHandlerService;
-        private readonly IInternalPowerShellExecutionService _executionService;
-        private readonly WorkspaceService _workspaceService;
-        private readonly IPowerShellDebugContext _debugContext;
 
-        // TODO: Decrease these arguments since they're a bunch of interfaces that can be simplified
-        // (i.e., `IRunspaceContext` should just be available on `IPowerShellExecutionService`).
         public ConfigurationDoneHandler(
-            ILoggerFactory loggerFactory,
-            IDebugAdapterServerFacade debugAdapterServer,
             DebugService debugService,
-            DebugStateService debugStateService,
-            DebugEventHandlerService debugEventHandlerService,
-            IInternalPowerShellExecutionService executionService,
-            WorkspaceService workspaceService,
-            IPowerShellDebugContext debugContext)
+            DebugStateService debugStateService)
         {
-            _logger = loggerFactory.CreateLogger<ConfigurationDoneHandler>();
-            _debugAdapterServer = debugAdapterServer;
             _debugService = debugService;
             _debugStateService = debugStateService;
-            _debugEventHandlerService = debugEventHandlerService;
-            _executionService = executionService;
-            _workspaceService = workspaceService;
-            _debugContext = debugContext;
         }
 
-        public Task<ConfigurationDoneResponse> Handle(ConfigurationDoneArguments request, CancellationToken cancellationToken)
+        public async Task<ConfigurationDoneResponse> Handle(ConfigurationDoneArguments request, CancellationToken cancellationToken)
         {
             _debugService.IsClientAttached = true;
 
-            if (!string.IsNullOrEmpty(_debugStateService.ScriptToLaunch))
-            {
-                // NOTE: This is an unawaited task because responding to "configuration done" means
-                // setting up the debugger, and in our case that means starting the script but not
-                // waiting for it to finish.
-                Task _ = LaunchScriptAsync(_debugStateService.ScriptToLaunch).HandleErrorsAsync(_logger);
-            }
+            // Tells the attach/launch request handler that the config is done
+            // and it can continue starting the script.
+            await _debugStateService.SetConfigurationDoneAsync(cancellationToken).ConfigureAwait(false);
 
-            if (_debugStateService.IsInteractiveDebugSession && _debugService.IsDebuggerStopped)
-            {
-                if (_debugService.CurrentDebuggerStoppedEventArgs is not null)
-                {
-                    // If this is an interactive session and there's a pending breakpoint, send that
-                    // information along to the debugger client.
-                    _debugEventHandlerService.TriggerDebuggerStopped(_debugService.CurrentDebuggerStoppedEventArgs);
-                }
-                else
-                {
-                    // If this is an interactive session and there's a pending breakpoint that has
-                    // not been propagated through the debug service, fire the debug service's
-                    // OnDebuggerStop event.
-                    _debugService.OnDebuggerStopAsync(null, _debugContext.LastStopEventArgs);
-                }
-            }
-
-            return Task.FromResult(new ConfigurationDoneResponse());
-        }
-
-        // NOTE: We test this function in `DebugServiceTests` so it both needs to be internal, and
-        // use conditional-access on `_debugStateService` and `_debugAdapterServer` as its not set
-        // by tests.
-        internal async Task LaunchScriptAsync(string scriptToLaunch)
-        {
-            PSCommand command;
-            if (System.IO.File.Exists(scriptToLaunch))
-            {
-                // For a saved file we just execute its path (after escaping it), with the configured operator
-                // (which can't be called that because it's a reserved keyword in C#).
-                string executeMode = _debugStateService?.ExecuteMode == "Call" ? "&" : ".";
-                command = PSCommandHelpers.BuildDotSourceCommandWithArguments(
-                    PSCommandHelpers.EscapeScriptFilePath(scriptToLaunch), _debugStateService?.Arguments, executeMode);
-            }
-            else // It's a URI to an untitled script, or a raw script.
-            {
-                bool isScriptFile = _workspaceService.TryGetFile(scriptToLaunch, out ScriptFile untitledScript);
-                if (isScriptFile)
-                {
-                    // Parse untitled files with their `Untitled:` URI as the filename which will
-                    // cache the URI and contents within the PowerShell parser. By doing this, we
-                    // light up the ability to debug untitled files with line breakpoints.
-                    ScriptBlockAst ast = Parser.ParseInput(
-                        untitledScript.Contents,
-                        untitledScript.DocumentUri.ToString(),
-                        out Token[] _,
-                        out ParseError[] _);
-
-                    // In order to use utilize the parser's cache (and therefore hit line
-                    // breakpoints) we need to use the AST's `ScriptBlock` object. Due to
-                    // limitations in PowerShell's public API, this means we must use the
-                    // `PSCommand.AddArgument(object)` method, hence this hack where we dot-source
-                    // `$args[0]. Fortunately the dot-source operator maintains a stack of arguments
-                    // on each invocation, so passing the user's arguments directly in the initial
-                    // `AddScript` surprisingly works.
-                    command = PSCommandHelpers
-                        .BuildDotSourceCommandWithArguments("$args[0]", _debugStateService?.Arguments)
-                        .AddArgument(ast.GetScriptBlock());
-                }
-                else
-                {
-                    // Without the new APIs we can only execute the untitled script's contents.
-                    // Command breakpoints and `Wait-Debugger` will work. We must wrap the script
-                    // with newlines so that any included comments don't break the command.
-                    command = PSCommandHelpers.BuildDotSourceCommandWithArguments(
-                        string.Concat(
-                            "{" + System.Environment.NewLine,
-                            isScriptFile ? untitledScript.Contents : scriptToLaunch,
-                            System.Environment.NewLine + "}"),
-                            _debugStateService?.Arguments);
-                }
-            }
-
-            await _executionService.ExecutePSCommandAsync(
-                command,
-                CancellationToken.None,
-                s_debuggerExecutionOptions).ConfigureAwait(false);
-
-            _debugAdapterServer?.SendNotification(EventNames.Terminated);
+            return new ConfigurationDoneResponse();
         }
     }
 }

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -552,10 +552,10 @@ namespace PowerShellEditorServices.Test.Debugging
                     new[] { BreakpointDetails.Create(scriptPath, 1) });
             }
 
-            ConfigurationDoneHandler configurationDoneHandler = new(
-                NullLoggerFactory.Instance, null, debugService, null, null, psesHost, workspace, null);
+            LaunchAndAttachHandler launchAndAttachHandler = new(
+                NullLoggerFactory.Instance, null, null, null, debugService, psesHost, psesHost, workspace, null, null);
 
-            Task _ = configurationDoneHandler.LaunchScriptAsync(scriptPath);
+            Task _ = launchAndAttachHandler.LaunchScriptAsync(scriptPath, [], "DotSource");
             await AssertDebuggerStopped(scriptPath, 1);
 
             VariableDetailsBase[] variables = await GetVariables(VariableContainerDetails.CommandVariablesName);
@@ -574,9 +574,9 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task RecordsF5CommandInPowerShellHistory()
         {
-            ConfigurationDoneHandler configurationDoneHandler = new(
-                NullLoggerFactory.Instance, null, debugService, null, null, psesHost, workspace, null);
-            await configurationDoneHandler.LaunchScriptAsync(debugScriptFile.FilePath);
+            LaunchAndAttachHandler launchAndAttachHandler = new(
+                NullLoggerFactory.Instance, null, null, null, debugService, psesHost, psesHost, workspace, null, null);
+            await launchAndAttachHandler.LaunchScriptAsync(debugScriptFile.FilePath, [], "DotSource");
 
             IReadOnlyList<string> historyResult = await psesHost.ExecutePSCommandAsync<string>(
                 new PSCommand().AddScript("(Get-History).CommandLine"),
@@ -614,9 +614,9 @@ namespace PowerShellEditorServices.Test.Debugging
         [Fact]
         public async Task OddFilePathsLaunchCorrectly()
         {
-            ConfigurationDoneHandler configurationDoneHandler = new(
-                NullLoggerFactory.Instance, null, debugService, null, null, psesHost, workspace, null);
-            await configurationDoneHandler.LaunchScriptAsync(oddPathScriptFile.FilePath);
+            LaunchAndAttachHandler launchAndAttachHandler = new(
+                NullLoggerFactory.Instance, null, null, null, debugService, psesHost, psesHost, workspace, null, null);
+            await launchAndAttachHandler.LaunchScriptAsync(oddPathScriptFile.FilePath, [], "DotSource");
 
             IReadOnlyList<string> historyResult = await psesHost.ExecutePSCommandAsync<string>(
                 new PSCommand().AddScript("(Get-History).CommandLine"),


### PR DESCRIPTION
# PR Summary
Updates the sequence of launching and attaching scripts until after
configuration done is received. This aligns the behviour of starting a
debug session with other debug adapters. A side effect of this change is
that it is now possible to set breakpoints and do other actions in an
attached runspace target during the initialisation.

Also adds a new option `NotifyOnAttach` for an attach request which will
create the `PSES.Attached` event before calling `Debug-Runspace`
allowing attached scripts to wait for an attach event.

## PR Context
Fixes: https://github.com/PowerShell/PowerShellEditorServices/issues/2191
Fixes: https://github.com/PowerShell/PowerShellEditorServices/issues/2245

The changes include the commit from https://github.com/PowerShell/PowerShellEditorServices/pull/2251 which includes some test runner changes and to verify all the recent stuff added by myself work properly. I'll take this out of draft once we know what is happening with #2251.

PR to document new option in `vscode-powershell` https://github.com/PowerShell/vscode-powershell/pull/5249.
