### PR TITLE
Add AlignEnumMemberValues setting

### DIFF
--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -207,6 +207,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         public bool WhitespaceInsideBrace { get; set; }
         public bool IgnoreOneLineBlock { get; set; }
         public bool AlignPropertyValuePairs { get; set; }
+        public bool AlignEnumMemberValues { get; set; }
         public bool UseCorrectCasing { get; set; }
 
         /// <summary>
@@ -298,7 +299,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                     "PSAlignAssignmentStatement",
                     new Hashtable {
                     { "Enable", true },
-                    { "CheckHashtable", AlignPropertyValuePairs }
+                    { "CheckHashtable", AlignPropertyValuePairs },
+                    { "CheckEnums", AlignEnumMemberValues },
                 }
                 },
                 {


### PR DESCRIPTION
# PR Summary

This PR exposes the new PSSA setting for controlling whether Enum formatting is enabled or disabled.

## PR Context

[PSScriptAnalyzer 1.25.0](https://github.com/PowerShell/PSScriptAnalyzer/releases/tag/1.25.0) has been released (🎉) and contains https://github.com/PowerShell/PSScriptAnalyzer/pull/2132 which added support for Enum formatting.

There is a corresponding PR for the vscode-powershell which expose the setting to users. https://github.com/PowerShell/vscode-powershell/pull/5442
