### PR TITLE
Guard against null workspaceFolders on initialize

### DIFF
--- a/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
+++ b/src/PowerShellEditorServices/Server/PsesLanguageServer.cs
@@ -140,10 +140,7 @@ namespace Microsoft.PowerShell.EditorServices.Server
 
                             // Set the workspace path from the parameters.
                             WorkspaceService workspaceService = languageServer.Services.GetService<WorkspaceService>();
-                            if (initializeParams.WorkspaceFolders is not null)
-                            {
-                                workspaceService.WorkspaceFolders.AddRange(initializeParams.WorkspaceFolders);
-                            }
+                            workspaceService.AddWorkspaceFolders(initializeParams.WorkspaceFolders);
 
                             // Parse initialization options.
                             JObject initializationOptions = initializeParams.InitializationOptions as JObject;

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -107,6 +107,35 @@ namespace Microsoft.PowerShell.EditorServices.Services
         public IEnumerable<string> WorkspacePaths => WorkspaceFolders.Select(i => i.Uri.GetFileSystemPath());
 
         /// <summary>
+        /// Adds the given workspace folders, ignoring any that are null or lack a URI.
+        /// </summary>
+        /// <remarks>
+        /// Some LSP clients send workspace folders without a URI on initialize. Adding such a
+        /// folder would later throw a <see cref="NullReferenceException"/> when its URI is
+        /// dereferenced (e.g. when resolving the initial working directory or a relative path),
+        /// breaking the handshake. See
+        /// https://github.com/PowerShell/PowerShellEditorServices/issues/2300.
+        /// </remarks>
+        public void AddWorkspaceFolders(IEnumerable<WorkspaceFolder> workspaceFolders)
+        {
+            if (workspaceFolders is null)
+            {
+                return;
+            }
+
+            foreach (WorkspaceFolder workspaceFolder in workspaceFolders)
+            {
+                if (workspaceFolder?.Uri is null)
+                {
+                    logger.LogWarning("Ignored workspace folder without a URI: " + workspaceFolder?.Name);
+                    continue;
+                }
+
+                WorkspaceFolders.Add(workspaceFolder);
+            }
+        }
+
+        /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.
         /// <para>IMPORTANT: Not all documents have a backing file e.g. untitled: scheme documents.  Consider using
         /// <see cref="TryGetFile(string, out ScriptFile)"/> instead.</para>

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -118,22 +118,24 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </remarks>
         public void AddWorkspaceFolders(IEnumerable<WorkspaceFolder> workspaceFolders)
         {
-            foreach (WorkspaceFolder workspaceFolder in GetValidWorkspaceFolders(workspaceFolders))
+            if (workspaceFolders is null)
             {
+                return;
+            }
+
+            foreach (WorkspaceFolder workspaceFolder in workspaceFolders)
+            {
+                // Some LSP clients send folders without a URI; skip them (and warn) so we never
+                // store a folder whose URI would later be dereferenced and throw.
+                if (workspaceFolder?.Uri is null)
+                {
+                    logger.LogWarning($"Ignoring workspace folder without a URI: {workspaceFolder?.Name}");
+                    continue;
+                }
+
                 WorkspaceFolders.Add(workspaceFolder);
             }
         }
-
-        /// <summary>
-        /// Filters workspace folders down to those usable by the service: non-null folders with a
-        /// non-null URI. The <c>workspaceFolders</c> field is optional in LSP, so the collection
-        /// itself may also be null.
-        /// </summary>
-        /// <param name="workspaceFolders">The workspace folders from the initialize parameters.</param>
-        /// <returns>The folders that have a non-null URI, or an empty sequence.</returns>
-        internal static IEnumerable<WorkspaceFolder> GetValidWorkspaceFolders(IEnumerable<WorkspaceFolder> workspaceFolders)
-            => workspaceFolders?.Where(static folder => folder?.Uri is not null)
-                ?? Enumerable.Empty<WorkspaceFolder>();
 
         /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -118,22 +118,22 @@ namespace Microsoft.PowerShell.EditorServices.Services
         /// </remarks>
         public void AddWorkspaceFolders(IEnumerable<WorkspaceFolder> workspaceFolders)
         {
-            if (workspaceFolders is null)
+            foreach (WorkspaceFolder workspaceFolder in GetValidWorkspaceFolders(workspaceFolders))
             {
-                return;
-            }
-
-            foreach (WorkspaceFolder workspaceFolder in workspaceFolders)
-            {
-                if (workspaceFolder?.Uri is null)
-                {
-                    logger.LogWarning("Ignored workspace folder without a URI: " + workspaceFolder?.Name);
-                    continue;
-                }
-
                 WorkspaceFolders.Add(workspaceFolder);
             }
         }
+
+        /// <summary>
+        /// Filters workspace folders down to those usable by the service: non-null folders with a
+        /// non-null URI. The <c>workspaceFolders</c> field is optional in LSP, so the collection
+        /// itself may also be null.
+        /// </summary>
+        /// <param name="workspaceFolders">The workspace folders from the initialize parameters.</param>
+        /// <returns>The folders that have a non-null URI, or an empty sequence.</returns>
+        internal static IEnumerable<WorkspaceFolder> GetValidWorkspaceFolders(IEnumerable<WorkspaceFolder> workspaceFolders)
+            => workspaceFolders?.Where(static folder => folder?.Uri is not null)
+                ?? Enumerable.Empty<WorkspaceFolder>();
 
         /// <summary>
         /// Gets an open file in the workspace. If the file isn't open but exists on the filesystem, load and return it.

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -86,6 +86,32 @@ namespace PowerShellEditorServices.Test.Session
             };
         }
 
+        // Regression test for https://github.com/PowerShell/PowerShellEditorServices/issues/2300:
+        // a client that sends a workspace folder without a URI on initialize used to crash the
+        // server with a NullReferenceException when the URI was later dereferenced.
+        [Fact]
+        public void AddWorkspaceFoldersIgnoresNullAndUrilessFolders()
+        {
+            WorkspaceService workspace = new(NullLoggerFactory.Instance);
+
+            // Null collection is a no-op rather than a throw.
+            workspace.AddWorkspaceFolders(null);
+            Assert.Empty(workspace.WorkspaceFolders);
+
+            workspace.AddWorkspaceFolders(new[]
+            {
+                new WorkspaceFolder { Uri = DocumentUri.FromFileSystemPath(s_workspacePath), Name = "valid" },
+                new WorkspaceFolder { Name = "missing-uri" },
+                null
+            });
+
+            WorkspaceFolder folder = Assert.Single(workspace.WorkspaceFolders);
+            Assert.Equal("valid", folder.Name);
+
+            // The downstream dereferences that previously threw now succeed.
+            Assert.Equal(s_workspacePath, Assert.Single(workspace.WorkspacePaths));
+        }
+
         [Fact]
         public void HasDefaultForWorkspacePaths()
         {

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -113,31 +113,6 @@ namespace PowerShellEditorServices.Test.Session
         }
 
         [Fact]
-        public void GetValidWorkspaceFoldersReturnsEmptyWhenNull()
-            => Assert.Empty(WorkspaceService.GetValidWorkspaceFolders(null));
-
-        [Fact]
-        public void GetValidWorkspaceFoldersReturnsEmptyWhenEmpty()
-            => Assert.Empty(WorkspaceService.GetValidWorkspaceFolders(new Container<WorkspaceFolder>()));
-
-        [Fact]
-        public void GetValidWorkspaceFoldersSkipsNullFoldersAndNullUris()
-        {
-            WorkspaceFolder valid = new()
-            {
-                Uri = DocumentUri.FromFileSystemPath(s_workspacePath),
-                Name = "valid"
-            };
-
-            Container<WorkspaceFolder> folders = new(
-                null,
-                new WorkspaceFolder { Name = "missing-uri" },
-                valid);
-
-            Assert.Equal(valid, Assert.Single(WorkspaceService.GetValidWorkspaceFolders(folders)));
-        }
-
-        [Fact]
         public void HasDefaultForWorkspacePaths()
         {
             WorkspaceService workspace = FixturesWorkspace();

--- a/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
+++ b/test/PowerShellEditorServices.Test/Session/WorkspaceTests.cs
@@ -113,6 +113,31 @@ namespace PowerShellEditorServices.Test.Session
         }
 
         [Fact]
+        public void GetValidWorkspaceFoldersReturnsEmptyWhenNull()
+            => Assert.Empty(WorkspaceService.GetValidWorkspaceFolders(null));
+
+        [Fact]
+        public void GetValidWorkspaceFoldersReturnsEmptyWhenEmpty()
+            => Assert.Empty(WorkspaceService.GetValidWorkspaceFolders(new Container<WorkspaceFolder>()));
+
+        [Fact]
+        public void GetValidWorkspaceFoldersSkipsNullFoldersAndNullUris()
+        {
+            WorkspaceFolder valid = new()
+            {
+                Uri = DocumentUri.FromFileSystemPath(s_workspacePath),
+                Name = "valid"
+            };
+
+            Container<WorkspaceFolder> folders = new(
+                null,
+                new WorkspaceFolder { Name = "missing-uri" },
+                valid);
+
+            Assert.Equal(valid, Assert.Single(WorkspaceService.GetValidWorkspaceFolders(folders)));
+        }
+
+        [Fact]
         public void HasDefaultForWorkspacePaths()
         {
             WorkspaceService workspace = FixturesWorkspace();


### PR DESCRIPTION
Fixes #2300.

## Problem

When a client sends `workspaceFolders` on `initialize` and one of the entries has no `uri`, the `OnInitialize` handler threw a `NullReferenceException` while resolving the initial working directory:

```csharp
workspaceService.WorkspaceFolders.FirstOrDefault()?.Uri.GetFileSystemPath()
```

The `?.` only guarded the folder being null, not its `Uri`, so calling the instance method `GetFileSystemPath()` on a null `Uri` threw. The `initialize` response was never returned and the server was unusable for that client. The same hazard exists everywhere else we dereference `folder.Uri` (`WorkspacePaths`, `GetRelativePath`, `FindFileInWorkspace`).

## Investigation note

The issue describes this as Linux-only with a repro whose `workspaceFolders` entry has a **valid** `uri`. I drove a locally-built PSES over stdio and that exact payload does **not** throw. The real trigger is a workspace folder **lacking a URI**, which matches the captured stack trace pointing at `PsesLanguageServer.cs:line 150` (the `HostStartOptions` initializer). Reproduced the NRE with a uriless folder and confirmed it's gone after this change.

## Fix

- Add `WorkspaceService.AddWorkspaceFolders`, which owns the invariant that every folder in `WorkspaceFolders` has a non-null `Uri`. It skips null folders and folders without a URI (logging a warning), and treats a null collection as "no folders yet", falling back to the existing single-root / CWD behavior.
- Call it from `OnInitialize` instead of the inline null-check + `AddRange`.
- Add a regression test covering null input and uriless/null folders.

## Validation

- `dotnet build` clean.
- `Category=Workspace` tests pass on net8.0 (7/7).
- Manually drove a built PSES over stdio with a uriless `workspaceFolders` entry: before, NRE in `OnInitialize` and no `initialize` response; after, the handshake completes normally.

---
🤖 Drafted by Copilot (Claude Opus 4.8) — please review/edit before merging.