### PR TITLE
Add setting for the formatter to trim trailing whitespace

### DIFF
--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -208,6 +208,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
         public bool UseCorrectCasing { get; set; }
+        public bool RemoveTrailingWhitespace { get; set; }
 
         /// <summary>
         /// Get the settings hashtable that will be consumed by PSScriptAnalyzer.
@@ -326,6 +327,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                 // Empty hashtable required to activate the rule,
                 // since PSAvoidUsingCmdletAliases inherits from IScriptRule and not ConfigurableRule
                 ruleConfigurations.Add("PSAvoidUsingCmdletAliases", new Hashtable());
+            }
+
+            if (RemoveTrailingWhitespace)
+            {
+                // Empty hashtable required to activate the rule,
+                // since PSAvoidTrailingWhitespace inherits from IScriptRule and not ConfigurableRule
+                ruleConfigurations.Add("PSAvoidTrailingWhitespace", new Hashtable());
             }
 
             return new Hashtable()


### PR DESCRIPTION
# PR Summary

Expose a setting to include the `PSAvoidTrailingWhitespace` rule when formatting

## PR Context

Since the release of PSSA 1.24, `PSAvoidTrailingWhitespace` correctly fixes trailing whitespace through `Invoke-Formatter`. (https://github.com/PowerShell/PSScriptAnalyzer/pull/1993)
