### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.13" />
@@ -13,15 +13,15 @@
     <PackageVersion Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.14.1">
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.14.1">
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.14.1">
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
@@ -32,6 +32,6 @@
     <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates NuGet packages to latest within-range versions.

## Changes

- `Microsoft.Extensions.FileSystemGlobbing`: 10.0.0 → 10.0.3
- `Microsoft.Extensions.Logging`: 10.0.0 → 10.0.3
- `Microsoft.Extensions.Logging.Debug`: 10.0.0 → 10.0.3
- `Roslynator.Analyzers`: 4.14.1 → 4.15.0
- `Roslynator.CodeAnalysis.Analyzers`: 4.14.1 → 4.15.0
- `Roslynator.Formatting.Analyzers`: 4.14.1 → 4.15.0
- `Xunit.SkippableFact`: 1.5.23 → 1.5.61

Skipped (major version bumps or intentional pins):
- `xunit.runner.visualstudio`: v3 (major breaking change)
- `Microsoft.PowerShell.SDK`: intentional version pin in test project