### PR TITLE
Add `FileContext.GetText(IFileRange)` overload

### DIFF
--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
         /// <returns>A string with the specified range of content.</returns>
-        public string GetText(FileRange bufferRange)
+        public string GetText(IFileRange bufferRange)
         {
             return
                 string.Join(
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// </summary>
         /// <param name="fileRange">The buffer range for which content will be extracted.</param>
         /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
-        public string[] GetTextLines(FileRange fileRange) => scriptFile.GetLinesInRange(fileRange.ToBufferRange());
+        public string[] GetTextLines(IFileRange fileRange) => scriptFile.GetLinesInRange(fileRange.ToBufferRange());
 
         #endregion
 

--- a/test/PowerShellEditorServices.Test/Extensions/FileContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/FileContextTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.PowerShell.EditorServices.Extensions;
+using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Microsoft.PowerShell.EditorServices.Test.Shared;
+using Xunit;
+
+namespace PowerShellEditorServices.Test.Extensions
+{
+    [Trait("Category", "Extensions")]
+    public class FileContextTests
+    {
+        private static EditorContext CreateEditorContext(string content, BufferRange selectedRange)
+        {
+            string filePath = TestUtilities.NormalizePath(@"C:\Temp\Test.ps1");
+            ScriptFile scriptFile = ScriptFile.Create(new Uri(filePath), content, new Version("7.0"));
+            return new EditorContext(
+                editorOperations: null,
+                scriptFile,
+                new BufferPosition(line: 1, column: 1),
+                selectedRange);
+        }
+
+        // Regression test for https://github.com/PowerShell/PowerShellEditorServices/issues/1496
+        // where $Context.CurrentFile.GetText($Context.SelectedRange) failed because GetText only
+        // accepted the concrete FileRange type rather than the IFileRange that SelectedRange returns.
+        [Fact]
+        public void CanGetTextFromSelectedRange()
+        {
+            EditorContext editorContext = CreateEditorContext(
+                "Line One\nLine Two\nLine Three",
+                new BufferRange(2, 1, 2, 9));
+
+            IFileRange selectedRange = editorContext.SelectedRange;
+            string text = editorContext.CurrentFile.GetText(selectedRange);
+
+            Assert.Equal("Line Two", text);
+        }
+
+        [Fact]
+        public void CanGetTextLinesFromSelectedRange()
+        {
+            EditorContext editorContext = CreateEditorContext(
+                "Line One\nLine Two\nLine Three",
+                new BufferRange(1, 1, 2, 9));
+
+            string[] lines = editorContext.CurrentFile.GetTextLines(editorContext.SelectedRange);
+
+            Assert.Equal(new[] { "Line One", "Line Two" }, lines);
+        }
+
+        [Fact]
+        public void CanGetTextFromConstructedFileRange()
+        {
+            EditorContext editorContext = CreateEditorContext(
+                "Line One\nLine Two\nLine Three",
+                BufferRange.None);
+
+            IFileRange range = new FileRange(
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(3, 1),
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(3, 11));
+
+            Assert.Equal("Line Three", editorContext.CurrentFile.GetText(range));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1496.

`EditorContext.SelectedRange` is typed as `IFileRange`, but `FileContext.GetText`/`GetTextLines` only accepted the concrete `FileRange` class. So the natural `$Context.CurrentFile.GetText($Context.SelectedRange)` failed overload resolution ("Cannot find an overload for GetText and the argument count: 1"), and the documented workaround of constructing a `FileRange` isn't reachable when that type isn't loaded.

This widens both parameters from `FileRange` to `IFileRange`. The bodies already route through the `ToBufferRange()` extension on `IFileRange`, so nothing else changes and existing `FileRange` callers keep working.

Adds focused regression tests covering `GetText`/`GetTextLines` with a `SelectedRange` and with a hand-built `FileRange`.