### PR TITLE
v4.7.0: Add a module metadata handler, enhance command and help handlers, and fix a Windows PowerShell host-start hang.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PowerShell Editor Services Release History
 
+## v4.7.0
+### Thursday, June 25, 2026
+
+See more details at the GitHub Release for [v4.7.0](https://github.com/PowerShell/PowerShellEditorServices/releases/tag/v4.7.0).
+
+Add a module metadata handler, enhance command and help handlers, and fix a Windows PowerShell host-start hang.
+
 ## v4.6.0
 ### Friday, May 15, 2026
 

--- a/PowerShellEditorServices.Common.props
+++ b/PowerShellEditorServices.Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.6.0</VersionPrefix>
+    <VersionPrefix>4.7.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation.</Copyright>

--- a/module/PowerShellEditorServices/PowerShellEditorServices.psd1
+++ b/module/PowerShellEditorServices/PowerShellEditorServices.psd1
@@ -19,7 +19,7 @@ RootModule = if ($PSEdition -eq 'Core')
     }
 
 # Version number of this module.
-ModuleVersion = '4.6.0'
+ModuleVersion = '4.7.0'
 
 # ID used to uniquely identify this module
 GUID = '9ca15887-53a2-479a-9cda-48d26bcb6c47'


### PR DESCRIPTION
Release PR bumping PowerShell Editor Services to `v4.7.0`. See `CHANGELOG.md` for details.