### PR TITLE
Restore concrete `FileRange` overloads on `FileContext` for binary compat

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,36 @@ Handlers live under `Services/<Feature>/Handlers/` and follow a consistent patte
 - Roslynator analyzers are enabled for formatting and code quality.
 - Use `Microsoft.Extensions.Logging` (`ILogger<T>` via `ILoggerFactory`) for all logging.
 
+### Public API & Binary Compatibility
+
+The public types under `Microsoft.PowerShell.EditorServices` are not consumed only
+through PowerShell script. Downstream modules **compile against the shipped PSES
+assemblies** and bind to that metadata at build time. The most prominent example is
+[`SeeminglyScience/EditorServicesCommandSuite`](https://github.com/SeeminglyScience/EditorServicesCommandSuite),
+which references the extension API surface (`FileContext`, `EditorContext`, the
+`IFileRange`/`FilePosition` types, `ILspCurrentFileContext`, `IEditorScriptFile`,
+etc.) directly from C#.
+
+Because of that, treat any change to an existing `public` member as potentially
+**binary breaking**, and review for it explicitly before merging:
+
+- Changing the **type of a parameter** (even widening a concrete class to an
+  interface it implements, e.g. `FileRange` -> `IFileRange`), the **return type**,
+  the **parameter count/order**, or **renaming/removing** a public member is
+  source-compatible at most but **binary-breaking**. The method's signature/metadata
+  token changes, so a precompiled caller throws `MissingMethodException` at runtime
+  even though it would recompile cleanly.
+- When you need a wider or different signature, **add an overload** instead of
+  editing the existing one. Keep the original signature in place and have it delegate
+  to the new implementation so existing binaries keep resolving. Cast as needed to
+  pick the new overload from the old body (e.g. `Foo((IFileRange)range)`).
+- Add a regression test that binds to the **old, concrete signature** (declare the
+  argument as the original parameter type, not the widened one) so overload
+  resolution to the compatibility shim is actually exercised.
+- If a breaking change is genuinely unavoidable, call it out in the PR description
+  as a binary breaking change so maintainers can weigh it and coordinate a
+  downstream release.
+
 ### Testing
 
 - **Framework:** xUnit with `Xunit.SkippableFact` for conditionally skipped tests.

--- a/src/PowerShellEditorServices/Extensions/FileContext.cs
+++ b/src/PowerShellEditorServices/Extensions/FileContext.cs
@@ -113,6 +113,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         }
 
         /// <summary>
+        /// Gets the file content in the specified range as a string.
+        /// </summary>
+        /// <param name="bufferRange">The buffer range for which content will be extracted.</param>
+        /// <returns>A string with the specified range of content.</returns>
+        /// <remarks>
+        /// This overload preserves binary compatibility with callers compiled
+        /// against the concrete <see cref="FileRange"/> parameter; it delegates
+        /// to the <see cref="GetText(IFileRange)"/> overload.
+        /// </remarks>
+        public string GetText(FileRange bufferRange) => GetText((IFileRange)bufferRange);
+
+        /// <summary>
         /// Gets the complete file content as an array of strings.
         /// </summary>
         /// <returns>An array of strings, each representing a line in the file.</returns>
@@ -124,6 +136,18 @@ namespace Microsoft.PowerShell.EditorServices.Extensions
         /// <param name="fileRange">The buffer range for which content will be extracted.</param>
         /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
         public string[] GetTextLines(IFileRange fileRange) => scriptFile.GetLinesInRange(fileRange.ToBufferRange());
+
+        /// <summary>
+        /// Gets the file content in the specified range as an array of strings.
+        /// </summary>
+        /// <param name="fileRange">The buffer range for which content will be extracted.</param>
+        /// <returns>An array of strings, each representing a line in the file within the specified range.</returns>
+        /// <remarks>
+        /// This overload preserves binary compatibility with callers compiled
+        /// against the concrete <see cref="FileRange"/> parameter; it delegates
+        /// to the <see cref="GetTextLines(IFileRange)"/> overload.
+        /// </remarks>
+        public string[] GetTextLines(FileRange fileRange) => GetTextLines((IFileRange)fileRange);
 
         #endregion
 

--- a/test/PowerShellEditorServices.Test/Extensions/FileContextTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/FileContextTests.cs
@@ -64,5 +64,36 @@ namespace PowerShellEditorServices.Test.Extensions
 
             Assert.Equal("Line Three", editorContext.CurrentFile.GetText(range));
         }
+
+        // The concrete FileRange overloads exist to preserve binary compatibility
+        // with callers compiled before GetText/GetTextLines were widened to IFileRange.
+        // Declaring the variable as FileRange (not IFileRange) selects those overloads.
+        [Fact]
+        public void CanGetTextFromConcreteFileRange()
+        {
+            EditorContext editorContext = CreateEditorContext(
+                "Line One\nLine Two\nLine Three",
+                BufferRange.None);
+
+            FileRange range = new(
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(3, 1),
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(3, 11));
+
+            Assert.Equal("Line Three", editorContext.CurrentFile.GetText(range));
+        }
+
+        [Fact]
+        public void CanGetTextLinesFromConcreteFileRange()
+        {
+            EditorContext editorContext = CreateEditorContext(
+                "Line One\nLine Two\nLine Three",
+                BufferRange.None);
+
+            FileRange range = new(
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(1, 1),
+                new Microsoft.PowerShell.EditorServices.Extensions.FilePosition(2, 9));
+
+            Assert.Equal(new[] { "Line One", "Line Two" }, editorContext.CurrentFile.GetTextLines(range));
+        }
     }
 }


### PR DESCRIPTION
## Why

[#2306](https://github.com/PowerShell/PowerShellEditorServices/pull/2306) widened the parameters of `FileContext.GetText` and `GetTextLines` from the concrete `FileRange` class to the `IFileRange` interface, so that `$Context.CurrentFile.GetText($Context.SelectedRange)` resolves (`SelectedRange` is typed as `IFileRange`). That fixed the script-side call but dropped the old concrete-typed method slots from the shipped assembly.

The public types under `Microsoft.PowerShell.EditorServices` are not consumed only through PowerShell script. Downstream modules compile against PSES and bind to its metadata at build time, most notably [`SeeminglyScience/EditorServicesCommandSuite`](https://github.com/SeeminglyScience/EditorServicesCommandSuite). A precompiled caller of the old `GetText(FileRange)` signature throws `MissingMethodException` at runtime even though it recompiles cleanly, so #2306 was a binary-breaking change.

## What

- Restore `GetText(FileRange)` and `GetTextLines(FileRange)` alongside the `IFileRange` overloads added in #2306. Each casts to `IFileRange` and delegates to the widened implementation, so old binaries keep resolving and there is no behavior change.
- Add regression tests that declare their argument as the concrete `FileRange` (not `IFileRange`) so overload resolution actually exercises the compatibility shims.
- Add a "Public API & Binary Compatibility" section to `.github/copilot-instructions.md` documenting this failure mode, the add-an-overload fix, and the expectation to test against the old concrete signature, so the next signature change gets reviewed for binary breakage.

## Notes for review

The instructions update is bundled here because it directly documents the lesson from this fix; happy to split it out if preferred. Built clean (Release config, 0 warnings) and the `FileContextTests` suite passes (5/5).