### PR TITLE
PSSA scheduling change

### DIFF
--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -94,8 +94,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
         private Lazy<PssaCmdletAnalysisEngine> _analysisEngineLazy;
 
-        private CancellationTokenSource _diagnosticsCancellationTokenSource;
-
         private readonly string _pssaModulePath;
 
         private string _pssaSettingsFilePath;
@@ -135,37 +133,32 @@ namespace Microsoft.PowerShell.EditorServices.Services
 
             EnsureEngineSettingsCurrent();
 
-            // If there's an existing task, we want to cancel it here;
-            CancellationTokenSource cancellationSource = new();
-            CancellationTokenSource oldTaskCancellation = Interlocked.Exchange(ref _diagnosticsCancellationTokenSource, cancellationSource);
-            if (oldTaskCancellation is not null)
-            {
-                try
-                {
-                    oldTaskCancellation.Cancel();
-                    oldTaskCancellation.Dispose();
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e, "Exception occurred while cancelling analysis task");
-                }
-            }
-
             if (filesToAnalyze.Length == 0)
             {
                 return;
             }
 
-            Task analysisTask = Task.Run(() => DelayThenInvokeDiagnosticsAsync(filesToAnalyze, _diagnosticsCancellationTokenSource.Token), _diagnosticsCancellationTokenSource.Token);
-
-            // Ensure that any next corrections request will wait for this diagnostics publication
+            // Analyze each file independently with its own cancellation token
             foreach (ScriptFile file in filesToAnalyze)
             {
-                CorrectionTableEntry fileCorrectionsEntry = _mostRecentCorrectionsByFile.GetOrAdd(
-                    file,
-                    CorrectionTableEntry.CreateForFile);
+                CorrectionTableEntry fileAnalysisEntry = _mostRecentCorrectionsByFile.GetOrAdd(file, CorrectionTableEntry.CreateForFile);
 
-                fileCorrectionsEntry.DiagnosticPublish = analysisTask;
+                CancellationTokenSource cancellationSource = new();
+                CancellationTokenSource oldTaskCancellation = Interlocked.Exchange(ref fileAnalysisEntry.CancellationSource, cancellationSource);
+                if (oldTaskCancellation is not null)
+                {
+                    try
+                    {
+                        oldTaskCancellation.Cancel();
+                        oldTaskCancellation.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Exception occurred while cancelling analysis task");
+                    }
+                }
+
+                _ = Task.Run(() => DelayThenInvokeDiagnosticsAsync(file, fileAnalysisEntry), cancellationSource.Token);
             }
         }
 
@@ -222,7 +215,9 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
 
             // Wait for diagnostics to be published for this file
+            #pragma warning disable VSTHRD003
             await corrections.DiagnosticPublish.ConfigureAwait(false);
+            #pragma warning restore VSTHRD003
 
             return corrections.Corrections;
         }
@@ -345,18 +340,20 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
         }
 
-        internal async Task DelayThenInvokeDiagnosticsAsync(ScriptFile[] filesToAnalyze, CancellationToken cancellationToken)
+        internal async Task DelayThenInvokeDiagnosticsAsync(ScriptFile fileToAnalyze, CorrectionTableEntry fileAnalysisEntry)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            CancellationToken cancellationToken = fileAnalysisEntry.CancellationSource.Token;
+            Task previousAnalysisTask = fileAnalysisEntry.DiagnosticPublish;
 
-            try
-            {
-                await Task.Delay(_analysisDelayMillis, cancellationToken).ConfigureAwait(false);
-            }
-            catch (TaskCanceledException)
+            // Shouldn't start a new analysis task until:
+            //  1. Delay/debounce period finishes (i.e. user has not started typing again)
+            //  2. Previous analysis task finishes (runspace pool is capped at 1, so we'd be sitting in a queue there)
+            Task debounceAndPrevious = Task.WhenAll(Task.Delay(_analysisDelayMillis), previousAnalysisTask ?? Task.CompletedTask);
+
+            // In parallel, we will keep an eye on our cancellation token
+            Task cancellationTask = Task.Delay(Timeout.Infinite, cancellationToken);
+
+            if (cancellationTask == await Task.WhenAny(debounceAndPrevious, cancellationTask).ConfigureAwait(false))
             {
                 return;
             }
@@ -368,16 +365,35 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // on.  It makes sense to send back the results from the first
             // delay period while the second one is ticking away.
 
-            foreach (ScriptFile scriptFile in filesToAnalyze)
+            TaskCompletionSource<ScriptFileMarker[]> placeholder = new TaskCompletionSource<ScriptFileMarker[]>();
+
+            // Try to take the place of the currently running task by atomically writing our task in the fileAnalysisEntry.
+            Task valueAtExchange = Interlocked.CompareExchange(ref fileAnalysisEntry.DiagnosticPublish, placeholder.Task, previousAnalysisTask);
+
+            if (valueAtExchange != previousAnalysisTask) {
+                // Some other task has managed to jump in front of us i.e. fileAnalysisEntry.DiagnosticPublish is
+                // no longer equal to previousAnalysisTask which we noted down at the start of this method
+                _logger.LogDebug("Failed to claim the running analysis task spot");
+                return;
+            }
+
+            // Successfully claimed the running task slot, we can actually run the analysis now
+            try
             {
-                ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(scriptFile.Contents).ConfigureAwait(false);
+                ScriptFileMarker[] semanticMarkers = await AnalysisEngine.AnalyzeScriptAsync(fileToAnalyze.Contents).ConfigureAwait(false);
+                placeholder.SetResult(semanticMarkers);
 
                 // Clear existing PSScriptAnalyzer markers (but keep parser errors where the source is "PowerShell")
                 // so that they are not duplicated when re-opening files.
-                scriptFile.DiagnosticMarkers.RemoveAll(m => m.Source == "PSScriptAnalyzer");
-                scriptFile.DiagnosticMarkers.AddRange(semanticMarkers);
+                fileToAnalyze.DiagnosticMarkers.RemoveAll(m => m.Source == "PSScriptAnalyzer");
+                fileToAnalyze.DiagnosticMarkers.AddRange(semanticMarkers);
 
-                PublishScriptDiagnostics(scriptFile);
+                PublishScriptDiagnostics(fileToAnalyze);
+            }
+            catch (Exception ex)
+            {
+                placeholder.SetException(ex);
+                throw;
             }
         }
 
@@ -480,8 +496,6 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     {
                         _analysisEngineLazy.Value.Dispose();
                     }
-
-                    _diagnosticsCancellationTokenSource?.Dispose();
                 }
 
                 disposedValue = true;
@@ -501,7 +515,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// wait for analysis to finish if needed,
         /// and then fetch the corrections set in the table entry by PSSA.
         /// </summary>
-        private class CorrectionTableEntry
+        internal class CorrectionTableEntry : IDisposable
         {
             public static CorrectionTableEntry CreateForFile(ScriptFile _) => new();
 
@@ -509,11 +523,17 @@ namespace Microsoft.PowerShell.EditorServices.Services
             {
                 Corrections = new ConcurrentDictionary<string, IEnumerable<MarkerCorrection>>();
                 DiagnosticPublish = Task.CompletedTask;
+                CancellationSource = new CancellationTokenSource();
             }
 
             public ConcurrentDictionary<string, IEnumerable<MarkerCorrection>> Corrections { get; }
 
-            public Task DiagnosticPublish { get; set; }
+            public Task DiagnosticPublish;
+
+            public CancellationTokenSource CancellationSource;
+
+            public void Dispose() =>
+                CancellationSource?.Dispose();
         }
     }
 }

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -348,7 +348,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Shouldn't start a new analysis task until:
             //  1. Delay/debounce period finishes (i.e. user has not started typing again)
             //  2. Previous analysis task finishes (runspace pool is capped at 1, so we'd be sitting in a queue there)
-            Task debounceAndPrevious = Task.WhenAll(Task.Delay(_analysisDelayMillis), previousAnalysisTask ?? Task.CompletedTask);
+            Task debounceAndPrevious = Task.WhenAll(Task.Delay(_analysisDelayMillis), previousAnalysisTask);
 
             // In parallel, we will keep an eye on our cancellation token
             Task cancellationTask = Task.Delay(Timeout.Infinite, cancellationToken);
@@ -370,7 +370,8 @@ namespace Microsoft.PowerShell.EditorServices.Services
             // Try to take the place of the currently running task by atomically writing our task in the fileAnalysisEntry.
             Task valueAtExchange = Interlocked.CompareExchange(ref fileAnalysisEntry.DiagnosticPublish, placeholder.Task, previousAnalysisTask);
 
-            if (valueAtExchange != previousAnalysisTask) {
+            if (valueAtExchange != previousAnalysisTask)
+            {
                 // Some other task has managed to jump in front of us i.e. fileAnalysisEntry.DiagnosticPublish is
                 // no longer equal to previousAnalysisTask which we noted down at the start of this method
                 _logger.LogDebug("Failed to claim the running analysis task spot");

--- a/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/AnalysisService.cs
@@ -497,6 +497,12 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     {
                         _analysisEngineLazy.Value.Dispose();
                     }
+
+                    foreach (CorrectionTableEntry entry in _mostRecentCorrectionsByFile.Values)
+                    {
+                        entry.Dispose();
+                    }
+                    _mostRecentCorrectionsByFile.Clear();
                 }
 
                 disposedValue = true;

--- a/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -252,10 +253,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
 
         private async Task<ScriptFileMarker[]> GetSemanticMarkersFromCommandAsync(PSCommand command)
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             PowerShellResult result = await InvokePowerShellAsync(command).ConfigureAwait(false);
+            stopwatch.Stop();
 
             IReadOnlyCollection<PSObject> diagnosticResults = result?.Output ?? s_emptyDiagnosticResult;
-            _logger.LogDebug(string.Format("Found {0} violations", diagnosticResults.Count));
+            _logger.LogDebug(string.Format("Found {0} violations in {1}ms", diagnosticResults.Count, stopwatch.ElapsedMilliseconds));
 
             ScriptFileMarker[] scriptMarkers = new ScriptFileMarker[diagnosticResults.Count];
             int i = 0;

--- a/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
+++ b/test/PowerShellEditorServices.Test/Services/Symbols/PSScriptAnalyzerTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerShell.EditorServices.Hosting;
@@ -69,15 +68,16 @@ namespace PowerShellEditorServices.Test.Services.Symbols
         public async Task DoesNotDuplicateScriptMarkersAsync()
         {
             ScriptFile scriptFile = workspaceService.GetFileBuffer("untitled:Untitled-1", script);
-            ScriptFile[] scriptFiles = { scriptFile };
+            AnalysisService.CorrectionTableEntry fileAnalysisEntry =
+                AnalysisService.CorrectionTableEntry.CreateForFile(scriptFile);
 
             await analysisService
-                .DelayThenInvokeDiagnosticsAsync(scriptFiles, CancellationToken.None);
+                .DelayThenInvokeDiagnosticsAsync(scriptFile, fileAnalysisEntry);
             Assert.Single(scriptFile.DiagnosticMarkers);
 
             // This is repeated to test that the markers are not duplicated.
             await analysisService
-                .DelayThenInvokeDiagnosticsAsync(scriptFiles, CancellationToken.None);
+                .DelayThenInvokeDiagnosticsAsync(scriptFile, fileAnalysisEntry);
             Assert.Single(scriptFile.DiagnosticMarkers);
         }
 
@@ -86,10 +86,11 @@ namespace PowerShellEditorServices.Test.Services.Symbols
         {
             // Causing a missing closing } parser error
             ScriptFile scriptFile = workspaceService.GetFileBuffer("untitled:Untitled-2", script.TrimEnd('}'));
-            ScriptFile[] scriptFiles = { scriptFile };
+            AnalysisService.CorrectionTableEntry fileAnalysisEntry =
+                AnalysisService.CorrectionTableEntry.CreateForFile(scriptFile);
 
             await analysisService
-                .DelayThenInvokeDiagnosticsAsync(scriptFiles, CancellationToken.None);
+                .DelayThenInvokeDiagnosticsAsync(scriptFile, fileAnalysisEntry);
 
             Assert.Collection(scriptFile.DiagnosticMarkers,
                 (actual) =>


### PR DESCRIPTION
# PR Summary

Change from a single PSSA queue to per-file queues. When a new analysis request comes in, it cancels all pending analysis requests for the same file.

Fixes #2260 

## PR Context

This change helps if you have PSSA rules that take more than 750ms to run. As the code is being edited this will prevent the number of pending analysis jobs from growing out of control.


### Interactive test / repro
Set up a new VSCode workspace:
`.vscode\settings.json`
```json
{
    "powershell.developer.editorServicesLogLevel": "Trace",
    "powershell.trace.server": "verbose",
    "powershell.scriptAnalysis.settingsPath": ".\\PSScriptAnalyzerSettings.psd1"
}
```
`PSScriptAnalyzerSettings.psd1`
```powershell
@{
    CustomRulePath = '.\SlowRule.psm1'
    IncludeDefaultRules = $false
}
```
`SlowRule.psm1`
```powershell
function SlowRule {
    [CmdletBinding()]
    param (
        # The script block that is being evaluated.
        [Parameter(Mandatory)]
        [ValidateNotNullOrEmpty()]
        [System.Management.Automation.Language.ScriptBlockAst]
        $ScriptBlockAst
    )

    Start-Sleep -Seconds 4
}
```
Compile from commit `548704c` to have PSSA timing information in the debug logs.

Open `SlowRule.psm1` and type e.g. "12345" in the comment, leaving about a second (importantly, more than the 750ms debounce delay) between each keypress. Notice how according to the logs each script analysis run takes longer and longer. What this also shows is that after you stop typing it takes a long time to analyze the code that you're seeing at on the screen.

```
2025-12-18 14:46:27.904 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 4518ms | 
2025-12-18 14:46:32.251 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 8014ms | 
2025-12-18 14:46:36.692 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 10745ms | 
2025-12-18 14:46:41.078 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 14347ms | 
```

Compiling from the tip of the branch and repeating the same test results in:

```
2025-12-18 09:56:59.254 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 4363ms | 
2025-12-18 09:57:03.692 [debug] [PSES] Microsoft.PowerShell.EditorServices.Services.Analysis.PssaCmdletAnalysisEngine: Found 0 violations in 4436ms | 
```
Runtimes are now ~same because analysis jobs are not stuck waiting for a PS runspace. And secondly, only two script analysis runs happened because "3", "4" and "5" keypresses had the chance to cancel the previous one that was waiting for "1" keypress analysis to finish.
