### PR TITLE
Add WindowActionOnEnd for Start-DebugAttachSession

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/Start-DebugAttachSession.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/Start-DebugAttachSession.ps1
@@ -39,6 +39,11 @@ function Start-DebugAttachSession {
         $ComputerName,
 
         [Parameter()]
+        [ValidateSet('Close', 'Hide', 'Keep')]
+        [string]
+        $WindowActionOnEnd,
+
+        [Parameter()]
         [switch]
         $AsJob
     )
@@ -125,6 +130,10 @@ function Start-DebugAttachSession {
         }
         elseif ($RunspaceName) {
             $configuration.runspaceName = $RunspaceName
+        }
+
+        if ($WindowActionOnEnd) {
+            $configuration.temporaryConsoleWindowActionOnDebugEnd = $WindowActionOnEnd.ToLowerInvariant()
         }
 
         # https://microsoft.github.io/debug-adapter-protocol/specification#Reverse_Requests_StartDebugging

--- a/module/docs/Start-DebugAttachSession.md
+++ b/module/docs/Start-DebugAttachSession.md
@@ -16,13 +16,14 @@ Starts a new debug session attached to the specified PowerShell instance.
 ### ProcessId (Default)
 ```
 Start-DebugAttachSession [-Name <String>] [-ProcessId <Int32>] [-RunspaceName <String>] [-RunspaceId <Int32>]
- [-ComputerName <String>] [-AsJob] [<CommonParameters>]
+ [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}] [-AsJob] [<CommonParameters>]
 ```
 
 ### CustomPipeName
 ```
 Start-DebugAttachSession [-Name <String>] [-CustomPipeName <String>] [-RunspaceName <String>]
- [-RunspaceId <Int32>] [-ComputerName <String>] [-AsJob] [<CommonParameters>]
+ [-RunspaceId <Int32>] [-ComputerName <String>] [-WindowActionOnEnd {Close | Hide | Keep}] [-AsJob]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -177,6 +178,22 @@ Accept wildcard characters: False
 ### -RunspaceName
 
 The name of the runspace to debug in the attached process. This option is mutually exclusive with `-RunspaceId`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WindowActionOnEnd
+
+Specifies the action to take on the temporary debug console created by the debug client after the attached session ends. This corresponds to the VSCode attach configuration option `temporaryConsoleWindowActionOnDebugEnd`. Setting to `Close` will close the debug console, `Hide` will move back to the last debug console before the attach session started, and `Keep` (default) will keep the active terminal as the attached session.
 
 ```yaml
 Type: String


### PR DESCRIPTION
# PR Summary
Adds the parameter `-WindowActionOnEnd` that corresponds to the new VSCode attach configuration option
`temporaryConsoleWindowActionOnDebugEnd`.

## PR Context

PR that added the VSCode debug option https://github.com/PowerShell/vscode-powershell/pull/5255.