### PR TITLE
Open hidden files in `Open-EditorFile`

### DIFF
--- a/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
+++ b/module/PowerShellEditorServices/Commands/Public/CmdletInterface.ps1
@@ -195,7 +195,7 @@ function Open-EditorFile {
             $preview = $true
         }
 
-        Get-ChildItem $Paths -File | ForEach-Object {
+        Get-ChildItem $Paths -File -Force | ForEach-Object {
             $psEditor.Workspace.OpenFile($_.FullName, $preview)
         }
     }


### PR DESCRIPTION
Fixes #1750.

On macOS and Linux, dot files are hidden, so `Get-ChildItem` skips them unless `-Force` is passed — meaning `psedit ~/.zshrc` (and similar) silently opened nothing. This adds `-Force` to the `Get-ChildItem` call in `Open-EditorFile` so hidden files resolve and open.

As the issue notes, this also means passing a *directory* will now enumerate its hidden files too. That is intentional: `psedit` exposes no switch to include or exclude hidden files, so the only predictable default is to always include them. Treating the directory case as "always include hidden" keeps the behavior consistent rather than special-casing it.
