### PR TITLE
Add `pathMappings` option to debugger

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Start-DebugAttachSession.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Start-DebugAttachSession.ps1
@@ -44,6 +44,10 @@ function Start-DebugAttachSession {
         $WindowActionOnEnd,
 
         [Parameter()]
+        [IDictionary[]]
+        $PathMapping,
+
+        [Parameter()]
         [switch]
         $AsJob
     )
@@ -110,11 +114,21 @@ function Start-DebugAttachSession {
                 return
             }
 
-            $configuration.name = "Attach Process $ProcessId"
+            if ($Name) {
+                $configuration.name = $Name
+            }
+            else {
+                $configuration.name = "Attach Process $ProcessId"
+            }
             $configuration.processId = $ProcessId
         }
         elseif ($CustomPipeName) {
-            $configuration.name = "Attach Pipe $CustomPipeName"
+            if ($Name) {
+                $configuration.name = $Name
+            }
+            else {
+                $configuration.name = "Attach Pipe $CustomPipeName"
+            }
             $configuration.customPipeName = $CustomPipeName
         }
         else {
@@ -134,6 +148,10 @@ function Start-DebugAttachSession {
 
         if ($WindowActionOnEnd) {
             $configuration.temporaryConsoleWindowActionOnDebugEnd = $WindowActionOnEnd.ToLowerInvariant()
+        }
+
+        if ($PathMapping) {
+            $configuration.pathMappings = $PathMapping
         }
 
         # https://microsoft.github.io/debug-adapter-protocol/specification#Reverse_Requests_StartDebugging

--- a/module/docs/Start-DebugAttachSession.md
+++ b/module/docs/Start-DebugAttachSession.md
@@ -16,14 +16,15 @@ Starts a new debug session attached to the specified PowerShell instance.
 ### ProcessId (Default)
 ```
 Start-DebugAttachSession [-Name <String>] [-ProcessId <Int32>] [-RunspaceName <String>] [-RunspaceId <Int32>]
- [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}] [-AsJob] [<CommonParameters>]
+ [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}] [-PathMapping <IDictionary[]>] [-AsJob]
+ [<CommonParameters>]
 ```
 
 ### CustomPipeName
 ```
 Start-DebugAttachSession [-Name <String>] [-CustomPipeName <String>] [-RunspaceName <String>]
- [-RunspaceId <Int32>] [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}] [-AsJob]
- [<CommonParameters>]
+ [-RunspaceId <Int32>] [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}]
+ [-PathMapping <IDictionary[]>] [-AsJob] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -74,6 +75,27 @@ Write-Host "Test $a - $PID"
 ```
 
 Launches a new PowerShell process with a custom pipe and starts a new attach configuration that will debug the new process under a child debugging session. The caller waits until the new process ends before ending the parent session.
+
+### -------------------------- EXAMPLE 2 --------------------------
+
+```powershell
+$attachParams = @{
+    ComputerName = 'remote-windows'
+    ProcessId = $remotePid
+    RunspaceId = 1
+    PathMapping = @(
+        @{
+            localRoot = 'C:\local\path\to\scripts\'
+            remoteRoot = 'C:\remote\path\on\remote-windows\'
+        }
+    )
+}
+Start-DebugAttachSession @attachParams
+```
+
+Attaches to a remote PSSession through the WSMan parameter and maps the remote path running the script in the PSSession to the same copy of files locally. For example `remote-windows` is running the script `C:\remote\path\on\remote-windows\script.ps1` but the same script(s) are located locally on the current host `C:\local\path\to\scripts\script.ps1`.
+
+The debug client can see the remote files as local when setting breakpoints and inspecting the callstack with this mapped path.
 
 ## PARAMETERS
 
@@ -133,6 +155,24 @@ The name of the debug session to show in the debug client.
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PathMapping
+
+An array of dictionaries with the keys `localRoot` and `remoteRoot` that maps a local and remote path root to each other. This option is useful when attaching to a PSSession running a script that is not accessible locally but can be found under a different path.
+
+It is a good idea to ensure the `localRoot` and `remoteRoot` entries are either the absolute path to a script or ends with the trailing directory separator if specifying a directory. A path can also be mapped from a Windows and non-Windows path, just ensure the correct directory separators are used for each OS type. For example `/` for non-Windows and `\` for Windows.
+
+```yaml
+Type: IDictionary[]
 Parameter Sets: (All)
 Aliases:
 

--- a/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/BreakpointService.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 // path which may or may not exist.
                 psCommand
                     .AddScript(_setPSBreakpointLegacy, useLocalScope: true)
-                    .AddParameter("Script", breakpoint.Source)
+                    .AddParameter("Script", breakpoint.MappedSource ?? breakpoint.Source)
                     .AddParameter("Line", breakpoint.LineNumber);
 
                 // Check if the user has specified the column number for the breakpoint.
@@ -219,7 +219,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 IEnumerable<Breakpoint> setBreakpoints = await _executionService
                     .ExecutePSCommandAsync<Breakpoint>(psCommand, CancellationToken.None)
                     .ConfigureAwait(false);
-                configuredBreakpoints.AddRange(setBreakpoints.Select((breakpoint) => BreakpointDetails.Create(breakpoint)));
+
+                int bpIdx = 0;
+                foreach (Breakpoint setBp in setBreakpoints)
+                {
+                    BreakpointDetails setBreakpoint = BreakpointDetails.Create(
+                        setBp,
+                        sourceBreakpoint: breakpoints[bpIdx]);
+                    configuredBreakpoints.Add(setBreakpoint);
+                    bpIdx++;
+                }
             }
             return configuredBreakpoints;
         }

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointApiUtils.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             {
                 BreakpointDetails lineBreakpoint => SetLineBreakpointDelegate(
                     debugger,
-                    lineBreakpoint.Source,
+                    lineBreakpoint.MappedSource ?? lineBreakpoint.Source,
                     lineBreakpoint.LineNumber,
                     lineBreakpoint.ColumnNumber ?? 0,
                     actionScriptBlock,

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Debugging/BreakpointDetails.cs
@@ -25,6 +25,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         public string Source { get; private set; }
 
         /// <summary>
+        /// Gets the source where the breakpoint is mapped to, will be null if no mapping exists.  Used only for debug purposes.
+        /// </summary>
+        public string MappedSource { get; private set; }
+
+        /// <summary>
         /// Gets the line number at which the breakpoint is set.
         /// </summary>
         public int LineNumber { get; private set; }
@@ -50,6 +55,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// <param name="condition"></param>
         /// <param name="hitCondition"></param>
         /// <param name="logMessage"></param>
+        /// <param name="mappedSource"></param>
         /// <returns></returns>
         internal static BreakpointDetails Create(
             string source,
@@ -57,7 +63,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             int? column = null,
             string condition = null,
             string hitCondition = null,
-            string logMessage = null)
+            string logMessage = null,
+            string mappedSource = null)
         {
             Validate.IsNotNullOrEmptyString(nameof(source), source);
 
@@ -69,7 +76,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
                 ColumnNumber = column,
                 Condition = condition,
                 HitCondition = hitCondition,
-                LogMessage = logMessage
+                LogMessage = logMessage,
+                MappedSource = mappedSource
             };
         }
 
@@ -79,10 +87,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
         /// </summary>
         /// <param name="breakpoint">The Breakpoint instance from which details will be taken.</param>
         /// <param name="updateType">The BreakpointUpdateType to determine if the breakpoint is verified.</param>
+        /// /// <param name="sourceBreakpoint">The breakpoint source from the debug client, if any.</param>
         /// <returns>A new instance of the BreakpointDetails class.</returns>
         internal static BreakpointDetails Create(
             Breakpoint breakpoint,
-            BreakpointUpdateType updateType = BreakpointUpdateType.Set)
+            BreakpointUpdateType updateType = BreakpointUpdateType.Set,
+            BreakpointDetails sourceBreakpoint = null)
         {
             Validate.IsNotNull(nameof(breakpoint), breakpoint);
 
@@ -96,10 +106,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.DebugAdapter
             {
                 Id = breakpoint.Id,
                 Verified = updateType != BreakpointUpdateType.Disabled,
-                Source = lineBreakpoint.Script,
+                Source = sourceBreakpoint?.MappedSource is not null ? sourceBreakpoint.Source : lineBreakpoint.Script,
                 LineNumber = lineBreakpoint.Line,
                 ColumnNumber = lineBreakpoint.Column,
-                Condition = lineBreakpoint.Action?.ToString()
+                Condition = lineBreakpoint.Action?.ToString(),
+                MappedSource = sourceBreakpoint?.MappedSource,
             };
 
             if (lineBreakpoint.Column > 0)

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             //       We should instead ensure that the debugger is in some valid state, lock it and then tear things down
 
             _debugEventHandlerService.UnregisterEventHandlers();
-            _debugService.UnsetPathMappings();
+            _debugService.PathMappings = [];
 
             if (!_debugStateService.ExecutionCompleted)
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/Handlers/DisconnectHandler.cs
@@ -50,6 +50,7 @@ namespace Microsoft.PowerShell.EditorServices.Handlers
             //       We should instead ensure that the debugger is in some valid state, lock it and then tear things down
 
             _debugEventHandlerService.UnregisterEventHandlers();
+            _debugService.UnsetPathMappings();
 
             if (!_debugStateService.ExecutionCompleted)
             {

--- a/src/PowerShellEditorServices/Services/DebugAdapter/PathMapping.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/PathMapping.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace Microsoft.PowerShell.EditorServices.Services;
+
+/// <summary>
+/// Used for attach requests to map a local and remote path together.
+/// </summary>
+internal record PathMapping
+{
+    /// <summary>
+    /// Gets or sets the local root of this mapping entry.
+    /// </summary>
+    public string? LocalRoot { get; set; }
+
+    /// <summary>
+    /// Gets or sets the remote root of this mapping entry.
+    /// </summary>
+    public string? RemoteRoot { get; set; }
+}
+
+#nullable disable

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/DscBreakpointCapability.cs
@@ -91,10 +91,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
                     .AddCommand(@"Microsoft.PowerShell.Core\Import-Module")
                     .AddParameter("Name", "PSDesiredStateConfiguration")
                     .AddParameter("PassThru")
-                    .AddParameter("ErrorAction", ActionPreference.Ignore);
+                    .AddParameter("ErrorAction", ActionPreference.Ignore)
+                    .AddCommand(@"Microsoft.PowerShell.Utility\Select-Object")
+                    .AddParameter("ExpandProperty", "Name");
 
-                IReadOnlyList<PSModuleInfo> dscModule =
-                    await executionService.ExecutePSCommandAsync<PSModuleInfo>(
+                IReadOnlyList<string> dscModule =
+                    await executionService.ExecutePSCommandAsync<string>(
                         psCommand,
                         CancellationToken.None,
                         new PowerShellExecutionOptions { ThrowOnError = false })

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -201,7 +201,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerAcceptsScriptArgs(string[] args)
         {
             IReadOnlyList<BreakpointDetails> breakpoints = await debugService.SetLineBreakpointsAsync(
-                oddPathScriptFile,
+                oddPathScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(oddPathScriptFile.FilePath, 3) });
 
             Assert.Single(breakpoints);
@@ -310,7 +310,7 @@ namespace PowerShellEditorServices.Test.Debugging
         {
             IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
-                    debugScriptFile,
+                    debugScriptFile.FilePath,
                     new[] {
                         BreakpointDetails.Create(debugScriptFile.FilePath, 5),
                         BreakpointDetails.Create(debugScriptFile.FilePath, 10)
@@ -323,7 +323,7 @@ namespace PowerShellEditorServices.Test.Debugging
             Assert.Equal(10, breakpoints[1].LineNumber);
 
             breakpoints = await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(debugScriptFile.FilePath, 2) });
             confirmedBreakpoints = await GetConfirmedBreakpoints(debugScriptFile);
 
@@ -331,7 +331,7 @@ namespace PowerShellEditorServices.Test.Debugging
             Assert.Equal(2, breakpoints[0].LineNumber);
 
             await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 Array.Empty<BreakpointDetails>());
 
             IReadOnlyList<LineBreakpoint> remainingBreakpoints = await GetConfirmedBreakpoints(debugScriptFile);
@@ -342,7 +342,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerStopsOnLineBreakpoints()
         {
             await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 new[] {
                     BreakpointDetails.Create(debugScriptFile.FilePath, 5),
                     BreakpointDetails.Create(debugScriptFile.FilePath, 7)
@@ -361,7 +361,7 @@ namespace PowerShellEditorServices.Test.Debugging
             const int breakpointValue2 = 20;
 
             await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 new[] {
                     BreakpointDetails.Create(debugScriptFile.FilePath, 7, null, $"$i -eq {breakpointValue1} -or $i -eq {breakpointValue2}"),
                 });
@@ -397,7 +397,7 @@ namespace PowerShellEditorServices.Test.Debugging
             const int hitCount = 5;
 
             await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 new[] {
                     BreakpointDetails.Create(debugScriptFile.FilePath, 6, null, null, $"{hitCount}"),
                 });
@@ -420,7 +420,7 @@ namespace PowerShellEditorServices.Test.Debugging
             const int hitCount = 5;
 
             await debugService.SetLineBreakpointsAsync(
-                debugScriptFile,
+                debugScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(debugScriptFile.FilePath, 6, null, "$i % 2 -eq 0", $"{hitCount}") });
 
             Task _ = ExecuteDebugFileAsync();
@@ -441,7 +441,7 @@ namespace PowerShellEditorServices.Test.Debugging
         {
             IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
-                    debugScriptFile,
+                    debugScriptFile.FilePath,
                     new[] {
                         // TODO: Add this breakpoint back when it stops moving around?! The ordering
                         // of these two breakpoints seems to do with which framework executes the
@@ -469,7 +469,7 @@ namespace PowerShellEditorServices.Test.Debugging
         {
             IReadOnlyList<BreakpointDetails> breakpoints =
                 await debugService.SetLineBreakpointsAsync(
-                    debugScriptFile,
+                    debugScriptFile.FilePath,
                     new[] {
                         BreakpointDetails.Create(debugScriptFile.FilePath, 5, column: null, condition: "$i == 100"),
                         BreakpointDetails.Create(debugScriptFile.FilePath, 7, column: null, condition: "$i > 100")
@@ -548,7 +548,7 @@ namespace PowerShellEditorServices.Test.Debugging
             else
             {
                 await debugService.SetLineBreakpointsAsync(
-                    scriptFile,
+                    scriptFile.FilePath,
                     new[] { BreakpointDetails.Create(scriptPath, 1) });
             }
 
@@ -630,7 +630,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariableStringDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 8) });
 
             Task _ = ExecuteVariableScriptFileAsync();
@@ -648,7 +648,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerGetsVariables()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 21) });
 
             Task _ = ExecuteVariableScriptFileAsync();
@@ -698,7 +698,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerSetsVariablesNoConversion()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 14) });
 
             Task _ = ExecuteVariableScriptFileAsync();
@@ -751,7 +751,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerSetsVariablesWithConversion()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 14) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -807,7 +807,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariableEnumDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 15) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -827,7 +827,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariableHashtableDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 11) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -860,7 +860,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariableNullStringDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 16) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -880,7 +880,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariablePSObjectDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 17) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -1076,7 +1076,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariablePSCustomObjectDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 18) });
 
             // Execute the script and wait for the breakpoint to be hit
@@ -1105,7 +1105,7 @@ namespace PowerShellEditorServices.Test.Debugging
         public async Task DebuggerVariableProcessObjectDisplaysCorrectly()
         {
             await debugService.SetLineBreakpointsAsync(
-                variableScriptFile,
+                variableScriptFile.FilePath,
                 new[] { BreakpointDetails.Create(variableScriptFile.FilePath, 19) });
 
             // Execute the script and wait for the breakpoint to be hit


### PR DESCRIPTION
# PR Summary

Adds the `pathMappings` option to the debugger that can be used to map a local to remote path and vice versa. This is useful if the local environment has a checkout of the files being run on a remote target but at a different path. The mappings are used to translate the paths that will the breakpoint will be set to in the target PowerShell instance. It is also used to update the stack trace paths received from the remote.

For a launch scenario, the path mappings are also used when launching a script if the integrated terminal has entered a remote runspace.

## PR Context

Fixes: https://github.com/PowerShell/PowerShellEditorServices/issues/2242
