### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/emacs-test.yml
+++ b/.github/workflows/emacs-test.yml
@@ -9,6 +9,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 jobs:
   emacs:
     name: ert


### PR DESCRIPTION
Potential fix for [https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/3](https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here (without changing functionality): add at workflow root (after `on` and before `jobs`) a minimal permission set:
- `contents: read`

This applies to all jobs unless overridden and is sufficient for this workflow’s current steps (not creating releases, commenting on PRs, or pushing commits).

File to edit:
- `.github/workflows/emacs-test.yml`
- Insert new lines between existing line 10 and line 12 (between trigger config and `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
