### PR TITLE
Add new code formatting preset "OTPS": OTBS with `else` on new line

### DIFF
--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -134,6 +134,11 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         OTBS,
 
         /// <summary>
+        /// Configure the formatting settings to resemble OTBS with else on new line.
+        /// </summary>
+        OTPS,
+
+        /// <summary>
         /// Configure the formatting settings to resemble the Stroustrup brace style variant of K&amp;R indent/brace style.
         /// </summary>
         Stroustrup
@@ -237,6 +242,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                     openBraceSettings["OnSameLine"] = true;
                     openBraceSettings["NewLineAfter"] = true;
                     closeBraceSettings["NewLineAfter"] = false;
+                    break;
+
+                case CodeFormattingPreset.OTPS:
+                    openBraceSettings["OnSameLine"] = true;
+                    openBraceSettings["NewLineAfter"] = true;
+                    closeBraceSettings["NewLineAfter"] = true;
                     break;
 
                 case CodeFormattingPreset.Stroustrup:


### PR DESCRIPTION
Edit: Blocked, see <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045#issuecomment-4016377821>.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

* Linked PR in PSSA: <https://github.com/PowerShell/PSScriptAnalyzer/pull/2158>
* Linked PR in vscode-powershell that can be merged after this and the PR to PSSA: <https://github.com/PowerShell/vscode-powershell/pull/5413>

This PR adds a new code formatting preset, "OTPS" (**O**ne **T**rue **P**owerShell **S**tyle): OTBS with `else` on new line.

## PR Context

Thoughts behind the name:

* To mock the idea of one true formatting style, even though there are none.
* We do ONE change from OTBS (`else` on new line), also in the name (change B with P).

Feature request:

* <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045>

Context:

* "There is no One True Brace Style": <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177>
  * About OTBS with `else` on a new line:
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518163>
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518179>
