### PR TITLE
Collect a hang dump on the wedging Windows PowerShell CI leg

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -52,6 +52,27 @@ jobs:
         shell: pwsh
         run: ./pwsh/tools/install-powershell.ps1 -Preview -Destination ./preview
 
+      - name: Install ProcDump for Windows PowerShell hang dumps
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # VSTest's built-in hang dumper only handles .NET Core test hosts, so
+          # capturing a dump of a wedged .NET Framework (net462 / Windows
+          # PowerShell 5.1) test host requires ProcDump, which isn't on the
+          # runner image. Install is best-effort: a failure must not fail CI
+          # (the net8 legs dump without it, and `--blame-hang` still terminates
+          # the host and writes a sequence file naming the hung test). See #2323.
+          try {
+            $zip = Join-Path $env:RUNNER_TEMP 'Procdump.zip'
+            $dir = Join-Path $env:RUNNER_TEMP 'procdump'
+            Invoke-WebRequest -Uri 'https://download.sysinternals.com/files/Procdump.zip' -OutFile $zip
+            Expand-Archive -Path $zip -DestinationPath $dir -Force
+            "PROCDUMP_PATH=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append
+            Write-Host "ProcDump installed to $dir"
+          } catch {
+            Write-Warning "ProcDump install failed; net462 hang dumps will be unavailable: $_"
+          }
+
       - name: Build and test
         shell: pwsh
         run: Invoke-Build -Configuration Release TestFull
@@ -79,4 +100,7 @@ jobs:
         if: always()
         with:
           name: PowerShellEditorServices-test-results-${{ matrix.os }}
-          path: '**/*.trx'
+          path: |
+            **/*.trx
+            **/*.dmp
+            **/*_Sequence.xml

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -32,6 +32,11 @@ $script:dotnetBuildArgs = @(
 
 $script:dotnetTestArgs = @("test") + $script:dotnetBuildArgs + $TestArgs + @(
     if ($TestFilter) { "--filter", $TestFilter }
+    # In CI, collect a hang dump and fail fast if any single test wedges instead
+    # of riding the job's `timeout-minutes` cap blind. The Windows PowerShell 5.1
+    # (net462) unit leg intermittently hangs under the 20260614 runner image; the
+    # dump names the offending test and captures its stacks. See #2323.
+    if ($env:GITHUB_ACTIONS) { "--blame-hang", "--blame-hang-timeout", "10m", "--blame-hang-dump-type", "full" }
     "--framework"
 )
 


### PR DESCRIPTION
## What

CI's `windows-latest` leg still intermittently wedges and rides its
`timeout-minutes: 60` cap to a cancelled `CI Tests` run, even after #2318's
discovery-time skips. This PR doesn't add another skip — it **instruments CI so
the next hang is actionable** instead of burning an hour blind.

## Where it wedges now

Pulling the Windows test-result artifacts from the last two hung runs and a
passing one (`TestFull` order is `TestPS74 → TestE2EPwsh → TestPS51 → …`):

| Run | Result | Legs that produced a `.trx` | net462 `TestPS51`? |
|-----|--------|------------------------------|--------------------|
| #2319 `e34a3ffee` | ✅ ~11 min | 7 (incl. **net462 `TestPS51`, 338 tests**) | yes |
| #2325 `dbd5dfc` | ❌ 1 h cap | 2 (`TestPS74`, `TestE2EPwsh`) | **no** |
| #2319 `7e0aa34` | ❌ 1 h cap | 2 (`TestPS74`, `TestE2EPwsh`) | **no** |

Both hung runs stop right after `TestE2EPwsh` and never emit a `TestPS51`
`.trx`, so they wedge in the **net462 / Windows PowerShell 5.1 _unit_ leg** —
not the E2E server path #2318 skipped, and not covered by any
`SkippableFactOnWindowsPowerShell` guard (those all live in the E2E project).
All three commits contain #2318's skip (verified via `merge-base`), so this is
**not a missing rebase** — the `20260614` runner-image regression still races,
just less often. See #2323 for the image root cause.

## Changes

- **`PowerShellEditorServices.build.ps1`** — add
  `--blame-hang --blame-hang-timeout 10m --blame-hang-dump-type full` to the CI
  `dotnet test` invocations, gated on `$env:GITHUB_ACTIONS` (local runs are
  byte-identical). Any single test that wedges past 10 minutes is dumped and
  its host process tree terminated, so the leg **fails fast and names the
  test** instead of riding the cap.
- **`.github/workflows/ci-test.yml`** — best-effort ProcDump install on the
  Windows leg (VSTest's built-in hang dumper only handles .NET Core hosts, so
  capturing a dump of the net462 host needs ProcDump, which isn't on the runner
  image; a download failure only warns and never fails CI), and extend the
  test-results upload to `**/*.dmp` + `**/*_Sequence.xml`.

## Caveat

If the wedge is in host startup/discovery rather than a _running_ test, the
per-test timer may not fire — but `_Sequence.xml` will still show how far
discovery got, which is itself diagnostic. Once a hung run identifies the
offending net462 unit test, we can give it the same targeted
`Skip.If(Desktop)` / polling fix we used for #2307 and #2314 instead of a
broad leg-wide skip.

## Validation

Local arg construction verified in both modes (CI inserts the flags with
`--framework` still last; local is unchanged); build script pwsh-parsed and
workflow YAML validated. The instrumentation itself can only be exercised on
the GitHub-hosted Windows image where the hang reproduces.

<sub><i>Drafted by Copilot (Claude Opus 4.8) on Andy's behalf.</i></sub>
