### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   ci:
     name: dotnet


### PR DESCRIPTION
Potential fix for [https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/4](https://github.com/PowerShell/PowerShellEditorServices/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/ci-test.yml` at the workflow root (after `on:` and before `jobs:`) so it applies to all jobs unless overridden. For this workflow, the minimal safe baseline is:

- `contents: read` (needed for checkout)
- `actions: read` (safe explicit read for Actions metadata)

This preserves behavior while ensuring the token is constrained and documented. No imports/methods/dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
