### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vim-test.yml
+++ b/.github/workflows/vim-test.yml
@@ -9,6 +9,9 @@ on:
   merge_group:
     types: [ checks_requested ]
 
+permissions:
+  contents: read
+
 jobs:
   vim:
     name: themis


### PR DESCRIPTION
Potential fix for [https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/5](https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is limited to least privilege.  
Best fix here: define workflow-level permissions with `contents: read`, since all jobs in this file can inherit it (there is only one job shown). This satisfies checkout and typical read operations while preventing unintended write scopes.

### What to change
- **File:** `.github/workflows/vim-test.yml`
- **Region:** near the top-level keys, after `on:` and before `jobs:`
- **Change:** add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
