### PR TITLE
Bump SDK to 10 and improve SDK check

### DIFF
--- a/.pipelines/PowerShellEditorServices-OneBranch.yml
+++ b/.pipelines/PowerShellEditorServices-OneBranch.yml
@@ -88,7 +88,7 @@ extends:
                   system: Custom
                   customVersion: $(package.version)
               - task: UseDotNet@2
-                displayName: Use .NET 8.x SDK
+                displayName: Use .NET SDK in global.json
                 inputs:
                   packageType: sdk
                   useGlobalJson: true

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -58,9 +58,6 @@ Task FindDotNet {
 
     [string[]]$dotnetInfo = dotnet --version 2>&1
     $missingDotnet = ($dotnetInfo -match '(Install the .+ \.NET SDK) or update')[0]
-    if ($missingDotnet) {
-        $missingDotnetMessage = $missingDotnet[0] -replace 'or update.+'
-    }
     Assert (!$missingDotnet) ($missingDotnet -replace 'or update.+')
     Write-Build DarkGreen "Using dotnet v$($dotnetInfo) at path $((Get-Command dotnet).Source)"
 }

--- a/PowerShellEditorServices.build.ps1
+++ b/PowerShellEditorServices.build.ps1
@@ -56,11 +56,13 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
 Task FindDotNet {
     Assert (Get-Command dotnet -ErrorAction SilentlyContinue) "dotnet not found, please install it: https://aka.ms/dotnet-cli"
 
-    # Strip out semantic version metadata so it can be cast to `Version`
-    [Version]$existingVersion, $null = (dotnet --version) -split " " -split "-"
-    Assert ($existingVersion -ge [Version]("8.0")) ".NET SDK 8.0 or higher is required, please update it: https://aka.ms/dotnet-cli"
-
-    Write-Build DarkGreen "Using dotnet v$(dotnet --version) at path $((Get-Command dotnet).Source)"
+    [string[]]$dotnetInfo = dotnet --version 2>&1
+    $missingDotnet = ($dotnetInfo -match '(Install the .+ \.NET SDK) or update')[0]
+    if ($missingDotnet) {
+        $missingDotnetMessage = $missingDotnet[0] -replace 'or update.+'
+    }
+    Assert (!$missingDotnet) ($missingDotnet -replace 'or update.+')
+    Write-Build DarkGreen "Using dotnet v$($dotnetInfo) at path $((Get-Command dotnet).Source)"
 }
 
 Task Clean FindDotNet, {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.416",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
+++ b/src/PowerShellEditorServices/Services/CodeLens/ReferencesCodeLensProvider.cs
@@ -25,7 +25,6 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// </summary>
         private readonly IDocumentSymbolProvider _symbolProvider;
         private readonly SymbolsService _symbolsService;
-        private readonly WorkspaceService _workspaceService;
 
         public static string Id => nameof(ReferencesCodeLensProvider);
 
@@ -38,11 +37,9 @@ namespace Microsoft.PowerShell.EditorServices.CodeLenses
         /// <summary>
         /// Construct a new ReferencesCodeLensProvider for a given EditorSession.
         /// </summary>
-        /// <param name="workspaceService"></param>
         /// <param name="symbolsService"></param>
-        public ReferencesCodeLensProvider(WorkspaceService workspaceService, SymbolsService symbolsService)
+        public ReferencesCodeLensProvider(SymbolsService symbolsService)
         {
-            _workspaceService = workspaceService;
             _symbolsService = symbolsService;
             // TODO: Pull this from components
             _symbolProvider = new ScriptDocumentSymbolProvider();

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/IPowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/IPowerShellDebugContext.cs
@@ -13,13 +13,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
 
         DebuggerStopEventArgs LastStopEventArgs { get; }
 
-        public bool IsDebuggingRemoteRunspace { get; set; }
+        bool IsDebuggingRemoteRunspace { get; set; }
 
-        public event Action<object, DebuggerStopEventArgs> DebuggerStopped;
+        event Action<object, DebuggerStopEventArgs> DebuggerStopped;
 
-        public event Action<object, DebuggerResumingEventArgs> DebuggerResuming;
+        event Action<object, DebuggerResumingEventArgs> DebuggerResuming;
 
-        public event Action<object, BreakpointUpdatedEventArgs> BreakpointUpdated;
+        event Action<object, BreakpointUpdatedEventArgs> BreakpointUpdated;
 
         void Continue();
 

--- a/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Debugging/PowerShellDebugContext.cs
@@ -114,9 +114,9 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Debugging
             // then this came over LSP and we need to set it.
             _psesHost.SetExit();
 
-            if (LastStopEventArgs is not null)
+            if (LastStopEventArgs is { } lastStopEventArgs)
             {
-                LastStopEventArgs.ResumeAction = debuggerResumeAction;
+                lastStopEventArgs.ResumeAction = debuggerResumeAction;
             }
 
             // We need to tell whatever is happening right now in the debug prompt to wrap up so we

--- a/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Execution/SynchronousTask.cs
@@ -20,15 +20,15 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Execution
 
     internal abstract class SynchronousTask<TResult> : ISynchronousTask
     {
-        private readonly TaskCompletionSource<TResult> _taskCompletionSource;
+        private TaskCompletionSource<TResult> _taskCompletionSource { get; }
 
-        private readonly CancellationToken _taskRequesterCancellationToken;
+        private CancellationToken _taskRequesterCancellationToken { get; }
 
-        private bool _executionCanceled;
+        private bool _executionCanceled { get; set; }
 
-        private TResult _result;
+        private TResult _result { get; set; }
 
-        private ExceptionDispatchInfo _exceptionInfo;
+        private ExceptionDispatchInfo _exceptionInfo { get; set; }
 
         protected SynchronousTask(
             ILogger logger,

--- a/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/ReferenceTable.cs
@@ -22,7 +22,7 @@ internal sealed class ReferenceTable
 
     private readonly ConcurrentDictionary<string, ConcurrentBag<SymbolReference>> _symbolReferences = new(StringComparer.OrdinalIgnoreCase);
 
-    private bool _isInited;
+    private bool _isInited { get; set; }
 
     public ReferenceTable(ScriptFile parent) => _parent = parent;
 

--- a/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
+++ b/src/PowerShellEditorServices/Services/Symbols/SymbolsService.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             _codeLensProviders = new ConcurrentDictionary<string, ICodeLensProvider>();
             if (configurationService.CurrentSettings.EnableReferencesCodeLens)
             {
-                ReferencesCodeLensProvider referencesProvider = new(_workspaceService, this);
+                ReferencesCodeLensProvider referencesProvider = new(this);
                 _ = _codeLensProviders.TryAdd(referencesProvider.ProviderId, referencesProvider);
             }
 
@@ -495,7 +495,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                     return;
                 }
 
-                TryRegisterCodeLensProvider(new ReferencesCodeLensProvider(_workspaceService, this));
+                TryRegisterCodeLensProvider(new ReferencesCodeLensProvider(this));
                 return;
             }
 

--- a/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/RemoteFileManagerService.cs
@@ -691,10 +691,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             }
             try
             {
-                if (runspaceInfo.Runspace.Events != null)
-                {
-                    runspaceInfo.Runspace.Events.ReceivedEvents.PSEventReceived -= HandlePSEventReceivedAsync;
-                }
+                runspaceInfo.Runspace.Events.ReceivedEvents.PSEventReceived -= HandlePSEventReceivedAsync;
 
                 if (runspaceInfo.Runspace.RunspaceStateInfo.State == RunspaceState.Opened)
                 {


### PR DESCRIPTION
# PR Summary

Updated the SDK version to 10 and enhanced the SDK check process. Note, does NOT update the output to net10, as we still need to support PowerShell 7.4+ until November.

## PR Context

This change ensures compatibility with the latest SDK version and improves error handling for missing SDK installations. It helps maintain the project's dependency on the .NET SDK by enforcing the use of version 10.0.100, and updates Invoke-Build for a check tied into global.json

