### PR TITLE
Remove redundant check from Start-EditorServices

### DIFF
--- a/module/PowerShellEditorServices/Start-EditorServices.ps1
+++ b/module/PowerShellEditorServices/Start-EditorServices.ps1
@@ -49,9 +49,9 @@ param(
     [ValidateSet("Diagnostic", "Verbose", "Normal", "Warning", "Error", "Trace", "Debug", "Information", "Critical", "None")]
     $LogLevel,
 
-	[ValidateNotNullOrEmpty()]
-	[string]
-	$SessionDetailsPath,
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $SessionDetailsPath,
 
     [switch]
     $EnableConsoleRepl,
@@ -106,14 +106,6 @@ param(
     [string]
     $DebugServiceOutPipeName
 )
-
-#Translate legacy PSES log levels to MEL levels
-$LogLevel = switch ($LogLevel) {
-    'Diagnostic' { 'Trace' }
-    'Verbose' { 'Debug' }
-    'Normal' { 'Information' }
-    default { $LogLevel }
-}
 
 Import-Module -Name "$PSScriptRoot/PowerShellEditorServices.psd1"
 Start-EditorServices @PSBoundParameters


### PR DESCRIPTION
6f76c6e319e5245f3d235b35f68329b6067aa120 introduced a correct change to the ValidateSet, but added a redundant check that is already handled in `StartEditorServicesCommand.cs` in its `StartLogging()` routine. In fact, exchanging the values in Start-EditorServices will suppress the warning about the old PSES log levels that `StartLogging()` would normally emit.

However, the check is actually harmful on top of this issue since it doesn't check if LogLevel is even set.
If LogLevel is `$null`, then the default option
```
default { $LogLevel }
```
isn't valid PowerShell anymore:
```
The variable cannot be validated because the value $null is not a valid value for the LogLevel variable.
```