### PR TITLE
Fix focus stealing when clearing terminal scrollback

### DIFF
--- a/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
+++ b/src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Services.PowerShell.Host;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
@@ -17,15 +18,18 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
         private readonly PsesInternalHost _psesHost;
         private readonly WorkspaceService _workspaceService;
         private readonly ILanguageServerFacade _languageServer;
+        private readonly ConfigurationService _configurationService;
 
         public EditorOperationsService(
             PsesInternalHost psesHost,
             WorkspaceService workspaceService,
-            ILanguageServerFacade languageServer)
+            ILanguageServerFacade languageServer,
+            ConfigurationService configurationService)
         {
             _psesHost = psesHost;
             _workspaceService = workspaceService;
             _languageServer = languageServer;
+            _configurationService = configurationService;
         }
 
         public async Task<EditorContext> GetEditorContextAsync()
@@ -260,6 +264,12 @@ namespace Microsoft.PowerShell.EditorServices.Services.Extension
 
         public void ClearTerminal()
         {
+            if (_configurationService.CurrentSettings.IntegratedConsole.ForceClearScrollbackBuffer)
+            {
+                Console.Write("\u001b[3J");
+                return;
+            }
+
             if (!TestHasLanguageServer(warnUser: false))
             {
                 return;

--- a/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
         public CodeFormattingSettings CodeFormatting { get; set; }
         public CodeFoldingSettings CodeFolding { get; set; }
         public PesterSettings Pester { get; set; }
+        public IntegratedConsoleSettings IntegratedConsole { get; set; }
         public string Cwd { get; set; }
         public bool EnableReferencesCodeLens { get; set; } = true;
         public bool AnalyzeOpenDocumentsOnly { get; set; }
@@ -31,6 +32,7 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
             CodeFormatting = new CodeFormattingSettings();
             CodeFolding = new CodeFoldingSettings();
             Pester = new PesterSettings();
+            IntegratedConsole = new IntegratedConsoleSettings();
         }
 
         public void Update(
@@ -47,12 +49,28 @@ namespace Microsoft.PowerShell.EditorServices.Services.Configuration
                     CodeFormatting = new CodeFormattingSettings(settings.CodeFormatting);
                     CodeFolding.Update(settings.CodeFolding, logger);
                     Pester.Update(settings.Pester, logger);
+                    IntegratedConsole = new IntegratedConsoleSettings(settings.IntegratedConsole);
                     Cwd = settings.Cwd;
                     EnableReferencesCodeLens = settings.EnableReferencesCodeLens;
                     AnalyzeOpenDocumentsOnly = settings.AnalyzeOpenDocumentsOnly;
                 }
             }
         }
+    }
+
+    internal class IntegratedConsoleSettings
+    {
+        public IntegratedConsoleSettings() { }
+
+        public IntegratedConsoleSettings(IntegratedConsoleSettings integratedConsoleSettings)
+        {
+            if (integratedConsoleSettings is not null)
+            {
+                ForceClearScrollbackBuffer = integratedConsoleSettings.ForceClearScrollbackBuffer;
+            }
+        }
+
+        public bool ForceClearScrollbackBuffer { get; set; }
     }
 
     internal class ScriptAnalysisSettings

--- a/test/PowerShellEditorServices.Test/Extensions/EditorOperationsServiceTests.cs
+++ b/test/PowerShellEditorServices.Test/Extensions/EditorOperationsServiceTests.cs
@@ -6,13 +6,21 @@ using System.IO;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.PowerShell.EditorServices.Extensions;
 using Microsoft.PowerShell.EditorServices.Services;
+using Microsoft.PowerShell.EditorServices.Services.Configuration;
 using Microsoft.PowerShell.EditorServices.Services.Extension;
 using Microsoft.PowerShell.EditorServices.Services.TextDocument;
+using Newtonsoft.Json;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using Xunit;
 
 namespace PowerShellEditorServices.Test.Extensions
 {
+    [CollectionDefinition("Console", DisableParallelization = true)]
+    public class ConsoleCollectionDefinition
+    {
+    }
+
+    [Collection("Console")]
     [Trait("Category", "Extensions")]
     public class EditorOperationsServiceTests
     {
@@ -36,7 +44,8 @@ namespace PowerShellEditorServices.Test.Extensions
             EditorOperationsService editorOperationsService = new(
                 psesHost: null,
                 workspaceService,
-                languageServer: null);
+                languageServer: null,
+                new ConfigurationService());
 
             WorkspaceOpenDocument[] documents = editorOperationsService.GetWorkspaceOpenDocuments();
 
@@ -60,7 +69,8 @@ namespace PowerShellEditorServices.Test.Extensions
             EditorOperationsService editorOperationsService = new(
                 psesHost: null,
                 workspaceService,
-                languageServer: null);
+                languageServer: null,
+                new ConfigurationService());
 
             WorkspaceOpenDocument[] initialDocuments = editorOperationsService.GetWorkspaceOpenDocuments();
             Assert.Contains(initialDocuments, static document => document.Path.EndsWith("open-saved.ps1") && document.Saved);
@@ -85,6 +95,45 @@ namespace PowerShellEditorServices.Test.Extensions
             WorkspaceOpenDocument[] savedDocuments = editorOperationsService.GetWorkspaceOpenDocuments();
             Assert.Contains(savedDocuments, static document => document.Path.EndsWith("open-saved.ps1") && document.Saved);
             Assert.Contains(savedDocuments, static document => document.Path.StartsWith("untitled:", StringComparison.Ordinal) && !document.Saved);
+        }
+
+        [Fact]
+        public void LanguageServerSettingsUpdatesForceClearScrollbackBuffer()
+        {
+            LanguageServerSettings incomingSettings = JsonConvert.DeserializeObject<LanguageServerSettings>(
+                "{\"integratedConsole\":{\"forceClearScrollbackBuffer\":true}}");
+            LanguageServerSettings currentSettings = new();
+
+            currentSettings.Update(incomingSettings, workspaceRootPath: string.Empty, NullLogger.Instance);
+
+            Assert.True(currentSettings.IntegratedConsole.ForceClearScrollbackBuffer);
+        }
+
+        [Fact]
+        public void ClearTerminalWritesEraseSavedLinesWhenConfigured()
+        {
+            WorkspaceService workspaceService = new(NullLoggerFactory.Instance);
+            ConfigurationService configurationService = new();
+            configurationService.CurrentSettings.IntegratedConsole.ForceClearScrollbackBuffer = true;
+            EditorOperationsService editorOperationsService = new(
+                psesHost: null,
+                workspaceService,
+                languageServer: null,
+                configurationService);
+            StringWriter output = new();
+            TextWriter originalOutput = Console.Out;
+
+            try
+            {
+                Console.SetOut(output);
+                editorOperationsService.ClearTerminal();
+            }
+            finally
+            {
+                Console.SetOut(originalOutput);
+            }
+
+            Assert.Equal("\u001b[3J", output.ToString());
         }
 
         private static ScriptFile CreateFileBuffer(WorkspaceService workspaceService, string fileName)


### PR DESCRIPTION
## Summary

- I map `powershell.integratedConsole.forceClearScrollbackBuffer` into the language-server settings.
- I emit xterm's `CSI 3 J` sequence directly from PSES when the setting is enabled, so clearing saved lines no longer invokes the focus-stealing client command.
- I added regression coverage for settings updates and the in-band terminal output.

## Validation

- `Invoke-Build -Configuration Release TestFull` (351 unit tests passed with 1 platform skip; 48 stable-PowerShell E2E tests passed with 2 platform skips; 48 preview-PowerShell E2E tests passed with 2 platform skips)
- Focused Release `EditorOperationsServiceTests` (4 passed)
- `dotnet format PowerShellEditorServices.sln --no-restore --verify-no-changes --include src/PowerShellEditorServices/Services/Workspace/LanguageServerSettings.cs src/PowerShellEditorServices/Services/Extension/EditorOperationsService.cs test/PowerShellEditorServices.Test/Extensions/EditorOperationsServiceTests.cs`
- `git diff --check upstream/main...HEAD`

The Windows PowerShell 5.1-only legs were not available on this Linux host and remain covered by upstream CI.

Fixes #2313
