### PR TITLE
Resolve evaluate/watch variables from the correct scope

### DIFF
--- a/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
+++ b/src/PowerShellEditorServices/Services/DebugAdapter/DebugService.cs
@@ -308,7 +308,16 @@ namespace Microsoft.PowerShell.EditorServices.Services
             await debugInfoHandle.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                variableList = variables;
+                // Search the scope containers in order of narrowest to broadest scope (local,
+                // then script, then global) so that a variable defined in a more local scope
+                // correctly shadows one of the same name in a parent scope, matching
+                // PowerShell's own variable resolution. The flattened list of every variable is
+                // appended as a fallback so that names not present in those scopes (such as
+                // frame-specific variables) still resolve. See issue #1882.
+                variableList = new[] { localScopeVariables, scriptScopeVariables, globalScopeVariables }
+                    .Where(container => container is not null)
+                    .SelectMany(container => container.Children.Values)
+                    .Concat(variables);
             }
             finally
             {

--- a/test/PowerShellEditorServices.Test.Shared/Debugging/VariableScopeTest.ps1
+++ b/test/PowerShellEditorServices.Test.Shared/Debugging/VariableScopeTest.ps1
@@ -1,0 +1,5 @@
+$scopeTestVariable = "from parent scope"
+& {
+    $scopeTestVariable = "from local scope"
+    Write-Output $scopeTestVariable
+}

--- a/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Debugging/DebugServiceTests.cs
@@ -644,6 +644,27 @@ namespace PowerShellEditorServices.Test.Debugging
             Assert.False(var.IsExpandable);
         }
 
+        // Regression test for #1882: when a variable of the same name exists in both a parent
+        // scope and the current (more local) scope, evaluating it via a watch/evaluate request
+        // must return the most-local value, matching what's shown in the Variables explorer and
+        // PowerShell's own variable resolution.
+        [Fact]
+        public async Task DebuggerResolvesVariableFromMostLocalScope()
+        {
+            ScriptFile scopeScriptFile = GetDebugScript("VariableScopeTest.ps1");
+            await debugService.SetLineBreakpointsAsync(
+                scopeScriptFile.FilePath,
+                new[] { BreakpointDetails.Create(scopeScriptFile.FilePath, 4) });
+
+            Task _ = ExecuteScriptFileAsync(scopeScriptFile.FilePath);
+            await AssertDebuggerStopped(scopeScriptFile.FilePath, 4);
+
+            VariableDetailsBase resolved = await debugService.GetVariableFromExpression(
+                "$scopeTestVariable", CancellationToken.None);
+            Assert.NotNull(resolved);
+            Assert.Equal("\"from local scope\"", resolved.ValueString);
+        }
+
         [Fact]
         public async Task DebuggerGetsVariables()
         {


### PR DESCRIPTION
## Problem

Fixes #1882.

While stopped at a breakpoint, a watch / `evaluate` request for a naked variable could return the value from a *parent* scope instead of the current one. Given:

```powershell
$myVarName = 123
& {
    $myVarName = 456
    $myVarName   # break here
}
```

evaluating `$myVarName` returned `123` instead of `456`, even though the Variables explorer (and PowerShell itself) correctly show `456`.

## Cause

`DebugService.GetVariableFromExpression` searched the flat `variables` list with `FirstOrDefault`. That list is populated broadest-to-narrowest (global → script → local → stack frames), so the global/parent copy of a shadowed name was always matched first.

## Fix

Search the `Local`, `Script`, then `Global` scope containers in that order first, falling back to the full flat list so frame-only names still resolve. This matches PowerShell's own variable resolution and what the Variables explorer displays. Only the name lookup changed; ID-based lookups elsewhere are unaffected.

## Testing

- Added `DebuggerResolvesVariableFromMostLocalScope` plus a shared `VariableScopeTest.ps1` that shadows a variable across scopes and asserts the local value wins.
- Confirmed it fails without the fix (returns the parent value) and passes with it.
- All 36 `DebugServiceTests` pass on net8.0.