### PR TITLE
Update rename disclaimer link and improve test skipping

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/RenameService.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/RenameService.cs
@@ -190,7 +190,7 @@ internal class RenameService(
         if (DisclaimerDeclinedForSession) { throw new HandlerErrorException(disclaimerDeclinedMessage); }
         if (acceptDisclaimerOption || DisclaimerAcceptedForSession) { return true; }
 
-        const string renameDisclaimer = "PowerShell rename functionality is only supported in a limited set of circumstances. [Please review the notice](https://github.com/PowerShell/PowerShellEditorServices?tab=readme-ov-file#rename-disclaimer) and accept the limitations and risks.";
+        const string renameDisclaimer = "PowerShell rename functionality is only supported in a limited set of circumstances. [Please review the notice](https://aka.ms/powershell-rename-disclaimer) and accept the limitations and risks.";
         const string acceptAnswer = "I Accept";
         const string declineAnswer = "Decline";
 

--- a/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/DebugAdapterProtocolMessageTests.cs
@@ -621,7 +621,7 @@ namespace PowerShellEditorServices.Test.E2E
             await terminatedTcs.Task;
         }
 
-        [SkippableFact(Timeout = 10000)]
+        [SkippableFact(Timeout = 15000)]
         public async Task CanAttachScriptWithPathMappings()
         {
             Skip.If(PsesStdioLanguageServerProcessHost.RunningInConstrainedLanguageMode,

--- a/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
+++ b/test/PowerShellEditorServices.Test.E2E/LanguageServerProtocolMessageTests.cs
@@ -1239,7 +1239,10 @@ function CanSendGetCommentHelpRequest {
         [SkippableFact(Timeout = 120000)]
         public async Task CanSendGetCommandRequestAsync()
         {
-            Skip.If(Environment.GetEnvironmentVariable("TF_BUILD") is not null,
+            Skip.If(
+                Environment.GetEnvironmentVariable("TF_BUILD") is not null ||
+                Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null ||
+                Environment.GetEnvironmentVariable("CI") is not null,
                 "This test is too slow in CI.");
 
             List<object> pSCommandMessages =


### PR DESCRIPTION
The pull request updates the disclaimer link to point to the new aka.ms URL and enhances the test skipping logic to account for additional CI platforms. This change improves clarity and ensures tests run efficiently across different environments.

