### PR TITLE
Correct example PowerShell -Uri argument name

### DIFF
--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -45,7 +45,7 @@ Alternatively, you can extract the zip file into the same place:
 $DownloadUrl = 'https://github.com/neovim/nvim-lspconfig/archive/refs/heads/master.zip';
 $ZipPath = "$HOME/AppData/local/nvim/nvim-lspconfig.zip";
 $InstallPath = "$HOME/AppData/local/nvim/pack/complete/start/nvim-lspconfig";
-Invoke-WebRequest -Method 'GET' Uri $DownloadUrl -OutFile $ZipPath;
+Invoke-WebRequest -Method 'GET' -Uri $DownloadUrl -OutFile $ZipPath;
 Expand-Archive -Path $ZipPath -DestinationPath $InstallPath;
 ```
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The [Getting Started](https://github.com/PowerShell/PowerShellEditorServices/blob/40cf5e1ea4fed40a75af59871cc5c05e9707bab2/docs/guide/getting_started.md) page has sample PowerShell that readers can execute to integrate with Neovim. However, the sample code has a typo, with the hyphen missing for the `-Uri` argument.

I've corrected the typo.

## PR Context

This is the error that readers would encounter before this fix:

```
> Invoke-WebRequest -Method 'GET' Uri $DownloadUrl -OutFile $ZipPath;
Invoke-WebRequest: A positional parameter cannot be found that accepts argument 'https://github.com/neovim/nvim-lspconfig/archive/refs/heads/master.zip'.
```

This is the line with the bug:

https://github.com/PowerShell/PowerShellEditorServices/blob/40cf5e1ea4fed40a75af59871cc5c05e9707bab2/docs/guide/getting_started.md?plain=1#L48