### PR TITLE
Fix #2297: guard PrepareRenameHandler against null rename capability

### DIFF
--- a/src/PowerShellEditorServices/Services/TextDocument/Handlers/RenameHandler.cs
+++ b/src/PowerShellEditorServices/Services/TextDocument/Handlers/RenameHandler.cs
@@ -20,7 +20,11 @@ internal class PrepareRenameHandler
     RenameService renameService
 ) : IPrepareRenameHandler
 {
-    public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => capability.PrepareSupport ? new() { PrepareProvider = true } : new();
+    // A null capability means the client omitted textDocument.rename from its initialize
+    // request; treat that as "no prepare support" instead of dereferencing it. Dereferencing
+    // the null capability threw a NullReferenceException that hung the initialize handshake.
+    // Fixes PowerShell/PowerShellEditorServices#2297.
+    public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => capability is { PrepareSupport: true } ? new() { PrepareProvider = true } : new();
 
     public async Task<RangeOrPlaceholderRange?> Handle(PrepareRenameParams request, CancellationToken cancellationToken)
         => await renameService.PrepareRenameSymbol(request, cancellationToken).ConfigureAwait(false);
@@ -34,7 +38,9 @@ internal class RenameHandler(
 ) : IRenameHandler
 {
     // RenameOptions may only be specified if the client states that it supports prepareSupport in its initial initialize request.
-    public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => capability.PrepareSupport ? new() { PrepareProvider = true } : new();
+    // A null capability means the client omitted textDocument.rename; guard it rather than
+    // dereferencing (the NRE hung initialize). Fixes PowerShell/PowerShellEditorServices#2297.
+    public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => capability is { PrepareSupport: true } ? new() { PrepareProvider = true } : new();
 
     public async Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
         => await renameService.RenameSymbol(request, cancellationToken).ConfigureAwait(false);

--- a/test/PowerShellEditorServices.Test/Refactoring/PrepareRenameHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Refactoring/PrepareRenameHandlerTests.cs
@@ -113,6 +113,19 @@ public class PrepareRenameHandlerTests
         Assert.True(result?.DefaultBehavior?.DefaultBehavior);
     }
 
+    [Fact]
+    public void GetRegistrationOptionsToleratesOmittedRenameCapability()
+    {
+        // Regression for PowerShell/PowerShellEditorServices#2297: when the client's
+        // initialize omits textDocument.rename, the framework passes a null
+        // RenameCapability. GetRegistrationOptions must not dereference it -- the
+        // NullReferenceException hung the initialize handshake. A null capability means
+        // the client has no prepare support.
+        RenameRegistrationOptions options = testHandler.GetRegistrationOptions(null!, new());
+        Assert.NotNull(options);
+        Assert.False(options.PrepareProvider, "omitted rename capability must not enable PrepareProvider");
+    }
+
     // TODO: Bad Path Tests (strings, parameters, etc.)
 }
 

--- a/test/PowerShellEditorServices.Test/Refactoring/RenameHandlerTests.cs
+++ b/test/PowerShellEditorServices.Test/Refactoring/RenameHandlerTests.cs
@@ -125,4 +125,15 @@ public class RenameHandlerTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void GetRegistrationOptionsToleratesOmittedRenameCapability()
+    {
+        // Regression for PowerShell/PowerShellEditorServices#2297: a client that omits
+        // textDocument.rename causes the framework to pass a null RenameCapability;
+        // GetRegistrationOptions must not dereference it (the NRE hung initialize).
+        RenameRegistrationOptions options = testHandler.GetRegistrationOptions(null!, new());
+        Assert.NotNull(options);
+        Assert.False(options.PrepareProvider, "omitted rename capability must not enable PrepareProvider");
+    }
 }


### PR DESCRIPTION
# Drafted PR -- PSES PrepareRename/Rename null RenameCapability guard (#2297)

**Status:** PR-READY, **NOT SUBMITTED**. The fix branch is pushed to Mike's fork:

- Fork branch: `manderse21/PowerShellEditorServices` @ `fix/2297-prepare-rename-null-capability`
- Base: `PowerShell/PowerShellEditorServices` @ `main` (which is `v4.6.0`, commit `d2112c21`)
- Commit: `Fix #2297: guard null RenameCapability in rename handlers`

Opening the PR (fork branch -> upstream `main`) is **Mike's explicit action**. Nothing
has been submitted, commented, or posted upstream.

---

## PR title

```
Fix #2297: guard null RenameCapability in rename handlers
```

## PR body (draft)

### Summary

`PrepareRenameHandler` and `RenameHandler` both read `capability.PrepareSupport` in
`GetRegistrationOptions`. The language-server framework passes a **null**
`RenameCapability` when the client's `initialize` omits `textDocument.rename`, so the
dereference throws a `NullReferenceException` during capability registration. The
exception leaves the `initialize` request unanswered, so the handshake **hangs** for
any client that legitimately omits the optional `rename` capability (#2297).

The rename provider is new in `v4.6.0` (#2292), so this affects `v4.6.0`.

### Fix

Guard both handlers with a property pattern, so an absent capability is treated as
"no prepare support" instead of dereferenced:

```csharp
// before
public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities)
    => capability.PrepareSupport ? new() { PrepareProvider = true } : new();

// after
public RenameRegistrationOptions GetRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities)
    => capability is { PrepareSupport: true } ? new() { PrepareProvider = true } : new();
```

### Tests

Adds a regression test to each handler's test class asserting
`GetRegistrationOptions(null, ...)` does not throw and reports no prepare provider.

### Validation (performed locally before submission)

- `dotnet build -c Release` is clean (the Release configuration's documentation/analyzer
  gate passes).
- The rename test category is green: **102 tests** including the two new regression tests
  (`Category=PrepareRename|Category=RenameHandlerFunction`, net8.0 Release).
- **Adversarial control:** reverting only the guard makes both new tests fail with the
  exact NRE -- `RenameHandler.GetRegistrationOptions` (`RenameHandler.cs:37`) and
  `PrepareRenameHandler.GetRegistrationOptions` (`RenameHandler.cs:23`) -- and they pass
  again with the guard restored, confirming the tests guard the regression and the fix
  is the cause.
- **End-to-end:** an `initialize` that omits `rename`, sent over `-Stdio`, never returns
  an `initialize` response against a stock `v4.6.0` bundle (hang reproduced); the same
  probe against a bundle in which only `Microsoft.PowerShell.EditorServices.dll` is
  rebuilt from this branch returns the `initialize` response and completes the handshake.
- The full `PowerShellEditorServices.Test` unit project runs **315/320** green on net8.0
  Release. The 5 failures are pre-existing environment dependencies unrelated to this
  change -- `CanLoadPSReadLine`, `CanLoadPSScriptAnalyzerAsync`, and three PSSA-dependent
  tests (parse-error / script-marker / built-in command help) -- which need PSReadLine and
  PSScriptAnalyzer provisioned (this local sandbox does not install them; the project's CI
  does). No rename test fails.

Closes #2297.
